### PR TITLE
Add fenced code block support

### DIFF
--- a/Sources/MarkdownEditorCore/BlockParser.swift
+++ b/Sources/MarkdownEditorCore/BlockParser.swift
@@ -45,16 +45,63 @@ public enum BlockParser {
 
     // MARK: - Helpers
 
-    /// Splits text into paragraphs on single newlines.
+    /// Splits text into paragraphs on single newlines, merging fenced code blocks
+    /// into single multi-line blocks.
     private static func splitParagraphs(_ text: String) -> [String] {
         if text.isEmpty { return [""] }
 
-        // Split on each \n.  This gives us one block per line.
-        let parts = text.components(separatedBy: "\n")
+        let lines = text.components(separatedBy: "\n")
+        var result: [String] = []
+        var i = 0
 
-        // If the text ends with \n, components(separatedBy:) produces a
-        // trailing empty string.  Keep it — it represents the new empty
-        // block the user just created by pressing Enter.
-        return parts
+        while i < lines.count {
+            // Detect opening code fence
+            if let fence = codeFenceInfo(lines[i]) {
+                var merged = [lines[i]]
+                i += 1
+                while i < lines.count {
+                    let line = lines[i]
+                    merged.append(line)
+                    i += 1
+                    if isClosingFence(line, char: fence.char, count: fence.count) {
+                        break
+                    }
+                }
+                result.append(merged.joined(separator: "\n"))
+                continue
+            }
+
+            result.append(lines[i])
+            i += 1
+        }
+
+        return result
+    }
+
+    /// Returns fence info (character and count) if the line is an opening code fence.
+    private static func codeFenceInfo(_ line: String) -> (char: Character, count: Int)? {
+        let trimmed = line.drop(while: { $0 == " " })
+        let leadingSpaces = line.count - trimmed.count
+        guard leadingSpaces <= 3 else { return nil }
+        guard let first = trimmed.first, (first == "`" || first == "~") else { return nil }
+        let count = trimmed.prefix(while: { $0 == first }).count
+        guard count >= 3 else { return nil }
+        if first == "`" {
+            let afterFence = trimmed.dropFirst(count)
+            if afterFence.contains("`") { return nil }
+        }
+        return (first, count)
+    }
+
+    /// Returns true if the line is a valid closing fence for the given char/count.
+    private static func isClosingFence(_ line: String, char: Character, count: Int) -> Bool {
+        let trimmed = line.drop(while: { $0 == " " })
+        let leadingSpaces = line.count - trimmed.count
+        guard leadingSpaces <= 3 else { return false }
+        guard let first = trimmed.first, first == char else { return false }
+        let fenceCount = trimmed.prefix(while: { $0 == char }).count
+        guard fenceCount >= count else { return false }
+        let after = trimmed.dropFirst(fenceCount)
+        return after.allSatisfy { $0 == " " || $0 == "\t" }
     }
 }

