### PR TITLE
Fix list indentation and rendering

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -190,11 +190,14 @@ extension EditorTextView {
             case .listItem(let ordered, let checkbox):
                 guard span.fullRange.upperBound <= result.length else { continue }
                 let nesting = listNestingLevel(for: markdown, span: span)
-                // Measure marker width for hanging indent on wrapped lines
-                let markerLen = span.contentRange.location - span.fullRange.location
-                let markerStr = (markdown as NSString).substring(with: NSRange(location: span.fullRange.location, length: markerLen))
+                // Measure marker width (including leading whitespace) for hanging indent.
+                // Everything from position 0 to content start is the "marker" area.
+                let markerStr = (markdown as NSString).substring(to: span.contentRange.location)
                 let markerWidth = (markerStr as NSString).size(withAttributes: [.font: bodyFont]).width
-                result.addAttribute(.paragraphStyle, value: listParagraphStyle(nestingLevel: nesting, markerWidth: markerWidth), range: span.fullRange)
+                // Apply paragraph style from position 0 — NSTextView uses the paragraph
+                // style from the first character of a paragraph. If leading whitespace
+                // at position 0 has the default style, the list indent is ignored.
+                result.addAttribute(.paragraphStyle, value: listParagraphStyle(nestingLevel: nesting, markerWidth: markerWidth), range: NSRange(location: 0, length: result.length))
                 // Strikethrough checked items
                 if !ordered, checkbox == .checked {
                     result.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: span.contentRange)

--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -30,15 +30,19 @@ extension EditorTextView {
     /// Near-zero size makes them effectively invisible and zero-width.
     var hiddenFont: NSFont { NSFont.systemFont(ofSize: 0.01) }
 
-    /// Paragraph style with hanging indentation for list items.
-    /// The raw whitespace characters provide first-line indentation (deletable
-    /// by the user). Wrapped lines use `headIndent` to align with content
-    /// after the marker.
+    /// Fixed padding before the bullet/number marker for all list items.
+    var listPadding: CGFloat { 16 }
+
+    /// Paragraph style for list items. A fixed padding pushes the marker
+    /// away from the left edge. Nesting beyond level 1 comes from raw
+    /// whitespace characters (deletable by the user). Wrapped lines use
+    /// `headIndent` to align with content after the marker.
     private func listParagraphStyle(markerWidth: CGFloat = 0) -> NSParagraphStyle {
         let ps = NSMutableParagraphStyle()
         ps.lineSpacing = bodyParagraphStyle.lineSpacing
         ps.paragraphSpacing = bodyParagraphStyle.paragraphSpacing
-        ps.headIndent = markerWidth
+        ps.firstLineHeadIndent = listPadding
+        ps.headIndent = listPadding + markerWidth
         return ps
     }
 

--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -30,49 +30,16 @@ extension EditorTextView {
     /// Near-zero size makes them effectively invisible and zero-width.
     var hiddenFont: NSFont { NSFont.systemFont(ofSize: 0.01) }
 
-    /// Indentation amount for list items.
-    var listIndent: CGFloat { 16 }
-
     /// Paragraph style with hanging indentation for list items.
-    /// The first line starts at `listIndent`; wrapped lines align with the
-    /// content after the marker (bullet / number / checkbox).
-    private func listParagraphStyle(nestingLevel: Int = 0, markerWidth: CGFloat = 0) -> NSParagraphStyle {
+    /// The raw whitespace characters provide first-line indentation (deletable
+    /// by the user). Wrapped lines use `headIndent` to align with content
+    /// after the marker.
+    private func listParagraphStyle(markerWidth: CGFloat = 0) -> NSParagraphStyle {
         let ps = NSMutableParagraphStyle()
         ps.lineSpacing = bodyParagraphStyle.lineSpacing
         ps.paragraphSpacing = bodyParagraphStyle.paragraphSpacing
-        let indent = listIndent * CGFloat(1 + nestingLevel)
-        ps.firstLineHeadIndent = indent
-        ps.headIndent = indent + markerWidth
+        ps.headIndent = markerWidth
         return ps
-    }
-
-    /// Computes list nesting level from leading whitespace in raw markdown.
-    /// Each tab or 2 spaces counts as one nesting level.
-    /// Scans from the start of the line (position 0 in the block) since
-    /// swift-markdown's span range may exclude leading whitespace.
-    private func listNestingLevel(for markdown: String, span: SyntaxHighlighter.Span) -> Int {
-        let nsMarkdown = markdown as NSString
-        var level = 0
-        var col = 0
-        var i = 0
-        let end = span.fullRange.location + span.fullRange.length
-        while i < end {
-            let ch = nsMarkdown.character(at: i)
-            if ch == 0x09 {        // tab
-                level += 1
-                col = 0
-            } else if ch == 0x20 { // space
-                col += 1
-                if col == 2 {
-                    level += 1
-                    col = 0
-                }
-            } else {
-                break
-            }
-            i += 1
-        }
-        return level
     }
 
     /// Paragraph style with a left border for blockquotes.
@@ -189,15 +156,13 @@ extension EditorTextView {
 
             case .listItem(let ordered, let checkbox):
                 guard span.fullRange.upperBound <= result.length else { continue }
-                let nesting = listNestingLevel(for: markdown, span: span)
                 // Measure marker width (including leading whitespace) for hanging indent.
                 // Everything from position 0 to content start is the "marker" area.
                 let markerStr = (markdown as NSString).substring(to: span.contentRange.location)
                 let markerWidth = (markerStr as NSString).size(withAttributes: [.font: bodyFont]).width
                 // Apply paragraph style from position 0 — NSTextView uses the paragraph
-                // style from the first character of a paragraph. If leading whitespace
-                // at position 0 has the default style, the list indent is ignored.
-                result.addAttribute(.paragraphStyle, value: listParagraphStyle(nestingLevel: nesting, markerWidth: markerWidth), range: NSRange(location: 0, length: result.length))
+                // style from the first character of a paragraph.
+                result.addAttribute(.paragraphStyle, value: listParagraphStyle(markerWidth: markerWidth), range: NSRange(location: 0, length: result.length))
                 // Strikethrough checked items
                 if !ordered, checkbox == .checked {
                     result.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: span.contentRange)

--- a/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
+++ b/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
@@ -148,6 +148,26 @@ public enum SyntaxHighlighter {
             contentRange: content,
             delimiterRanges: [delim]
         ))
+
+        // Re-parse the content for inline formatting (bold, italic, code, etc.)
+        // since swift-markdown treated the whole line as code and skipped them.
+        let contentStr = nsText.substring(with: content)
+        let inlineSpans = parse(contentStr)
+        for s in inlineSpans {
+            // Skip any listItem spans from the recursive parse
+            if case .listItem = s.kind { continue }
+            // Offset ranges by the content start position
+            let offsetFull = NSRange(location: s.fullRange.location + content.location,
+                                     length: s.fullRange.length)
+            let offsetContent = NSRange(location: s.contentRange.location + content.location,
+                                        length: s.contentRange.length)
+            let offsetDelims = s.delimiterRanges.map {
+                NSRange(location: $0.location + content.location, length: $0.length)
+            }
+            spans.append(Span(kind: s.kind, fullRange: offsetFull,
+                              contentRange: offsetContent,
+                              delimiterRanges: offsetDelims))
+        }
     }
 
     // MARK: - AST Walker

--- a/Tests/MarkdownEditorTests/BlockStylingTests.swift
+++ b/Tests/MarkdownEditorTests/BlockStylingTests.swift
@@ -66,10 +66,10 @@ struct BlockStylingActiveTests {
         let a = attrs(at: 0, in: editor)
         let ps = a[.paragraphStyle] as? NSParagraphStyle
         #expect(ps != nil)
-        #expect(ps!.firstLineHeadIndent == editor.listIndent)
+        #expect(ps!.headIndent > 0)
     }
 
-    @Test("Active indented list item (4 spaces) has deeper indent")
+    @Test("Active indented list item (4 spaces) has hanging indent")
     @MainActor func activeIndentedBulletList() {
         let editor = makeEditor()
         editor.loadContent("    - item")
@@ -78,7 +78,7 @@ struct BlockStylingActiveTests {
         let a = attrs(at: 0, in: editor)
         let ps = a[.paragraphStyle] as? NSParagraphStyle
         #expect(ps != nil)
-        #expect(ps!.firstLineHeadIndent > editor.listIndent)
+        #expect(ps!.headIndent > 0)
     }
 
     @Test("Active - prefix is dimmed")
@@ -102,7 +102,7 @@ struct BlockStylingActiveTests {
         let a = attrs(at: 0, in: editor)
         let ps = a[.paragraphStyle] as? NSParagraphStyle
         #expect(ps != nil)
-        #expect(ps!.firstLineHeadIndent == editor.listIndent)
+        #expect(ps!.headIndent > 0)
     }
 
     // MARK: - Todo Lists
@@ -116,7 +116,7 @@ struct BlockStylingActiveTests {
         let a = attrs(at: 0, in: editor)
         let ps = a[.paragraphStyle] as? NSParagraphStyle
         #expect(ps != nil)
-        #expect(ps!.firstLineHeadIndent == editor.listIndent)
+        #expect(ps!.headIndent > 0)
     }
 
     // MARK: - Blockquotes
@@ -211,7 +211,7 @@ struct BlockStylingNonActiveTests {
         let a = attrs(at: 0, in: editor)
         let ps = a[.paragraphStyle] as? NSParagraphStyle
         #expect(ps != nil)
-        #expect(ps!.firstLineHeadIndent == editor.listIndent)
+        #expect(ps!.headIndent > 0)
     }
 
     // MARK: - Numbered Lists

--- a/Tests/MarkdownEditorTests/EditorRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/EditorRenderingTests.swift
@@ -302,17 +302,17 @@ struct EditorStylingTests {
         #expect(!isHidden(at: 0, in: styled))
     }
 
-    @Test("List items have indented paragraph style")
+    @Test("List items have hanging indent paragraph style")
     @MainActor func listIndentation() {
         let editor = makeEditor()
         let styled = editor.styleBlock("- hello")
-        var hasIndent = false
+        var hasHangingIndent = false
         styled.enumerateAttribute(.paragraphStyle, in: NSRange(location: 0, length: styled.length)) { val, _, _ in
-            if let ps = val as? NSParagraphStyle, ps.firstLineHeadIndent > 0 {
-                hasIndent = true
+            if let ps = val as? NSParagraphStyle, ps.headIndent > 0 {
+                hasHangingIndent = true
             }
         }
-        #expect(hasIndent)
+        #expect(hasHangingIndent)
     }
 
     @Test("Ordered list keeps its number and dims it")
@@ -323,42 +323,23 @@ struct EditorStylingTests {
         #expect(isDimmed(at: 0, in: styled))
     }
 
-    @Test("Indented list (4 spaces) has deeper indent than top-level")
+    @Test("Indented list (4 spaces) has wider hanging indent than top-level")
     @MainActor func indentedListDeeper() {
         let editor = makeEditor()
         let topLevel = editor.styleBlock("- hello")
         let indented = editor.styleBlock("    - hello")
 
-        var topIndent: CGFloat = 0
+        var topHanging: CGFloat = 0
         topLevel.enumerateAttribute(.paragraphStyle, in: NSRange(location: 0, length: topLevel.length)) { val, _, _ in
-            if let ps = val as? NSParagraphStyle { topIndent = ps.firstLineHeadIndent }
+            if let ps = val as? NSParagraphStyle { topHanging = ps.headIndent }
         }
 
-        var subIndent: CGFloat = 0
+        var subHanging: CGFloat = 0
         indented.enumerateAttribute(.paragraphStyle, in: NSRange(location: 0, length: indented.length)) { val, _, _ in
-            if let ps = val as? NSParagraphStyle { subIndent = ps.firstLineHeadIndent }
+            if let ps = val as? NSParagraphStyle { subHanging = ps.headIndent }
         }
 
-        #expect(subIndent > topIndent)
-    }
-
-    @Test("Tab-indented list has same depth as 2-space-indented list")
-    @MainActor func tabIndentedList() {
-        let editor = makeEditor()
-        let spaced = editor.styleBlock("  - hello")
-        let tabbed = editor.styleBlock("\t- hello")
-
-        var spacedIndent: CGFloat = 0
-        spaced.enumerateAttribute(.paragraphStyle, in: NSRange(location: 0, length: spaced.length)) { val, _, _ in
-            if let ps = val as? NSParagraphStyle { spacedIndent = ps.firstLineHeadIndent }
-        }
-
-        var tabbedIndent: CGFloat = 0
-        tabbed.enumerateAttribute(.paragraphStyle, in: NSRange(location: 0, length: tabbed.length)) { val, _, _ in
-            if let ps = val as? NSParagraphStyle { tabbedIndent = ps.firstLineHeadIndent }
-        }
-
-        #expect(tabbedIndent == spacedIndent)
+        #expect(subHanging > topHanging)
     }
 
     @Test("Wrapped list lines have deeper indent than first line (hanging indent)")
@@ -366,16 +347,14 @@ struct EditorStylingTests {
         let editor = makeEditor()
         let styled = editor.styleBlock("- hello")
 
-        var firstLine: CGFloat = 0
         var wrapped: CGFloat = 0
         styled.enumerateAttribute(.paragraphStyle, in: NSRange(location: 0, length: styled.length)) { val, _, _ in
             if let ps = val as? NSParagraphStyle {
-                firstLine = ps.firstLineHeadIndent
                 wrapped = ps.headIndent
             }
         }
 
-        #expect(wrapped > firstLine)
+        #expect(wrapped > 0)
     }
 
     @Test("Table has monospace font and dimmed pipes")

--- a/Tests/MarkdownEditorTests/SyntaxHighlighterTests.swift
+++ b/Tests/MarkdownEditorTests/SyntaxHighlighterTests.swift
@@ -487,6 +487,17 @@ struct ListItemTests {
         let items = spans.filter { if case .listItem = $0.kind { return true }; return false }
         #expect(items.count == 1)
     }
+
+    @Test("Indented list item preserves inline formatting")
+    func indentedListInlineFormatting() {
+        let spans = SyntaxHighlighter.parse("    - *italic* and **bold**")
+        let items = spans.filter { if case .listItem = $0.kind { return true }; return false }
+        #expect(items.count == 1)
+        let italics = spans.filter { $0.kind == .italic }
+        #expect(italics.count == 1)
+        let bolds = spans.filter { $0.kind == .bold }
+        #expect(bolds.count == 1)
+    }
 }
 
 // MARK: - Tables


### PR DESCRIPTION
## Summary
- Fix nested list indent by applying paragraph style from position 0 (NSTextView reads paragraph style from the first character)
- Fix inline formatting (italic, bold) in deeply-indented (4+ space) list items by re-parsing content
- Use raw whitespace for nesting indentation so users can delete it
- Add fixed padding before bullet markers so they aren't flush with the left edge

## Test plan
- [x] All 358 tests pass
- [ ] Verify nested lists render with increasing indentation
- [ ] Verify italic/bold works inside 3rd-level list items
- [ ] Verify indentation spaces are selectable and deletable

🤖 Generated with [Claude Code](https://claude.com/claude-code)