### PR TITLE
Style list markers with accent and checkbox colors

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -106,6 +106,90 @@ extension EditorTextView {
         }
     }
 
+    // MARK: - List Marker Styling
+
+    /// Applies custom non-active styling to a list item's delimiter range.
+    /// - Unordered bullet: accent-colored `-`/`*`/`+`, dimmed space
+    /// - Unchecked checkbox: dimmed `- `, secondary-label `[ ]`
+    /// - Checked checkbox: dimmed `- `, accent-colored `[x]`
+    /// - Ordered: all dimmed
+    private func styleListDelimiter(
+        _ result: NSMutableAttributedString,
+        markdown: String,
+        delimiterRange dr: NSRange,
+        ordered: Bool,
+        checkbox: SyntaxHighlighter.Span.Kind.CheckboxState?
+    ) {
+        if ordered {
+            result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
+            return
+        }
+
+        let nsDelim = (markdown as NSString).substring(with: dr) as NSString
+
+        if let checkbox = checkbox {
+            // --- Checkbox item: find [ ] or [x] within delimiter ---
+            let bracketOpen = nsDelim.range(of: "[")
+            guard bracketOpen.location != NSNotFound else {
+                result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
+                return
+            }
+            let afterOpen = NSRange(location: bracketOpen.upperBound,
+                                     length: nsDelim.length - bracketOpen.upperBound)
+            let bracketClose = nsDelim.range(of: "]", options: [], range: afterOpen)
+            guard bracketClose.location != NSNotFound else {
+                result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
+                return
+            }
+
+            let cbRange = NSRange(
+                location: dr.location + bracketOpen.location,
+                length: bracketClose.upperBound - bracketOpen.location
+            )
+
+            // Dim everything before `[`
+            if bracketOpen.location > 0 {
+                let before = NSRange(location: dr.location, length: bracketOpen.location)
+                result.addAttribute(.foregroundColor, value: syntaxDimColor, range: before)
+            }
+            // Color the checkbox
+            let cbColor: NSColor = checkbox == .checked ? accentColor : .secondaryLabelColor
+            result.addAttribute(.foregroundColor, value: cbColor, range: cbRange)
+            // Dim everything after `]`
+            let afterEnd = cbRange.upperBound
+            if afterEnd < dr.upperBound {
+                let after = NSRange(location: afterEnd, length: dr.upperBound - afterEnd)
+                result.addAttribute(.foregroundColor, value: syntaxDimColor, range: after)
+            }
+        } else {
+            // --- Plain unordered bullet: color the marker character ---
+            for i in 0..<nsDelim.length {
+                let ch = nsDelim.character(at: i)
+                // 0x2D = '-', 0x2A = '*', 0x2B = '+'
+                guard ch == 0x2D || ch == 0x2A || ch == 0x2B else { continue }
+
+                // Dim leading whitespace
+                if i > 0 {
+                    let ws = NSRange(location: dr.location, length: i)
+                    result.addAttribute(.foregroundColor, value: syntaxDimColor, range: ws)
+                }
+                // Accent-color the bullet character
+                let bullet = NSRange(location: dr.location + i, length: 1)
+                result.addAttribute(.foregroundColor, value: accentColor, range: bullet)
+                // Dim trailing characters (space)
+                let after = dr.location + i + 1
+                if after < dr.upperBound {
+                    let trailing = NSRange(location: after, length: dr.upperBound - after)
+                    result.addAttribute(.foregroundColor, value: syntaxDimColor, range: trailing)
+                }
+                return
+            }
+
+            // Fallback: dim everything
+            result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
+        }
+    }
+
     // MARK: - Unified Styling
 
     /// Styles raw markdown text with rich attributes. Inline delimiters are hidden
@@ -244,6 +328,15 @@ extension EditorTextView {
                         result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
                     }
                     // Non-active: already hidden, don't override
+                } else if case .listItem(let ordered, let checkbox) = span.kind {
+                    // List markers: custom styling when non-active, dimmed when active
+                    if cursorInToken {
+                        result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
+                    } else {
+                        styleListDelimiter(result, markdown: markdown,
+                                           delimiterRange: dr, ordered: ordered,
+                                           checkbox: checkbox)
+                    }
                 } else if cursorInToken || !isDelimiterHideable(span.kind) {
                     // Visible: dim the delimiters
                     result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)

