### PR TITLE
Add table support

### DIFF
--- a/Sources/MarkdownEditorCore/BlockParser.swift
+++ b/Sources/MarkdownEditorCore/BlockParser.swift
@@ -45,16 +45,44 @@ public enum BlockParser {
 
     // MARK: - Helpers
 
-    /// Splits text into paragraphs on single newlines.
+    /// Splits text into paragraphs on single newlines, merging table rows
+    /// into single multi-line blocks.
     private static func splitParagraphs(_ text: String) -> [String] {
         if text.isEmpty { return [""] }
 
-        // Split on each \n.  This gives us one block per line.
-        let parts = text.components(separatedBy: "\n")
+        let lines = text.components(separatedBy: "\n")
+        var result: [String] = []
+        var i = 0
 
-        // If the text ends with \n, components(separatedBy:) produces a
-        // trailing empty string.  Keep it — it represents the new empty
-        // block the user just created by pressing Enter.
-        return parts
+        while i < lines.count {
+            // Detect table: header row followed by separator row
+            if i + 1 < lines.count && isTableRow(lines[i]) && isTableSeparator(lines[i + 1]) {
+                var merged = [lines[i]]
+                i += 1
+                while i < lines.count && (isTableRow(lines[i]) || isTableSeparator(lines[i])) {
+                    merged.append(lines[i])
+                    i += 1
+                }
+                result.append(merged.joined(separator: "\n"))
+                continue
+            }
+
+            result.append(lines[i])
+            i += 1
+        }
+
+        return result
+    }
+
+    /// Returns true if the line contains a pipe character (potential table row).
+    private static func isTableRow(_ line: String) -> Bool {
+        return line.contains("|")
+    }
+
+    /// Returns true if the line is a table separator (e.g., "| --- | --- |").
+    private static func isTableSeparator(_ line: String) -> Bool {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.contains("|") && trimmed.contains("---") else { return false }
+        return trimmed.allSatisfy { "|:- \t".contains($0) }
     }
 }

--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -10,6 +10,11 @@ extension EditorTextView {
     /// Color for inline code spans.
     var codeColor: NSColor { NSColor(calibratedRed: 0.541, green: 0.141, blue: 0.145, alpha: 1.0) }
 
+    /// Monospaced font for tables.
+    var tableFont: NSFont {
+        NSFont.monospacedSystemFont(ofSize: bodyFont.pointSize * 0.9, weight: .regular)
+    }
+
     /// Indentation amount for list items (active and inactive).
     var listIndent: CGFloat { 16 }
 
@@ -104,6 +109,20 @@ extension EditorTextView {
             case .listItem:
                 guard span.fullRange.upperBound <= result.length else { continue }
                 result.addAttribute(.paragraphStyle, value: listParagraphStyle(), range: span.fullRange)
+
+            case .table:
+                guard span.fullRange.upperBound <= result.length else { continue }
+                result.addAttribute(.font, value: tableFont, range: span.fullRange)
+                // Dim all pipe characters
+                let nsStr = (result.string as NSString)
+                var searchRange = span.fullRange
+                while searchRange.length > 0 {
+                    let pipeRange = nsStr.range(of: "|", options: [], range: searchRange)
+                    guard pipeRange.location != NSNotFound else { break }
+                    result.addAttribute(.foregroundColor, value: syntaxDimColor, range: pipeRange)
+                    let newStart = pipeRange.upperBound
+                    searchRange = NSRange(location: newStart, length: max(0, span.fullRange.upperBound - newStart))
+                }
             }
         }
 
@@ -168,6 +187,8 @@ extension EditorTextView {
             return span.delimiterRanges
         case .listItem(let ordered, _):
             return ordered ? [] : span.delimiterRanges
+        case .table:
+            return span.delimiterRanges
         }
     }
 
@@ -291,6 +312,23 @@ extension EditorTextView {
                             result.addAttribute(.foregroundColor, value: syntaxDimColor, range: mappedDR)
                         }
                     }
