### PR TITLE
Fix unmatched emphasis delimiters being hidden

### DIFF
--- a/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
+++ b/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
@@ -241,6 +241,39 @@ public enum SyntaxHighlighter {
             return delims
         }
 
+        /// Trims delimiter ranges to the expected width for emphasis types.
+        /// When cmark includes unmatched delimiter characters in the emphasis
+        /// node's source range (e.g. `**here*` → italic with opening `**`),
+        /// this trims them so only the real delimiter chars are styled.
+        /// Returns adjusted (fullRange, delimiterRanges).
+        func trimEmphasisDelimiters(
+            expectedWidth: Int, full: NSRange, delims: [NSRange]
+        ) -> (NSRange, [NSRange]) {
+            guard delims.count == 2 else { return (full, delims) }
+            var trimmedDelims = delims
+            var trimmedFull = full
+
+            // Opening delimiter: keep only the last `expectedWidth` chars
+            if delims[0].length > expectedWidth {
+                let excess = delims[0].length - expectedWidth
+                trimmedDelims[0] = NSRange(location: delims[0].location + excess,
+                                            length: expectedWidth)
+                trimmedFull = NSRange(location: trimmedFull.location + excess,
+                                      length: trimmedFull.length - excess)
+            }
+
+            // Closing delimiter: keep only the first `expectedWidth` chars
+            if delims[1].length > expectedWidth {
+                let excess = delims[1].length - expectedWidth
+                trimmedDelims[1] = NSRange(location: delims[1].location,
+                                            length: expectedWidth)
+                trimmedFull = NSRange(location: trimmedFull.location,
+                                      length: trimmedFull.length - excess)
+            }
+
+            return (trimmedFull, trimmedDelims)
+        }
+
         /// Compute content range from full range and delimiter ranges.
         func contentRange(full: NSRange, delims: [NSRange]) -> NSRange {
             var start = full.location
@@ -295,11 +328,13 @@ public enum SyntaxHighlighter {
                 if strongNS == full {
                     // This is boldItalic. Compute delimiters from the Strong's children
                     // (the text nodes inside), not from the Emphasis's children (the Strong).
-                    let delims = delimiterRanges(parent: full, children: strong.children)
-                    let content = contentRange(full: full, delims: delims)
+                    let rawDelims = delimiterRanges(parent: full, children: strong.children)
+                    let (trimmedFull, delims) = trimEmphasisDelimiters(
+                        expectedWidth: 3, full: full, delims: rawDelims)
+                    let content = contentRange(full: trimmedFull, delims: delims)
                     spans.append(Span(
                         kind: .boldItalic,
-                        fullRange: full,
+                        fullRange: trimmedFull,
                         contentRange: content,
                         delimiterRanges: delims
                     ))
@@ -309,11 +344,13 @@ public enum SyntaxHighlighter {
             }
 
             // Regular italic
-            let delims = delimiterRanges(parent: full, children: emphasis.children)
-            let content = contentRange(full: full, delims: delims)
+            let rawDelims = delimiterRanges(parent: full, children: emphasis.children)
+            let (trimmedFull, delims) = trimEmphasisDelimiters(
+                expectedWidth: 1, full: full, delims: rawDelims)
+            let content = contentRange(full: trimmedFull, delims: delims)
             spans.append(Span(
                 kind: .italic,
-                fullRange: full,
+                fullRange: trimmedFull,
                 contentRange: content,
                 delimiterRanges: delims
             ))
@@ -344,11 +381,13 @@ public enum SyntaxHighlighter {
                let emphRange = emph.range {
                 let emphNS = nsRange(for: emphRange)
                 if emphNS == full {
-                    let delims = delimiterRanges(parent: full, children: emph.children)
-                    let content = contentRange(full: full, delims: delims)
+                    let rawDelims = delimiterRanges(parent: full, children: emph.children)
+                    let (trimmedFull, delims) = trimEmphasisDelimiters(
+                        expectedWidth: 3, full: full, delims: rawDelims)
+                    let content = contentRange(full: trimmedFull, delims: delims)
                     spans.append(Span(
                         kind: .boldItalic,
-                        fullRange: full,
+                        fullRange: trimmedFull,
                         contentRange: content,
                         delimiterRanges: delims
                     ))
@@ -357,11 +396,13 @@ public enum SyntaxHighlighter {
             }
 
             // Regular bold
-            let delims = delimiterRanges(parent: full, children: strong.children)
-            let content = contentRange(full: full, delims: delims)
+            let rawDelims = delimiterRanges(parent: full, children: strong.children)
+            let (trimmedFull, delims) = trimEmphasisDelimiters(
+                expectedWidth: 2, full: full, delims: rawDelims)
+            let content = contentRange(full: trimmedFull, delims: delims)
             spans.append(Span(
                 kind: .bold,
-                fullRange: full,
+                fullRange: trimmedFull,
                 contentRange: content,
                 delimiterRanges: delims
             ))

--- a/Tests/MarkdownEditorTests/UnmatchedDebugTests.swift
+++ b/Tests/MarkdownEditorTests/UnmatchedDebugTests.swift
@@ -1,0 +1,94 @@
+import Testing
+import Foundation
+@testable import MarkdownEditorCore
+
+// MARK: - Unmatched Emphasis Delimiters
+
+@Suite("SyntaxHighlighter — Unmatched Delimiters")
+struct UnmatchedDelimiterTests {
+
+    @Test("**here* trims opening delimiter to single *")
+    func doubleStarHereStar() {
+        let spans = SyntaxHighlighter.parse("**here*")
+        #expect(spans.count == 1)
+        let s = spans[0]
+        #expect(s.kind == .italic)
+        #expect(s.fullRange == NSRange(location: 1, length: 6))
+        #expect(s.contentRange == NSRange(location: 2, length: 4))
+        #expect(s.delimiterRanges == [
+            NSRange(location: 1, length: 1),
+            NSRange(location: 6, length: 1),
+        ])
+    }
+
+    @Test("_here__ trims closing delimiter to single _")
+    func underscoreHereDoubleUnderscore() {
+        let spans = SyntaxHighlighter.parse("_here__")
+        #expect(spans.count == 1)
+        let s = spans[0]
+        #expect(s.kind == .italic)
+        #expect(s.fullRange == NSRange(location: 0, length: 6))
+        #expect(s.contentRange == NSRange(location: 1, length: 4))
+        #expect(s.delimiterRanges == [
+            NSRange(location: 0, length: 1),
+            NSRange(location: 5, length: 1),
+        ])
+    }
+
+    @Test("***bold** trims opening delimiter to **")
+    func tripleStarBoldDoubleStar() {
+        let spans = SyntaxHighlighter.parse("***bold**")
+        #expect(spans.count == 1)
+        let s = spans[0]
+        #expect(s.kind == .bold)
+        #expect(s.fullRange == NSRange(location: 1, length: 8))
+        #expect(s.contentRange == NSRange(location: 3, length: 4))
+        #expect(s.delimiterRanges == [
+            NSRange(location: 1, length: 2),
+            NSRange(location: 7, length: 2),
+        ])
+    }
+
+    @Test("***here* trims opening delimiter to single *")
+    func tripleStarHereStar() {
+        let spans = SyntaxHighlighter.parse("***here*")
+        #expect(spans.count == 1)
+        let s = spans[0]
+        #expect(s.kind == .italic)
+        #expect(s.fullRange == NSRange(location: 2, length: 6))
+        #expect(s.contentRange == NSRange(location: 3, length: 4))
+        #expect(s.delimiterRanges == [
+            NSRange(location: 2, length: 1),
+            NSRange(location: 7, length: 1),
+        ])
+    }
+
+    @Test("****here*** trims opening delimiter to ***")
+    func quadStarHereTripleStar() {
+        let spans = SyntaxHighlighter.parse("****here***")
+        #expect(spans.count == 1)
+        let s = spans[0]
+        #expect(s.kind == .boldItalic)
+        #expect(s.fullRange == NSRange(location: 1, length: 10))
+        #expect(s.contentRange == NSRange(location: 4, length: 4))
+        #expect(s.delimiterRanges == [
+            NSRange(location: 1, length: 3),
+            NSRange(location: 8, length: 3),
+        ])
+    }
+
+    @Test("Matched delimiters are unchanged")
+    func matchedDelimitersUnchanged() {
+        let bold = SyntaxHighlighter.parse("**bold**")
+        #expect(bold[0].fullRange == NSRange(location: 0, length: 8))
+        #expect(bold[0].delimiterRanges[0] == NSRange(location: 0, length: 2))
+
+        let italic = SyntaxHighlighter.parse("*italic*")
+        #expect(italic[0].fullRange == NSRange(location: 0, length: 8))
+        #expect(italic[0].delimiterRanges[0] == NSRange(location: 0, length: 1))
+
+        let bi = SyntaxHighlighter.parse("***both***")
+        #expect(bi[0].fullRange == NSRange(location: 0, length: 10))
+        #expect(bi[0].delimiterRanges[0] == NSRange(location: 0, length: 3))
+    }
+}


### PR DESCRIPTION
## Summary
- Unmatched `*` and `_` characters (e.g. `**here*`, `_here__`) were being hidden as delimiters when they should display as normal text
- Added `trimEmphasisDelimiters` to trim delimiter ranges to the expected width for each emphasis type
- Fixes the case where cmark-gfm includes extra literal characters in emphasis node source ranges

## Test plan
- [x] All 372 tests pass (6 new regression tests for unmatched delimiter cases)
- [ ] Verify `**here*` shows the leading `*` as normal text, `here` as italic
- [ ] Verify `_here__` shows the trailing `_` as normal text, `here` as italic

🤖 Generated with [Claude Code](https://claude.com/claude-code)