### PR TITLE
Style thematic breaks and inline code

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -46,6 +46,35 @@ extension EditorTextView {
         return ps
     }
 
+    /// Monospaced font for inline code spans, same size as body text.
+    var inlineCodeFont: NSFont {
+        NSFont.monospacedSystemFont(ofSize: bodyFont.pointSize * 0.9, weight: .regular)
+    }
+
+    /// Subtle background color for inline code spans.
+    var inlineCodeBackground: NSColor {
+        NSColor(calibratedWhite: 0.5, alpha: 0.1)
+    }
+
+    /// Paragraph style for thematic breaks. Uses an NSTextBlock with a
+    /// top border to render a full-width horizontal line.
+    private func thematicBreakParagraphStyle() -> NSParagraphStyle {
+        let ps = NSMutableParagraphStyle()
+        ps.paragraphSpacing = bodyParagraphStyle.paragraphSpacing
+        ps.paragraphSpacingBefore = bodyParagraphStyle.paragraphSpacingBefore
+
+        let block = NSTextBlock()
+        block.setContentWidth(100, type: .percentageValueType)
+        // NSMinYEdge (1) = top in flipped coordinates (NSTextView)
+        let topEdge = NSRectEdge(rawValue: 1)!
+        block.setWidth(1, type: .absoluteValueType, for: .border, edge: topEdge)
+        block.setBorderColor(.separatorColor, for: topEdge)
+        block.setWidth(4, type: .absoluteValueType, for: .padding, edge: topEdge)
+        ps.textBlocks = [block]
+
+        return ps
+    }
+
     /// Paragraph style with a left border for blockquotes.
     private func blockquoteParagraphStyle() -> NSParagraphStyle {
         let ps = NSMutableParagraphStyle()
@@ -116,7 +145,9 @@ extension EditorTextView {
 
             case .code:
                 guard span.contentRange.upperBound <= result.length else { continue }
+                result.addAttribute(.font, value: inlineCodeFont, range: span.contentRange)
                 result.addAttribute(.foregroundColor, value: codeColor, range: span.contentRange)
+                result.addAttribute(.backgroundColor, value: inlineCodeBackground, range: span.contentRange)
 
             case .codeBlock:
                 guard span.contentRange.upperBound <= result.length else { continue }
@@ -189,7 +220,15 @@ extension EditorTextView {
 
             case .thematicBreak:
                 guard span.fullRange.upperBound <= result.length else { continue }
-                result.addAttribute(.foregroundColor, value: syntaxDimColor, range: span.fullRange)
+                if cursorInToken {
+                    // Active: show raw dashes, dimmed
+                    result.addAttribute(.foregroundColor, value: syntaxDimColor, range: span.fullRange)
+                } else {
+                    // Non-active: horizontal line via NSTextBlock, hide raw text
+                    result.addAttribute(.paragraphStyle, value: thematicBreakParagraphStyle(), range: span.fullRange)
+                    result.addAttribute(.font, value: hiddenFont, range: span.fullRange)
+                    result.addAttribute(.foregroundColor, value: NSColor.clear, range: span.fullRange)
+                }
 
             case .lineBreak:
                 break  // Delimiter handling done below
@@ -198,7 +237,14 @@ extension EditorTextView {
             // --- Delimiter treatment (applied after content styling so it takes precedence) ---
             for dr in span.delimiterRanges {
                 guard dr.upperBound <= result.length else { continue }
-                if cursorInToken || !isDelimiterHideable(span.kind) {
+
+                if case .thematicBreak = span.kind {
+                    // Thematic break: fully handled in content styling above
+                    if cursorInToken {
+                        result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
+                    }
+                    // Non-active: already hidden, don't override
+                } else if cursorInToken || !isDelimiterHideable(span.kind) {
                     // Visible: dim the delimiters
                     result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
                 } else if case .blockquote = span.kind {

--- a/Tests/MarkdownEditorTests/BlockStylingTests.swift
+++ b/Tests/MarkdownEditorTests/BlockStylingTests.swift
@@ -582,28 +582,37 @@ struct ThematicBreakActiveTests {
 @Suite("Integration — Thematic Break (Non-Active Block)")
 struct ThematicBreakNonActiveTests {
 
-    @Test("Non-active --- stays as raw text, dimmed")
-    @MainActor func nonActiveDashDimmed() {
+    @Test("Non-active --- is hidden with horizontal line paragraph style")
+    @MainActor func nonActiveDashHorizontalLine() {
         let editor = makeEditor()
         editor.loadContent("---\nother")
         activateBlock(1, in: editor)
 
+        // Raw text still present
         let text = displayText(for: 0, in: editor)
         #expect(text == "---")
-        let color = fgColor(at: 0, in: editor)
-        #expect(color == NSColor.tertiaryLabelColor)
+        // Characters are hidden (visual line rendered via NSTextBlock)
+        #expect(isHidden(at: 0, in: editor.textStorage!))
+        // Paragraph style has an NSTextBlock
+        let a = attrs(at: 0, in: editor)
+        let ps = a[.paragraphStyle] as? NSParagraphStyle
+        #expect(ps != nil)
+        #expect(!ps!.textBlocks.isEmpty)
     }
 
-    @Test("Non-active *** stays as raw text, dimmed")
-    @MainActor func nonActiveAsteriskDimmed() {
+    @Test("Non-active *** is hidden with horizontal line paragraph style")
+    @MainActor func nonActiveAsteriskHorizontalLine() {
         let editor = makeEditor()
         editor.loadContent("***\nother")
         activateBlock(1, in: editor)
 
         let text = displayText(for: 0, in: editor)
         #expect(text == "***")
-        let color = fgColor(at: 0, in: editor)
-        #expect(color == NSColor.tertiaryLabelColor)
+        #expect(isHidden(at: 0, in: editor.textStorage!))
+        let a = attrs(at: 0, in: editor)
+        let ps = a[.paragraphStyle] as? NSParagraphStyle
+        #expect(ps != nil)
+        #expect(!ps!.textBlocks.isEmpty)
     }
 }
 

--- a/Tests/MarkdownEditorTests/EditorRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/EditorRenderingTests.swift
@@ -179,6 +179,23 @@ struct EditorStylingTests {
         #expect(color!.redComponent > 0.5 && color!.greenComponent < 0.2)
     }
 
+    @Test("Inline code content has monospace font")
+    @MainActor func codeMonospace() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("`code`")
+        let f = styled.attribute(.font, at: 1, effectiveRange: nil) as? NSFont
+        #expect(f != nil)
+        #expect(f!.isFixedPitch)
+    }
+
+    @Test("Inline code content has background color")
+    @MainActor func codeBackground() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("`code`")
+        let bg = styled.attribute(.backgroundColor, at: 1, effectiveRange: nil) as? NSColor
+        #expect(bg != nil)
+    }
+
     @Test("Link delimiters are hidden when cursor is outside")
     @MainActor func linkDelimitersHidden() {
         let editor = makeEditor()
@@ -369,11 +386,24 @@ struct EditorStylingTests {
         #expect(isDimmed(at: 0, in: styled))
     }
 
-    @Test("Thematic break is dimmed, never hidden")
-    @MainActor func thematicBreakDimmed() {
+    @Test("Non-active thematic break is hidden with horizontal line style")
+    @MainActor func thematicBreakHidden() {
         let editor = makeEditor()
         let styled = editor.styleBlock("---")
         #expect(styled.string == "---")
+        // Characters are hidden (visual line via NSTextBlock)
+        #expect(isHidden(at: 0, in: styled))
+        // Paragraph style has a text block for the border
+        let a = styled.attributes(at: 0, effectiveRange: nil)
+        let ps = a[.paragraphStyle] as? NSParagraphStyle
+        #expect(ps != nil)
+        #expect(!ps!.textBlocks.isEmpty)
+    }
+
+    @Test("Active thematic break is dimmed, not hidden")
+    @MainActor func thematicBreakActiveDimmed() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("---", cursorPosition: 1)
         #expect(isDimmed(at: 0, in: styled))
         #expect(!isHidden(at: 0, in: styled))
     }


### PR DESCRIPTION
## Summary
- Thematic breaks (`---`/`***`) render as a full-width horizontal line (NSTextBlock border) when cursor is elsewhere; raw dashes shown dimmed when active
- Inline code spans now have monospace font and a subtle gray background in addition to code color

## Test plan
- [x] All 361 tests pass
- [ ] Type `---` then move cursor away — should show a horizontal line
- [ ] Type `***` then move cursor away — same horizontal line
- [ ] Click back into `---` — raw dashes appear dimmed
- [ ] Inline `` `code` `` shows monospace font with light background
- [ ] Verify in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)