### PR TITLE
Default to .md for new documents

### DIFF
--- a/Sources/MarkdownEditor/Document.swift
+++ b/Sources/MarkdownEditor/Document.swift
@@ -27,7 +27,7 @@ class Document: NSDocument {
     }
 
     override class var writableTypes: [String] {
-        ["public.plain-text", "net.daringfireball.markdown"]
+        ["net.daringfireball.markdown", "public.plain-text"]
     }
 
     override class func isNativeType(_ name: String) -> Bool {
@@ -35,7 +35,12 @@ class Document: NSDocument {
     }
 
     override func writableTypes(for saveOperation: NSDocument.SaveOperationType) -> [String] {
-        ["public.plain-text", "net.daringfireball.markdown"]
+        switch saveOperation {
+        case .saveAsOperation, .saveToOperation:
+            ["net.daringfireball.markdown", "public.plain-text"]
+        default:
+            ["net.daringfireball.markdown"]
+        }
     }
 
     // MARK: - Window Setup

--- a/Sources/MarkdownEditor/DocumentController.swift
+++ b/Sources/MarkdownEditor/DocumentController.swift
@@ -16,7 +16,7 @@ class DocumentController: NSDocumentController {
     }
 
     override var defaultType: String? {
-        "public.plain-text"
+        "net.daringfireball.markdown"
     }
 
     override func documentClass(forType typeName: String) -> AnyClass? {


### PR DESCRIPTION
## Summary
- Default document type changed from plain text to markdown — new documents save as `.md`
- Regular Save only offers `.md`
- Save As still offers both `.md` and `.txt`
- Can still open `.txt` files

## Test plan
- [x] All 356 tests pass
- [ ] Cmd+N then Cmd+S saves as `.md`
- [ ] Cmd+Shift+S shows both `.md` and `.txt` in format dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)