### PR TITLE
Switch to word-level delimiter hiding

### DIFF
--- a/Sources/MarkdownEditorCore/BlockParser.swift
+++ b/Sources/MarkdownEditorCore/BlockParser.swift
@@ -71,18 +71,6 @@ public enum BlockParser {
                 continue
             }
 
-            // Detect blockquote: consecutive lines starting with >
-            if isBlockquoteLine(lines[i]) {
-                var merged = [lines[i]]
-                i += 1
-                while i < lines.count && isBlockquoteLine(lines[i]) {
-                    merged.append(lines[i])
-                    i += 1
-                }
-                result.append(merged.joined(separator: "\n"))
-                continue
-            }
-
             // Detect table: header row followed by separator row
             if i + 1 < lines.count && isTableRow(lines[i]) && isTableSeparator(lines[i + 1]) {
                 var merged = [lines[i]]
@@ -100,14 +88,6 @@ public enum BlockParser {
         }
 
         return result
-    }
-
-    /// Returns true if the line is a blockquote line (starts with optional 0–3 spaces then `>`).
-    private static func isBlockquoteLine(_ line: String) -> Bool {
-        let trimmed = line.drop(while: { $0 == " " })
-        let leadingSpaces = line.count - trimmed.count
-        guard leadingSpaces <= 3 else { return false }
-        return trimmed.first == ">"
     }
 
     /// Returns true if the line contains a pipe character (potential table row).