+                }
+            case .table:
+                // Apply monospace font to full range
+                let fullStart = mappedOffset(span.fullRange.location, removals: removals)
+                let fullEnd = mappedOffset(span.fullRange.upperBound, removals: removals)
+                let mappedFull = NSRange(location: fullStart, length: max(0, fullEnd - fullStart))
+                guard mappedFull.upperBound <= result.length else { continue }
+                result.addAttribute(.font, value: tableFont, range: mappedFull)
+                // Dim pipe characters and separator row
+                let nsStr = (result.string as NSString)
+                var searchRange = mappedFull
+                while searchRange.length > 0 {
+                    let pipeRange = nsStr.range(of: "|", options: [], range: searchRange)
+                    guard pipeRange.location != NSNotFound else { break }
+                    result.addAttribute(.foregroundColor, value: syntaxDimColor, range: pipeRange)
+                    let newStart = pipeRange.upperBound
+                    searchRange = NSRange(location: newStart, length: max(0, mappedFull.upperBound - newStart))
                 }
             }
         }

--- a/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
+++ b/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
@@ -28,6 +28,7 @@ public enum SyntaxHighlighter {
             case link(destination: String)
             case blockquote
             case listItem(ordered: Bool, checkbox: CheckboxState? = nil)
+            case table
 
             public enum CheckboxState: Equatable, Sendable {
                 case checked, unchecked
@@ -356,6 +357,50 @@ public enum SyntaxHighlighter {
                 delimiterRanges: delims
             ))
             descendInto(blockQuote)
+        }
+
+        // MARK: - Tables
+
+        mutating func visitTable(_ table: Table) {
+            guard let range = table.range else {
+                descendInto(table)
+                return
+            }
+            let full = nsRange(for: range)
+
+            // Compute gaps between child rows (head/body) as delimiters
+            // (this captures the separator row between head and body)
+            var childRanges: [NSRange] = []
+            for child in table.children {
+                if let cr = child.range {
+                    childRanges.append(nsRange(for: cr))
+                }
+            }
+
+            var delims: [NSRange] = []
+            if let first = childRanges.first, first.location > full.location {
+                delims.append(NSRange(location: full.location,
+                                      length: first.location - full.location))
+            }
+            for i in 0..<(childRanges.count - 1) {
+                let gapStart = childRanges[i].upperBound
+                let gapEnd = childRanges[i + 1].location
+                if gapEnd > gapStart {
+                    delims.append(NSRange(location: gapStart,
+                                          length: gapEnd - gapStart))
+                }
+            }
+            if let last = childRanges.last, last.upperBound < full.upperBound {
+                delims.append(NSRange(location: last.upperBound,
+                                      length: full.upperBound - last.upperBound))
+            }
+
+            spans.append(Span(
+                kind: .table,
+                fullRange: full,
+                contentRange: full,
+                delimiterRanges: delims
+            ))
         }
 
         // MARK: - Lists

--- a/Tests/MarkdownEditorTests/BlockParserTests.swift
+++ b/Tests/MarkdownEditorTests/BlockParserTests.swift
@@ -194,4 +194,47 @@ struct BlockParserTests {
         #expect(blocks[0].range.length == ("👋" as NSString).length)
         #expect(blocks[1].content == "hi")
     }
