### PR TITLE
Fix list indentation and nesting

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+Indentation.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Indentation.swift
@@ -5,7 +5,7 @@ import AppKit
 extension EditorTextView {
 
     private static let listLineRegex = try! NSRegularExpression(pattern: #"^\s*(?:[-*+]|\d+\.)\s"#)
-    static let indentUnit = "    "  // 4 spaces
+    static let indentUnit = "  "  // 2 spaces
 
     /// Returns true if the line looks like a markdown list item
     /// (optionally indented): `- `, `* `, `+ `, `1. `, etc.
@@ -110,11 +110,16 @@ extension EditorTextView {
         let rawEnd = displayOffsetToRawOffset(sel.location + sel.length)
         let maxRemove = (Self.indentUnit as NSString).length
 
-        // Compute how many leading spaces to strip from each block.
+        // Compute how many leading whitespace characters to strip from each block.
         var removed: [Int] = Array(repeating: 0, count: blocks.count)
         for i in startBlock...endBlock {
-            let leading = blocks[i].content.prefix(while: { $0 == " " }).count
-            removed[i] = min(leading, maxRemove)
+            let content = blocks[i].content
+            if content.hasPrefix("\t") {
+                removed[i] = 1
+            } else {
+                let leading = content.prefix(while: { $0 == " " }).count
+                removed[i] = min(leading, maxRemove)
+            }
         }
 
         let totalRemoved = removed[startBlock...endBlock].reduce(0, +)

--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -33,30 +33,46 @@ extension EditorTextView {
     /// Indentation amount for list items.
     var listIndent: CGFloat { 16 }
 
-    /// Paragraph style with indentation for list items.
-    /// `nestingLevel` adds additional indent for sub-lists (each level = one `listIndent`).
-    private func listParagraphStyle(nestingLevel: Int = 0) -> NSParagraphStyle {
+    /// Paragraph style with hanging indentation for list items.
+    /// The first line starts at `listIndent`; wrapped lines align with the
+    /// content after the marker (bullet / number / checkbox).
+    private func listParagraphStyle(nestingLevel: Int = 0, markerWidth: CGFloat = 0) -> NSParagraphStyle {
         let ps = NSMutableParagraphStyle()
         ps.lineSpacing = bodyParagraphStyle.lineSpacing
         ps.paragraphSpacing = bodyParagraphStyle.paragraphSpacing
         let indent = listIndent * CGFloat(1 + nestingLevel)
         ps.firstLineHeadIndent = indent
-        ps.headIndent = indent
+        ps.headIndent = indent + markerWidth
         return ps
     }
 
     /// Computes list nesting level from leading whitespace in raw markdown.
-    /// Uses the Tab indent unit (4 spaces) as one nesting level.
+    /// Each tab or 2 spaces counts as one nesting level.
+    /// Scans from the start of the line (position 0 in the block) since
+    /// swift-markdown's span range may exclude leading whitespace.
     private func listNestingLevel(for markdown: String, span: SyntaxHighlighter.Span) -> Int {
         let nsMarkdown = markdown as NSString
-        let lineStart = span.fullRange.location
-        var spaces = 0
-        while lineStart + spaces < span.fullRange.upperBound {
-            let ch = nsMarkdown.character(at: lineStart + spaces)
-            guard ch == 0x20 else { break }  // space
-            spaces += 1
+        var level = 0
+        var col = 0
+        var i = 0
+        let end = span.fullRange.location + span.fullRange.length
+        while i < end {
+            let ch = nsMarkdown.character(at: i)
+            if ch == 0x09 {        // tab
+                level += 1
+                col = 0
+            } else if ch == 0x20 { // space
+                col += 1
+                if col == 2 {
+                    level += 1
+                    col = 0
+                }
+            } else {
+                break
+            }
+            i += 1
         }
-        return spaces / 4
+        return level
     }
 
     /// Paragraph style with a left border for blockquotes.
@@ -174,7 +190,11 @@ extension EditorTextView {
             case .listItem(let ordered, let checkbox):
                 guard span.fullRange.upperBound <= result.length else { continue }
                 let nesting = listNestingLevel(for: markdown, span: span)
-                result.addAttribute(.paragraphStyle, value: listParagraphStyle(nestingLevel: nesting), range: span.fullRange)
+                // Measure marker width for hanging indent on wrapped lines
+                let markerLen = span.contentRange.location - span.fullRange.location
+                let markerStr = (markdown as NSString).substring(with: NSRange(location: span.fullRange.location, length: markerLen))
+                let markerWidth = (markerStr as NSString).size(withAttributes: [.font: bodyFont]).width
+                result.addAttribute(.paragraphStyle, value: listParagraphStyle(nestingLevel: nesting, markerWidth: markerWidth), range: span.fullRange)
                 // Strikethrough checked items
                 if !ordered, checkbox == .checked {
                     result.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: span.contentRange)

--- a/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
+++ b/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
@@ -110,11 +110,10 @@ public enum SyntaxHighlighter {
         ))
     }
 
-    /// Detects list items with 4+ leading spaces that swift-markdown parses as
-    /// indented code instead of list items. Uses the same regex pattern as
-    /// `isListLine` to identify them.
+    /// Detects list items with deep indentation (4+ spaces or tabs) that
+    /// swift-markdown parses as indented code instead of list items.
     private static let indentedListRegex = try! NSRegularExpression(
-        pattern: #"^(\s{4,})([-*+])\s"#
+        pattern: #"^([\t ]*\t[\t ]*|[ ]{4,})([-*+])\s"#
     )
 
     private static func parseIndentedListItem(_ text: String, into spans: inout [Span]) {

--- a/Tests/MarkdownEditorTests/EditorFeatureTests.swift
+++ b/Tests/MarkdownEditorTests/EditorFeatureTests.swift
@@ -85,8 +85,8 @@ struct TabIndentIntegrationTests {
         type("- item", into: editor)
         editor.insertTab(nil)
 
-        #expect(editor.rawSource == "    - item")
-        #expect(editor.textStorage!.string.contains("    - item"))
+        #expect(editor.rawSource == "  - item")
+        #expect(editor.textStorage!.string.contains("  - item"))
     }
 
     @Test("Tab on multi-line list indents all lines")
@@ -100,21 +100,21 @@ struct TabIndentIntegrationTests {
 
         #expect(editor.blocks.count == 3)
         for block in editor.blocks {
-            #expect(block.content.hasPrefix("    "))
+            #expect(block.content.hasPrefix("  "))
         }
     }
 
     @Test("Shift-Tab dedents, Undo reverts, Redo re-applies")
     @MainActor func dedentUndoRedo() {
         let editor = makeEditor()
-        editor.loadContent("    - item")
+        editor.loadContent("  - item")
         editor.setSelectedRange(NSRange(location: 0, length: 0))
 
         editor.insertBacktab(nil)
         #expect(editor.rawSource == "- item")
 
         editor.undo(nil)
-        #expect(editor.rawSource == "    - item")
+        #expect(editor.rawSource == "  - item")
 
         editor.redo(nil)
         #expect(editor.rawSource == "- item")
@@ -138,7 +138,7 @@ struct TabIndentIntegrationTests {
         editor.setSelectedRange(NSRange(location: 0, length: len))
         editor.insertTab(nil)
 
-        #expect(editor.rawSource == "    - bullet\n    1. numbered")
+        #expect(editor.rawSource == "  - bullet\n  1. numbered")
     }
 
     @Test("Multiple indent/dedent cycles are stable")
@@ -150,7 +150,7 @@ struct TabIndentIntegrationTests {
         // Indent twice
         editor.insertTab(nil)
         editor.insertTab(nil)
-        #expect(editor.rawSource == "        - item")
+        #expect(editor.rawSource == "    - item")
 
         // Dedent twice
         editor.insertBacktab(nil)

--- a/Tests/MarkdownEditorTests/EditorIndentationTests.swift
+++ b/Tests/MarkdownEditorTests/EditorIndentationTests.swift
@@ -39,23 +39,23 @@ struct EditorTextViewListIndentationTests {
 
     // MARK: - Tab Indent
 
-    @Test("Tab on single list line adds 4 spaces")
+    @Test("Tab on single list line adds 2 spaces")
     @MainActor func tabIndentsSingleLine() {
         let editor = makeEditor()
         editor.loadContent("- item")
         // Place cursor somewhere in the line
         editor.setSelectedRange(NSRange(location: 2, length: 0))
         editor.insertTab(nil)
-        #expect(editor.rawSource == "    - item")
+        #expect(editor.rawSource == "  - item")
     }
 
-    @Test("Tab on ordered list line adds 4 spaces")
+    @Test("Tab on ordered list line adds 2 spaces")
     @MainActor func tabIndentsOrderedList() {
         let editor = makeEditor()
         editor.loadContent("1. item")
         editor.setSelectedRange(NSRange(location: 0, length: 0))
         editor.insertTab(nil)
-        #expect(editor.rawSource == "    1. item")
+        #expect(editor.rawSource == "  1. item")
     }
 
     @Test("Tab on non-list line inserts tab character")
@@ -75,7 +75,7 @@ struct EditorTextViewListIndentationTests {
         let len = editor.textStorage!.length
         editor.setSelectedRange(NSRange(location: 0, length: len))
         editor.insertTab(nil)
-        #expect(editor.rawSource == "    - a\n    - b\n    - c")
+        #expect(editor.rawSource == "  - a\n  - b\n  - c")
     }
 
     @Test("Tab stacks indentation on repeated use")
@@ -85,7 +85,7 @@ struct EditorTextViewListIndentationTests {
         editor.setSelectedRange(NSRange(location: 0, length: 0))
         editor.insertTab(nil)
         editor.insertTab(nil)
-        #expect(editor.rawSource == "        - item")
+        #expect(editor.rawSource == "    - item")
     }
 
     @Test("Tab on mixed list and non-list falls through to default")
@@ -96,24 +96,24 @@ struct EditorTextViewListIndentationTests {
         editor.setSelectedRange(NSRange(location: 0, length: len))
         editor.insertTab(nil)
         // Should NOT have indented; default behavior inserts a tab
-        #expect(!editor.rawSource.hasPrefix("    - a"))
+        #expect(!editor.rawSource.hasPrefix("  - a"))
     }
 
     // MARK: - Shift-Tab Dedent
 
-    @Test("Shift-Tab removes up to 4 leading spaces")
+    @Test("Shift-Tab removes up to 2 leading spaces")
     @MainActor func shiftTabRemovesSpaces() {
         let editor = makeEditor()
-        editor.loadContent("    - item")
+        editor.loadContent("  - item")
         editor.setSelectedRange(NSRange(location: 0, length: 0))
         editor.insertBacktab(nil)
         #expect(editor.rawSource == "- item")
     }
 
-    @Test("Shift-Tab removes partial indent (fewer than 4 spaces)")
+    @Test("Shift-Tab removes partial indent (1 space)")
     @MainActor func shiftTabRemovesPartialIndent() {
         let editor = makeEditor()
-        editor.loadContent("  - item")
+        editor.loadContent(" - item")
         editor.setSelectedRange(NSRange(location: 0, length: 0))
         editor.insertBacktab(nil)
         #expect(editor.rawSource == "- item")
@@ -131,17 +131,17 @@ struct EditorTextViewListIndentationTests {
     @Test("Shift-Tab dedents multiple selected lines")
     @MainActor func shiftTabDedentsMultipleLines() {
         let editor = makeEditor()
-        editor.loadContent("    - a\n    - b\n    - c")
+        editor.loadContent("  - a\n  - b\n  - c")
         let len = editor.textStorage!.length
         editor.setSelectedRange(NSRange(location: 0, length: len))
         editor.insertBacktab(nil)
         #expect(editor.rawSource == "- a\n- b\n- c")
     }
 
-    @Test("Shift-Tab with mixed indent levels removes up to 4 from each")
+    @Test("Shift-Tab with mixed indent levels removes up to 2 from each")
     @MainActor func shiftTabMixedIndentLevels() {
         let editor = makeEditor()
-        editor.loadContent("        - a\n    - b\n  - c")
+        editor.loadContent("      - a\n  - b\n - c")
         let len = editor.textStorage!.length
         editor.setSelectedRange(NSRange(location: 0, length: len))
         editor.insertBacktab(nil)
@@ -156,7 +156,7 @@ struct EditorTextViewListIndentationTests {
         editor.loadContent("- item")
         editor.setSelectedRange(NSRange(location: 0, length: 0))
         editor.insertTab(nil)
-        #expect(editor.rawSource == "    - item")
+        #expect(editor.rawSource == "  - item")
         editor.undo(nil)
         #expect(editor.rawSource == "- item")
     }
@@ -164,12 +164,12 @@ struct EditorTextViewListIndentationTests {
     @Test("Undo reverts shift-tab dedent")
     @MainActor func undoRevertsDedent() {
         let editor = makeEditor()
-        editor.loadContent("    - item")
+        editor.loadContent("  - item")
         editor.setSelectedRange(NSRange(location: 0, length: 0))
         editor.insertBacktab(nil)
         #expect(editor.rawSource == "- item")
         editor.undo(nil)
-        #expect(editor.rawSource == "    - item")
+        #expect(editor.rawSource == "  - item")
     }
 
     @Test("Tab then Shift-Tab roundtrips")
@@ -178,7 +178,7 @@ struct EditorTextViewListIndentationTests {
         editor.loadContent("- item")
         editor.setSelectedRange(NSRange(location: 0, length: 0))
         editor.insertTab(nil)
-        #expect(editor.rawSource == "    - item")
+        #expect(editor.rawSource == "  - item")
         editor.insertBacktab(nil)
         #expect(editor.rawSource == "- item")
     }
@@ -206,12 +206,12 @@ struct EditorListIndentIntegrationTests {
 
         // Indent the second line (cursor is already there)
         editor.insertTab(nil)
-        #expect(editor.rawSource == "- apples\n    - bananas")
-        #expect(editor.blocks[1].content == "    - bananas")
+        #expect(editor.rawSource == "- apples\n  - bananas")
+        #expect(editor.blocks[1].content == "  - bananas")
 
         // Verify text storage contains the indented text
         let display = editor.textStorage!.string
-        #expect(display.contains("    - bananas"))
+        #expect(display.contains("  - bananas"))
     }
 
     @Test("Type mixed list, select all, indent, verify all indented")
@@ -230,11 +230,11 @@ struct EditorListIndentIntegrationTests {
         editor.setSelectedRange(NSRange(location: 0, length: len))
         editor.insertTab(nil)
 
-        #expect(editor.rawSource == "    - first\n    - second\n    - third")
+        #expect(editor.rawSource == "  - first\n  - second\n  - third")
 
         // Verify each block was indented
         for block in editor.blocks {
-            #expect(block.content.hasPrefix("    - "))
+            #expect(block.content.hasPrefix("  - "))
         }
     }
 
@@ -270,26 +270,26 @@ struct EditorListIndentIntegrationTests {
         editor.setSelectedRange(NSRange(location: 4, length: 0))
         editor.insertTab(nil)
 
-        // rawSource should be "    - hello", cursor should be at offset 8
-        #expect(editor.rawSource == "    - hello")
+        // rawSource should be "  - hello", cursor should be at offset 6
+        #expect(editor.rawSource == "  - hello")
         let sel = editor.selectedRange()
-        // Cursor shifted by 4 (the indent)
-        #expect(sel.location == 8)
+        // Cursor shifted by 2 (the indent)
+        #expect(sel.location == 6)
         #expect(sel.length == 0)
     }
 
     @Test("Cursor position preserved after dedent on single line")
     @MainActor func cursorPositionAfterDedent() {
         let editor = makeEditor()
-        editor.loadContent("    - hello")
+        editor.loadContent("  - hello")
 
-        // Place cursor after the indent + "- he" → offset 8
-        editor.setSelectedRange(NSRange(location: 8, length: 0))
+        // Place cursor after the indent + "- he" → offset 6
+        editor.setSelectedRange(NSRange(location: 6, length: 0))
         editor.insertBacktab(nil)
 
         #expect(editor.rawSource == "- hello")
         let sel = editor.selectedRange()
-        // Cursor shifted back by 4
+        // Cursor shifted back by 2
         #expect(sel.location == 4)
         #expect(sel.length == 0)
     }
@@ -306,15 +306,15 @@ struct EditorListIndentIntegrationTests {
 
         // Indent second item
         editor.insertTab(nil)
-        #expect(editor.rawSource == "- a\n    - b")
+        #expect(editor.rawSource == "- a\n  - b")
 
         // Type more on the indented line
         type("ee", into: editor)
-        #expect(editor.rawSource == "- a\n    - bee")
+        #expect(editor.rawSource == "- a\n  - bee")
 
         // Undo the typing ("ee")
         editor.undo(nil)
-        #expect(editor.rawSource == "- a\n    - b")
+        #expect(editor.rawSource == "- a\n  - b")
 
         // Undo the indent
         editor.undo(nil)
@@ -352,11 +352,11 @@ struct EditorListIndentIntegrationTests {
         // Now indent — should indent block 1 only
         editor.insertTab(nil)
         #expect(editor.blocks[0].content == "- first")
-        #expect(editor.blocks[1].content == "    - second")
+        #expect(editor.blocks[1].content == "  - second")
         #expect(editor.blocks[2].content == "- third")
     }
 
-    @Test("Double indent creates 8-space prefix")
+    @Test("Double indent creates 4-space prefix")
     @MainActor func doubleIndent() {
         let editor = makeEditor()
         editor.loadContent("- item")
@@ -364,12 +364,12 @@ struct EditorListIndentIntegrationTests {
 
         editor.insertTab(nil)
         editor.insertTab(nil)
-        #expect(editor.rawSource == "        - item")
-        #expect(editor.blocks[0].content.hasPrefix("        - "))
+        #expect(editor.rawSource == "    - item")
+        #expect(editor.blocks[0].content.hasPrefix("    - "))
 
         // Double dedent brings it back
         editor.insertBacktab(nil)
-        #expect(editor.rawSource == "    - item")
+        #expect(editor.rawSource == "  - item")
         editor.insertBacktab(nil)
         #expect(editor.rawSource == "- item")
     }
@@ -383,7 +383,7 @@ struct EditorListIndentIntegrationTests {
         editor.setSelectedRange(NSRange(location: 0, length: len))
         editor.insertTab(nil)
 
-        #expect(editor.rawSource == "    - bullet\n    1. numbered\n    + plus")
+        #expect(editor.rawSource == "  - bullet\n  1. numbered\n  + plus")
     }
 
     @Test("Checkbox list items indent correctly")
@@ -395,6 +395,6 @@ struct EditorListIndentIntegrationTests {
         editor.setSelectedRange(NSRange(location: 0, length: len))
         editor.insertTab(nil)
 
-        #expect(editor.rawSource == "    - [ ] todo\n    - [x] done")
+        #expect(editor.rawSource == "  - [ ] todo\n  - [x] done")
     }
 }

--- a/Tests/MarkdownEditorTests/EditorRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/EditorRenderingTests.swift
@@ -342,6 +342,42 @@ struct EditorStylingTests {
         #expect(subIndent > topIndent)
     }
 
+    @Test("Tab-indented list has same depth as 2-space-indented list")
+    @MainActor func tabIndentedList() {
+        let editor = makeEditor()
+        let spaced = editor.styleBlock("  - hello")
+        let tabbed = editor.styleBlock("\t- hello")
+
+        var spacedIndent: CGFloat = 0
+        spaced.enumerateAttribute(.paragraphStyle, in: NSRange(location: 0, length: spaced.length)) { val, _, _ in
+            if let ps = val as? NSParagraphStyle { spacedIndent = ps.firstLineHeadIndent }
+        }
+
+        var tabbedIndent: CGFloat = 0
+        tabbed.enumerateAttribute(.paragraphStyle, in: NSRange(location: 0, length: tabbed.length)) { val, _, _ in
+            if let ps = val as? NSParagraphStyle { tabbedIndent = ps.firstLineHeadIndent }
+        }
+
+        #expect(tabbedIndent == spacedIndent)
+    }
+
+    @Test("Wrapped list lines have deeper indent than first line (hanging indent)")
+    @MainActor func hangingIndent() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("- hello")
+
+        var firstLine: CGFloat = 0
+        var wrapped: CGFloat = 0
+        styled.enumerateAttribute(.paragraphStyle, in: NSRange(location: 0, length: styled.length)) { val, _, _ in
+            if let ps = val as? NSParagraphStyle {
+                firstLine = ps.firstLineHeadIndent
+                wrapped = ps.headIndent
+            }
+        }
+
+        #expect(wrapped > firstLine)
+    }
+
     @Test("Table has monospace font and dimmed pipes")
     @MainActor func tableStyling() {
         let editor = makeEditor()


### PR DESCRIPTION
## Summary
- Add hanging indentation — wrapped list lines align with content after the bullet/number
- Change indent unit from 4 to 2 spaces per nesting level
- Support tab characters for nesting detection and Shift-Tab dedent
- Fix nesting level scan to start from line beginning (swift-markdown excludes leading whitespace from span ranges)

## Test plan
- [x] All 358 tests pass
- [ ] Long list items wrap with hanging indent aligned to content
- [ ] 2-space indented sub-lists render at deeper indent level
- [ ] Tab/Shift-Tab indent/dedent by 2 spaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)