--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -10,6 +10,11 @@ extension EditorTextView {
     /// Color for inline code spans.
     var codeColor: NSColor { NSColor(calibratedRed: 0.541, green: 0.141, blue: 0.145, alpha: 1.0) }
 
+    /// Monospaced font for code blocks.
+    var codeBlockFont: NSFont {
+        NSFont.monospacedSystemFont(ofSize: bodyFont.pointSize * 0.9, weight: .regular)
+    }
+
     /// Indentation amount for list items (active and inactive).
     var listIndent: CGFloat { 16 }
 
@@ -73,6 +78,16 @@ extension EditorTextView {
             case .code:
                 guard span.contentRange.upperBound <= result.length else { continue }
                 result.addAttribute(.foregroundColor, value: codeColor, range: span.contentRange)
+
+            case .codeBlock:
+                guard span.contentRange.upperBound <= result.length else { continue }
+                result.addAttribute(.font, value: codeBlockFont, range: span.contentRange)
+                result.addAttribute(.foregroundColor, value: codeColor, range: span.contentRange)
+                // Dim the fence lines
+                for dr in span.delimiterRanges {
+                    guard dr.upperBound <= result.length else { continue }
+                    result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
+                }
 
             case .strikethrough:
                 guard span.contentRange.upperBound <= result.length else { continue }
@@ -164,7 +179,7 @@ extension EditorTextView {
                 NSRange(location: span.contentRange.location - 2, length: 2),
                 NSRange(location: span.contentRange.upperBound, length: 2),
             ]
-        case .code, .heading, .link, .blockquote:
+        case .code, .codeBlock, .heading, .link, .blockquote:
             return span.delimiterRanges
         case .listItem(let ordered, _):
             return ordered ? [] : span.delimiterRanges
@@ -236,6 +251,9 @@ extension EditorTextView {
                 let bi = NSFontManager.shared.convert(bodyFont, toHaveTrait: [.boldFontMask, .italicFontMask])
                 result.addAttribute(.font, value: bi, range: mappedRange)
             case .code:
+                result.addAttribute(.foregroundColor, value: codeColor, range: mappedRange)
+            case .codeBlock:
+                result.addAttribute(.font, value: codeBlockFont, range: mappedRange)
                 result.addAttribute(.foregroundColor, value: codeColor, range: mappedRange)
             case .strikethrough:
                 result.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: mappedRange)

--- a/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
+++ b/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
@@ -22,6 +22,7 @@ public enum SyntaxHighlighter {
             case italic
             case boldItalic
             case code
+            case codeBlock(language: String?)
             case strikethrough
             case highlight
             case heading(Int)
@@ -295,6 +296,56 @@ public enum SyntaxHighlighter {
                 fullRange: full,
                 contentRange: content,
                 delimiterRanges: [openDelim, closeDelim]
+            ))
+        }
+
+        // MARK: - Code Blocks
+
+        mutating func visitCodeBlock(_ codeBlock: CodeBlock) {
+            guard let range = codeBlock.range else { return }
+            let full = nsRange(for: range)
+            guard full.length > 0 else { return }
+
+            let nsSource = source as NSString
+            let blockText = nsSource.substring(with: full) as NSString
+            var delims: [NSRange] = []
+            var cStart = full.location
+            var cEnd = full.upperBound
+
+            let firstNL = blockText.range(of: "\n")
+            if firstNL.location != NSNotFound {
+                // Opening fence line (including newline)
+                let openLen = firstNL.location + 1
+                delims.append(NSRange(location: full.location, length: openLen))
+                cStart = full.location + openLen
+
+                // Look for closing fence line
+                let lastNL = blockText.range(of: "\n", options: .backwards)
+                if lastNL.location != NSNotFound && lastNL.location != firstNL.location {
+                    let lastLineStart = lastNL.location + 1
+                    if lastLineStart < blockText.length {
+                        let lastLine = blockText.substring(from: lastLineStart)
+                            .trimmingCharacters(in: .whitespaces)
+                        if lastLine.hasPrefix("```") || lastLine.hasPrefix("~~~") {
+                            let closeStart = full.location + lastNL.location
+                            delims.append(NSRange(location: closeStart,
+                                                  length: full.upperBound - closeStart))
+                            cEnd = closeStart
+                        }
+                    }
+                }
+            } else {
+                // Single line (shouldn't normally happen with fenced code blocks)
+                delims.append(full)
+                cStart = full.upperBound
+            }
+
+            let content = NSRange(location: cStart, length: max(0, cEnd - cStart))
+            spans.append(Span(
+                kind: .codeBlock(language: codeBlock.language),
+                fullRange: full,
+                contentRange: content,
+                delimiterRanges: delims
             ))
         }
 

--- a/Tests/MarkdownEditorTests/BlockParserTests.swift
+++ b/Tests/MarkdownEditorTests/BlockParserTests.swift
@@ -194,4 +194,63 @@ struct BlockParserTests {
         #expect(blocks[0].range.length == ("👋" as NSString).length)
         #expect(blocks[1].content == "hi")
     }
+
+    // MARK: - Code Fence Merging
+
+    @Test("Fenced code block merges into single block")
+    func codeFenceMerge() {
+        let text = "```\nhello\n```"
+        let blocks = BlockParser.parse(text)
+        #expect(blocks.count == 1)
+        #expect(blocks[0].content == "```\nhello\n```")
+    }
+
+    @Test("Code fence with language merges into single block")
+    func codeFenceWithLanguage() {
+        let text = "```swift\nlet x = 1\n```"
+        let blocks = BlockParser.parse(text)
+        #expect(blocks.count == 1)
+        #expect(blocks[0].content == "```swift\nlet x = 1\n```")
+    }
+
+    @Test("Tilde code fence merges into single block")
+    func tildeFenceMerge() {
+        let text = "~~~\ncode\n~~~"
+        let blocks = BlockParser.parse(text)
+        #expect(blocks.count == 1)
+        #expect(blocks[0].content == "~~~\ncode\n~~~")
+    }
+
+    @Test("Code fence between paragraphs")
+    func codeFenceBetweenParagraphs() {
+        let text = "above\n```\ncode\n```\nbelow"
+        let blocks = BlockParser.parse(text)
+        #expect(blocks.count == 3)
+        #expect(blocks[0].content == "above")
+        #expect(blocks[1].content == "```\ncode\n```")
+        #expect(blocks[2].content == "below")
+    }
+
+    @Test("Unclosed code fence merges to end of document")
+    func unclosedFence() {
+        let text = "```\nline1\nline2"
+        let blocks = BlockParser.parse(text)
+        #expect(blocks.count == 1)
+        #expect(blocks[0].content == "```\nline1\nline2")
+    }
+
+    @Test("Code fence with multiple content lines")
+    func multiLineFence() {
+        let text = "```\na\nb\nc\n```"
+        let blocks = BlockParser.parse(text)
+        #expect(blocks.count == 1)
+        #expect(blocks[0].content.contains("a\nb\nc"))
+    }
+
+    @Test("Code fence range covers full text")
+    func codeFenceRange() {
+        let text = "```\nhello\n```"
+        let blocks = BlockParser.parse(text)
+        #expect(blocks[0].range == NSRange(location: 0, length: (text as NSString).length))
+    }
 }