--- a/Sources/MarkdownEditorCore/EditorTextView+Composition.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Composition.swift
@@ -4,33 +4,44 @@ import AppKit
 
 extension EditorTextView {
 
-    // MARK: - Display Composition (full recompose)
+    // MARK: - Display Composition
     //
-    // Called when the active block changes.  Replaces the entire text storage.
+    // Text storage content = rawSource, always.
+    // Styling is attribute-only; the string never changes during recompose.
 
     func recompose(cursorInRaw: Int, selectionInRaw: NSRange? = nil) {
         isUpdating = true
 
         activeBlockIndex = blockIndexForRawOffset(cursorInRaw)
 
-        let composed = NSMutableAttributedString()
-        displayRanges = []
+        // Build styled attributed string from rawSource.
+        // The string content IS rawSource — no delimiter stripping.
+        let composed = NSMutableAttributedString(string: rawSource, attributes: baseAttributes)
 
         for (i, block) in blocks.enumerated() {
-            if i > 0 {
-                composed.append(NSAttributedString(string: blockSeparator, attributes: baseAttributes))
-            }
+            guard block.range.upperBound <= composed.length else { continue }
 
-            let blockDisplayStart = composed.length
-
+            // Cursor position within this block (nil for non-active blocks)
+            let cursorInBlock: Int?
             if i == activeBlockIndex {
-                composed.append(highlightSyntax(block.content))
+                cursorInBlock = max(0, cursorInRaw - block.range.location)
             } else {
-                composed.append(renderMarkdown(block.content))
+                cursorInBlock = nil
             }
 
-            let blockDisplayLength = composed.length - blockDisplayStart
-            displayRanges.append(NSRange(location: blockDisplayStart, length: blockDisplayLength))
+            let styled = styleBlock(block.content, cursorPosition: cursorInBlock)
+
+            // Apply attributes from the styled block onto the composed string
+            styled.enumerateAttributes(
+                in: NSRange(location: 0, length: styled.length), options: []
+            ) { attrs, range, _ in
+                let tsRange = NSRange(
+                    location: range.location + block.range.location,
+                    length: range.length
+                )
+                guard tsRange.upperBound <= composed.length else { return }
+                composed.setAttributes(attrs, range: tsRange)
+            }
         }
 
         let fullRange = NSRange(location: 0, length: textStorage!.length)
@@ -38,18 +49,19 @@ extension EditorTextView {
         textStorage?.replaceCharacters(in: fullRange, with: composed)
         textStorage?.endEditing()
 
+        // displayRanges = block ranges (identity mapping)
+        displayRanges = blocks.map { $0.range }
+
+        // Cursor placement: display offset = raw offset (identity)
         if let rawSel = selectionInRaw, rawSel.length > 0 {
-            let displayStart = rawOffsetToDisplayOffset(rawSel.location)
-            let displayEnd = rawOffsetToDisplayOffset(rawSel.location + rawSel.length)
             let len = textStorage!.length
             let displaySel = NSRange(
-                location: min(displayStart, len),
-                length: max(0, min(displayEnd, len) - min(displayStart, len))
+                location: min(rawSel.location, len),
+                length: max(0, min(rawSel.upperBound, len) - min(rawSel.location, len))
             )
             setSelectedRange(displaySel)
         } else {
-            let displayCursor = rawOffsetToDisplayOffset(cursorInRaw)
-            let clamped = min(displayCursor, textStorage!.length)
+            let clamped = min(cursorInRaw, textStorage!.length)
             setSelectedRange(NSRange(location: clamped, length: 0))
         }
 
@@ -58,27 +70,15 @@ extension EditorTextView {
         isUpdating = false
     }
 
-    /// Recalculates displayRanges from current blocks without touching textStorage.
+    /// Recalculates displayRanges from current blocks.
+    /// With word-level rendering, display ranges = raw block ranges.
     func recalcDisplayRanges() {
-        displayRanges = []
-        var offset = 0
-        for (i, block) in blocks.enumerated() {
-            if i > 0 {
-                offset += separatorLength
-            }
-            let displayLen: Int
-            if i == activeBlockIndex {
-                displayLen = (block.content as NSString).length
-            } else {
-                let rendered = renderMarkdown(block.content)
-                displayLen = rendered.length
-            }
-            displayRanges.append(NSRange(location: offset, length: displayLen))
-            offset += displayLen
-        }
+        displayRanges = blocks.map { $0.range }
     }
 
     // MARK: - Coordinate Mapping
+    //
+    // With text storage = rawSource, display offset = raw offset (identity).
 
     func blockIndexForRawOffset(_ rawOffset: Int) -> Int? {
         for (i, block) in blocks.enumerated() {
@@ -90,76 +90,14 @@ extension EditorTextView {
     }
 
     func displayOffsetToRawOffset(_ displayOffset: Int) -> Int {
-        for (i, displayRange) in displayRanges.enumerated() {
-            guard i < blocks.count else { break }
-            let block = blocks[i]
-
-            if displayOffset <= displayRange.upperBound {
-                let offsetInBlock = max(0, displayOffset - displayRange.location)
-
-                if i == activeBlockIndex {
-                    let clampedOffset = min(offsetInBlock, (block.content as NSString).length)
-                    return block.range.location + clampedOffset
-                } else {
-                    let displayLen = displayRange.length
-                    let rawLen = (block.content as NSString).length
-                    if displayLen > 0 {
-                        let proportion = Double(offsetInBlock) / Double(displayLen)
-                        let mapped = Int(proportion * Double(rawLen))
-                        return block.range.location + min(mapped, rawLen)
-                    }
-                    return block.range.location
-                }
-            }
-
-            let separatorEnd = (i + 1 < displayRanges.count)
-                ? displayRanges[i + 1].location
-                : (textStorage?.length ?? displayRange.upperBound)
-            if displayOffset < separatorEnd {
-                let sepOffset = displayOffset - displayRange.upperBound
-                return block.range.upperBound + sepOffset
-            }
-        }
-
-        return (rawSource as NSString).length
+        return displayOffset
     }
 
     func rawOffsetToDisplayOffset(_ rawOffset: Int) -> Int {
-        for (i, block) in blocks.enumerated() {
-            guard i < displayRanges.count else { break }
-            let displayRange = displayRanges[i]
-
-            if rawOffset <= block.range.upperBound {
-                let offsetInBlock = max(0, rawOffset - block.range.location)
-
-                if i == activeBlockIndex {
-                    return displayRange.location + min(offsetInBlock, displayRange.length)
-                } else {
-                    let rawLen = (block.content as NSString).length
-                    if rawLen > 0 {
-                        let proportion = Double(offsetInBlock) / Double(rawLen)
-                        let mapped = Int(proportion * Double(displayRange.length))
-                        return displayRange.location + min(mapped, displayRange.length)
-                    }
-                    return displayRange.location
-                }
-            }
-
-            let nextRawStart = (i + 1 < blocks.count)
-                ? blocks[i + 1].range.location
-                : (rawSource as NSString).length
-            if rawOffset < nextRawStart {
-                let sepOffset = rawOffset - block.range.upperBound
-                return displayRange.upperBound + sepOffset
-            }
-        }
-
-        return textStorage?.length ?? 0
+        return rawOffset
     }
 
     func displayRangeToRawRange(_ displayRange: NSRange) -> NSRange {
-        let rawStart = displayOffsetToRawOffset(displayRange.location)
-        let rawEnd = displayOffsetToRawOffset(displayRange.location + displayRange.length)
-        return NSRange(location: rawStart, length: max(0, rawEnd - rawStart))
+        return displayRange
     }
 }

--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -1,6 +1,12 @@
 import AppKit
 
-// MARK: - Active Block Syntax Highlighting & Inactive Block Rendering
+// MARK: - Word-Level Styling
+//
+// All blocks are styled the same way: content gets rich text attributes,
+// and inline delimiters are either hidden (cursor elsewhere) or dimmed
+// (cursor inside the token). Block-level markers are always dimmed.
+//
+// The text storage always contains the raw markdown — no string mutation.
 
 extension EditorTextView {
 
@@ -20,7 +26,11 @@ extension EditorTextView {
         NSFont.monospacedSystemFont(ofSize: bodyFont.pointSize * 0.9, weight: .regular)
     }
 
-    /// Indentation amount for list items (active and inactive).
+    /// Font used to visually hide delimiter characters.
+    /// Near-zero size makes them effectively invisible and zero-width.
+    var hiddenFont: NSFont { NSFont.systemFont(ofSize: 0.01) }
+
+    /// Indentation amount for list items.
     var listIndent: CGFloat { 16 }
 
     /// Paragraph style with indentation for list items.
@@ -59,27 +69,48 @@ extension EditorTextView {
         block.setContentWidth(100, type: .percentageValueType)
         let leftEdge = NSRectEdge(rawValue: 0)!
         block.setWidth(2, type: .absoluteValueType, for: .border, edge: leftEdge)
-        block.setWidth(10, type: .absoluteValueType, for: .padding, edge: leftEdge)
         block.setBorderColor(.tertiaryLabelColor, for: leftEdge)
         ps.textBlocks = [block]
 
         return ps
     }
 
-    // MARK: - Active Block Syntax Highlighting
+    // MARK: - Delimiter Hiding Classification
 
-    /// Builds an NSAttributedString of the raw markdown with syntax highlighting.
-    func highlightSyntax(_ markdown: String) -> NSAttributedString {
+    /// Returns true if this span kind's delimiters should be hidden (not just
+    /// dimmed) when the cursor is not inside the token.
+    private func isDelimiterHideable(_ kind: SyntaxHighlighter.Span.Kind) -> Bool {
+        switch kind {
+        case .bold, .italic, .boldItalic, .strikethrough, .highlight,
+             .code, .link, .image, .lineBreak,
+             .heading, .blockquote:
+            return true
+        case .listItem, .table, .codeBlock, .thematicBreak:
+            return false
+        }
+    }
+
+    // MARK: - Unified Styling
+
+    /// Styles raw markdown text with rich attributes. Inline delimiters are hidden
+    /// unless the cursor is inside the token (in which case they're dimmed).
+    /// Block-level markers are always dimmed, never hidden.
+    ///
+    /// - Parameters:
+    ///   - markdown: Raw markdown text.
+    ///   - cursorPosition: Cursor offset within the markdown (nil = hide all inline delimiters).
+    func styleBlock(_ markdown: String, cursorPosition: Int? = nil) -> NSAttributedString {
         let result = NSMutableAttributedString(string: markdown, attributes: baseAttributes)
+        guard !markdown.isEmpty else { return result }
+
         let spans = SyntaxHighlighter.parse(markdown)
 
         for span in spans {
-            // Dim delimiter characters
-            for dr in span.delimiterRanges {
-                guard dr.upperBound <= result.length else { continue }
-                result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
-            }
+            let cursorInToken = cursorPosition.map {
+                $0 >= span.fullRange.location && $0 <= span.fullRange.upperBound
+            } ?? false
 
+            // --- Content styling (applied first) ---
             switch span.kind {
             case .bold:
                 guard span.contentRange.upperBound <= result.length else { continue }
@@ -104,11 +135,6 @@ extension EditorTextView {
                 guard span.contentRange.upperBound <= result.length else { continue }
                 result.addAttribute(.font, value: codeBlockFont, range: span.contentRange)
                 result.addAttribute(.foregroundColor, value: codeColor, range: span.contentRange)
-                // Dim the fence lines
-                for dr in span.delimiterRanges {
-                    guard dr.upperBound <= result.length else { continue }
-                    result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
-                }
 
             case .strikethrough:
                 guard span.contentRange.upperBound <= result.length else { continue }
@@ -125,26 +151,35 @@ extension EditorTextView {
                                    size: bodyFont.pointSize * scale) ?? bodyFont
                 let heading = NSFontManager.shared.convert(sized, toHaveTrait: .boldFontMask)
                 result.addAttribute(.font, value: heading, range: span.fullRange)
-                for dr in span.delimiterRanges {
-                    guard dr.upperBound <= result.length else { continue }
-                    result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
-                }
 
             case .link:
                 guard span.contentRange.upperBound <= result.length else { continue }
                 result.addAttribute(.foregroundColor, value: accentColor, range: span.contentRange)
+                result.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: span.contentRange)
 
             case .image:
                 guard span.contentRange.upperBound <= result.length else { continue }
                 result.addAttribute(.foregroundColor, value: accentColor, range: span.contentRange)
+                let italic = NSFontManager.shared.convert(bodyFont, toHaveTrait: .italicFontMask)
+                result.addAttribute(.font, value: italic, range: span.contentRange)
 
             case .blockquote:
-                break  // Just dim the "> " prefix (handled by generic delimiter loop)
+                guard span.fullRange.upperBound <= result.length else { continue }
+                // Paragraph style must cover fullRange so the first character of each
+                // paragraph (the `> ` delimiter) carries the NSTextBlock border.
+                // NSTextView uses the paragraph style from the first char of a paragraph.
+                result.addAttribute(.paragraphStyle, value: blockquoteParagraphStyle(), range: span.fullRange)
+                result.addAttribute(.foregroundColor, value: NSColor.secondaryLabelColor, range: span.contentRange)
 
-            case .listItem:
+            case .listItem(let ordered, let checkbox):
                 guard span.fullRange.upperBound <= result.length else { continue }
                 let nesting = listNestingLevel(for: markdown, span: span)
                 result.addAttribute(.paragraphStyle, value: listParagraphStyle(nestingLevel: nesting), range: span.fullRange)
+                // Strikethrough checked items
+                if !ordered, checkbox == .checked {
+                    result.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: span.contentRange)
+                    result.addAttribute(.foregroundColor, value: syntaxDimColor, range: span.contentRange)
+                }
 
             case .table:
                 guard span.fullRange.upperBound <= result.length else { continue }
@@ -159,269 +194,63 @@ extension EditorTextView {
                     let newStart = pipeRange.upperBound
                     searchRange = NSRange(location: newStart, length: max(0, span.fullRange.upperBound - newStart))
                 }
+
             case .thematicBreak:
                 guard span.fullRange.upperBound <= result.length else { continue }
                 result.addAttribute(.foregroundColor, value: syntaxDimColor, range: span.fullRange)
 
             case .lineBreak:
-                break  // Delimiter dimming handled by generic loop
+                break  // Delimiter handling done below
+            }
+
+            // --- Delimiter treatment (applied after content styling so it takes precedence) ---
+            for dr in span.delimiterRanges {
+                guard dr.upperBound <= result.length else { continue }
+                if cursorInToken || !isDelimiterHideable(span.kind) {
+                    // Visible: dim the delimiters
+                    result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
+                } else if case .blockquote = span.kind {
+                    // Blockquote: invisible but preserve width for indentation
+                    result.addAttribute(.foregroundColor, value: NSColor.clear, range: dr)
+                } else {
+                    // Hidden: make delimiters invisible and near-zero-width
+                    result.addAttribute(.font, value: hiddenFont, range: dr)
+                    result.addAttribute(.foregroundColor, value: NSColor.clear, range: dr)
+                }
             }
         }
 
         return result
     }
 
-    /// Re-applies syntax highlighting to the active block in the text storage.
+    // MARK: - In-Place Block Restyling
+
+    /// Re-applies styling to a single block in the text storage.
     /// Called after each keystroke to keep formatting in sync with content.
-    func applySyntaxHighlighting() {
+    func applyBlockStyle() {
         guard let ts = textStorage,
               let activeIdx = activeBlockIndex,
-              activeIdx < displayRanges.count,
               activeIdx < blocks.count else { return }
 
-        let displayRange = displayRanges[activeIdx]
-        guard displayRange.upperBound <= ts.length else { return }
+        let blockRange = blocks[activeIdx].range
+        guard blockRange.upperBound <= ts.length else { return }
 
         let content = blocks[activeIdx].content
-        let highlighted = highlightSyntax(content)
-        let offset = displayRange.location
+        let cursorInBlock = max(0, selectedRange().location - blockRange.location)
+        let styled = styleBlock(content, cursorPosition: cursorInBlock)
+        let offset = blockRange.location
 
         isUpdating = true
         ts.beginEditing()
 
-        highlighted.enumerateAttributes(in: NSRange(location: 0, length: highlighted.length), options: []) { attrs, range, _ in
-            let displayR = NSRange(location: range.location + offset, length: range.length)
-            ts.setAttributes(attrs, range: displayR)
+        styled.enumerateAttributes(in: NSRange(location: 0, length: styled.length), options: []) { attrs, range, _ in
+            let tsRange = NSRange(location: range.location + offset, length: range.length)
+            ts.setAttributes(attrs, range: tsRange)
         }
 
         ts.endEditing()
         isUpdating = false
 
         typingAttributes = baseAttributes
-    }
-
-    // MARK: - Inactive Block Rendering
-
-    /// Computes the exact delimiter ranges to strip for a rendered (inactive) block.
-    private func renderDelimiters(for span: SyntaxHighlighter.Span) -> [NSRange] {
-        switch span.kind {
-        case .italic:
-            return [
-                NSRange(location: span.contentRange.location - 1, length: 1),
-                NSRange(location: span.contentRange.upperBound, length: 1),
-            ]
-        case .bold:
-            return [
-                NSRange(location: span.contentRange.location - 2, length: 2),
-                NSRange(location: span.contentRange.upperBound, length: 2),
-            ]
-        case .boldItalic:
-            return [
-                NSRange(location: span.contentRange.location - 3, length: 3),
-                NSRange(location: span.contentRange.upperBound, length: 3),
-            ]
-        case .strikethrough, .highlight:
-            return [
-                NSRange(location: span.contentRange.location - 2, length: 2),
-                NSRange(location: span.contentRange.upperBound, length: 2),
-            ]
-        case .code, .codeBlock, .heading, .link, .image, .blockquote:
-            return span.delimiterRanges
-        case .listItem(let ordered, _):
-            return ordered ? [] : span.delimiterRanges
-        case .table, .thematicBreak, .lineBreak:
-            return span.delimiterRanges
-        }
-    }
-
-    func renderMarkdown(_ markdown: String) -> NSAttributedString {
-        let spans = SyntaxHighlighter.parse(markdown)
-
-        // Pre-compute list nesting levels from the original (pre-strip) markdown
-        var listNesting: [Int: Int] = [:]  // keyed by span fullRange.location
-        for span in spans {
-            if case .listItem = span.kind {
-                listNesting[span.fullRange.location] = listNestingLevel(for: markdown, span: span)
-            }
-        }
-
-        // Compute exact delimiter ranges for each span, sorted descending for back-to-front removal
-        var allDelimRanges: [NSRange] = []
-        for span in spans {
-            allDelimRanges.append(contentsOf: renderDelimiters(for: span))
-        }
-        allDelimRanges.sort { $0.location > $1.location }
-
-        // Build stripped text by removing delimiters
-        var stripped = markdown
-        var removals: [(location: Int, length: Int)] = []
-        for dr in allDelimRanges {
-            guard dr.location >= 0, dr.upperBound <= (stripped as NSString).length else { continue }
-            let startUTF16 = stripped.utf16.index(stripped.utf16.startIndex, offsetBy: dr.location)
-            let endUTF16 = stripped.utf16.index(startUTF16, offsetBy: dr.length)
-            stripped.removeSubrange(startUTF16..<endUTF16)
-            removals.append((location: dr.location, length: dr.length))
-        }
-        removals.reverse()
-
-        // For thematic breaks, insert a visual divider line.
-        let thematicBreakSpans = spans.filter { $0.kind == .thematicBreak }
-        for span in thematicBreakSpans.reversed() {
-            let insertPos = mappedOffset(span.fullRange.location, removals: removals)
-            let idx = stripped.utf16.index(stripped.utf16.startIndex, offsetBy: insertPos)
-            let divider = "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}"  // 20× ─
-            stripped.insert(contentsOf: divider, at: idx)
-            removals.append((location: span.fullRange.location, length: -(divider as NSString).length))
-        }
-
-        // For unordered list items, insert bullet/checkbox replacement at the start.
-        let unorderedListSpans = spans.filter {
-            if case .listItem(ordered: false, _) = $0.kind { return true }
-            return false
-        }
-        for span in unorderedListSpans.reversed() {
-            let insertPos = mappedOffset(span.contentRange.location, removals: removals)
-            let idx = stripped.utf16.index(stripped.utf16.startIndex, offsetBy: insertPos)
-            let bullet: String
-            if case .listItem(_, let checkbox) = span.kind {
-                switch checkbox {
-                case .unchecked: bullet = "\u{25CB} "  // ○
-                case .checked:   bullet = "\u{25CF} "  // ●
-                case .none:      bullet = "\u{2022} "  // •
-                }
-            } else {
-                bullet = "\u{2022} "
-            }
-            stripped.insert(contentsOf: bullet, at: idx)
-            removals.append((location: span.contentRange.location - 1, length: -2))
-        }
-
-        removals.sort { $0.location < $1.location }
-
-        let result = NSMutableAttributedString(string: stripped, attributes: baseAttributes)
-
-        for span in spans {
-            let start = mappedOffset(span.contentRange.location, removals: removals)
-            let end = mappedOffset(span.contentRange.upperBound, removals: removals)
-            let mappedRange = NSRange(location: start, length: max(0, end - start))
-            guard mappedRange.upperBound <= result.length else { continue }
-
-            switch span.kind {
-            case .bold:
-                let bold = NSFontManager.shared.convert(bodyFont, toHaveTrait: .boldFontMask)
-                result.addAttribute(.font, value: bold, range: mappedRange)
-            case .italic:
-                let italic = NSFontManager.shared.convert(bodyFont, toHaveTrait: .italicFontMask)
-                result.addAttribute(.font, value: italic, range: mappedRange)
-            case .boldItalic:
-                let bi = NSFontManager.shared.convert(bodyFont, toHaveTrait: [.boldFontMask, .italicFontMask])
-                result.addAttribute(.font, value: bi, range: mappedRange)
-            case .code:
-                result.addAttribute(.foregroundColor, value: codeColor, range: mappedRange)
-            case .codeBlock:
-                result.addAttribute(.font, value: codeBlockFont, range: mappedRange)
-                result.addAttribute(.foregroundColor, value: codeColor, range: mappedRange)
-            case .strikethrough:
-                result.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: mappedRange)
-            case .highlight:
-                result.addAttribute(.backgroundColor, value: NSColor.systemYellow.withAlphaComponent(0.3), range: mappedRange)
-            case .heading(let level):
-                let fullStart = mappedOffset(span.fullRange.location, removals: removals)
-                let fullEnd = mappedOffset(span.fullRange.upperBound, removals: removals)
-                let mappedFull = NSRange(location: fullStart, length: max(0, fullEnd - fullStart))
-                guard mappedFull.upperBound <= result.length else { continue }
-                let scale: CGFloat = level == 1 ? 1.5 : level == 2 ? 1.3 : level == 3 ? 1.15 : 1.0
-                let sized = NSFont(descriptor: bodyFont.fontDescriptor,
-                                   size: bodyFont.pointSize * scale) ?? bodyFont
-                let heading = NSFontManager.shared.convert(sized, toHaveTrait: .boldFontMask)
-                result.addAttribute(.font, value: heading, range: mappedFull)
-            case .link:
-                result.addAttribute(.foregroundColor, value: accentColor, range: mappedRange)
-                result.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: mappedRange)
-            case .blockquote:
-                result.addAttribute(.foregroundColor, value: NSColor.secondaryLabelColor, range: mappedRange)
-                result.addAttribute(.paragraphStyle, value: blockquoteParagraphStyle(), range: mappedRange)
-            case .listItem(let ordered, let checkbox):
-                // Apply indentation to the full line, scaled by nesting level
-                let nesting = listNesting[span.fullRange.location] ?? 0
-                let lineStart: Int
-                if !ordered {
-                    lineStart = mappedRange.location - 2  // "• " or checkbox was inserted
-                } else {
-                    lineStart = mappedOffset(span.fullRange.location, removals: removals)
-                }
-                let lineEnd = mappedRange.upperBound
-                if lineStart >= 0 && lineEnd <= result.length {
-                    let lineRange = NSRange(location: lineStart, length: lineEnd - lineStart)
-                    result.addAttribute(.paragraphStyle, value: listParagraphStyle(nestingLevel: nesting), range: lineRange)
-                }
-                if !ordered {
-                    // Dim the bullet/checkbox
-                    let bulletRange = NSRange(location: mappedRange.location - 2, length: 2)
-                    if bulletRange.location >= 0 && bulletRange.upperBound <= result.length {
-                        result.addAttribute(.foregroundColor, value: syntaxDimColor, range: bulletRange)
-                    }
-                    // Strikethrough checked items
-                    if checkbox == .checked {
-                        result.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: mappedRange)
-                        result.addAttribute(.foregroundColor, value: syntaxDimColor, range: mappedRange)
-                    }
-                } else {
-                    // Dim the number/marker
-                    for dr in span.delimiterRanges {
-                        let drStart = mappedOffset(dr.location, removals: removals)
-                        let drEnd = mappedOffset(dr.upperBound, removals: removals)
-                        let mappedDR = NSRange(location: drStart, length: max(0, drEnd - drStart))
-                        if mappedDR.location >= 0 && mappedDR.upperBound <= result.length {
-                            result.addAttribute(.foregroundColor, value: syntaxDimColor, range: mappedDR)
-                        }
-                    }
-                }
-            case .table:
-                // Apply monospace font to full range
-                let fullStart = mappedOffset(span.fullRange.location, removals: removals)
-                let fullEnd = mappedOffset(span.fullRange.upperBound, removals: removals)
-                let mappedFull = NSRange(location: fullStart, length: max(0, fullEnd - fullStart))
-                guard mappedFull.upperBound <= result.length else { continue }
-                result.addAttribute(.font, value: tableFont, range: mappedFull)
-                // Dim pipe characters and separator row
-                let nsStr = (result.string as NSString)
-                var searchRange = mappedFull
-                while searchRange.length > 0 {
-                    let pipeRange = nsStr.range(of: "|", options: [], range: searchRange)
-                    guard pipeRange.location != NSNotFound else { break }
-                    result.addAttribute(.foregroundColor, value: syntaxDimColor, range: pipeRange)
-                    let newStart = pipeRange.upperBound
-                    searchRange = NSRange(location: newStart, length: max(0, mappedFull.upperBound - newStart))
-                }
-            case .image:
-                result.addAttribute(.foregroundColor, value: accentColor, range: mappedRange)
-                let italic = NSFontManager.shared.convert(bodyFont, toHaveTrait: .italicFontMask)
-                result.addAttribute(.font, value: italic, range: mappedRange)
-            case .thematicBreak:
-                // The divider text was inserted earlier; apply dim color to it.
-                let fullStart = mappedOffset(span.fullRange.location, removals: removals)
-                let fullEnd = mappedOffset(span.fullRange.upperBound, removals: removals)
-                let mappedFull = NSRange(location: fullStart, length: max(0, fullEnd - fullStart))
-                if mappedFull.upperBound <= result.length {
-                    result.addAttribute(.foregroundColor, value: syntaxDimColor, range: mappedFull)
-                }
-            case .lineBreak:
-                break
-            }
-        }
-
-        return result
-    }
-
-    /// Maps an offset in the original text to the stripped/modified text.
-    private func mappedOffset(_ original: Int, removals: [(location: Int, length: Int)]) -> Int {
-        var shift = 0
-        for r in removals {
-            if original > r.location {
-                shift += r.length
-            }
-        }
-        return original - shift
     }
 }

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -1,27 +1,29 @@
 import AppKit
 
-/// A single NSTextView that renders each paragraph block as either:
-///   - **Rich text** (rendered markdown) — for non-active blocks
-///   - **Raw markdown** — for the block containing the cursor
+/// A single NSTextView with word-level inline preview.
 ///
 /// ## Architecture
 ///
-/// `rawSource` is the **sole source of truth** for the document content.
-/// The text storage is a display output rebuilt from rawSource.
+/// `rawSource` is the **sole source of truth** for document content.
+/// The text storage always contains rawSource — no delimiter stripping.
+/// All formatting is achieved through NSAttributedString attributes:
+///   - Inline delimiters (`**`, `*`, `` ` ``, etc.) are hidden via near-zero
+///     font size when the cursor is not inside the token.
+///   - Block-level markers (`#`, `>`, `-`, etc.) are always visible and dimmed.
+///   - Content gets rich text styling (bold, italic, colors, etc.).
 ///
 /// **Edits** flow through NSTextView's normal path:
 ///   1. `shouldChangeText` records an undo snapshot (coalesced), returns `true`
 ///   2. NSTextView applies the edit to the text storage
-///   3. `didChangeText` fires — we sync `rawSource` from the text storage
+///   3. `didChangeText` fires — we sync `rawSource` and re-style the block
 ///
 /// **Cursor movement** is detected via `didChangeSelectionNotification`.
-/// When the cursor moves to a different block, we do a full recompose
-/// (async, after the event finishes) to render/unrender blocks.
+/// When the cursor moves to a different block, we restyle both blocks.
+/// When it moves within a block, we update which token's delimiters
+/// are visible (the "active token").
 ///
 /// **Undo/Redo** uses custom stacks of `rawSource` snapshots, completely
-/// bypassing NSTextView's built-in undo.  This avoids the fundamental
-/// problem where `recompose` (which replaces the entire text storage)
-/// invalidates NSUndoManager's position-based undo actions.
+/// bypassing NSTextView's built-in undo.
 public class EditorTextView: NSTextView {
 
     // MARK: - Document Link
@@ -190,113 +192,33 @@ public class EditorTextView: NSTextView {
             if !isUndoRedoing {
                 recordUndoIfNeeded(editRange: affectedCharRange, replacement: replacement)
             }
-            if editTouchesSeparator(range: affectedCharRange) {
-                handleSeparatorEdit(displayRange: affectedCharRange, replacement: replacement)
-                return false
-            }
         }
         return true
-    }
-
-    /// Returns true if the edit range overlaps a separator gap between blocks.
-    private func editTouchesSeparator(range: NSRange) -> Bool {
-        guard displayRanges.count > 1 else { return false }
-        for i in 0..<(displayRanges.count - 1) {
-            let gapStart = displayRanges[i].upperBound
-            let gapEnd = displayRanges[i + 1].location
-            if range.location < gapEnd && range.upperBound > gapStart {
-                return true
-            }
-        }
-        return false
-    }
-
-    /// Applies an edit that crosses a block separator directly to rawSource,
-    /// then re-parses and recomposes.
-    private func handleSeparatorEdit(displayRange editRange: NSRange, replacement: String) {
-        let rawStart = displayOffsetToRawOffset(editRange.location)
-        let rawEnd = displayOffsetToRawOffset(editRange.location + editRange.length)
-        let rawRange = NSRange(location: rawStart, length: max(0, rawEnd - rawStart))
-
-        let nsRaw = rawSource as NSString
-        rawSource = nsRaw.replacingCharacters(in: rawRange, with: replacement)
-
-        let newCursorRaw = rawStart + (replacement as NSString).length
-        blocks = BlockParser.parse(rawSource, previous: blocks)
-        recompose(cursorInRaw: newCursorRaw)
     }
 
     public override func didChangeText() {
         super.didChangeText()
         guard !isUpdating, !isUndoRedoing else { return }
         syncRawSourceFromDisplay()
-        applySyntaxHighlighting()
+        applyBlockStyle()
         document?.updateChangeCount(.changeDone)
     }
 
-    /// Reads the active block's content from the text storage and rebuilds rawSource.
+    /// Syncs rawSource from the text storage and re-parses blocks.
+    /// With word-level rendering, text storage = rawSource, so this is simple.
     private func syncRawSourceFromDisplay() {
         guard let ts = textStorage else { return }
-        let displayString = ts.string as NSString
 
-        if blocks.isEmpty || displayRanges.isEmpty {
-            rawSource = ts.string
-            blocks = BlockParser.parse(rawSource)
-            return
-        }
-
-        guard let activeIdx = activeBlockIndex, activeIdx < displayRanges.count else {
-            rawSource = ts.string
-            blocks = BlockParser.parse(rawSource)
-            return
-        }
-
-        let activeDisplayStart: Int
-        if activeIdx == 0 {
-            activeDisplayStart = 0
-        } else {
-            activeDisplayStart = displayRanges[activeIdx - 1].upperBound + separatorLength
-        }
-
-        let activeDisplayEnd: Int
-        if activeIdx == displayRanges.count - 1 {
-            activeDisplayEnd = displayString.length
-        } else {
-            var suffixLength = 0
-            for i in (activeIdx + 1)..<displayRanges.count {
-                suffixLength += separatorLength + displayRanges[i].length
-            }
-            activeDisplayEnd = displayString.length - suffixLength
-        }
-
-        let safeStart = max(0, activeDisplayStart)
-        let safeEnd = max(safeStart, min(activeDisplayEnd, displayString.length))
-        let activeDisplayRange = NSRange(location: safeStart, length: safeEnd - safeStart)
-
-        let newActiveContent = displayString.substring(with: activeDisplayRange)
-
+        rawSource = ts.string
         let sel = selectedRange()
-        let cursorInBlock = max(0, sel.location - safeStart)
-        let rawCursor = blocks[activeIdx].range.location
-            + min(cursorInBlock, (newActiveContent as NSString).length)
-
-        var parts: [String] = []
-        for (i, block) in blocks.enumerated() {
-            if i == activeIdx {
-                parts.append(newActiveContent)
-            } else {
-                parts.append(block.content)
-            }
-        }
-        rawSource = parts.joined(separator: blockSeparator)
+        let cursorRaw = min(sel.location, (rawSource as NSString).length)
 
         blocks = BlockParser.parse(rawSource, previous: blocks)
         recalcDisplayRanges()
 
-        let clampedRawCursor = min(rawCursor, (rawSource as NSString).length)
-        let newBlockIndex = blockIndexForRawOffset(clampedRawCursor)
+        let newBlockIndex = blockIndexForRawOffset(cursorRaw)
         if newBlockIndex != activeBlockIndex {
-            recompose(cursorInRaw: clampedRawCursor)
+            recompose(cursorInRaw: cursorRaw)
         }
     }
 
@@ -306,7 +228,7 @@ public class EditorTextView: NSTextView {
         guard !isUpdating else { return }
 
         let sel = selectedRange()
-        let rawOffset = displayOffsetToRawOffset(sel.location)
+        let rawOffset = sel.location
         let newActiveIndex = blockIndexForRawOffset(rawOffset)
 
         if newActiveIndex != activeBlockIndex && !pendingRecompose {
@@ -316,19 +238,21 @@ public class EditorTextView: NSTextView {
                 self.pendingRecompose = false
 
                 let currentSel = self.selectedRange()
-                let rawStart = self.displayOffsetToRawOffset(currentSel.location)
-                let rawEnd = self.displayOffsetToRawOffset(currentSel.location + currentSel.length)
+                let rawStart = currentSel.location
+                let rawEnd = currentSel.location + currentSel.length
                 let rawSel = NSRange(location: rawStart, length: rawEnd - rawStart)
                 self.recompose(cursorInRaw: rawStart, selectionInRaw: rawSel)
             }
+        } else if newActiveIndex == activeBlockIndex {
+            // Same block — update active token (re-style to show/hide delimiters)
+            applyBlockStyle()
         }
     }
 
     // MARK: - Helpers
 
     func currentCursorInRaw() -> Int {
-        let sel = selectedRange()
-        return displayOffsetToRawOffset(sel.location)
+        return selectedRange().location
     }
 
     // MARK: - Content Loading (called by Document)

--- a/Tests/MarkdownEditorTests/BlockParserTests.swift
+++ b/Tests/MarkdownEditorTests/BlockParserTests.swift
@@ -297,24 +297,27 @@ struct BlockParserTests {
         #expect(blocks[0].range == NSRange(location: 0, length: (text as NSString).length))
     }
 
-    // MARK: - Blockquote Merging
+    // MARK: - Blockquotes (each line is its own block)
 
-    @Test("Consecutive blockquote lines merge into single block")
-    func blockquoteMerge() {
+    @Test("Consecutive blockquote lines are separate blocks")
+    func blockquoteSeparateBlocks() {
         let text = "> line1\n> line2\n> line3"
         let blocks = BlockParser.parse(text)
-        #expect(blocks.count == 1)
-        #expect(blocks[0].content == text)
+        #expect(blocks.count == 3)
+        #expect(blocks[0].content == "> line1")
+        #expect(blocks[1].content == "> line2")
+        #expect(blocks[2].content == "> line3")
     }
 
     @Test("Blockquote between paragraphs")
     func blockquoteBetweenParagraphs() {
         let text = "above\n> line1\n> line2\nbelow"
         let blocks = BlockParser.parse(text)
-        #expect(blocks.count == 3)
+        #expect(blocks.count == 4)
         #expect(blocks[0].content == "above")
-        #expect(blocks[1].content == "> line1\n> line2")
-        #expect(blocks[2].content == "below")
+        #expect(blocks[1].content == "> line1")
+        #expect(blocks[2].content == "> line2")
+        #expect(blocks[3].content == "below")
     }
 
     @Test("Single blockquote line is one block")
@@ -325,11 +328,12 @@ struct BlockParserTests {
         #expect(blocks[0].content == "> just one")
     }
 
-    @Test("Blockquote range covers full text")
+    @Test("Blockquote line range covers single line")
     func blockquoteRange() {
         let text = "> a\n> b"
         let blocks = BlockParser.parse(text)
-        #expect(blocks[0].range == NSRange(location: 0, length: (text as NSString).length))
+        #expect(blocks[0].range == NSRange(location: 0, length: 3))
+        #expect(blocks[1].range == NSRange(location: 4, length: 3))
     }
 
     @Test("Non-consecutive blockquotes are separate blocks")

--- a/Tests/MarkdownEditorTests/BlockStylingTests.swift
+++ b/Tests/MarkdownEditorTests/BlockStylingTests.swift
@@ -131,220 +131,218 @@ struct BlockStylingActiveTests {
         #expect(delimColor == NSColor.tertiaryLabelColor)
     }
 
-    @Test("Active multi-line blockquote shows all raw lines")
-    @MainActor func activeMultiLineBlockquote() {
+    @Test("Active blockquote line shows its raw text")
+    @MainActor func activeBlockquoteLine() {
         let editor = makeEditor()
         editor.loadContent("> line1\n> line2\nother")
         activateBlock(0, in: editor)
 
+        // Each > line is its own block now
         let text = displayText(for: 0, in: editor)
-        #expect(text.contains("> line1"))
-        #expect(text.contains("> line2"))
+        #expect(text == "> line1")
     }
 }
 
 // ============================================================================
-// MARK: - Block Styling: Inactive Block
+// MARK: - Block Styling: Non-Active Block (delimiters hidden, not stripped)
 // ============================================================================
 
-@Suite("Integration — Block Styling (Inactive Block)")
-struct BlockStylingInactiveTests {
+@Suite("Integration — Block Styling (Non-Active Block)")
+struct BlockStylingNonActiveTests {
 
     // MARK: - Headings
 
-    @Test("Inactive # heading strips prefix, applies bold scaled font")
-    @MainActor func inactiveH1() {
+    @Test("Non-active # heading has bold scaled font, # is hidden")
+    @MainActor func nonActiveH1() {
         let editor = makeEditor()
         editor.loadContent("# Title\nother")
         activateBlock(1, in: editor)
 
+        // Text storage still contains raw "# Title"
         let text = displayText(for: 0, in: editor)
-        #expect(text == "Title")
-        let f = font(at: editor.displayRanges[0].location, in: editor)!
+        #expect(text == "# Title")
+        // # is hidden (cursor not in this block)
+        #expect(fgColor(at: 0, in: editor) == NSColor.clear)
+        #expect(font(at: 0, in: editor)!.pointSize < 1.0)
+        // Content has bold scaled font
+        let f = font(at: 2, in: editor)!
         let expectedSize = editor.bodyFont.pointSize * 1.5
         #expect(abs(f.pointSize - expectedSize) < 0.1)
         #expect(NSFontManager.shared.traits(of: f).contains(.boldFontMask))
     }
 
-    @Test("Inactive ## heading strips prefix, applies correct scale")
-    @MainActor func inactiveH2() {
+    @Test("Non-active ## heading applies correct scale")
+    @MainActor func nonActiveH2() {
         let editor = makeEditor()
         editor.loadContent("## Sub\nother")
         activateBlock(1, in: editor)
 
-        let text = displayText(for: 0, in: editor)
-        #expect(text == "Sub")
-        let f = font(at: editor.displayRanges[0].location, in: editor)!
+        let f = font(at: 3, in: editor)!
         let expectedSize = editor.bodyFont.pointSize * 1.3
         #expect(abs(f.pointSize - expectedSize) < 0.1)
     }
 
-    @Test("Inactive ### heading strips prefix, applies correct scale")
-    @MainActor func inactiveH3() {
+    @Test("Non-active ### heading applies correct scale")
+    @MainActor func nonActiveH3() {
         let editor = makeEditor()
         editor.loadContent("### Sec\nother")
         activateBlock(1, in: editor)
 
-        let text = displayText(for: 0, in: editor)
-        #expect(text == "Sec")
-        let f = font(at: editor.displayRanges[0].location, in: editor)!
+        let f = font(at: 4, in: editor)!
         let expectedSize = editor.bodyFont.pointSize * 1.15
         #expect(abs(f.pointSize - expectedSize) < 0.1)
     }
 
     // MARK: - Bullet Lists
 
-    @Test("Inactive - item shows bullet character and has list paragraph style")
-    @MainActor func inactiveBulletList() {
+    @Test("Non-active list item has raw text, dimmed marker, indent")
+    @MainActor func nonActiveBulletList() {
         let editor = makeEditor()
         editor.loadContent("- apples\nother")
         activateBlock(1, in: editor)
 
+        // Text unchanged
         let text = displayText(for: 0, in: editor)
-        #expect(text.contains("\u{2022}"))  // bullet •
-        #expect(text.contains("apples"))
-
-        let base = editor.displayRanges[0].location
-        let a = attrs(at: base, in: editor)
+        #expect(text == "- apples")
+        // Marker is dimmed
+        let delimColor = fgColor(at: 0, in: editor)
+        #expect(delimColor == NSColor.tertiaryLabelColor)
+        // Has indent
+        let a = attrs(at: 0, in: editor)
         let ps = a[.paragraphStyle] as? NSParagraphStyle
         #expect(ps != nil)
         #expect(ps!.firstLineHeadIndent == editor.listIndent)
     }
 
-    @Test("Inactive bullet is dimmed")
-    @MainActor func inactiveBulletDimmed() {
-        let editor = makeEditor()
-        editor.loadContent("- apples\nother")
-        activateBlock(1, in: editor)
-
-        let base = editor.displayRanges[0].location
-        let bulletColor = fgColor(at: base, in: editor)
-        #expect(bulletColor == NSColor.tertiaryLabelColor)
-    }
-
     // MARK: - Numbered Lists
 
-    @Test("Inactive 1. item keeps number and has list paragraph style")
-    @MainActor func inactiveNumberedList() {
+    @Test("Non-active ordered list has dimmed number and indent")
+    @MainActor func nonActiveNumberedList() {
         let editor = makeEditor()
         editor.loadContent("1. first\nother")
         activateBlock(1, in: editor)
 
         let text = displayText(for: 0, in: editor)
-        #expect(text.contains("1."))
-        #expect(text.contains("first"))
-
-        let base = editor.displayRanges[0].location
-        let a = attrs(at: base, in: editor)
-        let ps = a[.paragraphStyle] as? NSParagraphStyle
-        #expect(ps != nil)
-    }
-
-    @Test("Inactive ordered list number is dimmed")
-    @MainActor func inactiveNumberDimmed() {
-        let editor = makeEditor()
-        editor.loadContent("1. first\nother")
-        activateBlock(1, in: editor)
-
-        let base = editor.displayRanges[0].location
-        let numColor = fgColor(at: base, in: editor)
+        #expect(text == "1. first")
+        let numColor = fgColor(at: 0, in: editor)
         #expect(numColor == NSColor.tertiaryLabelColor)
     }
 
     // MARK: - Todo Lists
 
-    @Test("Inactive - [ ] unchecked shows open circle")
-    @MainActor func inactiveTodoUnchecked() {
+    @Test("Non-active - [ ] shows raw text with dimmed marker")
+    @MainActor func nonActiveTodoUnchecked() {
         let editor = makeEditor()
         editor.loadContent("- [ ] task\nother")
         activateBlock(1, in: editor)
 
         let text = displayText(for: 0, in: editor)
-        #expect(text.contains("\u{25CB}"))  // ○
-        #expect(text.contains("task"))
+        #expect(text == "- [ ] task")
     }
 
-    @Test("Inactive - [x] checked shows filled circle and strikethrough")
-    @MainActor func inactiveTodoChecked() {
+    @Test("Non-active - [x] checked has strikethrough on content")
+    @MainActor func nonActiveTodoChecked() {
         let editor = makeEditor()
         editor.loadContent("- [x] done\nother")
         activateBlock(1, in: editor)
 
         let text = displayText(for: 0, in: editor)
-        #expect(text.contains("\u{25CF}"))  // ●
-        #expect(text.contains("done"))
+        #expect(text == "- [x] done")
 
-        // "done" should have strikethrough
-        let base = editor.displayRanges[0].location
-        // Find "done" offset: "● done" → bullet(1) + space(1) + "done" at offset 2
-        let doneOffset = base + 2
-        let a = attrs(at: doneOffset, in: editor)
+        // Content "done" should have strikethrough
+        // "- [x] done" — content starts after "- [x] " at offset 6
+        let a = attrs(at: 6, in: editor)
         #expect(a[.strikethroughStyle] as? Int == NSUnderlineStyle.single.rawValue)
     }
 
     // MARK: - Blockquotes
 
-    @Test("Inactive > quote strips prefix, applies secondary label color")
-    @MainActor func inactiveBlockquote() {
+    @Test("Non-active > quote: prefix invisible (width-preserving), content has secondary color")
+    @MainActor func nonActiveBlockquote() {
         let editor = makeEditor()
         editor.loadContent("> wise words\nother")
         activateBlock(1, in: editor)
 
         let text = displayText(for: 0, in: editor)
-        #expect(text == "wise words")
-        let color = fgColor(at: editor.displayRanges[0].location, in: editor)
-        #expect(color == NSColor.secondaryLabelColor)
+        #expect(text == "> wise words")
+        // > is invisible but preserves width (color clear, font NOT shrunk)
+        #expect(fgColor(at: 0, in: editor) == NSColor.clear)
+        #expect(font(at: 0, in: editor)!.pointSize >= 1.0)
+        // Content has secondary label color
+        let contentColor = fgColor(at: 2, in: editor)
+        #expect(contentColor == NSColor.secondaryLabelColor)
     }
 
-    @Test("Inactive > quote has blockquote paragraph style with text block")
-    @MainActor func inactiveBlockquoteParagraphStyle() {
+    @Test("Non-active > quote has blockquote paragraph style with text block")
+    @MainActor func nonActiveBlockquoteParagraphStyle() {
         let editor = makeEditor()
-        editor.loadContent("> wise words\nother")
-        activateBlock(1, in: editor)
+        let styled = editor.styleBlock("> wise words")
 
-        let a = attrs(at: editor.displayRanges[0].location, in: editor)
-        let ps = a[.paragraphStyle] as? NSParagraphStyle
-        #expect(ps != nil)
-        #expect(!ps!.textBlocks.isEmpty)
+        // Paragraph style must be on offset 0 (the >) so NSTextView uses it
+        // for the whole paragraph (it reads the style from the first char).
+        let a0 = styled.attributes(at: 0, effectiveRange: nil)
+        let ps0 = a0[.paragraphStyle] as? NSParagraphStyle
+        #expect(ps0 != nil)
+        #expect(!ps0!.textBlocks.isEmpty)
+
+        // Content should also have the same paragraph style
+        let a2 = styled.attributes(at: 2, effectiveRange: nil)
+        let ps2 = a2[.paragraphStyle] as? NSParagraphStyle
+        #expect(ps2 != nil)
+        #expect(!ps2!.textBlocks.isEmpty)
     }
 
-    @Test("Inactive multi-line blockquote strips all > prefixes")
-    @MainActor func inactiveMultiLineBlockquote() {
+    @Test("Non-active consecutive blockquote lines: each > hidden independently")
+    @MainActor func nonActiveConsecutiveBlockquoteLines() {
         let editor = makeEditor()
+        // Each > line is its own block; activate the last block
         editor.loadContent("> line1\n> line2\nother")
-        activateBlock(1, in: editor)
+        activateBlock(2, in: editor)
 
-        let text = displayText(for: 0, in: editor)
-        #expect(!text.contains(">"))
-        #expect(text.contains("line1"))
-        #expect(text.contains("line2"))
+        // Block 0: "> line1", > hidden
+        let text0 = displayText(for: 0, in: editor)
+        #expect(text0 == "> line1")
+        #expect(fgColor(at: 0, in: editor) == NSColor.clear)
+
+        // Block 1: "> line2", > hidden
+        let text1 = displayText(for: 1, in: editor)
+        #expect(text1 == "> line2")
+        let b1 = editor.displayRanges[1].location
+        #expect(fgColor(at: b1, in: editor) == NSColor.clear)
     }
 
-    @Test("Inactive multi-line blockquote has text block style")
-    @MainActor func inactiveMultiLineBlockquoteParagraphStyle() {
+    @Test("Non-active blockquote line has text block style")
+    @MainActor func nonActiveBlockquoteLineParagraphStyle() {
         let editor = makeEditor()
-        editor.loadContent("> line1\n> line2\nother")
-        activateBlock(1, in: editor)
+        let styled = editor.styleBlock("> wise words")
 
-        let a = attrs(at: editor.displayRanges[0].location, in: editor)
-        let ps = a[.paragraphStyle] as? NSParagraphStyle
-        #expect(ps != nil)
-        #expect(!ps!.textBlocks.isEmpty)
+        // Paragraph style at offset 0 (first char) carries the text block border
+        let a0 = styled.attributes(at: 0, effectiveRange: nil)
+        let ps0 = a0[.paragraphStyle] as? NSParagraphStyle
+        #expect(ps0 != nil)
+        #expect(!ps0!.textBlocks.isEmpty)
     }
 
     // MARK: - Nested Content
 
-    @Test("Inactive bold inside blockquote is rendered")
-    @MainActor func inactiveBoldInBlockquote() {
+    @Test("Non-active bold inside blockquote: all delimiters hidden")
+    @MainActor func nonActiveBoldInBlockquote() {
         let editor = makeEditor()
         editor.loadContent("> **important**\nother")
         activateBlock(1, in: editor)
 
         let text = displayText(for: 0, in: editor)
-        // Blockquote ">" stripped, bold "**" stripped
-        #expect(text == "important")
-        let f = font(at: editor.displayRanges[0].location, in: editor)!
-        #expect(NSFontManager.shared.traits(of: f).contains(.boldFontMask))
+        #expect(text == "> **important**")
+        // > is hidden (cursor not in this block)
+        #expect(fgColor(at: 0, in: editor) == NSColor.clear)
+        // ** delimiters at 2,3 should be hidden (inline)
+        let ts = editor.textStorage!
+        let f = ts.attribute(.font, at: 2, effectiveRange: nil) as? NSFont
+        #expect(f != nil)
+        #expect(f!.pointSize < 1.0)
+        // Content "important" at 4-12 should have bold font
+        let contentFont = font(at: 4, in: editor)!
+        #expect(NSFontManager.shared.traits(of: contentFont).contains(.boldFontMask))
     }
 }
 
@@ -387,11 +385,11 @@ struct TableActiveTests {
     }
 }
 
-@Suite("Integration — Table (Inactive Block)")
-struct TableInactiveTests {
+@Suite("Integration — Table (Non-Active Block)")
+struct TableNonActiveTests {
 
-    @Test("Inactive table has monospace font")
-    @MainActor func inactiveMonospace() {
+    @Test("Non-active table has monospace font")
+    @MainActor func nonActiveMonospace() {
         let editor = makeEditor()
         editor.loadContent("| A | B |\n| --- | --- |\n| 1 | 2 |\nother")
         activateBlock(1, in: editor)
@@ -400,8 +398,8 @@ struct TableInactiveTests {
         #expect(f.isFixedPitch)
     }
 
-    @Test("Inactive table pipes are dimmed")
-    @MainActor func inactivePipesDimmed() {
+    @Test("Non-active table pipes are dimmed")
+    @MainActor func nonActivePipesDimmed() {
         let editor = makeEditor()
         editor.loadContent("| A | B |\n| --- | --- |\n| 1 | 2 |\nother")
         activateBlock(1, in: editor)
@@ -435,7 +433,6 @@ struct CodeBlockActiveTests {
         editor.loadContent("```\nhello\n```\nother")
         activateBlock(0, in: editor)
 
-        // First character of opening fence
         let color = fgColor(at: 0, in: editor)
         #expect(color == NSColor.tertiaryLabelColor)
     }
@@ -446,99 +443,101 @@ struct CodeBlockActiveTests {
         editor.loadContent("```\nhello\n```\nother")
         activateBlock(0, in: editor)
 
-        // "hello" starts at offset 4 (after "```\n")
         let f = font(at: 4, in: editor)!
         #expect(f.isFixedPitch)
     }
 }
 
-@Suite("Integration — Code Block (Inactive Block)")
-struct CodeBlockInactiveTests {
+@Suite("Integration — Code Block (Non-Active Block)")
+struct CodeBlockNonActiveTests {
 
-    @Test("Inactive code block strips fences, shows content only")
-    @MainActor func inactiveStripsDelimiters() {
+    @Test("Non-active code block shows raw text, fences are dimmed")
+    @MainActor func nonActiveFencesDimmed() {
         let editor = makeEditor()
         editor.loadContent("```\nhello\n```\nother")
         activateBlock(1, in: editor)
 
+        // Text storage has the raw text
         let text = displayText(for: 0, in: editor)
-        #expect(text.contains("hello"))
-        #expect(!text.contains("```"))
+        #expect(text == "```\nhello\n```")
+        // Fences dimmed
+        let color = fgColor(at: 0, in: editor)
+        #expect(color == NSColor.tertiaryLabelColor)
     }
 
-    @Test("Inactive code block has monospace font")
-    @MainActor func inactiveMonospace() {
+    @Test("Non-active code block content has monospace font")
+    @MainActor func nonActiveMonospace() {
         let editor = makeEditor()
         editor.loadContent("```\nhello\n```\nother")
         activateBlock(1, in: editor)
 
-        let f = font(at: editor.displayRanges[0].location, in: editor)!
+        // Content "hello" at offset 4
+        let f = font(at: 4, in: editor)!
         #expect(f.isFixedPitch)
     }
 
-    @Test("Inactive code block has code color")
-    @MainActor func inactiveCodeColor() {
+    @Test("Non-active code block content has code color")
+    @MainActor func nonActiveCodeColor() {
         let editor = makeEditor()
         editor.loadContent("```\nhello\n```\nother")
         activateBlock(1, in: editor)
 
-        let color = fgColor(at: editor.displayRanges[0].location, in: editor)
+        let color = fgColor(at: 4, in: editor)
         #expect(color != nil)
     }
 }
 
 // ============================================================================
-// MARK: - Block Transition (Active ↔ Inactive)
+// MARK: - Block Transition
 // ============================================================================
 
 @Suite("Integration — Block Transition")
 struct BlockTransitionTests {
 
-    @Test("Switching from active to inactive renders markdown")
-    @MainActor func activeToInactive() {
+    @Test("Text storage always contains raw markdown regardless of active block")
+    @MainActor func textStorageAlwaysRaw() {
         let editor = makeEditor()
         editor.loadContent("**bold**\nplain")
 
-        // Block 0 is active (cursor at 0), shows raw markdown
         activateBlock(0, in: editor)
-        let activeText = displayText(for: 0, in: editor)
-        #expect(activeText == "**bold**")
+        #expect(editor.textStorage!.string == "**bold**\nplain")
 
-        // Switch to block 1 — block 0 becomes inactive, rendered
         activateBlock(1, in: editor)
-        let inactiveText = displayText(for: 0, in: editor)
-        #expect(inactiveText == "bold")
+        #expect(editor.textStorage!.string == "**bold**\nplain")
     }
 
-    @Test("Switching from inactive to active shows raw markdown")
-    @MainActor func inactiveToActive() {
+    @Test("Switching active block changes which delimiters are visible")
+    @MainActor func switchingBlockChangesDelimiterVisibility() {
         let editor = makeEditor()
-        editor.loadContent("# Title\ntext")
+        editor.loadContent("**bold**\n*italic*")
 
-        // Activate block 1 so block 0 is inactive
-        activateBlock(1, in: editor)
-        let inactiveText = displayText(for: 0, in: editor)
-        #expect(inactiveText == "Title")
-
-        // Activate block 0 — shows raw
+        // Block 0 active: ** delimiters dimmed (visible)
         activateBlock(0, in: editor)
-        let activeText = displayText(for: 0, in: editor)
-        #expect(activeText == "# Title")
+        let dimColor = fgColor(at: 0, in: editor)
+        #expect(dimColor == NSColor.tertiaryLabelColor)
+
+        // Switch to block 1: block 0's ** delimiters become hidden
+        activateBlock(1, in: editor)
+        let ts = editor.textStorage!
+        let f = ts.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        #expect(f != nil)
+        #expect(f!.pointSize < 1.0)  // hidden
     }
 
-    @Test("Multiple blocks: only active block shows raw, others rendered")
-    @MainActor func multipleBlocksRendering() {
+    @Test("Multiple blocks: all inline delimiters hidden except active token")
+    @MainActor func multipleBlocksDelimiterHiding() {
         let editor = makeEditor()
         editor.loadContent("**a**\n*b*\n`c`")
 
         activateBlock(1, in: editor)
 
-        // Block 0 inactive: "a" (bold rendered)
-        #expect(displayText(for: 0, in: editor) == "a")
-        // Block 1 active: "*b*" (raw markdown)
-        #expect(displayText(for: 1, in: editor) == "*b*")
-        // Block 2 inactive: "c" (code rendered)
-        #expect(displayText(for: 2, in: editor) == "c")
+        let ts = editor.textStorage!
+        // Block 0 "**a**": ** at 0,1 should be hidden
+        let f0 = ts.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        #expect(f0!.pointSize < 1.0)
+        // Block 2 "`c`": ` at 10 should be hidden
+        let f2 = ts.attribute(.font, at: 10, effectiveRange: nil) as? NSFont
+        #expect(f2!.pointSize < 1.0)
     }
 }
 
@@ -580,52 +579,31 @@ struct ThematicBreakActiveTests {
     }
 }
 
-@Suite("Integration — Thematic Break (Inactive Block)")
-struct ThematicBreakInactiveTests {
+@Suite("Integration — Thematic Break (Non-Active Block)")
+struct ThematicBreakNonActiveTests {
 
-    @Test("Inactive --- renders as visual divider")
-    @MainActor func inactiveDashDivider() {
+    @Test("Non-active --- stays as raw text, dimmed")
+    @MainActor func nonActiveDashDimmed() {
         let editor = makeEditor()
         editor.loadContent("---\nother")
         activateBlock(1, in: editor)
 
         let text = displayText(for: 0, in: editor)
-        // The divider is 20× ─ (U+2500)
-        let expectedDivider = String(repeating: "\u{2500}", count: 20)
-        #expect(text == expectedDivider)
-    }
-
-    @Test("Inactive --- divider has dimmed color")
-    @MainActor func inactiveDividerDimmed() {
-        let editor = makeEditor()
-        editor.loadContent("---\nother")
-        activateBlock(1, in: editor)
-
-        let color = fgColor(at: editor.displayRanges[0].location, in: editor)
+        #expect(text == "---")
+        let color = fgColor(at: 0, in: editor)
         #expect(color == NSColor.tertiaryLabelColor)
     }
 
-    @Test("Inactive *** renders as visual divider")
-    @MainActor func inactiveAsteriskDivider() {
+    @Test("Non-active *** stays as raw text, dimmed")
+    @MainActor func nonActiveAsteriskDimmed() {
         let editor = makeEditor()
         editor.loadContent("***\nother")
         activateBlock(1, in: editor)
 
         let text = displayText(for: 0, in: editor)
-        let expectedDivider = String(repeating: "\u{2500}", count: 20)
-        #expect(text == expectedDivider)
-    }
-
-    @Test("Thematic break between content blocks renders correctly")
-    @MainActor func betweenBlocks() {
-        let editor = makeEditor()
-        editor.loadContent("above\n\n---\n\nbelow")
-        activateBlock(4, in: editor)  // activate "below"
-
-        // Block 2 is "---", should be rendered as divider
-        let text = displayText(for: 2, in: editor)
-        let expectedDivider = String(repeating: "\u{2500}", count: 20)
-        #expect(text == expectedDivider)
+        #expect(text == "***")
+        let color = fgColor(at: 0, in: editor)
+        #expect(color == NSColor.tertiaryLabelColor)
     }
 }
 
@@ -652,7 +630,6 @@ struct ImageActiveTests {
         editor.loadContent("![alt](url)")
         activateBlock(0, in: editor)
 
-        // "alt" starts at offset 2
         let color = fgColor(at: 2, in: editor)
         #expect(color != nil)
     }
@@ -663,42 +640,47 @@ struct ImageActiveTests {
         editor.loadContent("![alt](url)")
         activateBlock(0, in: editor)
 
-        // "![" at offset 0
         let delimColor = fgColor(at: 0, in: editor)
         #expect(delimColor == NSColor.tertiaryLabelColor)
     }
 }
 
-@Suite("Integration — Image (Inactive Block)")
-struct ImageInactiveTests {
+@Suite("Integration — Image (Non-Active Block)")
+struct ImageNonActiveTests {
 
-    @Test("Inactive ![alt](url) strips delimiters, shows alt text only")
-    @MainActor func inactiveImageStripsDelimiters() {
-        let editor = makeEditor()
-        editor.loadContent("![photo](https://example.com/img.png)\nother")
-        activateBlock(1, in: editor)
-
-        let text = displayText(for: 0, in: editor)
-        #expect(text == "photo")
-    }
-
-    @Test("Inactive image has italic font")
-    @MainActor func inactiveImageItalic() {
+    @Test("Non-active image: delimiters hidden, alt text styled")
+    @MainActor func nonActiveImageDelimitersHidden() {
         let editor = makeEditor()
         editor.loadContent("![photo](url)\nother")
         activateBlock(1, in: editor)
 
-        let f = font(at: editor.displayRanges[0].location, in: editor)!
+        // Text storage has raw text
+        let text = displayText(for: 0, in: editor)
+        #expect(text == "![photo](url)")
+        // Delimiters hidden
+        let ts = editor.textStorage!
+        let f = ts.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        #expect(f!.pointSize < 1.0)
+    }
+
+    @Test("Non-active image has italic font on content")
+    @MainActor func nonActiveImageItalic() {
+        let editor = makeEditor()
+        editor.loadContent("![photo](url)\nother")
+        activateBlock(1, in: editor)
+
+        // "photo" is at positions 2-6
+        let f = font(at: 2, in: editor)!
         #expect(NSFontManager.shared.traits(of: f).contains(.italicFontMask))
     }
 
-    @Test("Inactive image has accent color")
-    @MainActor func inactiveImageAccentColor() {
+    @Test("Non-active image content has accent color")
+    @MainActor func nonActiveImageAccentColor() {
         let editor = makeEditor()
         editor.loadContent("![photo](url)\nother")
         activateBlock(1, in: editor)
 
-        let color = fgColor(at: editor.displayRanges[0].location, in: editor)
+        let color = fgColor(at: 2, in: editor)
         #expect(color != nil)
     }
 }
@@ -720,31 +702,37 @@ struct LineBreakActiveTests {
         #expect(text == "hello\\")
     }
 
-    @Test("Active trailing backslash is dimmed")
+    @Test("Active trailing backslash is dimmed when cursor is inside token")
     @MainActor func activeBackslashDimmed() {
         let editor = makeEditor()
         editor.loadContent("hello\\")
-        activateBlock(0, in: editor)
+        // Place cursor at the backslash (offset 5) so it's the active token
+        editor.recompose(cursorInRaw: 5)
 
         let color = fgColor(at: 5, in: editor)
         #expect(color == NSColor.tertiaryLabelColor)
     }
 }
 
-@Suite("Integration — Line Break (Inactive Block)")
-struct LineBreakInactiveTests {
+@Suite("Integration — Line Break (Non-Active Block)")
+struct LineBreakNonActiveTests {
 
-    @Test("Inactive trailing backslash is stripped")
-    @MainActor func inactiveStripsBackslash() {
+    @Test("Non-active trailing backslash is hidden")
+    @MainActor func nonActiveBackslashHidden() {
         let editor = makeEditor()
         editor.loadContent("hello\\\nother")
         activateBlock(1, in: editor)
 
+        // Text storage still has backslash
         let text = displayText(for: 0, in: editor)
-        #expect(text == "hello")
+        #expect(text == "hello\\")
+        // But it's hidden
+        let ts = editor.textStorage!
+        let f = ts.attribute(.font, at: 5, effectiveRange: nil) as? NSFont
+        #expect(f!.pointSize < 1.0)
     }
 
-    @Test("Text without backslash renders unchanged when inactive")
+    @Test("Text without backslash renders unchanged when non-active")
     @MainActor func noBackslashUnchanged() {
         let editor = makeEditor()
         editor.loadContent("plain text\nother")

--- a/Tests/MarkdownEditorTests/EditorDocumentTests.swift
+++ b/Tests/MarkdownEditorTests/EditorDocumentTests.swift
@@ -52,19 +52,24 @@ struct EditorDocumentLoadingTests {
         #expect(editor.blocks[0].content == "")
     }
 
-    @Test("loadContent renders markdown in non-active blocks")
+    @Test("loadContent styles markdown in non-active blocks (text preserved, delimiters hidden)")
     @MainActor func loadContentRendersInactiveBlocks() {
         let editor = makeEditor()
         editor.loadContent("**bold**\n*italic*")
         #expect(editor.blocks.count == 2)
 
-        // The text storage should contain rendered content for inactive blocks.
-        // Block 0 is active (cursor at 0), block 1 is inactive and rendered.
+        // With word-level rendering, text storage always = rawSource.
+        // Block 0 is active (cursor at 0), block 1 is non-active.
         let ts = editor.textStorage!.string
-        // Active block shows raw markdown, inactive block strips delimiters
-        #expect(ts.contains("**bold**"))  // active — raw
-        #expect(ts.contains("italic"))     // inactive — rendered (no *)
-        #expect(!ts.contains("*italic*"))  // delimiters stripped
+        #expect(ts.contains("**bold**"))   // active — raw
+        #expect(ts.contains("*italic*"))   // non-active — raw text preserved
+
+        // Non-active block's delimiters are hidden via attributes, not stripped.
+        // "*" at block 1 start should have hidden font.
+        let b1Start = editor.displayRanges[1].location
+        let delimFont = font(at: b1Start, in: editor)!
+        #expect(delimFont.pointSize < 1.0)
+        #expect(fgColor(at: b1Start, in: editor) == NSColor.clear)
     }
 
     @Test("loadContent with markdown preserves rawSource exactly")

--- a/Tests/MarkdownEditorTests/EditorFeatureTests.swift
+++ b/Tests/MarkdownEditorTests/EditorFeatureTests.swift
@@ -220,14 +220,17 @@ struct FontIntegrationTests {
         #expect(abs(f.pointSize - expectedSize) < 0.1)
     }
 
-    @Test("updateFont affects inactive block rendering")
+    @Test("updateFont affects non-active block rendering")
     @MainActor func updateFontInactive() {
         let editor = makeEditor()
         editor.loadContent("**bold**\nother")
         editor.updateFont(name: "Helvetica", size: 18)
         activateBlock(1, in: editor)
 
-        let f = font(at: editor.displayRanges[0].location, in: editor)!
+        // In word-level rendering, offset 0 is a delimiter (hidden font).
+        // Content "bold" starts at offset 2.
+        let base = editor.displayRanges[0].location
+        let f = font(at: base + 2, in: editor)!
         #expect(NSFontManager.shared.traits(of: f).contains(.boldFontMask))
         #expect(f.pointSize == 18)
     }
@@ -316,23 +319,24 @@ struct AppearanceIntegrationTests {
         #expect(color == editor.accentColor)
     }
 
-    @Test("Code color is used for inline code in both active and inactive")
+    @Test("Code color is used for inline code in both active and non-active")
     @MainActor func codeColorBothStates() {
         let editor = makeEditor()
         editor.loadContent("`active`\n`inactive`")
 
-        // Active block 0
+        // Active block 0: content at offset 1
         activateBlock(0, in: editor)
         let activeColor = fgColor(at: 1, in: editor)
         #expect(activeColor == editor.codeColor)
 
-        // Switch to block 1, making block 0 inactive
+        // Switch to block 1, making block 0 non-active.
+        // Offset 0 is backtick (hidden), content "active" starts at offset 1.
         activateBlock(1, in: editor)
-        let inactiveColor = fgColor(at: editor.displayRanges[0].location, in: editor)
-        #expect(inactiveColor == editor.codeColor)
+        let nonActiveColor = fgColor(at: editor.displayRanges[0].location + 1, in: editor)
+        #expect(nonActiveColor == editor.codeColor)
     }
 
-    @Test("Syntax delimiter dimming uses tertiaryLabelColor")
+    @Test("Active token delimiters are dimmed, non-active token delimiters are hidden")
     @MainActor func delimiterDimming() {
         let editor = makeEditor()
         // "**bold** *italic* `code`"
@@ -340,12 +344,11 @@ struct AppearanceIntegrationTests {
         editor.loadContent("**bold** *italic* `code`")
         activateBlock(0, in: editor)
 
-        // ** at 0
+        // Cursor at 0 → inside bold token. Bold delimiters dimmed.
         #expect(fgColor(at: 0, in: editor) == NSColor.tertiaryLabelColor)
-        // * at 9
-        #expect(fgColor(at: 9, in: editor) == NSColor.tertiaryLabelColor)
-        // ` at 18
-        #expect(fgColor(at: 18, in: editor) == NSColor.tertiaryLabelColor)
+        // Italic and code delimiters hidden (cursor not inside those tokens)
+        #expect(fgColor(at: 9, in: editor) == NSColor.clear)
+        #expect(fgColor(at: 18, in: editor) == NSColor.clear)
     }
 }
 
@@ -364,13 +367,16 @@ struct FullDocumentIntegrationTests {
         // Make block 2 active (the list item)
         activateBlock(2, in: editor)
 
-        // Block 0 (heading, inactive): "Title" with bold scaled font
+        // Block 0 (heading, non-active): raw text preserved, markers hidden
         let h = displayText(for: 0, in: editor)
-        #expect(h == "Title")
-        let hf = font(at: editor.displayRanges[0].location, in: editor)!
+        #expect(h == "# Title")
+        // Heading marker "#" at offset 0 is hidden. Content has bold font.
+        let hBase = editor.displayRanges[0].location
+        #expect(fgColor(at: hBase, in: editor) == NSColor.clear)
+        let hf = font(at: hBase + 2, in: editor)!
         #expect(NSFontManager.shared.traits(of: hf).contains(.boldFontMask))
 
-        // Block 1 (plain, inactive): "Some text"
+        // Block 1 (plain, non-active): "Some text"
         let p = displayText(for: 1, in: editor)
         #expect(p == "Some text")
 
@@ -378,9 +384,11 @@ struct FullDocumentIntegrationTests {
         let li = displayText(for: 2, in: editor)
         #expect(li == "- item")
 
-        // Block 3 (quote, inactive): "quote" (stripped >)
+        // Block 3 (quote, non-active): raw text preserved, ">" hidden
         let q = displayText(for: 3, in: editor)
-        #expect(q == "quote")
+        #expect(q == "> quote")
+        let qBase = editor.displayRanges[3].location
+        #expect(fgColor(at: qBase, in: editor) == NSColor.clear)
     }
 
     @Test("Type complete document from scratch, verify structure")
@@ -408,27 +416,31 @@ struct FullDocumentIntegrationTests {
         // Activate block 2 (code)
         activateBlock(2, in: editor)
 
-        // Block 0 inactive: "Bold title" with bold
-        #expect(displayText(for: 0, in: editor) == "Bold title")
-        let bf = font(at: editor.displayRanges[0].location, in: editor)!
+        // Block 0 non-active: raw text preserved, delimiters hidden, content bold
+        #expect(displayText(for: 0, in: editor) == "**Bold title**")
+        let b0 = editor.displayRanges[0].location
+        let bf = font(at: b0 + 2, in: editor)!  // content starts after **
         #expect(NSFontManager.shared.traits(of: bf).contains(.boldFontMask))
 
-        // Block 1 inactive: "Italic subtitle" with italic
-        #expect(displayText(for: 1, in: editor) == "Italic subtitle")
-        let itf = font(at: editor.displayRanges[1].location, in: editor)!
+        // Block 1 non-active: raw text preserved, delimiters hidden, content italic
+        #expect(displayText(for: 1, in: editor) == "*Italic subtitle*")
+        let b1 = editor.displayRanges[1].location
+        let itf = font(at: b1 + 1, in: editor)!  // content starts after *
         #expect(NSFontManager.shared.traits(of: itf).contains(.italicFontMask))
 
         // Block 2 active: "`code block`" (raw)
         #expect(displayText(for: 2, in: editor) == "`code block`")
 
-        // Block 3 inactive: "deleted" with strikethrough
-        #expect(displayText(for: 3, in: editor) == "deleted")
-        let a3 = attrs(at: editor.displayRanges[3].location, in: editor)
+        // Block 3 non-active: raw text preserved, delimiters hidden, content has strikethrough
+        #expect(displayText(for: 3, in: editor) == "~~deleted~~")
+        let b3 = editor.displayRanges[3].location
+        let a3 = attrs(at: b3 + 2, in: editor)  // content starts after ~~
         #expect(a3[.strikethroughStyle] as? Int == NSUnderlineStyle.single.rawValue)
 
-        // Block 4 inactive: "highlight" with background
-        #expect(displayText(for: 4, in: editor) == "highlight")
-        let a4 = attrs(at: editor.displayRanges[4].location, in: editor)
+        // Block 4 non-active: raw text preserved, delimiters hidden, content has background
+        #expect(displayText(for: 4, in: editor) == "==highlight==")
+        let b4 = editor.displayRanges[4].location
+        let a4 = attrs(at: b4 + 2, in: editor)  // content starts after ==
         #expect(a4[.backgroundColor] != nil)
     }
 }

--- a/Tests/MarkdownEditorTests/EditorRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/EditorRenderingTests.swift
@@ -7,8 +7,8 @@ import AppKit
 @Suite("EditorTextView — Coordinate Mapping")
 struct EditorCoordinateTests {
 
-    @Test("Single block: display offset equals raw offset")
-    @MainActor func singleBlockIdentity() {
+    @Test("Display offset equals raw offset (identity mapping)")
+    @MainActor func identityMapping() {
         let editor = makeEditor()
         type("hello", into: editor)
 
@@ -24,16 +24,15 @@ struct EditorCoordinateTests {
     @Test("blockIndexForRawOffset returns correct index")
     @MainActor func blockIndexMapping() {
         let editor = makeEditor()
-        // Set up multi-block state directly
         editor.rawSource = "hello\nworld"
         editor.blocks = BlockParser.parse(editor.rawSource)
         editor.recompose(cursorInRaw: 0)
 
-        #expect(editor.blockIndexForRawOffset(0) == 0)   // start of "hello"
-        #expect(editor.blockIndexForRawOffset(3) == 0)   // middle of "hello"
-        #expect(editor.blockIndexForRawOffset(5) == 0)   // end of "hello"
-        #expect(editor.blockIndexForRawOffset(6) == 1)   // start of "world"
-        #expect(editor.blockIndexForRawOffset(11) == 1)  // end of "world"
+        #expect(editor.blockIndexForRawOffset(0) == 0)
+        #expect(editor.blockIndexForRawOffset(3) == 0)
+        #expect(editor.blockIndexForRawOffset(5) == 0)
+        #expect(editor.blockIndexForRawOffset(6) == 1)
+        #expect(editor.blockIndexForRawOffset(11) == 1)
     }
 
     @Test("blockIndexForRawOffset clamps to last block")
@@ -47,216 +46,268 @@ struct EditorCoordinateTests {
     }
 }
 
-// MARK: - Markdown Rendering
+// MARK: - Word-Level Styling
 
-@Suite("EditorTextView — Markdown Rendering")
-struct EditorMarkdownTests {
+@Suite("EditorTextView — Word-Level Styling")
+struct EditorStylingTests {
 
-    @Test("Bold markdown renders to shorter text (removes **)")
-    @MainActor func boldRendering() {
+    // MARK: - String Preservation
+
+    @Test("styleBlock preserves raw text (no stripping)")
+    @MainActor func preservesRawText() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("**bold**")
-        #expect(rendered.string == "bold")
-    }
-
-    @Test("Italic markdown renders to shorter text (removes *)")
-    @MainActor func italicRendering() {
-        let editor = makeEditor()
-        let rendered = editor.renderMarkdown("*italic*")
-        #expect(rendered.string == "italic")
+        #expect(editor.styleBlock("**bold**").string == "**bold**")
+        #expect(editor.styleBlock("*italic*").string == "*italic*")
+        #expect(editor.styleBlock("`code`").string == "`code`")
+        #expect(editor.styleBlock("# Heading").string == "# Heading")
+        #expect(editor.styleBlock("> quote").string == "> quote")
+        #expect(editor.styleBlock("- item").string == "- item")
     }
 
     @Test("Plain text renders unchanged")
-    @MainActor func plainRendering() {
+    @MainActor func plainText() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("just plain text")
-        #expect(rendered.string == "just plain text")
+        let styled = editor.styleBlock("just plain text")
+        #expect(styled.string == "just plain text")
     }
 
-    @Test("Inline code renders without backticks")
-    @MainActor func codeRendering() {
+    @Test("Empty string produces empty attributed string")
+    @MainActor func emptyString() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("`code`")
-        #expect(rendered.string == "code")
+        #expect(editor.styleBlock("").string == "")
     }
 
-    @Test("Bold text is rendered (syntax stripped) and has font attribute")
-    @MainActor func boldFontTrait() {
+    // MARK: - Inline Delimiter Hiding (no cursor)
+
+    @Test("Bold delimiters are hidden when cursor is outside")
+    @MainActor func boldDelimitersHidden() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("**bold**")
-        // The markdown syntax ** should be stripped
-        #expect(rendered.string.contains("bold"))
-        #expect(!rendered.string.contains("**"))
-        // Font attribute should be present (trait may vary by environment)
-        var hasFont = false
-        rendered.enumerateAttribute(.font, in: NSRange(location: 0, length: rendered.length)) { val, _, _ in
-            if val is NSFont { hasFont = true }
-        }
-        #expect(hasFont)
+        let styled = editor.styleBlock("**bold**")
+        // ** at positions 0,1 and 6,7 should be hidden
+        #expect(isHidden(at: 0, in: styled))
+        #expect(isHidden(at: 1, in: styled))
+        #expect(isHidden(at: 6, in: styled))
+        #expect(isHidden(at: 7, in: styled))
     }
 
-    @Test("Italic text is rendered (syntax stripped) and has font attribute")
-    @MainActor func italicFontTrait() {
+    @Test("Bold content has bold font")
+    @MainActor func boldContentFont() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("*italic*")
-        // The markdown syntax * should be stripped
-        #expect(rendered.string.contains("italic"))
-        // Check that the wrapping *s are gone (the word itself doesn't start/end with *)
-        let trimmed = rendered.string.trimmingCharacters(in: .whitespacesAndNewlines)
-        #expect(!trimmed.hasPrefix("*"))
-        #expect(!trimmed.hasSuffix("*"))
-        // Font attribute should be present
-        var hasFont = false
-        rendered.enumerateAttribute(.font, in: NSRange(location: 0, length: rendered.length)) { val, _, _ in
-            if val is NSFont { hasFont = true }
-        }
-        #expect(hasFont)
+        let styled = editor.styleBlock("**bold**")
+        let f = styled.attribute(.font, at: 2, effectiveRange: nil) as? NSFont
+        #expect(f != nil)
+        #expect(NSFontManager.shared.traits(of: f!).contains(.boldFontMask))
     }
 
-    @Test("Empty string renders to empty attributed string")
-    @MainActor func emptyRendering() {
+    @Test("Italic delimiters are hidden when cursor is outside")
+    @MainActor func italicDelimitersHidden() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("")
-        #expect(rendered.string == "")
+        let styled = editor.styleBlock("*italic*")
+        #expect(isHidden(at: 0, in: styled))
+        #expect(isHidden(at: 7, in: styled))
     }
 
-    @Test("Heading renders without # prefix")
-    @MainActor func headingRendering() {
+    @Test("Italic content has italic font")
+    @MainActor func italicContentFont() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("# Hello")
-        #expect(rendered.string == "Hello")
+        let styled = editor.styleBlock("*italic*")
+        let f = styled.attribute(.font, at: 1, effectiveRange: nil) as? NSFont
+        #expect(f != nil)
+        #expect(NSFontManager.shared.traits(of: f!).contains(.italicFontMask))
     }
 
-    @Test("Bold italic renders without delimiters")
-    @MainActor func boldItalicRendering() {
+    @Test("Bold-italic delimiters are hidden when cursor is outside")
+    @MainActor func boldItalicDelimitersHidden() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("***both***")
-        #expect(rendered.string == "both")
+        let styled = editor.styleBlock("***both***")
+        #expect(isHidden(at: 0, in: styled))
+        #expect(isHidden(at: 1, in: styled))
+        #expect(isHidden(at: 2, in: styled))
+        #expect(isHidden(at: 7, in: styled))
     }
 
-    @Test("**hi* renders as *hi (extra * stays, matched delimiters stripped)")
-    @MainActor func mismatchedDoubleOpenSingleClose() {
+    @Test("Strikethrough delimiters are hidden when cursor is outside")
+    @MainActor func strikethroughDelimitersHidden() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("**hi*")
-        #expect(rendered.string == "*hi")
+        let styled = editor.styleBlock("~~deleted~~")
+        #expect(isHidden(at: 0, in: styled))
+        #expect(isHidden(at: 1, in: styled))
+        #expect(isHidden(at: 9, in: styled))
+        #expect(isHidden(at: 10, in: styled))
     }
 
-    @Test("*hi** renders as hi* (extra * stays, matched delimiters stripped)")
-    @MainActor func mismatchedSingleOpenDoubleClose() {
+    @Test("Strikethrough content has strikethrough attribute")
+    @MainActor func strikethroughAttribute() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("*hi**")
-        #expect(rendered.string == "hi*")
+        let styled = editor.styleBlock("~~deleted~~")
+        let val = styled.attribute(.strikethroughStyle, at: 2, effectiveRange: nil)
+        #expect(val != nil)
     }
 
-    @Test("***hi** renders as *hi (extra * stays, bold delimiters stripped)")
-    @MainActor func mismatchedTripleOpenDoubleClose() {
+    @Test("Highlight delimiters are hidden when cursor is outside")
+    @MainActor func highlightDelimitersHidden() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("***hi**")
-        #expect(rendered.string == "*hi")
+        let styled = editor.styleBlock("==important==")
+        #expect(isHidden(at: 0, in: styled))
+        #expect(isHidden(at: 1, in: styled))
+        #expect(isHidden(at: 11, in: styled))
+        #expect(isHidden(at: 12, in: styled))
     }
 
-    @Test("Link renders as text only (delimiters stripped)")
-    @MainActor func linkRendering() {
+    @Test("Highlight content has background color")
+    @MainActor func highlightBackground() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("[click here](https://example.com)")
-        #expect(rendered.string == "click here")
+        let styled = editor.styleBlock("==important==")
+        let val = styled.attribute(.backgroundColor, at: 2, effectiveRange: nil)
+        #expect(val != nil)
     }
 
-    @Test("Blockquote renders without > prefix")
-    @MainActor func blockquoteRendering() {
+    @Test("Code delimiters are hidden when cursor is outside")
+    @MainActor func codeDelimitersHidden() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("> hello world")
-        #expect(rendered.string == "hello world")
+        let styled = editor.styleBlock("`code`")
+        #expect(isHidden(at: 0, in: styled))
+        #expect(isHidden(at: 5, in: styled))
     }
 
-    @Test("Unordered list item renders with bullet")
-    @MainActor func unorderedListRendering() {
+    @Test("Inline code content has code color")
+    @MainActor func codeColor() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("- hello")
-        #expect(rendered.string == "\u{2022} hello")
+        let styled = editor.styleBlock("`code`")
+        let color = styled.attribute(.foregroundColor, at: 1, effectiveRange: nil) as? NSColor
+        #expect(color != nil)
+        #expect(color!.redComponent > 0.5 && color!.greenComponent < 0.2)
     }
 
-    @Test("Ordered list item keeps its number")
-    @MainActor func orderedListRendering() {
+    @Test("Link delimiters are hidden when cursor is outside")
+    @MainActor func linkDelimitersHidden() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("1. hello")
-        #expect(rendered.string == "1. hello")
+        let styled = editor.styleBlock("[text](url)")
+        // "[" at 0 should be hidden
+        #expect(isHidden(at: 0, in: styled))
+        // "](url)" at 5-10 should be hidden
+        #expect(isHidden(at: 5, in: styled))
     }
 
-    @Test("Inline code renders in dark red")
-    @MainActor func inlineCodeColor() {
+    @Test("Link content has accent color and underline")
+    @MainActor func linkStyling() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("`code`")
-        #expect(rendered.string == "code")
-        var foundCodeColor = false
-        rendered.enumerateAttribute(.foregroundColor, in: NSRange(location: 0, length: rendered.length)) { val, _, _ in
-            if let color = val as? NSColor {
-                // Check it's approximately #8a2425
-                if color.redComponent > 0.5 && color.greenComponent < 0.2 && color.blueComponent < 0.2 {
-                    foundCodeColor = true
-                }
-            }
-        }
-        #expect(foundCodeColor)
+        let styled = editor.styleBlock("[text](url)")
+        // "text" is at positions 1-4
+        let color = styled.attribute(.foregroundColor, at: 1, effectiveRange: nil) as? NSColor
+        #expect(color != nil)
+        let underline = styled.attribute(.underlineStyle, at: 1, effectiveRange: nil)
+        #expect(underline != nil)
     }
 
-    @Test("Active block inline code has dark red content")
-    @MainActor func activeCodeColor() {
+    @Test("Image delimiters are hidden when cursor is outside")
+    @MainActor func imageDelimitersHidden() {
         let editor = makeEditor()
-        let highlighted = editor.highlightSyntax("`code`")
-        #expect(highlighted.string == "`code`")
-        // Check the content range (chars 1-4) has the code color
-        var foundCodeColor = false
-        highlighted.enumerateAttribute(.foregroundColor, in: NSRange(location: 1, length: 4)) { val, _, _ in
-            if let color = val as? NSColor {
-                if color.redComponent > 0.5 && color.greenComponent < 0.2 && color.blueComponent < 0.2 {
-                    foundCodeColor = true
-                }
-            }
-        }
-        #expect(foundCodeColor)
+        let styled = editor.styleBlock("![alt](url)")
+        // "![" at 0-1 should be hidden
+        #expect(isHidden(at: 0, in: styled))
     }
 
-    @Test("Link rendered text has underline attribute")
-    @MainActor func linkUnderline() {
+    @Test("Image content has accent color and italic font")
+    @MainActor func imageStyling() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("[text](url)")
-        #expect(rendered.string == "text")
-        var hasUnderline = false
-        rendered.enumerateAttribute(.underlineStyle, in: NSRange(location: 0, length: rendered.length)) { val, _, _ in
-            if val != nil { hasUnderline = true }
-        }
-        #expect(hasUnderline)
+        let styled = editor.styleBlock("![photo](url)")
+        // "photo" is at positions 2-6
+        let color = styled.attribute(.foregroundColor, at: 2, effectiveRange: nil) as? NSColor
+        #expect(color != nil)
+        let f = styled.attribute(.font, at: 2, effectiveRange: nil) as? NSFont
+        #expect(f != nil)
+        #expect(NSFontManager.shared.traits(of: f!).contains(.italicFontMask))
     }
 
-    @Test("Blockquote rendered text has secondary label color")
+    @Test("Line break backslash is hidden when cursor is outside")
+    @MainActor func lineBreakHidden() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("hello\\")
+        #expect(isHidden(at: 5, in: styled))
+    }
+
+    // MARK: - Heading & Blockquote Markers (hidden when no cursor, dimmed when active)
+
+    @Test("Heading # is hidden when cursor is outside")
+    @MainActor func headingMarkerHidden() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("# Hello")
+        #expect(isHidden(at: 0, in: styled))
+        #expect(isHidden(at: 1, in: styled))  // space after #
+    }
+
+    @Test("Heading # is dimmed when cursor is inside")
+    @MainActor func headingMarkerDimmedActive() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("# Hello", cursorPosition: 3)
+        #expect(isDimmed(at: 0, in: styled))
+        #expect(!isHidden(at: 0, in: styled))
+    }
+
+    @Test("Heading content has bold scaled font")
+    @MainActor func headingContentFont() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("# Hello")
+        let f = styled.attribute(.font, at: 2, effectiveRange: nil) as? NSFont
+        #expect(f != nil)
+        #expect(NSFontManager.shared.traits(of: f!).contains(.boldFontMask))
+        #expect(f!.pointSize > editor.bodyFont.pointSize)
+    }
+
+    @Test("Blockquote > is invisible (color-only) when cursor is outside")
+    @MainActor func blockquoteMarkerHidden() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("> text")
+        // Blockquote delimiters preserve width (font not shrunk), only color is clear
+        #expect(isInvisible(at: 0, in: styled))
+        #expect(isInvisible(at: 1, in: styled))  // space after >
+    }
+
+    @Test("Blockquote > is dimmed when cursor is inside")
+    @MainActor func blockquoteMarkerDimmedActive() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("> text", cursorPosition: 3)
+        #expect(isDimmed(at: 0, in: styled))
+        #expect(!isHidden(at: 0, in: styled))
+    }
+
+    @Test("Blockquote content has secondary label color")
     @MainActor func blockquoteColor() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("> text")
-        var hasSecondaryColor = false
-        rendered.enumerateAttribute(.foregroundColor, in: NSRange(location: 0, length: rendered.length)) { val, _, _ in
-            if let color = val as? NSColor, color == NSColor.secondaryLabelColor {
-                hasSecondaryColor = true
-            }
-        }
-        #expect(hasSecondaryColor)
+        let styled = editor.styleBlock("> text")
+        // Content starts after "> " (position 2)
+        let color = styled.attribute(.foregroundColor, at: 2, effectiveRange: nil) as? NSColor
+        #expect(color == NSColor.secondaryLabelColor)
     }
 
-    @Test("Multi-line blockquote strips all > prefixes")
-    @MainActor func multiLineBlockquoteRendering() {
+    @Test("Blockquote has paragraph style with text block")
+    @MainActor func blockquoteTextBlock() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("> line1\n> line2")
-        #expect(!rendered.string.contains(">"))
-        #expect(rendered.string.contains("line1"))
-        #expect(rendered.string.contains("line2"))
+        let styled = editor.styleBlock("> text")
+        var hasTextBlock = false
+        styled.enumerateAttribute(.paragraphStyle, in: NSRange(location: 0, length: styled.length)) { val, _, _ in
+            if let ps = val as? NSParagraphStyle, !ps.textBlocks.isEmpty {
+                hasTextBlock = true
+            }
+        }
+        #expect(hasTextBlock)
+    }
+
+    @Test("List marker is dimmed, never hidden")
+    @MainActor func listMarkerDimmed() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("- hello")
+        #expect(isDimmed(at: 0, in: styled))
+        #expect(!isHidden(at: 0, in: styled))
     }
 
     @Test("List items have indented paragraph style")
     @MainActor func listIndentation() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("- hello")
+        let styled = editor.styleBlock("- hello")
         var hasIndent = false
-        rendered.enumerateAttribute(.paragraphStyle, in: NSRange(location: 0, length: rendered.length)) { val, _, _ in
+        styled.enumerateAttribute(.paragraphStyle, in: NSRange(location: 0, length: styled.length)) { val, _, _ in
             if let ps = val as? NSParagraphStyle, ps.firstLineHeadIndent > 0 {
                 hasIndent = true
             }
@@ -264,24 +315,19 @@ struct EditorMarkdownTests {
         #expect(hasIndent)
     }
 
-    @Test("Active list items have indented paragraph style")
-    @MainActor func activeListIndentation() {
+    @Test("Ordered list keeps its number and dims it")
+    @MainActor func orderedListDimmed() {
         let editor = makeEditor()
-        let highlighted = editor.highlightSyntax("- hello")
-        var hasIndent = false
-        highlighted.enumerateAttribute(.paragraphStyle, in: NSRange(location: 0, length: highlighted.length)) { val, _, _ in
-            if let ps = val as? NSParagraphStyle, ps.firstLineHeadIndent > 0 {
-                hasIndent = true
-            }
-        }
-        #expect(hasIndent)
+        let styled = editor.styleBlock("1. hello")
+        #expect(styled.string == "1. hello")
+        #expect(isDimmed(at: 0, in: styled))
     }
 
-    @Test("Indented list item (4 spaces) renders with more indent than top-level")
-    @MainActor func indentedListRendering() {
+    @Test("Indented list (4 spaces) has deeper indent than top-level")
+    @MainActor func indentedListDeeper() {
         let editor = makeEditor()
-        let topLevel = editor.renderMarkdown("- hello")
-        let indented = editor.renderMarkdown("    - hello")
+        let topLevel = editor.styleBlock("- hello")
+        let indented = editor.styleBlock("    - hello")
 
         var topIndent: CGFloat = 0
         topLevel.enumerateAttribute(.paragraphStyle, in: NSRange(location: 0, length: topLevel.length)) { val, _, _ in
@@ -296,257 +342,121 @@ struct EditorMarkdownTests {
         #expect(subIndent > topIndent)
     }
 
-    @Test("Indented list item (4 spaces) renders with bullet, not as code")
-    @MainActor func indentedListBullet() {
+    @Test("Table has monospace font and dimmed pipes")
+    @MainActor func tableStyling() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("    - hello")
-        #expect(rendered.string.contains("\u{2022}"))  // bullet •
-        #expect(rendered.string.contains("hello"))
+        let styled = editor.styleBlock("| A | B |\n| --- | --- |\n| 1 | 2 |")
+        // Monospace font on content
+        let f = styled.attribute(.font, at: 2, effectiveRange: nil) as? NSFont
+        #expect(f != nil)
+        #expect(f!.isFixedPitch)
+        // Pipes are dimmed
+        #expect(isDimmed(at: 0, in: styled))
     }
 
-    @Test("Ordered list number is dimmed")
-    @MainActor func orderedListNumberDimmed() {
+    @Test("Thematic break is dimmed, never hidden")
+    @MainActor func thematicBreakDimmed() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("1. hello")
-        // The "1. " should have the dim color
-        var hasDimColor = false
-        rendered.enumerateAttribute(.foregroundColor, in: NSRange(location: 0, length: 3)) { val, _, _ in
-            if val is NSColor { hasDimColor = true }
-        }
-        #expect(hasDimColor)
+        let styled = editor.styleBlock("---")
+        #expect(styled.string == "---")
+        #expect(isDimmed(at: 0, in: styled))
+        #expect(!isHidden(at: 0, in: styled))
     }
 
-    @Test("Strikethrough renders without ~~ delimiters")
-    @MainActor func strikethroughRendering() {
+    @Test("Code block fences are dimmed, content has monospace+code color")
+    @MainActor func codeBlockStyling() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("~~deleted~~")
-        #expect(rendered.string == "deleted")
-        var hasStrikethrough = false
-        rendered.enumerateAttribute(.strikethroughStyle, in: NSRange(location: 0, length: rendered.length)) { val, _, _ in
-            if val != nil { hasStrikethrough = true }
-        }
-        #expect(hasStrikethrough)
+        let styled = editor.styleBlock("```\nhello\n```")
+        #expect(styled.string == "```\nhello\n```")
+        // Fences dimmed
+        #expect(isDimmed(at: 0, in: styled))
+        // Content "hello" at offset 4 has code color and monospace
+        let f = styled.attribute(.font, at: 4, effectiveRange: nil) as? NSFont
+        #expect(f != nil)
+        #expect(f!.isFixedPitch)
+        let color = styled.attribute(.foregroundColor, at: 4, effectiveRange: nil) as? NSColor
+        #expect(color != nil)
+        #expect(color!.redComponent > 0.5 && color!.greenComponent < 0.2)
     }
 
-    @Test("Active block strikethrough has strikethrough attribute")
-    @MainActor func activeStrikethrough() {
+    // MARK: - Active Token (cursor inside)
+
+    @Test("Bold delimiters are dimmed (not hidden) when cursor is inside")
+    @MainActor func boldDelimitersDimmedWhenActive() {
         let editor = makeEditor()
-        let highlighted = editor.highlightSyntax("~~deleted~~")
-        #expect(highlighted.string == "~~deleted~~")
-        var hasStrikethrough = false
-        highlighted.enumerateAttribute(.strikethroughStyle, in: NSRange(location: 2, length: 7)) { val, _, _ in
-            if val != nil { hasStrikethrough = true }
-        }
-        #expect(hasStrikethrough)
+        // Cursor at position 3 = inside "**bold**"
+        let styled = editor.styleBlock("**bold**", cursorPosition: 3)
+        #expect(isDimmed(at: 0, in: styled))
+        #expect(isDimmed(at: 1, in: styled))
+        #expect(isDimmed(at: 6, in: styled))
+        #expect(!isHidden(at: 0, in: styled))
     }
 
-    @Test("Highlight renders without == delimiters")
-    @MainActor func highlightRendering() {
+    @Test("Code delimiters are dimmed when cursor is inside")
+    @MainActor func codeDelimitersDimmedWhenActive() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("==important==")
-        #expect(rendered.string == "important")
-        var hasBackground = false
-        rendered.enumerateAttribute(.backgroundColor, in: NSRange(location: 0, length: rendered.length)) { val, _, _ in
-            if val != nil { hasBackground = true }
-        }
-        #expect(hasBackground)
+        let styled = editor.styleBlock("`code`", cursorPosition: 2)
+        #expect(isDimmed(at: 0, in: styled))
+        #expect(isDimmed(at: 5, in: styled))
+        #expect(!isHidden(at: 0, in: styled))
     }
 
-    @Test("Active block highlight has background color")
-    @MainActor func activeHighlight() {
+    @Test("Line break backslash is dimmed when cursor is inside")
+    @MainActor func lineBreakDimmedWhenActive() {
         let editor = makeEditor()
-        let highlighted = editor.highlightSyntax("==important==")
-        #expect(highlighted.string == "==important==")
-        var hasBackground = false
-        highlighted.enumerateAttribute(.backgroundColor, in: NSRange(location: 2, length: 9)) { val, _, _ in
-            if val != nil { hasBackground = true }
-        }
-        #expect(hasBackground)
+        let styled = editor.styleBlock("hello\\", cursorPosition: 5)
+        #expect(isDimmed(at: 5, in: styled))
+        #expect(!isHidden(at: 5, in: styled))
     }
 
-    @Test("Blockquote has paragraph style with text block")
-    @MainActor func blockquoteTextBlock() {
+    @Test("Heading markers: hidden without cursor, dimmed with cursor")
+    @MainActor func headingMarkerVisibility() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("> text")
-        var hasTextBlock = false
-        rendered.enumerateAttribute(.paragraphStyle, in: NSRange(location: 0, length: rendered.length)) { val, _, _ in
-            if let ps = val as? NSParagraphStyle, !ps.textBlocks.isEmpty {
-                hasTextBlock = true
-            }
-        }
-        #expect(hasTextBlock)
+        // Without cursor → hidden
+        let noActive = editor.styleBlock("# Hello")
+        #expect(isHidden(at: 0, in: noActive))
+        // With cursor inside → dimmed
+        let active = editor.styleBlock("# Hello", cursorPosition: 3)
+        #expect(isDimmed(at: 0, in: active))
     }
 
-    @Test("Table rendered text has monospace font")
-    @MainActor func tableMonospace() {
+    // MARK: - Edge Cases
+
+    @Test("**hi* mismatched: italic delimiters hidden, extra * stays visible")
+    @MainActor func mismatchedBoldItalic() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("| A | B |\n| --- | --- |\n| 1 | 2 |")
-        var hasMonospace = false
-        rendered.enumerateAttribute(.font, in: NSRange(location: 0, length: rendered.length)) { val, _, _ in
-            if let f = val as? NSFont, f.isFixedPitch {
-                hasMonospace = true
-            }
-        }
-        #expect(hasMonospace)
+        let styled = editor.styleBlock("**hi*")
+        // cmark parses this as: literal *, then italic *hi*
+        // The first * at position 0 is literal (no span), the * at 1 is italic open, * at 4 is italic close
+        // Content "hi" at 2-3 should have italic font
+        let f = styled.attribute(.font, at: 2, effectiveRange: nil) as? NSFont
+        #expect(f != nil)
+        #expect(NSFontManager.shared.traits(of: f!).contains(.italicFontMask))
     }
 
-    @Test("Active table has monospace font")
-    @MainActor func activeTableMonospace() {
+    @Test("Single-line blockquote: > invisible (color-only) when no cursor")
+    @MainActor func singleLineBlockquoteHidden() {
         let editor = makeEditor()
-        let highlighted = editor.highlightSyntax("| A | B |\n| --- | --- |\n| 1 | 2 |")
-        var hasMonospace = false
-        highlighted.enumerateAttribute(.font, in: NSRange(location: 0, length: highlighted.length)) { val, _, _ in
-            if let f = val as? NSFont, f.isFixedPitch {
-                hasMonospace = true
-            }
-        }
-        #expect(hasMonospace)
+        let styled = editor.styleBlock("> some quote")
+        // Blockquote delimiters preserve width, only color is clear
+        #expect(isInvisible(at: 0, in: styled))
+        #expect(isInvisible(at: 1, in: styled))
     }
 
-    @Test("Active table pipes are dimmed")
-    @MainActor func activeTablePipesDimmed() {
+    @Test("Single-line blockquote: > dimmed when cursor inside")
+    @MainActor func singleLineBlockquoteDimmed() {
         let editor = makeEditor()
-        let highlighted = editor.highlightSyntax("| A | B |\n| --- | --- |\n| 1 | 2 |")
-        // First character is "|"
-        let color = highlighted.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
-        #expect(color == NSColor.tertiaryLabelColor)
+        let styled = editor.styleBlock("> some quote", cursorPosition: 3)
+        #expect(isDimmed(at: 0, in: styled))
+        #expect(!isHidden(at: 0, in: styled))
     }
 
-    @Test("Code block renders without fence lines")
-    @MainActor func codeBlockRendering() {
+    @Test("Checked task item has strikethrough on content")
+    @MainActor func checkedTaskStrikethrough() {
         let editor = makeEditor()
-        let rendered = editor.renderMarkdown("```\nhello\n```")
-        // Fence lines should be stripped, only content remains
-        #expect(rendered.string.contains("hello"))
-        #expect(!rendered.string.contains("```"))
-    }
-
-    @Test("Code block rendered content has monospace font")
-    @MainActor func codeBlockFont() {
-        let editor = makeEditor()
-        let rendered = editor.renderMarkdown("```\nhello\n```")
-        var hasMonospace = false
-        rendered.enumerateAttribute(.font, in: NSRange(location: 0, length: rendered.length)) { val, _, _ in
-            if let f = val as? NSFont, f.isFixedPitch {
-                hasMonospace = true
-            }
-        }
-        #expect(hasMonospace)
-    }
-
-    @Test("Code block rendered content has code color")
-    @MainActor func codeBlockColor() {
-        let editor = makeEditor()
-        let rendered = editor.renderMarkdown("```\nhello\n```")
-        var hasCodeColor = false
-        rendered.enumerateAttribute(.foregroundColor, in: NSRange(location: 0, length: rendered.length)) { val, _, _ in
-            if let color = val as? NSColor {
-                if color.redComponent > 0.5 && color.greenComponent < 0.2 && color.blueComponent < 0.2 {
-                    hasCodeColor = true
-                }
-            }
-        }
-        #expect(hasCodeColor)
-    }
-
-    @Test("Active code block content has monospace font")
-    @MainActor func activeCodeBlockFont() {
-        let editor = makeEditor()
-        let highlighted = editor.highlightSyntax("```\nhello\n```")
-        // Content "hello\n" starts at offset 4
-        var hasMonospace = false
-        highlighted.enumerateAttribute(.font, in: NSRange(location: 4, length: 6)) { val, _, _ in
-            if let f = val as? NSFont, f.isFixedPitch {
-                hasMonospace = true
-            }
-        }
-        #expect(hasMonospace)
-    }
-
-    @Test("Active code block fences are dimmed")
-    @MainActor func activeCodeBlockDimmedFences() {
-        let editor = makeEditor()
-        let highlighted = editor.highlightSyntax("```\nhello\n```")
-        // Opening "```\n" is at offset 0
-        let color = highlighted.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
-        #expect(color == NSColor.tertiaryLabelColor)
-    }
-
-    @Test("Image renders as alt text only (delimiters stripped)")
-    @MainActor func imageRendering() {
-        let editor = makeEditor()
-        let rendered = editor.renderMarkdown("![photo](https://example.com/img.png)")
-        #expect(rendered.string == "photo")
-    }
-
-    @Test("Image rendered text has accent color")
-    @MainActor func imageColor() {
-        let editor = makeEditor()
-        let rendered = editor.renderMarkdown("![photo](url)")
-        var hasAccentColor = false
-        rendered.enumerateAttribute(.foregroundColor, in: NSRange(location: 0, length: rendered.length)) { val, _, _ in
-            if val is NSColor { hasAccentColor = true }
-        }
-        #expect(hasAccentColor)
-    }
-
-    @Test("Image rendered text has italic font")
-    @MainActor func imageItalic() {
-        let editor = makeEditor()
-        let rendered = editor.renderMarkdown("![photo](url)")
-        var hasItalic = false
-        rendered.enumerateAttribute(.font, in: NSRange(location: 0, length: rendered.length)) { val, _, _ in
-            if let f = val as? NSFont {
-                if NSFontManager.shared.traits(of: f).contains(.italicFontMask) {
-                    hasItalic = true
-                }
-            }
-        }
-        #expect(hasItalic)
-    }
-
-    @Test("Image with empty alt is not parsed (stays as raw text)")
-    @MainActor func imageEmptyAlt() {
-        let editor = makeEditor()
-        let rendered = editor.renderMarkdown("![](url)")
-        // swift-markdown doesn't produce an image node for empty alt text
-        #expect(rendered.string == "![](url)")
-    }
-
-    @Test("Active block image has accent color on alt text")
-    @MainActor func activeImageColor() {
-        let editor = makeEditor()
-        let highlighted = editor.highlightSyntax("![alt](url)")
-        #expect(highlighted.string == "![alt](url)")
-        var hasAccentColor = false
-        // "alt" is at positions 2-4
-        highlighted.enumerateAttribute(.foregroundColor, in: NSRange(location: 2, length: 3)) { val, _, _ in
-            if val is NSColor { hasAccentColor = true }
-        }
-        #expect(hasAccentColor)
-    }
-
-    @Test("Line break trailing backslash is stripped in rendered output")
-    @MainActor func lineBreakRendering() {
-        let editor = makeEditor()
-        let rendered = editor.renderMarkdown("hello\\")
-        #expect(rendered.string == "hello")
-    }
-
-    @Test("Active block trailing backslash is dimmed")
-    @MainActor func activeLineBreakDimmed() {
-        let editor = makeEditor()
-        let highlighted = editor.highlightSyntax("hello\\")
-        #expect(highlighted.string == "hello\\")
-        let color = highlighted.attribute(.foregroundColor, at: 5, effectiveRange: nil) as? NSColor
-        #expect(color == NSColor.tertiaryLabelColor)
-    }
-
-    @Test("Text without trailing backslash renders unchanged")
-    @MainActor func noLineBreakRendering() {
-        let editor = makeEditor()
-        let rendered = editor.renderMarkdown("hello")
-        #expect(rendered.string == "hello")
+        let styled = editor.styleBlock("- [x] done")
+        let val = styled.attribute(.strikethroughStyle, at: 6, effectiveRange: nil)
+        #expect(val != nil)
     }
 }
 
@@ -555,44 +465,31 @@ struct EditorMarkdownTests {
 @Suite("EditorTextView — Recompose")
 struct EditorRecomposeTests {
 
-    @Test("Active block shows raw markdown in text storage")
-    @MainActor func activeBlockShowsRaw() {
+    @Test("Text storage always contains raw markdown")
+    @MainActor func textStorageIsRaw() {
         let editor = makeEditor()
         editor.rawSource = "**bold**\nplain"
         editor.blocks = BlockParser.parse(editor.rawSource)
-        // Cursor in block 0 — block 0 stays raw
+
+        // Cursor in block 0
+        editor.recompose(cursorInRaw: 0)
+        #expect(editor.textStorage!.string == "**bold**\nplain")
+
+        // Cursor in block 1
+        editor.recompose(cursorInRaw: 9)
+        #expect(editor.textStorage!.string == "**bold**\nplain")
+    }
+
+    @Test("Display ranges equal block ranges (identity)")
+    @MainActor func displayRangesAreBlockRanges() {
+        let editor = makeEditor()
+        editor.rawSource = "**bold**\nplain"
+        editor.blocks = BlockParser.parse(editor.rawSource)
         editor.recompose(cursorInRaw: 0)
 
-        let display = editor.textStorage!.string
-        #expect(display.hasPrefix("**bold**"))
-    }
-
-    @Test("Non-active block shows rendered markdown in text storage")
-    @MainActor func nonActiveBlockRendered() {
-        let editor = makeEditor()
-        editor.rawSource = "**bold**\nplain"
-        editor.blocks = BlockParser.parse(editor.rawSource)
-        // Cursor in block 1 — block 0 gets rendered
-        editor.recompose(cursorInRaw: 9)  // offset 9 = start of "plain"
-
-        let display = editor.textStorage!.string
-        // Block 0 should be rendered: "**bold**" → "bold"
-        #expect(display.hasPrefix("bold"))
-        #expect(display.hasSuffix("plain"))
-    }
-
-    @Test("Display ranges are computed correctly after recompose")
-    @MainActor func displayRangesCorrect() {
-        let editor = makeEditor()
-        editor.rawSource = "**bold**\nplain"
-        editor.blocks = BlockParser.parse(editor.rawSource)
-        editor.recompose(cursorInRaw: 9)
-
         #expect(editor.displayRanges.count == 2)
-        // Block 0 rendered: "bold" = 4 chars
-        #expect(editor.displayRanges[0].length == 4)
-        // Block 1 active: "plain" = 5 chars
-        #expect(editor.displayRanges[1].length == 5)
+        #expect(editor.displayRanges[0].length == 8)  // "**bold**"
+        #expect(editor.displayRanges[1].length == 5)  // "plain"
     }
 
     @Test("activeBlockIndex is set correctly")
@@ -609,5 +506,37 @@ struct EditorRecomposeTests {
 
         editor.recompose(cursorInRaw: 8)
         #expect(editor.activeBlockIndex == 2)
+    }
+
+    @Test("Non-active block has inline delimiters hidden")
+    @MainActor func nonActiveBlockDelimitersHidden() {
+        let editor = makeEditor()
+        editor.rawSource = "**bold**\nplain"
+        editor.blocks = BlockParser.parse(editor.rawSource)
+        // Cursor in block 1 — block 0 should have hidden ** delimiters
+        editor.recompose(cursorInRaw: 9)
+
+        let ts = editor.textStorage!
+        // ** at positions 0,1 should be hidden
+        let f = ts.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        #expect(f != nil)
+        #expect(f!.pointSize < 1.0)
+    }
+
+    @Test("Active block with cursor in token shows delimiters")
+    @MainActor func activeBlockTokenDelimitersVisible() {
+        let editor = makeEditor()
+        editor.rawSource = "**bold**\nplain"
+        editor.blocks = BlockParser.parse(editor.rawSource)
+        // Cursor at position 3 = inside "**bold**"
+        editor.recompose(cursorInRaw: 3)
+
+        let ts = editor.textStorage!
+        // ** at position 0 should be dimmed (visible), not hidden
+        let color = ts.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+        #expect(color == NSColor.tertiaryLabelColor)
+        let f = ts.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        #expect(f != nil)
+        #expect(f!.pointSize > 1.0)  // Not hidden
     }
 }

--- a/Tests/MarkdownEditorTests/InlineStylingTests.swift
+++ b/Tests/MarkdownEditorTests/InlineStylingTests.swift
@@ -214,157 +214,196 @@ struct InlineStylingActiveTests {
 }
 
 // ============================================================================
-// MARK: - Inline Styling: Inactive Block
+// MARK: - Inline Styling: Non-Active Block
 // ============================================================================
 
-@Suite("Integration — Inline Styling (Inactive Block)")
+@Suite("Integration — Inline Styling (Non-Active Block)")
 struct InlineStylingInactiveTests {
 
-    @Test("Inactive **bold** strips delimiters and applies bold font")
-    @MainActor func inactiveBold() {
+    @Test("Non-active **bold** preserves raw text, hides delimiters, applies bold font")
+    @MainActor func nonActiveBold() {
         let editor = makeEditor()
         editor.loadContent("**bold**\nother")
-        activateBlock(1, in: editor)  // Make block 0 inactive
+        activateBlock(1, in: editor)
 
+        // Raw text preserved
         let text = displayText(for: 0, in: editor)
-        #expect(text == "bold")
-        let f = font(at: editor.displayRanges[0].location, in: editor)!
+        #expect(text == "**bold**")
+
+        let base = editor.displayRanges[0].location
+        // Delimiters hidden
+        #expect(font(at: base, in: editor)!.pointSize < 1.0)
+        #expect(fgColor(at: base, in: editor) == NSColor.clear)
+        // Content has bold font
+        let f = font(at: base + 2, in: editor)!
         #expect(NSFontManager.shared.traits(of: f).contains(.boldFontMask))
     }
 
-    @Test("Inactive __bold__ with underscores strips and applies bold")
-    @MainActor func inactiveBoldUnderscores() {
+    @Test("Non-active __bold__ with underscores hides delimiters and applies bold")
+    @MainActor func nonActiveBoldUnderscores() {
         let editor = makeEditor()
         editor.loadContent("__bold__\nother")
         activateBlock(1, in: editor)
 
         let text = displayText(for: 0, in: editor)
-        #expect(text == "bold")
-        let f = font(at: editor.displayRanges[0].location, in: editor)!
+        #expect(text == "__bold__")
+
+        let base = editor.displayRanges[0].location
+        #expect(font(at: base, in: editor)!.pointSize < 1.0)
+        let f = font(at: base + 2, in: editor)!
         #expect(NSFontManager.shared.traits(of: f).contains(.boldFontMask))
     }
 
-    @Test("Inactive *italic* strips delimiters and applies italic font")
-    @MainActor func inactiveItalic() {
+    @Test("Non-active *italic* hides delimiters and applies italic font")
+    @MainActor func nonActiveItalic() {
         let editor = makeEditor()
         editor.loadContent("*italic*\nother")
         activateBlock(1, in: editor)
 
         let text = displayText(for: 0, in: editor)
-        #expect(text == "italic")
-        let f = font(at: editor.displayRanges[0].location, in: editor)!
+        #expect(text == "*italic*")
+
+        let base = editor.displayRanges[0].location
+        #expect(font(at: base, in: editor)!.pointSize < 1.0)
+        let f = font(at: base + 1, in: editor)!
         #expect(NSFontManager.shared.traits(of: f).contains(.italicFontMask))
     }
 
-    @Test("Inactive _italic_ with underscores strips and applies italic")
-    @MainActor func inactiveItalicUnderscores() {
+    @Test("Non-active _italic_ with underscores hides delimiters and applies italic")
+    @MainActor func nonActiveItalicUnderscores() {
         let editor = makeEditor()
         editor.loadContent("_italic_\nother")
         activateBlock(1, in: editor)
 
         let text = displayText(for: 0, in: editor)
-        #expect(text == "italic")
-        let f = font(at: editor.displayRanges[0].location, in: editor)!
+        #expect(text == "_italic_")
+
+        let base = editor.displayRanges[0].location
+        #expect(font(at: base, in: editor)!.pointSize < 1.0)
+        let f = font(at: base + 1, in: editor)!
         #expect(NSFontManager.shared.traits(of: f).contains(.italicFontMask))
     }
 
-    @Test("Inactive ***bolditalic*** strips delimiters and applies both traits")
-    @MainActor func inactiveBoldItalic() {
+    @Test("Non-active ***bolditalic*** hides delimiters and applies both traits")
+    @MainActor func nonActiveBoldItalic() {
         let editor = makeEditor()
         editor.loadContent("***both***\nother")
         activateBlock(1, in: editor)
 
         let text = displayText(for: 0, in: editor)
-        #expect(text == "both")
-        let f = font(at: editor.displayRanges[0].location, in: editor)!
+        #expect(text == "***both***")
+
+        let base = editor.displayRanges[0].location
+        #expect(font(at: base, in: editor)!.pointSize < 1.0)
+        let f = font(at: base + 3, in: editor)!
         let traits = NSFontManager.shared.traits(of: f)
         #expect(traits.contains(.boldFontMask))
         #expect(traits.contains(.italicFontMask))
     }
 
-    @Test("Inactive `code` strips backticks and applies code color")
-    @MainActor func inactiveCode() {
+    @Test("Non-active `code` hides backticks and applies code color")
+    @MainActor func nonActiveCode() {
         let editor = makeEditor()
         editor.loadContent("`code`\nother")
         activateBlock(1, in: editor)
 
         let text = displayText(for: 0, in: editor)
-        #expect(text == "code")
-        let color = fgColor(at: editor.displayRanges[0].location, in: editor)
+        #expect(text == "`code`")
+
+        let base = editor.displayRanges[0].location
+        #expect(font(at: base, in: editor)!.pointSize < 1.0)
+        let color = fgColor(at: base + 1, in: editor)
         #expect(color == editor.codeColor)
     }
 
-    @Test("Inactive ~~strikethrough~~ strips delimiters and applies strikethrough")
-    @MainActor func inactiveStrikethrough() {
+    @Test("Non-active ~~strikethrough~~ hides delimiters and applies strikethrough")
+    @MainActor func nonActiveStrikethrough() {
         let editor = makeEditor()
         editor.loadContent("~~struck~~\nother")
         activateBlock(1, in: editor)
 
         let text = displayText(for: 0, in: editor)
-        #expect(text == "struck")
-        let a = attrs(at: editor.displayRanges[0].location, in: editor)
+        #expect(text == "~~struck~~")
+
+        let base = editor.displayRanges[0].location
+        #expect(font(at: base, in: editor)!.pointSize < 1.0)
+        let a = attrs(at: base + 2, in: editor)
         #expect(a[.strikethroughStyle] as? Int == NSUnderlineStyle.single.rawValue)
     }
 
-    @Test("Inactive ==highlight== strips delimiters and applies background color")
-    @MainActor func inactiveHighlight() {
+    @Test("Non-active ==highlight== hides delimiters and applies background color")
+    @MainActor func nonActiveHighlight() {
         let editor = makeEditor()
         editor.loadContent("==marked==\nother")
         activateBlock(1, in: editor)
 
         let text = displayText(for: 0, in: editor)
-        #expect(text == "marked")
-        let a = attrs(at: editor.displayRanges[0].location, in: editor)
+        #expect(text == "==marked==")
+
+        let base = editor.displayRanges[0].location
+        #expect(font(at: base, in: editor)!.pointSize < 1.0)
+        let a = attrs(at: base + 2, in: editor)
         #expect(a[.backgroundColor] != nil)
     }
 
-    @Test("Inactive [link](url) strips syntax, shows text with underline and accent color")
-    @MainActor func inactiveLink() {
+    @Test("Non-active [link](url) hides syntax, link text has underline and accent color")
+    @MainActor func nonActiveLink() {
         let editor = makeEditor()
         editor.loadContent("[click](https://example.com)\nother")
         activateBlock(1, in: editor)
 
         let text = displayText(for: 0, in: editor)
-        #expect(text == "click")
-        let offset = editor.displayRanges[0].location
-        let color = fgColor(at: offset, in: editor)
+        #expect(text == "[click](https://example.com)")
+
+        let base = editor.displayRanges[0].location
+        // "[" delimiter hidden
+        #expect(font(at: base, in: editor)!.pointSize < 1.0)
+        // "click" content has accent color and underline
+        let color = fgColor(at: base + 1, in: editor)
         #expect(color == editor.accentColor)
-        let a = attrs(at: offset, in: editor)
+        let a = attrs(at: base + 1, in: editor)
         #expect(a[.underlineStyle] as? Int == NSUnderlineStyle.single.rawValue)
     }
 
-    @Test("Inactive mixed bold + italic + code all rendered correctly")
-    @MainActor func inactiveMixed() {
+    @Test("Non-active mixed bold + italic + code all rendered correctly")
+    @MainActor func nonActiveMixed() {
         let editor = makeEditor()
+        // "**bold** *italic* `code`"
+        //  0123456789012345678901234
         editor.loadContent("**bold** *italic* `code`\nother")
         activateBlock(1, in: editor)
 
         let text = displayText(for: 0, in: editor)
-        // Delimiters stripped: "bold italic code"
-        #expect(text == "bold italic code")
+        #expect(text == "**bold** *italic* `code`")
 
         let base = editor.displayRanges[0].location
-        // "bold" starts at base+0
-        let bf = font(at: base, in: editor)!
+        // ** delimiters hidden
+        #expect(font(at: base, in: editor)!.pointSize < 1.0)
+        // "bold" at base+2 has bold font
+        let bf = font(at: base + 2, in: editor)!
         #expect(NSFontManager.shared.traits(of: bf).contains(.boldFontMask))
 
-        // "italic" starts at base+5
-        let itf = font(at: base + 5, in: editor)!
+        // * delimiters at 9 hidden
+        #expect(font(at: base + 9, in: editor)!.pointSize < 1.0)
+        // "italic" at base+10 has italic font
+        let itf = font(at: base + 10, in: editor)!
         #expect(NSFontManager.shared.traits(of: itf).contains(.italicFontMask))
 
-        // "code" starts at base+12
-        let cc = fgColor(at: base + 12, in: editor)
+        // ` delimiter at 18 hidden
+        #expect(font(at: base + 18, in: editor)!.pointSize < 1.0)
+        // "code" at base+19 has code color
+        let cc = fgColor(at: base + 19, in: editor)
         #expect(cc == editor.codeColor)
     }
 
-    @Test("Inactive *hi** renders correctly (uneven delimiters)")
-    @MainActor func inactiveUnevenDelimiters() {
+    @Test("Non-active *hi** preserves raw text (uneven delimiters)")
+    @MainActor func nonActiveUnevenDelimiters() {
         let editor = makeEditor()
         editor.loadContent("*hi**\nother")
         activateBlock(1, in: editor)
 
-        // swift-markdown: "*hi*" matches italic, trailing "*" is literal
+        // Raw text always preserved
         let text = displayText(for: 0, in: editor)
-        #expect(text == "hi*")
+        #expect(text == "*hi**")
     }
 }

--- a/Tests/MarkdownEditorTests/TestHelpers.swift
+++ b/Tests/MarkdownEditorTests/TestHelpers.swift
@@ -97,3 +97,36 @@ func activateBlock(_ index: Int, in editor: EditorTextView) {
     let rawOffset = editor.blocks[index].range.location
     editor.recompose(cursorInRaw: rawOffset)
 }
+
+/// Returns true if the character at `offset` has hidden delimiter attributes
+/// (near-zero font size and clear color).
+@MainActor
+func isHidden(at offset: Int, in result: NSAttributedString) -> Bool {
+    guard offset < result.length else { return false }
+    let a = result.attributes(at: offset, effectiveRange: nil)
+    guard let f = a[.font] as? NSFont else { return false }
+    guard let c = a[.foregroundColor] as? NSColor else { return false }
+    return f.pointSize < 1.0 && c == NSColor.clear
+}
+
+/// Returns true if the character at `offset` is invisible but preserves its width
+/// (foreground color is clear, font size is NOT shrunk). Used for blockquote `> ` delimiters.
+@MainActor
+func isInvisible(at offset: Int, in result: NSAttributedString) -> Bool {
+    guard offset < result.length else { return false }
+    let a = result.attributes(at: offset, effectiveRange: nil)
+    guard let c = a[.foregroundColor] as? NSColor else { return false }
+    guard c == NSColor.clear else { return false }
+    // Font should NOT be tiny (width is preserved)
+    if let f = a[.font] as? NSFont { return f.pointSize >= 1.0 }
+    return true
+}
+
+/// Returns true if the character at `offset` is dimmed (tertiary label color).
+@MainActor
+func isDimmed(at offset: Int, in result: NSAttributedString) -> Bool {
+    guard offset < result.length else { return false }
+    let a = result.attributes(at: offset, effectiveRange: nil)
+    guard let c = a[.foregroundColor] as? NSColor else { return false }
+    return c == NSColor.tertiaryLabelColor
+}


### PR DESCRIPTION
## Summary
- Replace block-level active/inactive rendering with word-level delimiter hiding — text storage always contains raw markdown, delimiters hidden via attributes when cursor is outside the token
- Unified `styleBlock()` replaces dual `renderMarkdown`/`highlightSyntax` code paths, coordinate mapping becomes identity
- Blockquotes rendered as single-line blocks with width-preserving invisible `>` and left border via NSTextBlock

## Test plan
- [x] All 356 tests pass (`swift test`)
- [ ] Open test.md, verify inline delimiters (bold, italic, code) are hidden when cursor is elsewhere
- [ ] Click into a bold/italic word, verify delimiters appear dimmed
- [ ] Verify headings, lists, blockquotes, tables, code blocks render correctly
- [ ] Verify undo/redo and Tab/Shift-Tab indentation still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)