### PR TITLE
Add .app bundle build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.build
+/build
 /Packages
 xcuserdata/
 DerivedData/

--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>md</string>
+    <key>CFBundleDisplayName</key>
+    <string>md</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.inatang.md</string>
+    <key>CFBundleExecutable</key>
+    <string>MarkdownEditor</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>13.0</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSSupportsAutomaticTermination</key>
+    <false/>
+    <key>NSSupportsSuddenTermination</key>
+    <false/>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>Markdown Document</string>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>net.daringfireball.markdown</string>
+            </array>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>md</string>
+                <string>markdown</string>
+                <string>mdown</string>
+                <string>mkd</string>
+            </array>
+        </dict>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>Plain Text</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>public.plain-text</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Build md.app — a standalone macOS application bundle.
+# Usage: ./scripts/build-app.sh
+# Output: build/md.app (ready to drag into /Applications)
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+APP_NAME="md"
+BUNDLE="build/${APP_NAME}.app"
+EXECUTABLE="MarkdownEditor"
+
+echo "Building release binary..."
+swift build -c release 2>&1 | tail -3
+
+echo "Creating ${APP_NAME}.app bundle..."
+rm -rf "$BUNDLE"
+mkdir -p "${BUNDLE}/Contents/MacOS"
+mkdir -p "${BUNDLE}/Contents/Resources"
+
+cp ".build/release/${EXECUTABLE}" "${BUNDLE}/Contents/MacOS/${EXECUTABLE}"
+cp Info.plist "${BUNDLE}/Contents/"
+
+# Ad-hoc codesign so macOS doesn't quarantine-block it
+codesign --force --sign - "${BUNDLE}"
+
+echo ""
+echo "Done: ${BUNDLE}"
+echo "To install: cp -R ${BUNDLE} /Applications/"


### PR DESCRIPTION
## Summary
- Add `scripts/build-app.sh` to build a proper `md.app` bundle
- Add `Info.plist` with document type registration for `.md` files
- Add `/build` to `.gitignore`

## Usage
```
./scripts/build-app.sh
cp -R build/md.app /Applications/
```

## Test plan
- [x] `./scripts/build-app.sh` produces `build/md.app`
- [ ] `build/md.app` launches and opens documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)