--- a/Tests/MarkdownEditorTests/BlockStylingTests.swift
+++ b/Tests/MarkdownEditorTests/BlockStylingTests.swift
@@ -302,6 +302,81 @@ struct BlockStylingInactiveTests {
 }
 
 // ============================================================================
+// MARK: - Code Block
+// ============================================================================
+
+@Suite("Integration — Code Block (Active Block)")
+struct CodeBlockActiveTests {
+
+    @Test("Active code block shows raw markdown with fences")
+    @MainActor func activeShowsRaw() {
+        let editor = makeEditor()
+        editor.loadContent("```\nhello\n```\nother")
+        activateBlock(0, in: editor)
+
+        let text = displayText(for: 0, in: editor)
+        #expect(text == "```\nhello\n```")
+    }
+
+    @Test("Active code block fences are dimmed")
+    @MainActor func activeFencesDimmed() {
+        let editor = makeEditor()
+        editor.loadContent("```\nhello\n```\nother")
+        activateBlock(0, in: editor)
+
+        // First character of opening fence
+        let color = fgColor(at: 0, in: editor)
+        #expect(color == NSColor.tertiaryLabelColor)
+    }
+
+    @Test("Active code block content has monospace font")
+    @MainActor func activeContentMonospace() {
+        let editor = makeEditor()
+        editor.loadContent("```\nhello\n```\nother")
+        activateBlock(0, in: editor)
+
+        // "hello" starts at offset 4 (after "```\n")
+        let f = font(at: 4, in: editor)!
+        #expect(f.isFixedPitch)
+    }
+}
+
+@Suite("Integration — Code Block (Inactive Block)")
+struct CodeBlockInactiveTests {
+
+    @Test("Inactive code block strips fences, shows content only")
+    @MainActor func inactiveStripsDelimiters() {
+        let editor = makeEditor()
+        editor.loadContent("```\nhello\n```\nother")
+        activateBlock(1, in: editor)
+
+        let text = displayText(for: 0, in: editor)
+        #expect(text.contains("hello"))
+        #expect(!text.contains("```"))
+    }
+
+    @Test("Inactive code block has monospace font")
+    @MainActor func inactiveMonospace() {
+        let editor = makeEditor()
+        editor.loadContent("```\nhello\n```\nother")
+        activateBlock(1, in: editor)
+
+        let f = font(at: editor.displayRanges[0].location, in: editor)!
+        #expect(f.isFixedPitch)
+    }
+
+    @Test("Inactive code block has code color")
+    @MainActor func inactiveCodeColor() {
+        let editor = makeEditor()
+        editor.loadContent("```\nhello\n```\nother")
+        activateBlock(1, in: editor)
+
+        let color = fgColor(at: editor.displayRanges[0].location, in: editor)
+        #expect(color != nil)
+    }
+}
+
+// ============================================================================
 // MARK: - Block Transition (Active ↔ Inactive)
 // ============================================================================
 

