### PR TITLE
Add multi-line blockquote support

### DIFF
--- a/Sources/MarkdownEditorCore/BlockParser.swift
+++ b/Sources/MarkdownEditorCore/BlockParser.swift
@@ -71,6 +71,18 @@ public enum BlockParser {
                 continue
             }
 
+            // Detect blockquote: consecutive lines starting with >
+            if isBlockquoteLine(lines[i]) {
+                var merged = [lines[i]]
+                i += 1
+                while i < lines.count && isBlockquoteLine(lines[i]) {
+                    merged.append(lines[i])
+                    i += 1
+                }
+                result.append(merged.joined(separator: "\n"))
+                continue
+            }
+
             // Detect table: header row followed by separator row
             if i + 1 < lines.count && isTableRow(lines[i]) && isTableSeparator(lines[i + 1]) {
                 var merged = [lines[i]]
@@ -88,6 +100,14 @@ public enum BlockParser {
         }
 
         return result
+    }
+
+    /// Returns true if the line is a blockquote line (starts with optional 0–3 spaces then `>`).
+    private static func isBlockquoteLine(_ line: String) -> Bool {
+        let trimmed = line.drop(while: { $0 == " " })
+        let leadingSpaces = line.count - trimmed.count
+        guard leadingSpaces <= 3 else { return false }
+        return trimmed.first == ">"
     }
 
     /// Returns true if the line contains a pipe character (potential table row).

--- a/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
+++ b/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
@@ -444,7 +444,30 @@ public enum SyntaxHighlighter {
                 return
             }
             let full = nsRange(for: range)
-            let delims = delimiterRanges(parent: full, children: blockQuote.children)
+            let nsSource = source as NSString
+
+            // Scan each line within the blockquote for "> " prefixes
+            var delims: [NSRange] = []
+            var cursor = full.location
+            while cursor < full.upperBound {
+                // Find the end of this line
+                let remaining = NSRange(location: cursor, length: full.upperBound - cursor)
+                let nlRange = nsSource.range(of: "\n", options: [], range: remaining)
+                let lineEnd = nlRange.location != NSNotFound ? nlRange.location : full.upperBound
+
+                // Check if line starts with optional spaces then ">"
+                let lineRange = NSRange(location: cursor, length: lineEnd - cursor)
+                let line = nsSource.substring(with: lineRange)
+                let stripped = line.drop(while: { $0 == " " })
+                if stripped.first == ">" {
+                    let prefixLen = line.count - stripped.count + 1  // spaces + ">"
+                    let delimLen = prefixLen + (stripped.dropFirst().first == " " ? 1 : 0)  // include trailing space
+                    delims.append(NSRange(location: cursor, length: delimLen))
+                }
+
+                cursor = nlRange.location != NSNotFound ? nlRange.location + 1 : full.upperBound
+            }
+
             let content = contentRange(full: full, delims: delims)
 
             spans.append(Span(

--- a/Tests/MarkdownEditorTests/BlockParserTests.swift
+++ b/Tests/MarkdownEditorTests/BlockParserTests.swift
@@ -296,4 +296,49 @@ struct BlockParserTests {
         let blocks = BlockParser.parse(text)
         #expect(blocks[0].range == NSRange(location: 0, length: (text as NSString).length))
     }
+
+    // MARK: - Blockquote Merging
+
+    @Test("Consecutive blockquote lines merge into single block")
+    func blockquoteMerge() {
+        let text = "> line1\n> line2\n> line3"
+        let blocks = BlockParser.parse(text)
+        #expect(blocks.count == 1)
+        #expect(blocks[0].content == text)
+    }
+
+    @Test("Blockquote between paragraphs")
+    func blockquoteBetweenParagraphs() {
+        let text = "above\n> line1\n> line2\nbelow"
+        let blocks = BlockParser.parse(text)
+        #expect(blocks.count == 3)
+        #expect(blocks[0].content == "above")
+        #expect(blocks[1].content == "> line1\n> line2")
+        #expect(blocks[2].content == "below")
+    }
+
+    @Test("Single blockquote line is one block")
+    func singleBlockquoteLine() {
+        let text = "> just one"
+        let blocks = BlockParser.parse(text)
+        #expect(blocks.count == 1)
+        #expect(blocks[0].content == "> just one")
+    }
+
+    @Test("Blockquote range covers full text")
+    func blockquoteRange() {
+        let text = "> a\n> b"
+        let blocks = BlockParser.parse(text)
+        #expect(blocks[0].range == NSRange(location: 0, length: (text as NSString).length))
+    }
+
+    @Test("Non-consecutive blockquotes are separate blocks")
+    func nonConsecutiveBlockquotes() {
+        let text = "> first\nparagraph\n> second"
+        let blocks = BlockParser.parse(text)
+        #expect(blocks.count == 3)
+        #expect(blocks[0].content == "> first")
+        #expect(blocks[1].content == "paragraph")
+        #expect(blocks[2].content == "> second")
+    }
 }

--- a/Tests/MarkdownEditorTests/BlockStylingTests.swift
+++ b/Tests/MarkdownEditorTests/BlockStylingTests.swift
@@ -118,6 +118,17 @@ struct BlockStylingActiveTests {
         let delimColor = fgColor(at: 0, in: editor)
         #expect(delimColor == NSColor.tertiaryLabelColor)
     }
+
+    @Test("Active multi-line blockquote shows all raw lines")
+    @MainActor func activeMultiLineBlockquote() {
+        let editor = makeEditor()
+        editor.loadContent("> line1\n> line2\nother")
+        activateBlock(0, in: editor)
+
+        let text = displayText(for: 0, in: editor)
+        #expect(text.contains("> line1"))
+        #expect(text.contains("> line2"))
+    }
 }
 
 // ============================================================================
