### PR TITLE
Add .app packaging and default to .md saves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.build
+/build
 /Packages
 xcuserdata/
 DerivedData/

--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>md</string>
+    <key>CFBundleDisplayName</key>
+    <string>md</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.inatang.md</string>
+    <key>CFBundleExecutable</key>
+    <string>MarkdownEditor</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>13.0</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSSupportsAutomaticTermination</key>
+    <false/>
+    <key>NSSupportsSuddenTermination</key>
+    <false/>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>Markdown Document</string>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>net.daringfireball.markdown</string>
+            </array>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>md</string>
+                <string>markdown</string>
+                <string>mdown</string>
+                <string>mkd</string>
+            </array>
+        </dict>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>Plain Text</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>public.plain-text</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Sources/MarkdownEditor/Document.swift
+++ b/Sources/MarkdownEditor/Document.swift
@@ -27,7 +27,7 @@ class Document: NSDocument {
     }
 
     override class var writableTypes: [String] {
-        ["public.plain-text", "net.daringfireball.markdown"]
+        ["net.daringfireball.markdown"]
     }
 
     override class func isNativeType(_ name: String) -> Bool {
@@ -35,7 +35,7 @@ class Document: NSDocument {
     }
 
     override func writableTypes(for saveOperation: NSDocument.SaveOperationType) -> [String] {
-        ["public.plain-text", "net.daringfireball.markdown"]
+        ["net.daringfireball.markdown"]
     }
 
     // MARK: - Window Setup

--- a/Sources/MarkdownEditor/DocumentController.swift
+++ b/Sources/MarkdownEditor/DocumentController.swift
@@ -16,7 +16,7 @@ class DocumentController: NSDocumentController {
     }
 
     override var defaultType: String? {
-        "public.plain-text"
+        "net.daringfireball.markdown"
     }
 
     override func documentClass(forType typeName: String) -> AnyClass? {

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Build md.app — a standalone macOS application bundle.
+# Usage: ./scripts/build-app.sh
+# Output: build/md.app (ready to drag into /Applications)
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+APP_NAME="md"
+BUNDLE="build/${APP_NAME}.app"
+EXECUTABLE="MarkdownEditor"
+
+echo "Building release binary..."
+swift build -c release 2>&1 | tail -3
+
+echo "Creating ${APP_NAME}.app bundle..."
+rm -rf "$BUNDLE"
+mkdir -p "${BUNDLE}/Contents/MacOS"
+mkdir -p "${BUNDLE}/Contents/Resources"
+
+cp ".build/release/${EXECUTABLE}" "${BUNDLE}/Contents/MacOS/${EXECUTABLE}"
+cp Info.plist "${BUNDLE}/Contents/"
+
+# Ad-hoc codesign so macOS doesn't quarantine-block it
+codesign --force --sign - "${BUNDLE}"
+
+echo ""
+echo "Done: ${BUNDLE}"
+echo "To install: cp -R ${BUNDLE} /Applications/"


### PR DESCRIPTION
## Summary
- Add `scripts/build-app.sh` to build a proper `md.app` bundle that can be installed in `/Applications`
- Add `Info.plist` with document type registration for `.md` files
- Default new documents to `.md` instead of `.txt`
- Remove plain text from writable types — Save As only offers `.md`

## Usage
```
./scripts/build-app.sh
cp -R build/md.app /Applications/
```

## Test plan
- [x] All 356 tests pass
- [ ] Run `./scripts/build-app.sh` and verify `build/md.app` launches
- [ ] Cmd+N creates untitled document, Cmd+S saves as `.md`
- [ ] Save As only shows `.md` option
- [ ] Can still open `.txt` files via Cmd+O

🤖 Generated with [Claude Code](https://claude.com/claude-code)