+
+    // MARK: - Table Merging
+
+    @Test("Table with header and separator merges into single block")
+    func tableMerge() {
+        let text = "| A | B |\n| --- | --- |\n| 1 | 2 |"
+        let blocks = BlockParser.parse(text)
+        #expect(blocks.count == 1)
+        #expect(blocks[0].content == text)
+    }
+
+    @Test("Table between paragraphs")
+    func tableBetweenParagraphs() {
+        let text = "above\n| A | B |\n| --- | --- |\n| 1 | 2 |\nbelow"
+        let blocks = BlockParser.parse(text)
+        #expect(blocks.count == 3)
+        #expect(blocks[0].content == "above")
+        #expect(blocks[1].content == "| A | B |\n| --- | --- |\n| 1 | 2 |")
+        #expect(blocks[2].content == "below")
+    }
+
+    @Test("Table with multiple data rows")
+    func tableMultipleRows() {
+        let text = "| H1 | H2 |\n| --- | --- |\n| a | b |\n| c | d |"
+        let blocks = BlockParser.parse(text)
+        #expect(blocks.count == 1)
+        #expect(blocks[0].content == text)
+    }
+
+    @Test("Single pipe line without separator is not a table")
+    func singlePipeNotTable() {
+        let text = "| not a table |"
+        let blocks = BlockParser.parse(text)
+        #expect(blocks.count == 1)
+        #expect(blocks[0].content == "| not a table |")
+    }
+
+    @Test("Table range covers full text")
+    func tableRange() {
+        let text = "| A |\n| --- |\n| 1 |"
+        let blocks = BlockParser.parse(text)
+        #expect(blocks[0].range == NSRange(location: 0, length: (text as NSString).length))
+    }
 }

--- a/Tests/MarkdownEditorTests/BlockStylingTests.swift
+++ b/Tests/MarkdownEditorTests/BlockStylingTests.swift
@@ -302,6 +302,70 @@ struct BlockStylingInactiveTests {
 }
 
 // ============================================================================
+// MARK: - Table
+// ============================================================================
+
+@Suite("Integration — Table (Active Block)")
+struct TableActiveTests {
+
+    @Test("Active table shows raw markdown")
+    @MainActor func activeShowsRaw() {
+        let editor = makeEditor()
+        editor.loadContent("| A | B |\n| --- | --- |\n| 1 | 2 |\nother")
+        activateBlock(0, in: editor)
+
+        let text = displayText(for: 0, in: editor)
+        #expect(text.contains("| A | B |"))
+        #expect(text.contains("| --- | --- |"))
+    }
+
+    @Test("Active table has monospace font")
+    @MainActor func activeMonospace() {
+        let editor = makeEditor()
+        editor.loadContent("| A | B |\n| --- | --- |\n| 1 | 2 |\nother")
+        activateBlock(0, in: editor)
+
+        let f = font(at: 2, in: editor)!
+        #expect(f.isFixedPitch)
+    }
+
+    @Test("Active table pipes are dimmed")
+    @MainActor func activePipesDimmed() {
+        let editor = makeEditor()
+        editor.loadContent("| A | B |\n| --- | --- |\n| 1 | 2 |\nother")
+        activateBlock(0, in: editor)
+
+        let color = fgColor(at: 0, in: editor)
+        #expect(color == NSColor.tertiaryLabelColor)
+    }
+}
+
+@Suite("Integration — Table (Inactive Block)")
+struct TableInactiveTests {
+
+    @Test("Inactive table has monospace font")
+    @MainActor func inactiveMonospace() {
+        let editor = makeEditor()
+        editor.loadContent("| A | B |\n| --- | --- |\n| 1 | 2 |\nother")
+        activateBlock(1, in: editor)
+
+        let f = font(at: editor.displayRanges[0].location, in: editor)!
+        #expect(f.isFixedPitch)
+    }
+
+    @Test("Inactive table pipes are dimmed")
+    @MainActor func inactivePipesDimmed() {
+        let editor = makeEditor()
+        editor.loadContent("| A | B |\n| --- | --- |\n| 1 | 2 |\nother")
+        activateBlock(1, in: editor)
+
+        let base = editor.displayRanges[0].location
+        let color = fgColor(at: base, in: editor)
+        #expect(color == NSColor.tertiaryLabelColor)
+    }
+}
+
+// ============================================================================
 // MARK: - Block Transition (Active ↔ Inactive)
 // ============================================================================
 

--- a/Tests/MarkdownEditorTests/EditorRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/EditorRenderingTests.swift
@@ -340,6 +340,41 @@ struct EditorMarkdownTests {
         }
         #expect(hasTextBlock)
     }