@@ -277,6 +288,30 @@ struct BlockStylingInactiveTests {
     @MainActor func inactiveBlockquoteParagraphStyle() {
         let editor = makeEditor()
         editor.loadContent("> wise words\nother")
+        activateBlock(1, in: editor)
+
+        let a = attrs(at: editor.displayRanges[0].location, in: editor)
+        let ps = a[.paragraphStyle] as? NSParagraphStyle
+        #expect(ps != nil)
+        #expect(!ps!.textBlocks.isEmpty)
+    }
+
+    @Test("Inactive multi-line blockquote strips all > prefixes")
+    @MainActor func inactiveMultiLineBlockquote() {
+        let editor = makeEditor()
+        editor.loadContent("> line1\n> line2\nother")
+        activateBlock(1, in: editor)
+
+        let text = displayText(for: 0, in: editor)
+        #expect(!text.contains(">"))
+        #expect(text.contains("line1"))
+        #expect(text.contains("line2"))
+    }
+
+    @Test("Inactive multi-line blockquote has text block style")
+    @MainActor func inactiveMultiLineBlockquoteParagraphStyle() {
+        let editor = makeEditor()
+        editor.loadContent("> line1\n> line2\nother")
         activateBlock(1, in: editor)
 
         let a = attrs(at: editor.displayRanges[0].location, in: editor)

--- a/Tests/MarkdownEditorTests/EditorRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/EditorRenderingTests.swift
@@ -242,6 +242,15 @@ struct EditorMarkdownTests {
         #expect(hasSecondaryColor)
     }
 
+    @Test("Multi-line blockquote strips all > prefixes")
+    @MainActor func multiLineBlockquoteRendering() {
+        let editor = makeEditor()
+        let rendered = editor.renderMarkdown("> line1\n> line2")
+        #expect(!rendered.string.contains(">"))
+        #expect(rendered.string.contains("line1"))
+        #expect(rendered.string.contains("line2"))
+    }
+
     @Test("List items have indented paragraph style")
     @MainActor func listIndentation() {
         let editor = makeEditor()


### PR DESCRIPTION
## Summary
- Merge consecutive `>` lines into a single block in `BlockParser`, matching the pattern used for code fences and tables
- Fix `SyntaxHighlighter.visitBlockQuote` to scan all lines for `> ` prefixes so every prefix is stripped when rendered inactive
- Add 9 new tests covering block merging, rendering, and styling

## Test plan
- [x] 359 tests pass (350 existing + 9 new)
- [x] Multi-line blockquote merges into single block
- [x] Inactive multi-line blockquote strips all `>` prefixes
- [x] Inactive multi-line blockquote has text block paragraph style

🤖 Generated with [Claude Code](https://claude.com/claude-code)