--- a/Tests/MarkdownEditorTests/EditorRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/EditorRenderingTests.swift
@@ -340,6 +340,66 @@ struct EditorMarkdownTests {
         }
         #expect(hasTextBlock)
     }
+
+    @Test("Code block renders without fence lines")
+    @MainActor func codeBlockRendering() {
+        let editor = makeEditor()
+        let rendered = editor.renderMarkdown("```\nhello\n```")
+        // Fence lines should be stripped, only content remains
+        #expect(rendered.string.contains("hello"))
+        #expect(!rendered.string.contains("```"))
+    }
+
+    @Test("Code block rendered content has monospace font")
+    @MainActor func codeBlockFont() {
+        let editor = makeEditor()
+        let rendered = editor.renderMarkdown("```\nhello\n```")
+        var hasMonospace = false
+        rendered.enumerateAttribute(.font, in: NSRange(location: 0, length: rendered.length)) { val, _, _ in
+            if let f = val as? NSFont, f.isFixedPitch {
+                hasMonospace = true
+            }
+        }
+        #expect(hasMonospace)
+    }
+
+    @Test("Code block rendered content has code color")
+    @MainActor func codeBlockColor() {
+        let editor = makeEditor()
+        let rendered = editor.renderMarkdown("```\nhello\n```")
+        var hasCodeColor = false
+        rendered.enumerateAttribute(.foregroundColor, in: NSRange(location: 0, length: rendered.length)) { val, _, _ in
+            if let color = val as? NSColor {
+                if color.redComponent > 0.5 && color.greenComponent < 0.2 && color.blueComponent < 0.2 {
+                    hasCodeColor = true
+                }
+            }
+        }
+        #expect(hasCodeColor)
+    }
+
+    @Test("Active code block content has monospace font")
+    @MainActor func activeCodeBlockFont() {
+        let editor = makeEditor()
+        let highlighted = editor.highlightSyntax("```\nhello\n```")
+        // Content "hello\n" starts at offset 4
+        var hasMonospace = false
+        highlighted.enumerateAttribute(.font, in: NSRange(location: 4, length: 6)) { val, _, _ in
+            if let f = val as? NSFont, f.isFixedPitch {
+                hasMonospace = true
+            }
+        }
+        #expect(hasMonospace)
+    }
+
+    @Test("Active code block fences are dimmed")
+    @MainActor func activeCodeBlockDimmedFences() {
+        let editor = makeEditor()
+        let highlighted = editor.highlightSyntax("```\nhello\n```")
+        // Opening "```\n" is at offset 0
+        let color = highlighted.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+        #expect(color == NSColor.tertiaryLabelColor)
+    }
 }
 
 // MARK: - Display Composition

--- a/Tests/MarkdownEditorTests/SyntaxHighlighterTests.swift
+++ b/Tests/MarkdownEditorTests/SyntaxHighlighterTests.swift
@@ -465,3 +465,88 @@ struct ListItemTests {
         }
     }
 }
