### PR TITLE
Extract visual settings into EditorTheme

### DIFF
--- a/Sources/MarkdownEditor/SettingsWindow.swift
+++ b/Sources/MarkdownEditor/SettingsWindow.swift
@@ -8,8 +8,14 @@ class SettingsWindowController: NSWindowController {
     private var sizeField: NSTextField!
     private var sizeStepper: NSStepper!
     private var previewLabel: NSTextField!
+    private var accentColorWell: NSColorWell!
+    private var codeColorWell: NSColorWell!
+    private var lineSpacingField: NSTextField!
+    private var lineSpacingStepper: NSStepper!
+    private var paragraphSpacingField: NSTextField!
+    private var paragraphSpacingStepper: NSStepper!
 
-    /// All open editor views get updated when font changes.
+    /// All open editor views get updated when settings change.
     private var fontFamilies: [String] = []
 
     /// Builds a complete list of font families by scanning system font
@@ -48,7 +54,7 @@ class SettingsWindowController: NSWindowController {
 
     convenience init() {
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 400, height: 160),
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 340),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false
@@ -67,108 +73,209 @@ class SettingsWindowController: NSWindowController {
         guard let contentView = window?.contentView else { return }
 
         let margin: CGFloat = 20
-        let labelWidth: CGFloat = 70
+        let labelWidth: CGFloat = 100
         let rowHeight: CGFloat = 26
         let spacing: CGFloat = 14
 
+        var y: CGFloat = 290
+
         // --- Row 1: Font Family ---
-        let fontLabel = NSTextField(labelWithString: "Font:")
-        fontLabel.frame = NSRect(x: margin, y: 110, width: labelWidth, height: rowHeight)
-        fontLabel.alignment = .right
-        contentView.addSubview(fontLabel)
+        addLabel("Font:", at: NSPoint(x: margin, y: y), width: labelWidth, in: contentView)
 
         fontFamilies = Self.allInstalledFontFamilies()
 
-        fontPopup = NSPopUpButton(frame: NSRect(x: margin + labelWidth + 8, y: 110, width: 220, height: rowHeight), pullsDown: false)
+        fontPopup = NSPopUpButton(frame: NSRect(x: margin + labelWidth + 8, y: y, width: 220, height: rowHeight), pullsDown: false)
         fontPopup.addItems(withTitles: fontFamilies)
         fontPopup.target = self
-        fontPopup.action = #selector(fontChanged(_:))
+        fontPopup.action = #selector(settingChanged(_:))
         contentView.addSubview(fontPopup)
 
         // --- Row 2: Font Size ---
-        let sizeLabel = NSTextField(labelWithString: "Size:")
-        sizeLabel.frame = NSRect(x: margin, y: 110 - rowHeight - spacing, width: labelWidth, height: rowHeight)
-        sizeLabel.alignment = .right
-        contentView.addSubview(sizeLabel)
+        y -= rowHeight + spacing
+        addLabel("Size:", at: NSPoint(x: margin, y: y), width: labelWidth, in: contentView)
 
-        let sizeY = 110 - rowHeight - spacing
-
-        sizeField = NSTextField(frame: NSRect(x: margin + labelWidth + 8, y: sizeY, width: 60, height: rowHeight))
-        sizeField.formatter = numberFormatter()
+        sizeField = NSTextField(frame: NSRect(x: margin + labelWidth + 8, y: y, width: 60, height: rowHeight))
+        sizeField.formatter = intFormatter(min: 8, max: 72)
         sizeField.target = self
         sizeField.action = #selector(sizeFieldChanged(_:))
         contentView.addSubview(sizeField)
 
-        sizeStepper = NSStepper(frame: NSRect(x: margin + labelWidth + 8 + 64, y: sizeY, width: 19, height: rowHeight))
+        sizeStepper = NSStepper(frame: NSRect(x: margin + labelWidth + 8 + 64, y: y, width: 19, height: rowHeight))
         sizeStepper.minValue = 8
         sizeStepper.maxValue = 72
         sizeStepper.increment = 1
         sizeStepper.valueWraps = false
         sizeStepper.target = self
-        sizeStepper.action = #selector(stepperChanged(_:))
+        sizeStepper.action = #selector(sizeStepperChanged(_:))
         contentView.addSubview(sizeStepper)
 
-        // --- Row 3: Preview ---
-        let previewY = sizeY - rowHeight - spacing
+        // --- Row 3: Accent Color ---
+        y -= rowHeight + spacing
+        addLabel("Accent color:", at: NSPoint(x: margin, y: y), width: labelWidth, in: contentView)
+
+        accentColorWell = NSColorWell(frame: NSRect(x: margin + labelWidth + 8, y: y, width: 44, height: rowHeight))
+        accentColorWell.target = self
+        accentColorWell.action = #selector(settingChanged(_:))
+        contentView.addSubview(accentColorWell)
+
+        // --- Row 4: Code Color ---
+        y -= rowHeight + spacing
+        addLabel("Code color:", at: NSPoint(x: margin, y: y), width: labelWidth, in: contentView)
+
+        codeColorWell = NSColorWell(frame: NSRect(x: margin + labelWidth + 8, y: y, width: 44, height: rowHeight))
+        codeColorWell.target = self
+        codeColorWell.action = #selector(settingChanged(_:))
+        contentView.addSubview(codeColorWell)
+
+        // --- Row 5: Line Spacing ---
+        y -= rowHeight + spacing
+        addLabel("Line spacing:", at: NSPoint(x: margin, y: y), width: labelWidth, in: contentView)
+
+        lineSpacingField = NSTextField(frame: NSRect(x: margin + labelWidth + 8, y: y, width: 60, height: rowHeight))
+        lineSpacingField.formatter = floatFormatter(min: 0, max: 20)
+        lineSpacingField.target = self
+        lineSpacingField.action = #selector(lineSpacingFieldChanged(_:))
+        contentView.addSubview(lineSpacingField)
+
+        lineSpacingStepper = NSStepper(frame: NSRect(x: margin + labelWidth + 8 + 64, y: y, width: 19, height: rowHeight))
+        lineSpacingStepper.minValue = 0
+        lineSpacingStepper.maxValue = 20
+        lineSpacingStepper.increment = 1
+        lineSpacingStepper.valueWraps = false
+        lineSpacingStepper.target = self
+        lineSpacingStepper.action = #selector(lineSpacingStepperChanged(_:))
+        contentView.addSubview(lineSpacingStepper)
+
+        // --- Row 6: Paragraph Spacing ---
+        y -= rowHeight + spacing
+        addLabel("Para spacing:", at: NSPoint(x: margin, y: y), width: labelWidth, in: contentView)
+
+        paragraphSpacingField = NSTextField(frame: NSRect(x: margin + labelWidth + 8, y: y, width: 60, height: rowHeight))
+        paragraphSpacingField.formatter = floatFormatter(min: 0, max: 20)
+        paragraphSpacingField.target = self
+        paragraphSpacingField.action = #selector(paragraphSpacingFieldChanged(_:))
+        contentView.addSubview(paragraphSpacingField)
+
+        paragraphSpacingStepper = NSStepper(frame: NSRect(x: margin + labelWidth + 8 + 64, y: y, width: 19, height: rowHeight))
+        paragraphSpacingStepper.minValue = 0
+        paragraphSpacingStepper.maxValue = 20
+        paragraphSpacingStepper.increment = 1
+        paragraphSpacingStepper.valueWraps = false
+        paragraphSpacingStepper.target = self
+        paragraphSpacingStepper.action = #selector(paragraphSpacingStepperChanged(_:))
+        contentView.addSubview(paragraphSpacingStepper)
+
+        // --- Row 7: Preview ---
+        y -= rowHeight + spacing
         previewLabel = NSTextField(labelWithString: "The quick brown fox jumps over the lazy dog.")
-        previewLabel.frame = NSRect(x: margin + labelWidth + 8, y: previewY, width: 280, height: rowHeight)
+        previewLabel.frame = NSRect(x: margin + labelWidth + 8, y: y, width: 280, height: rowHeight)
         previewLabel.lineBreakMode = .byTruncatingTail
         contentView.addSubview(previewLabel)
     }
 
-    private func numberFormatter() -> NumberFormatter {
+    // MARK: - Helpers
+
+    @discardableResult
+    private func addLabel(_ text: String, at origin: NSPoint, width: CGFloat, in view: NSView) -> NSTextField {
+        let label = NSTextField(labelWithString: text)
+        label.frame = NSRect(x: origin.x, y: origin.y, width: width, height: 26)
+        label.alignment = .right
+        view.addSubview(label)
+        return label
+    }
+
+    private func intFormatter(min: Int, max: Int) -> NumberFormatter {
         let nf = NumberFormatter()
         nf.numberStyle = .decimal
-        nf.minimum = 8
-        nf.maximum = 72
+        nf.minimum = NSNumber(value: min)
+        nf.maximum = NSNumber(value: max)
         nf.maximumFractionDigits = 0
+        return nf
+    }
+
+    private func floatFormatter(min: Double, max: Double) -> NumberFormatter {
+        let nf = NumberFormatter()
+        nf.numberStyle = .decimal
+        nf.minimum = NSNumber(value: min)
+        nf.maximum = NSNumber(value: max)
+        nf.maximumFractionDigits = 1
         return nf
     }
 
     // MARK: - Load Current Settings
 
     private func loadCurrentSettings() {
-        let name = UserDefaults.standard.string(forKey: "EditorFontName") ?? "Hoefler Text"
-        let size = CGFloat(UserDefaults.standard.float(forKey: "EditorFontSize"))
-        let resolvedSize = size > 0 ? size : 16
+        let theme = EditorTheme.load()
 
-        // Find the font family for the stored font name.
-        // The stored name might be a PostScript name — resolve to family.
+        // Font family — resolve PostScript name to family
         let family = fontFamilies.first { fam in
-            fam == name || (NSFont(name: name, size: 12)?.familyName == fam)
-        } ?? name
+            fam == theme.fontName || (NSFont(name: theme.fontName, size: 12)?.familyName == fam)
+        } ?? theme.fontName
 
         if let idx = fontFamilies.firstIndex(of: family) {
             fontPopup.selectItem(at: idx)
         }
-        sizeField.integerValue = Int(resolvedSize)
-        sizeStepper.doubleValue = Double(resolvedSize)
+        sizeField.integerValue = Int(theme.fontSize)
+        sizeStepper.doubleValue = Double(theme.fontSize)
+
+        accentColorWell.color = theme.accentColor
+        codeColorWell.color = theme.codeColor
+
+        lineSpacingField.doubleValue = Double(theme.lineSpacing)
+        lineSpacingStepper.doubleValue = Double(theme.lineSpacing)
+
+        paragraphSpacingField.doubleValue = Double(theme.paragraphSpacingBefore)
+        paragraphSpacingStepper.doubleValue = Double(theme.paragraphSpacingBefore)
+
         updatePreview()
     }
 
     // MARK: - Actions
 
-    @objc private func fontChanged(_ sender: NSPopUpButton) {
-        applyFont()
+    @objc private func settingChanged(_ sender: Any?) {
+        applyTheme()
     }
 
     @objc private func sizeFieldChanged(_ sender: NSTextField) {
         let size = max(8, min(72, sender.integerValue))
         sizeStepper.doubleValue = Double(size)
         sizeField.integerValue = size
-        applyFont()
+        applyTheme()
     }
 
-    @objc private func stepperChanged(_ sender: NSStepper) {
+    @objc private func sizeStepperChanged(_ sender: NSStepper) {
         sizeField.integerValue = Int(sender.doubleValue)
-        applyFont()
+        applyTheme()
+    }
+
+    @objc private func lineSpacingFieldChanged(_ sender: NSTextField) {
+        let val = max(0, min(20, sender.doubleValue))
+        lineSpacingStepper.doubleValue = val
+        lineSpacingField.doubleValue = val
+        applyTheme()
+    }
+
+    @objc private func lineSpacingStepperChanged(_ sender: NSStepper) {
+        lineSpacingField.doubleValue = sender.doubleValue
+        applyTheme()
+    }
+
+    @objc private func paragraphSpacingFieldChanged(_ sender: NSTextField) {
+        let val = max(0, min(20, sender.doubleValue))
+        paragraphSpacingStepper.doubleValue = val
+        paragraphSpacingField.doubleValue = val
+        applyTheme()
+    }
+
+    @objc private func paragraphSpacingStepperChanged(_ sender: NSStepper) {
+        paragraphSpacingField.doubleValue = sender.doubleValue
+        applyTheme()
     }
 
     // MARK: - Apply
 
-    private func applyFont() {
+    private func applyTheme() {
         guard let family = fontPopup.titleOfSelectedItem else { return }
-        let size = CGFloat(sizeField.integerValue)
 
         // Resolve family name to a usable font name
         let fontName: String
@@ -180,12 +287,21 @@ class SettingsWindowController: NSWindowController {
             fontName = family
         }
 
+        let theme = EditorTheme(
+            fontName: fontName,
+            fontSize: CGFloat(sizeField.integerValue),
+            accentHex: accentColorWell.color.hexString,
+            codeHex: codeColorWell.color.hexString,
+            lineSpacing: CGFloat(lineSpacingField.doubleValue),
+            paragraphSpacingBefore: CGFloat(paragraphSpacingField.doubleValue)
+        )
+
         updatePreview()
 
         // Update all open editor views
         for document in NSDocumentController.shared.documents {
             if let doc = document as? Document {
-                doc.editor?.updateFont(name: fontName, size: size)
+                doc.editor?.applyTheme(theme)
             }
         }
     }

--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -14,7 +14,7 @@ extension EditorTextView {
     var syntaxDimColor: NSColor { .tertiaryLabelColor }
 
     /// Color for inline code spans.
-    var codeColor: NSColor { NSColor(calibratedRed: 0.541, green: 0.141, blue: 0.145, alpha: 1.0) }
+    var codeColor: NSColor { theme.codeColor }
 
     /// Monospaced font for tables.
     var tableFont: NSFont {

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -60,9 +60,13 @@ public class EditorTextView: NSTextView {
     /// Must match what BlockParser splits on.
     let blockSeparator = "\n"
 
-    // MARK: - Colors (semantic — adapts to light/dark mode)
+    // MARK: - Theme (user-configurable visual settings)
 
-    let accentColor = NSColor(calibratedRed: 0.2, green: 0.4, blue: 0.9, alpha: 1.0)
+    public var theme: EditorTheme = .load()
+
+    // MARK: - Derived Visual Properties
+
+    var accentColor: NSColor { theme.accentColor }
 
     /// Foreground color for all body text. Uses the system text color so it
     /// flips automatically between near-black (light) and near-white (dark).
@@ -72,43 +76,25 @@ public class EditorTextView: NSTextView {
     /// standard semantic color for text-editing backgrounds (white / dark gray).
     private var editorBackgroundColor: NSColor { .textBackgroundColor }
 
-    // MARK: - Fonts & Style
+    // MARK: - Font & Paragraph Style (derived from theme)
 
-    // MARK: - Font Settings (persisted via UserDefaults)
+    public var bodyFont: NSFont { theme.bodyFont }
 
-    private static let defaultFontName = "Hoefler Text"
-    private static let defaultFontSize: CGFloat = 16
-    private static let fontNameKey = "EditorFontName"
-    private static let fontSizeKey = "EditorFontSize"
+    var bodyParagraphStyle: NSParagraphStyle {
+        let ps = NSMutableParagraphStyle()
+        ps.lineSpacing = theme.lineSpacing
+        ps.paragraphSpacingBefore = theme.paragraphSpacingBefore
+        ps.paragraphSpacing = 0
+        return ps
+    }
 
-    public var bodyFont: NSFont = {
-        let name = UserDefaults.standard.string(forKey: "EditorFontName") ?? defaultFontName
-        let size = CGFloat(UserDefaults.standard.float(forKey: "EditorFontSize"))
-        let resolvedSize = size > 0 ? size : defaultFontSize
-        if let font = NSFont(name: name, size: resolvedSize) { return font }
-        return NSFont.systemFont(ofSize: resolvedSize)
-    }()
-
-    /// Update the editor font and recompose. Persists to UserDefaults.
-    public func updateFont(name: String, size: CGFloat) {
-        UserDefaults.standard.set(name, forKey: Self.fontNameKey)
-        UserDefaults.standard.set(Float(size), forKey: Self.fontSizeKey)
-        if let font = NSFont(name: name, size: size) {
-            bodyFont = font
-        } else {
-            bodyFont = NSFont.systemFont(ofSize: size)
-        }
+    /// Apply a new theme, persist it, and recompose.
+    public func applyTheme(_ newTheme: EditorTheme) {
+        theme = newTheme
+        theme.save()
         typingAttributes = baseAttributes
         recompose(cursorInRaw: currentCursorInRaw())
     }
-
-    let bodyParagraphStyle: NSParagraphStyle = {
-        let ps = NSMutableParagraphStyle()
-        ps.lineSpacing = 4
-        ps.paragraphSpacingBefore = 2
-        ps.paragraphSpacing = 0
-        return ps
-    }()
 
     var baseAttributes: [NSAttributedString.Key: Any] {
         [

--- a/Sources/MarkdownEditorCore/EditorTheme.swift
+++ b/Sources/MarkdownEditorCore/EditorTheme.swift
@@ -1,0 +1,133 @@
+import AppKit
+
+/// All user-configurable visual settings for the editor.
+///
+/// Stored as simple types (String, CGFloat) so it serializes cleanly to
+/// UserDefaults. Computed properties provide the `NSFont` / `NSColor`
+/// equivalents for rendering.
+public struct EditorTheme: Equatable, Sendable {
+
+    // MARK: - Font
+
+    public var fontName: String
+    public var fontSize: CGFloat
+
+    // MARK: - Colors (hex strings, e.g. "#3366E6")
+
+    public var accentHex: String
+    public var codeHex: String
+
+    // MARK: - Spacing
+
+    public var lineSpacing: CGFloat
+    public var paragraphSpacingBefore: CGFloat
+
+    public init(fontName: String, fontSize: CGFloat, accentHex: String, codeHex: String,
+                lineSpacing: CGFloat, paragraphSpacingBefore: CGFloat) {
+        self.fontName = fontName
+        self.fontSize = fontSize
+        self.accentHex = accentHex
+        self.codeHex = codeHex
+        self.lineSpacing = lineSpacing
+        self.paragraphSpacingBefore = paragraphSpacingBefore
+    }
+
+    // MARK: - Defaults
+
+    public static let `default` = EditorTheme(
+        fontName: "Hoefler Text",
+        fontSize: 16,
+        accentHex: "#3366E6",
+        codeHex: "#8A2425",
+        lineSpacing: 4,
+        paragraphSpacingBefore: 2
+    )
+
+    // MARK: - Derived Properties
+
+    @MainActor public var bodyFont: NSFont {
+        NSFont(name: fontName, size: fontSize) ?? .systemFont(ofSize: fontSize)
+    }
+
+    @MainActor public var accentColor: NSColor {
+        NSColor(hex: accentHex) ?? .systemBlue
+    }
+
+    @MainActor public var codeColor: NSColor {
+        NSColor(hex: codeHex) ?? .systemRed
+    }
+
+    // MARK: - UserDefaults Persistence
+
+    private enum Keys {
+        static let fontName = "EditorFontName"
+        static let fontSize = "EditorFontSize"
+        static let accentHex = "EditorAccentHex"
+        static let codeHex = "EditorCodeHex"
+        static let lineSpacing = "EditorLineSpacing"
+        static let paragraphSpacingBefore = "EditorParagraphSpacingBefore"
+    }
+
+    public static func load() -> EditorTheme {
+        let d = UserDefaults.standard
+        let def = EditorTheme.default
+
+        let fontName = d.string(forKey: Keys.fontName) ?? def.fontName
+        let fontSize: CGFloat = {
+            let v = CGFloat(d.float(forKey: Keys.fontSize))
+            return v > 0 ? v : def.fontSize
+        }()
+        let accentHex = d.string(forKey: Keys.accentHex) ?? def.accentHex
+        let codeHex = d.string(forKey: Keys.codeHex) ?? def.codeHex
+        let lineSpacing: CGFloat = d.object(forKey: Keys.lineSpacing) != nil
+            ? CGFloat(d.float(forKey: Keys.lineSpacing))
+            : def.lineSpacing
+        let paragraphSpacingBefore: CGFloat = d.object(forKey: Keys.paragraphSpacingBefore) != nil
+            ? CGFloat(d.float(forKey: Keys.paragraphSpacingBefore))
+            : def.paragraphSpacingBefore
+
+        return EditorTheme(
+            fontName: fontName,
+            fontSize: fontSize,
+            accentHex: accentHex,
+            codeHex: codeHex,
+            lineSpacing: lineSpacing,
+            paragraphSpacingBefore: paragraphSpacingBefore
+        )
+    }
+
+    public func save() {
+        let d = UserDefaults.standard
+        d.set(fontName, forKey: Keys.fontName)
+        d.set(Float(fontSize), forKey: Keys.fontSize)
+        d.set(accentHex, forKey: Keys.accentHex)
+        d.set(codeHex, forKey: Keys.codeHex)
+        d.set(Float(lineSpacing), forKey: Keys.lineSpacing)
+        d.set(Float(paragraphSpacingBefore), forKey: Keys.paragraphSpacingBefore)
+    }
+}
+
+// MARK: - NSColor Hex Helpers
+
+extension NSColor {
+
+    /// Create a color from a hex string like "#3366E6" or "3366E6".
+    public convenience init?(hex: String) {
+        var h = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if h.hasPrefix("#") { h.removeFirst() }
+        guard h.count == 6, let rgb = UInt64(h, radix: 16) else { return nil }
+        let r = CGFloat((rgb >> 16) & 0xFF) / 255.0
+        let g = CGFloat((rgb >> 8) & 0xFF) / 255.0
+        let b = CGFloat(rgb & 0xFF) / 255.0
+        self.init(calibratedRed: r, green: g, blue: b, alpha: 1.0)
+    }
+
+    /// Returns the hex string representation (e.g. "#3366E6").
+    public var hexString: String {
+        guard let rgb = usingColorSpace(.deviceRGB) else { return "#000000" }
+        let r = Int(round(rgb.redComponent * 255))
+        let g = Int(round(rgb.greenComponent * 255))
+        let b = Int(round(rgb.blueComponent * 255))
+        return String(format: "#%02X%02X%02X", r, g, b)
+    }
+}

--- a/Tests/MarkdownEditorTests/EditorFeatureTests.swift
+++ b/Tests/MarkdownEditorTests/EditorFeatureTests.swift
@@ -176,17 +176,22 @@ struct FontIntegrationTests {
         #expect(f == editor.bodyFont)
     }
 
-    @Test("updateFont changes body font and recomposes")
-    @MainActor func updateFontChanges() {
+    @Test("applyTheme changes body font and recomposes")
+    @MainActor func applyThemeChangesFont() {
         let editor = makeEditor()
         editor.loadContent("hello")
 
         // Set to a known font first so we have a stable baseline
-        editor.updateFont(name: "Menlo", size: 12)
+        var theme = editor.theme
+        theme.fontName = "Menlo"
+        theme.fontSize = 12
+        editor.applyTheme(theme)
         #expect(editor.bodyFont.familyName == "Menlo")
 
         // Now change to a different font
-        editor.updateFont(name: "Helvetica", size: 20)
+        theme.fontName = "Helvetica"
+        theme.fontSize = 20
+        editor.applyTheme(theme)
         #expect(editor.bodyFont.familyName == "Helvetica")
         #expect(editor.bodyFont.pointSize == 20)
 
@@ -196,11 +201,14 @@ struct FontIntegrationTests {
         #expect(f?.pointSize == 20)
     }
 
-    @Test("updateFont affects bold rendering")
-    @MainActor func updateFontAffectsBold() {
+    @Test("applyTheme affects bold rendering")
+    @MainActor func applyThemeAffectsBold() {
         let editor = makeEditor()
         editor.loadContent("**bold**")
-        editor.updateFont(name: "Helvetica", size: 24)
+        var theme = editor.theme
+        theme.fontName = "Helvetica"
+        theme.fontSize = 24
+        editor.applyTheme(theme)
         activateBlock(0, in: editor)
 
         let f = font(at: 2, in: editor)!
@@ -208,11 +216,14 @@ struct FontIntegrationTests {
         #expect(f.pointSize == 24)
     }
 
-    @Test("updateFont affects heading scale")
-    @MainActor func updateFontAffectsHeading() {
+    @Test("applyTheme affects heading scale")
+    @MainActor func applyThemeAffectsHeading() {
         let editor = makeEditor()
         editor.loadContent("# Title")
-        editor.updateFont(name: "Helvetica", size: 20)
+        var theme = editor.theme
+        theme.fontName = "Helvetica"
+        theme.fontSize = 20
+        editor.applyTheme(theme)
         activateBlock(0, in: editor)
 
         let f = font(at: 2, in: editor)!
@@ -220,11 +231,14 @@ struct FontIntegrationTests {
         #expect(abs(f.pointSize - expectedSize) < 0.1)
     }
 
-    @Test("updateFont affects non-active block rendering")
-    @MainActor func updateFontInactive() {
+    @Test("applyTheme affects non-active block rendering")
+    @MainActor func applyThemeInactive() {
         let editor = makeEditor()
         editor.loadContent("**bold**\nother")
-        editor.updateFont(name: "Helvetica", size: 18)
+        var theme = editor.theme
+        theme.fontName = "Helvetica"
+        theme.fontSize = 18
+        editor.applyTheme(theme)
         activateBlock(1, in: editor)
 
         // In word-level rendering, offset 0 is a delimiter (hidden font).
@@ -235,21 +249,33 @@ struct FontIntegrationTests {
         #expect(f.pointSize == 18)
     }
 
-    @Test("Font size change persists to UserDefaults")
-    @MainActor func fontPersistence() {
+    @Test("Theme persists to UserDefaults")
+    @MainActor func themePersistence() {
         let editor = makeEditor()
-        editor.updateFont(name: "Courier", size: 14)
+        var theme = editor.theme
+        theme.fontName = "Courier"
+        theme.fontSize = 14
+        theme.accentHex = "#FF0000"
+        theme.lineSpacing = 8
+        editor.applyTheme(theme)
 
         let savedName = UserDefaults.standard.string(forKey: "EditorFontName")
         let savedSize = UserDefaults.standard.float(forKey: "EditorFontSize")
+        let savedAccent = UserDefaults.standard.string(forKey: "EditorAccentHex")
+        let savedSpacing = UserDefaults.standard.float(forKey: "EditorLineSpacing")
         #expect(savedName == "Courier")
         #expect(savedSize == 14)
+        #expect(savedAccent == "#FF0000")
+        #expect(savedSpacing == 8)
     }
 
     @Test("Invalid font name falls back to system font")
     @MainActor func invalidFontFallback() {
         let editor = makeEditor()
-        editor.updateFont(name: "NonExistentFont12345", size: 16)
+        var theme = editor.theme
+        theme.fontName = "NonExistentFont12345"
+        theme.fontSize = 16
+        editor.applyTheme(theme)
 
         #expect(editor.bodyFont.pointSize == 16)
         // Should be a system font since the name is invalid


### PR DESCRIPTION
## Summary
- Introduces `EditorTheme` struct that centralizes all user-configurable visual settings (font, colors, spacing) with UserDefaults persistence
- Replaces hardcoded `accentColor`, `codeColor`, `bodyFont`, and paragraph spacing in `EditorTextView` with theme-derived computed properties
- Expands Settings window with color wells for accent/code colors and steppers for line/paragraph spacing
- Replaces `updateFont(name:size:)` API with `applyTheme(_:)` — adding new settings is now just a field + key + control

## Test plan
- [x] All 358 tests pass
- [ ] Open Settings, change font → preview and editor update
- [ ] Change accent color → link colors update in all open documents
- [ ] Change code color → inline code and code blocks update
- [ ] Adjust line/paragraph spacing → text reflows
- [ ] Quit and relaunch → settings persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)