### PR TITLE
Implement incremental recompose

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+Composition.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Composition.swift
@@ -9,19 +9,19 @@ extension EditorTextView {
     // Text storage content = rawSource, always.
     // Styling is attribute-only; the string never changes during recompose.
 
+    /// Full recompose: replaces the entire text storage. Used for initial load,
+    /// content changes (undo/redo, loadContent), font/appearance changes.
     func recompose(cursorInRaw: Int, selectionInRaw: NSRange? = nil) {
         isUpdating = true
 
         activeBlockIndex = blockIndexForRawOffset(cursorInRaw)
 
         // Build styled attributed string from rawSource.
-        // The string content IS rawSource — no delimiter stripping.
         let composed = NSMutableAttributedString(string: rawSource, attributes: baseAttributes)
 
         for (i, block) in blocks.enumerated() {
             guard block.range.upperBound <= composed.length else { continue }
 
-            // Cursor position within this block (nil for non-active blocks)
             let cursorInBlock: Int?
             if i == activeBlockIndex {
                 cursorInBlock = max(0, cursorInRaw - block.range.location)
@@ -31,7 +31,6 @@ extension EditorTextView {
 
             let styled = styleBlock(block.content, cursorPosition: cursorInBlock)
 
-            // Apply attributes from the styled block onto the composed string
             styled.enumerateAttributes(
                 in: NSRange(location: 0, length: styled.length), options: []
             ) { attrs, range, _ in
@@ -49,10 +48,8 @@ extension EditorTextView {
         textStorage?.replaceCharacters(in: fullRange, with: composed)
         textStorage?.endEditing()
 
-        // displayRanges = block ranges (identity mapping)
         displayRanges = blocks.map { $0.range }
 
-        // Cursor placement: display offset = raw offset (identity)
         if let rawSel = selectionInRaw, rawSel.length > 0 {
             let len = textStorage!.length
             let displaySel = NSRange(
@@ -62,6 +59,51 @@ extension EditorTextView {
             setSelectedRange(displaySel)
         } else {
             let clamped = min(cursorInRaw, textStorage!.length)
+            setSelectedRange(NSRange(location: clamped, length: 0))
+        }
+
+        typingAttributes = baseAttributes
+
+        isUpdating = false
+    }
+
+    /// Incremental recompose: only re-styles the old and new active blocks.
+    /// Used when the cursor moves between blocks without changing content.
+    func recomposeIncremental(cursorInRaw: Int, selectionInRaw: NSRange? = nil) {
+        guard let ts = textStorage else { return }
+
+        isUpdating = true
+
+        let oldActiveIndex = activeBlockIndex
+        let newActiveIndex = blockIndexForRawOffset(cursorInRaw)
+        activeBlockIndex = newActiveIndex
+
+        ts.beginEditing()
+
+        // Re-style old active block (hide all inline delimiters)
+        if let oldIdx = oldActiveIndex, oldIdx < blocks.count {
+            restyleBlock(oldIdx, cursorInBlock: nil)
+        }
+
+        // Re-style new active block (show delimiters at cursor)
+        if let newIdx = newActiveIndex, newIdx < blocks.count {
+            let cursorInBlock = max(0, cursorInRaw - blocks[newIdx].range.location)
+            restyleBlock(newIdx, cursorInBlock: cursorInBlock)
+        }
+
+        ts.endEditing()
+
+        displayRanges = blocks.map { $0.range }
+
+        if let rawSel = selectionInRaw, rawSel.length > 0 {
+            let len = ts.length
+            let displaySel = NSRange(
+                location: min(rawSel.location, len),
+                length: max(0, min(rawSel.upperBound, len) - min(rawSel.location, len))
+            )
+            setSelectedRange(displaySel)
+        } else {
+            let clamped = min(cursorInRaw, ts.length)
             setSelectedRange(NSRange(location: clamped, length: 0))
         }
 

--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -217,29 +217,36 @@ extension EditorTextView {
 
     // MARK: - In-Place Block Restyling
 
-    /// Re-applies styling to a single block in the text storage.
-    /// Called after each keystroke to keep formatting in sync with content.
-    func applyBlockStyle() {
+    /// Re-styles a single block in the text storage in place (no string mutation).
+    /// `cursorInBlock` is the cursor offset within the block, or nil to hide
+    /// all inline delimiters (non-active block).
+    func restyleBlock(_ blockIndex: Int, cursorInBlock: Int? = nil) {
         guard let ts = textStorage,
-              let activeIdx = activeBlockIndex,
-              activeIdx < blocks.count else { return }
+              blockIndex < blocks.count else { return }
 
-        let blockRange = blocks[activeIdx].range
-        guard blockRange.upperBound <= ts.length else { return }
+        let block = blocks[blockIndex]
+        guard block.range.upperBound <= ts.length else { return }
 
-        let content = blocks[activeIdx].content
-        let cursorInBlock = max(0, selectedRange().location - blockRange.location)
-        let styled = styleBlock(content, cursorPosition: cursorInBlock)
-        let offset = blockRange.location
-
-        isUpdating = true
-        ts.beginEditing()
+        let styled = styleBlock(block.content, cursorPosition: cursorInBlock)
+        let offset = block.range.location
 
         styled.enumerateAttributes(in: NSRange(location: 0, length: styled.length), options: []) { attrs, range, _ in
             let tsRange = NSRange(location: range.location + offset, length: range.length)
             ts.setAttributes(attrs, range: tsRange)
         }
+    }
 
+    /// Re-applies styling to the active block. Called after each keystroke.
+    func applyBlockStyle() {
+        guard let ts = textStorage,
+              let activeIdx = activeBlockIndex,
+              activeIdx < blocks.count else { return }
+
+        let cursorInBlock = max(0, selectedRange().location - blocks[activeIdx].range.location)
+
+        isUpdating = true
+        ts.beginEditing()
+        restyleBlock(activeIdx, cursorInBlock: cursorInBlock)
         ts.endEditing()
         isUpdating = false
 

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -218,7 +218,7 @@ public class EditorTextView: NSTextView {
 
         let newBlockIndex = blockIndexForRawOffset(cursorRaw)
         if newBlockIndex != activeBlockIndex {
-            recompose(cursorInRaw: cursorRaw)
+            recomposeIncremental(cursorInRaw: cursorRaw)
         }
     }
 
@@ -241,7 +241,7 @@ public class EditorTextView: NSTextView {
                 let rawStart = currentSel.location
                 let rawEnd = currentSel.location + currentSel.length
                 let rawSel = NSRange(location: rawStart, length: rawEnd - rawStart)
-                self.recompose(cursorInRaw: rawStart, selectionInRaw: rawSel)
+                self.recomposeIncremental(cursorInRaw: rawStart, selectionInRaw: rawSel)
             }
         } else if newActiveIndex == activeBlockIndex {
             // Same block — update active token (re-style to show/hide delimiters)


### PR DESCRIPTION
## Summary
- Add `recomposeIncremental` that only re-styles the old and new active blocks when the cursor moves between blocks (2 blocks instead of N)
- Extract `restyleBlock(_:cursorInBlock:)` for targeted in-place block restyling
- Keep full `recompose` for initial load, undo/redo, font/appearance changes

## Test plan
- [x] All 358 tests pass
- [ ] Verify cursor movement between blocks shows/hides delimiters correctly
- [ ] Verify typing, undo/redo, and appearance changes still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)