+
+// MARK: - Code Blocks
+
+@Suite("SyntaxHighlighter — Code Blocks")
+struct CodeBlockTests {
+
+    @Test("Fenced code block with backticks produces codeBlock span")
+    func backtickFence() {
+        let text = "```\nhello\n```"
+        let spans = SyntaxHighlighter.parse(text)
+        let codeBlocks = spans.filter {
+            if case .codeBlock = $0.kind { return true }
+            return false
+        }
+        #expect(codeBlocks.count == 1)
+    }
+
+    @Test("Fenced code block with language annotation")
+    func languageAnnotation() {
+        let text = "```swift\nlet x = 1\n```"
+        let spans = SyntaxHighlighter.parse(text)
+        let codeBlocks = spans.filter {
+            if case .codeBlock = $0.kind { return true }
+            return false
+        }
+        #expect(codeBlocks.count == 1)
+        if case .codeBlock(let lang) = codeBlocks[0].kind {
+            #expect(lang == "swift")
+        }
+    }
+
+    @Test("Code block content range excludes fence lines")
+    func contentExcludesFences() {
+        let text = "```\nhello\n```"
+        let spans = SyntaxHighlighter.parse(text)
+        let codeBlocks = spans.filter {
+            if case .codeBlock = $0.kind { return true }
+            return false
+        }
+        #expect(codeBlocks.count == 1)
+        let content = (text as NSString).substring(with: codeBlocks[0].contentRange)
+        #expect(content == "hello")
+    }
+
+    @Test("Code block with tilde fences")
+    func tildeFence() {
+        let text = "~~~\ncode\n~~~"
+        let spans = SyntaxHighlighter.parse(text)
+        let codeBlocks = spans.filter {
+            if case .codeBlock = $0.kind { return true }
+            return false
+        }
+        #expect(codeBlocks.count == 1)
+    }
+
+    @Test("Code block with multiple lines of content")
+    func multipleLines() {
+        let text = "```\nline1\nline2\nline3\n```"
+        let spans = SyntaxHighlighter.parse(text)
+        let codeBlocks = spans.filter {
+            if case .codeBlock = $0.kind { return true }
+            return false
+        }
+        #expect(codeBlocks.count == 1)
+        let content = (text as NSString).substring(with: codeBlocks[0].contentRange)
+        #expect(content.contains("line1"))
+        #expect(content.contains("line2"))
+        #expect(content.contains("line3"))
+    }
+
+    @Test("Code block delimiter ranges cover fence lines")
+    func delimiterRanges() {
+        let text = "```\nhello\n```"
+        let spans = SyntaxHighlighter.parse(text)
+        let codeBlocks = spans.filter {
+            if case .codeBlock = $0.kind { return true }
+            return false
+        }
+        #expect(codeBlocks.count == 1)
+        #expect(codeBlocks[0].delimiterRanges.count == 2)
+        // Opening: "```\n"
+        let openDelim = (text as NSString).substring(with: codeBlocks[0].delimiterRanges[0])
+        #expect(openDelim == "```\n")
+    }
+}


### PR DESCRIPTION
## Summary
- **BlockParser**: merges fenced code blocks (``` or ~~~) into single multi-line blocks, including language annotations
- **SyntaxHighlighter**: visits CodeBlock AST nodes, extracts fence delimiter and content ranges
- **Active rendering**: monospace font + code color on content, dimmed fence lines
- **Inactive rendering**: fence lines stripped, monospace + code color on content

## Test plan
- [x] 291 tests passing (24 new tests added)
- [x] BlockParser tests for fence detection, merging, unclosed fences, and code between paragraphs
- [x] SyntaxHighlighter tests for backtick/tilde fences, language annotation, content/delimiter ranges
- [x] EditorRendering tests for rendered output, monospace font, code color, dimmed fences
- [x] BlockStyling integration tests for active/inactive code blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)