### PR TITLE
Fix secure restorable state warning on launch

### DIFF
--- a/Sources/MarkdownEditor/main.swift
+++ b/Sources/MarkdownEditor/main.swift
@@ -20,6 +20,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
+        true
+    }
+
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         true
     }


### PR DESCRIPTION
## Summary
- Implement `applicationSupportsSecureRestorableState` returning `true` in `AppDelegate` to silence the macOS runtime warning about secure coding

## Test plan
- [x] 350 tests pass
- [x] Warning no longer appears on `swift run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)