+
+    @Test("Table rendered text has monospace font")
+    @MainActor func tableMonospace() {
+        let editor = makeEditor()
+        let rendered = editor.renderMarkdown("| A | B |\n| --- | --- |\n| 1 | 2 |")
+        var hasMonospace = false
+        rendered.enumerateAttribute(.font, in: NSRange(location: 0, length: rendered.length)) { val, _, _ in
+            if let f = val as? NSFont, f.isFixedPitch {
+                hasMonospace = true
+            }
+        }
+        #expect(hasMonospace)
+    }
+
+    @Test("Active table has monospace font")
+    @MainActor func activeTableMonospace() {
+        let editor = makeEditor()
+        let highlighted = editor.highlightSyntax("| A | B |\n| --- | --- |\n| 1 | 2 |")
+        var hasMonospace = false
+        highlighted.enumerateAttribute(.font, in: NSRange(location: 0, length: highlighted.length)) { val, _, _ in
+            if let f = val as? NSFont, f.isFixedPitch {
+                hasMonospace = true
+            }
+        }
+        #expect(hasMonospace)
+    }
+
+    @Test("Active table pipes are dimmed")
+    @MainActor func activeTablePipesDimmed() {
+        let editor = makeEditor()
+        let highlighted = editor.highlightSyntax("| A | B |\n| --- | --- |\n| 1 | 2 |")
+        // First character is "|"
+        let color = highlighted.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+        #expect(color == NSColor.tertiaryLabelColor)
+    }
 }
 
 // MARK: - Display Composition

--- a/Tests/MarkdownEditorTests/SyntaxHighlighterTests.swift
+++ b/Tests/MarkdownEditorTests/SyntaxHighlighterTests.swift
@@ -465,3 +465,44 @@ struct ListItemTests {
         }
     }
 }
+
+// MARK: - Tables
+
+@Suite("SyntaxHighlighter — Tables")
+struct TableTests {
+
+    @Test("Table produces a table span")
+    func basicTable() {
+        let text = "| A | B |\n| --- | --- |\n| 1 | 2 |"
+        let spans = SyntaxHighlighter.parse(text)
+        let tables = spans.filter { $0.kind == .table }
+        #expect(tables.count == 1)
+    }
+
+    @Test("Table full range covers entire table text")
+    func tableFullRange() {
+        let text = "| A | B |\n| --- | --- |\n| 1 | 2 |"
+        let spans = SyntaxHighlighter.parse(text)
+        let tables = spans.filter { $0.kind == .table }
+        #expect(tables.count == 1)
+        #expect(tables[0].fullRange == NSRange(location: 0, length: (text as NSString).length))
+    }
+
+    @Test("Table with single column")
+    func singleColumn() {
+        let text = "| H |\n| --- |\n| V |"
+        let spans = SyntaxHighlighter.parse(text)
+        let tables = spans.filter { $0.kind == .table }
+        #expect(tables.count == 1)
+    }
+
+    @Test("Table delimiter ranges capture separator row")
+    func tableSeparatorInDelimiters() {
+        let text = "| A |\n| --- |\n| 1 |"
+        let spans = SyntaxHighlighter.parse(text)
+        let tables = spans.filter { $0.kind == .table }
+        #expect(tables.count == 1)
+        // There should be delimiter ranges between head and body (the separator)
+        #expect(!tables[0].delimiterRanges.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- **BlockParser**: detects table patterns (header + separator row) and merges consecutive table lines into single multi-line blocks
- **SyntaxHighlighter**: visits Table AST nodes, captures separator row gaps as delimiter ranges
- **Active rendering**: monospace font on full table, dimmed pipe characters
- **Inactive rendering**: monospace font, dimmed pipes, separator row stripped via delimiter ranges

## Test plan
- [x] 284 tests passing (17 new tests added)
- [x] BlockParser tests for table merging, multi-row tables, tables between paragraphs, edge cases
- [x] SyntaxHighlighter tests for table span, full range, delimiter ranges
- [x] EditorRendering tests for monospace font, dimmed pipes
- [x] BlockStyling integration tests for active/inactive table blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)