--- a/Tests/MarkdownEditorTests/BlockStylingTests.swift
+++ b/Tests/MarkdownEditorTests/BlockStylingTests.swift
@@ -195,7 +195,7 @@ struct BlockStylingNonActiveTests {
 
     // MARK: - Bullet Lists
 
-    @Test("Non-active list item has raw text, dimmed marker, indent")
+    @Test("Non-active list item has raw text, accent-colored bullet, indent")
     @MainActor func nonActiveBulletList() {
         let editor = makeEditor()
         editor.loadContent("- apples\nother")
@@ -204,9 +204,11 @@ struct BlockStylingNonActiveTests {
         // Text unchanged
         let text = displayText(for: 0, in: editor)
         #expect(text == "- apples")
-        // Marker is dimmed
+        // Bullet `-` is accent-colored (not dimmed)
         let delimColor = fgColor(at: 0, in: editor)
-        #expect(delimColor == NSColor.tertiaryLabelColor)
+        #expect(delimColor == editor.accentColor)
+        // Trailing space is dimmed
+        #expect(fgColor(at: 1, in: editor) == NSColor.tertiaryLabelColor)
         // Has indent
         let a = attrs(at: 0, in: editor)
         let ps = a[.paragraphStyle] as? NSParagraphStyle
@@ -230,7 +232,7 @@ struct BlockStylingNonActiveTests {
 
     // MARK: - Todo Lists
 
-    @Test("Non-active - [ ] shows raw text with dimmed marker")
+    @Test("Non-active - [ ] has dimmed prefix, secondary-label checkbox")
     @MainActor func nonActiveTodoUnchecked() {
         let editor = makeEditor()
         editor.loadContent("- [ ] task\nother")
@@ -238,9 +240,13 @@ struct BlockStylingNonActiveTests {
 
         let text = displayText(for: 0, in: editor)
         #expect(text == "- [ ] task")
+        // "- " prefix (offsets 0-1) is dimmed
+        #expect(fgColor(at: 0, in: editor) == NSColor.tertiaryLabelColor)
+        // "[ ]" (offsets 2-4) has secondary label color
+        #expect(fgColor(at: 2, in: editor) == NSColor.secondaryLabelColor)
     }
 
-    @Test("Non-active - [x] checked has strikethrough on content")
+    @Test("Non-active - [x] has dimmed prefix, accent-colored checkbox, strikethrough content")
     @MainActor func nonActiveTodoChecked() {
         let editor = makeEditor()
         editor.loadContent("- [x] done\nother")
@@ -248,11 +254,39 @@ struct BlockStylingNonActiveTests {
 
         let text = displayText(for: 0, in: editor)
         #expect(text == "- [x] done")
-
+        // "- " prefix (offsets 0-1) is dimmed
+        #expect(fgColor(at: 0, in: editor) == NSColor.tertiaryLabelColor)
+        // "[x]" (offsets 2-4) has accent color
+        #expect(fgColor(at: 2, in: editor) == editor.accentColor)
         // Content "done" should have strikethrough
-        // "- [x] done" — content starts after "- [x] " at offset 6
         let a = attrs(at: 6, in: editor)
         #expect(a[.strikethroughStyle] as? Int == NSUnderlineStyle.single.rawValue)
+    }
+
+    // MARK: - Multi-Level Lists
+
+    @Test("Non-active nested bullet (2 spaces) has accent-colored marker")
+    @MainActor func nonActiveNestedBullet() {
+        let editor = makeEditor()
+        editor.loadContent("  - nested\nother")
+        activateBlock(1, in: editor)
+
+        let text = displayText(for: 0, in: editor)
+        #expect(text == "  - nested")
+        // The `-` at offset 2 is accent-colored
+        #expect(fgColor(at: 2, in: editor) == editor.accentColor)
+    }
+
+    @Test("Non-active deeply-indented bullet (4 spaces) has accent-colored marker")
+    @MainActor func nonActiveDeeplyNestedBullet() {
+        let editor = makeEditor()
+        editor.loadContent("    - deep\nother")
+        activateBlock(1, in: editor)
+
+        let text = displayText(for: 0, in: editor)
+        #expect(text == "    - deep")
+        // The `-` at offset 4 is accent-colored
+        #expect(fgColor(at: 4, in: editor) == editor.accentColor)
     }
 
     // MARK: - Blockquotes

--- a/Tests/MarkdownEditorTests/EditorRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/EditorRenderingTests.swift
@@ -311,12 +311,51 @@ struct EditorStylingTests {
         #expect(hasTextBlock)
     }
 
-    @Test("List marker is dimmed, never hidden")
-    @MainActor func listMarkerDimmed() {
+    @Test("List bullet marker is accent-colored, never hidden")
+    @MainActor func listMarkerAccent() {
         let editor = makeEditor()
         let styled = editor.styleBlock("- hello")
-        #expect(isDimmed(at: 0, in: styled))
+        // The `-` is accent-colored (not dimmed, not hidden)
+        let a = styled.attributes(at: 0, effectiveRange: nil)
+        let color = a[.foregroundColor] as? NSColor
+        #expect(color == editor.accentColor)
         #expect(!isHidden(at: 0, in: styled))
+    }
+
+    @Test("Unchecked checkbox [ ] has secondary label color")
+    @MainActor func uncheckedCheckboxColor() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("- [ ] task")
+        // "- " at 0-1 is dimmed
+        #expect(isDimmed(at: 0, in: styled))
+        // "[ ]" at 2-4 has secondary label color
+        let a = styled.attributes(at: 2, effectiveRange: nil)
+        let color = a[.foregroundColor] as? NSColor
+        #expect(color == NSColor.secondaryLabelColor)
+    }
+
+    @Test("Checked checkbox [x] has accent color")
+    @MainActor func checkedCheckboxColor() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("- [x] done")
+        // "- " at 0-1 is dimmed
+        #expect(isDimmed(at: 0, in: styled))
+        // "[x]" at 2-4 has accent color
+        let a = styled.attributes(at: 2, effectiveRange: nil)
+        let color = a[.foregroundColor] as? NSColor
+        #expect(color == editor.accentColor)
+    }
+
+    @Test("Nested bullet (2 spaces) has accent-colored marker")
+    @MainActor func nestedBulletAccent() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("  - nested")
+        // Leading spaces have base text color (not part of delimiter)
+        #expect(!isDimmed(at: 0, in: styled))
+        // The `-` at offset 2 is accent-colored
+        let a = styled.attributes(at: 2, effectiveRange: nil)
+        let color = a[.foregroundColor] as? NSColor
+        #expect(color == editor.accentColor)
     }
 
     @Test("List items have hanging indent paragraph style")

--- a/test.md
+++ b/test.md
@@ -20,13 +20,18 @@ Other names:
 - Light/dark mode
 
 
-This should be *italicized*, and so is _this_. This is **bolded** and so is __this__. But this is even more ***important***. There's also several special cases like **here* and _here__. 
+This should be *italicized*, and so is _this_. This is **bolded** and so is __this__. But this is even more ***important***. There's also several special cases like **here* and _here__ (we should have extra * and _). 
 
 > Quote
 
 1. `code`
 2. ~~strikethrough~~
 3. [link](http://example.com)
+4. ==Highlight==
+
+Nest lists
+- Hello
+  - World
 
 
 ## TODOs
@@ -52,7 +57,6 @@ Refer to the implementation of [Swift Markdown Engine](https://github.com/nodes-
 - [x] Divider with `---`
 - [x] Code blocks
   - [ ] Syntax highlighting
-- [ ] Multi-line quotes
 - [ ] Callouts: GFM-flavored; use BlockDirectives in `swift-markdown`
   - [ ] Collapsible vs. not collapsible
   - [ ] Default to collapsible vs. not collapsible
@@ -60,7 +64,8 @@ Refer to the implementation of [Swift Markdown Engine](https://github.com/nodes-
 - [ ] Comments
 - [ ] Math: KaTex or some kind of swift math integration. 
 
-### Frontend
+
+### Frontend / UIUX
 
 - [x] Richer markdown rendering (headers, code, links, lists)
 - [x] title bar blending, window sizing, and dark mode 
@@ -83,10 +88,15 @@ Refer to the implementation of [Swift Markdown Engine](https://github.com/nodes-
   - [ ] Custom theme (see full customization)
 - [ ] Active block highlighting: wiggly (not fully straight) highlighter style by line
 - [ ] Title bar: Add horizontal line to divide content and bar
+- [ ] List: Automatic add list item upon new line in a list environment
+- [ ] List: Un-indent current line when upon new line on a empty line
 
 ### Bugs
 
 - [x] List indentation: ` -` has less indentation than `-` (which has rendered indentation). Render indentation for all `-` at the beginning of the line, even after whitespace. 
+- [ ] Unmatched * and _ should not be hidden
+- [ ] Todo list indentation: Align beginning of list marker with first character in upper-level text
+
 
 ### Maybes
 


### PR DESCRIPTION
## Summary
- Bullet markers (`-`/`*`/`+`) rendered in accent color instead of dimmed
- Unchecked checkboxes `[ ]` in secondary label color, checked `[x]` in accent color
- Ordered list markers remain dimmed
- Multi-level lists supported via existing whitespace indentation

## Test plan
- [x] All 366 tests pass
- [ ] Verify bullet markers show accent color in editor
- [ ] Verify checked/unchecked checkboxes have correct colors
- [ ] Verify nested lists render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)