### PR TITLE
Render todo checkboxes as circle icons

### DIFF
--- a/Sources/MarkdownEditor/Document.swift
+++ b/Sources/MarkdownEditor/Document.swift
@@ -70,7 +70,7 @@ class Document: NSDocument {
 
         // Build the text system chain:
         //   NSTextStorage → NSLayoutManager → NSTextContainer → NSTextView
-        let textStorage = NSTextStorage()
+        let textStorage = EditorTextStorage()
         let layoutManager = NSLayoutManager()
         textStorage.addLayoutManager(layoutManager)
 

--- a/Sources/MarkdownEditorCore/EditorTextStorage.swift
+++ b/Sources/MarkdownEditorCore/EditorTextStorage.swift
@@ -1,0 +1,45 @@
+import AppKit
+
+/// A text storage subclass that preserves `.attachment` attributes on
+/// any character, not just the object replacement character (\u{FFFC}).
+///
+/// Standard NSTextStorage strips attachments from non-FFFC characters
+/// during `fixAttributes`. This subclass skips attribute fixing since
+/// the editor explicitly manages all attributes for every character.
+public class EditorTextStorage: NSTextStorage {
+    private let backing = NSMutableAttributedString()
+
+    override public var string: String { backing.string }
+
+    override public func attributes(
+        at location: Int, effectiveRange range: NSRangePointer?
+    ) -> [NSAttributedString.Key: Any] {
+        backing.attributes(at: location, effectiveRange: range)
+    }
+
+    override public func replaceCharacters(in range: NSRange, with str: String) {
+        backing.replaceCharacters(in: range, with: str)
+        edited(.editedCharacters, range: range,
+               changeInLength: (str as NSString).length - range.length)
+    }
+
+    override public func replaceCharacters(in range: NSRange, with attrString: NSAttributedString) {
+        backing.replaceCharacters(in: range, with: attrString)
+        edited([.editedCharacters, .editedAttributes], range: range,
+               changeInLength: attrString.length - range.length)
+    }
+
+    override public func setAttributes(
+        _ attrs: [NSAttributedString.Key: Any]?, range: NSRange
+    ) {
+        backing.setAttributes(attrs, range: range)
+        edited(.editedAttributes, range: range, changeInLength: 0)
+    }
+
+    override public func fixAttributes(in range: NSRange) {
+        // Skip default attribute fixing. The editor sets all attributes
+        // explicitly for every character, so no automatic fixing is needed.
+        // This preserves .attachment attributes on non-FFFC characters
+        // (used for checkbox circle icons).
+    }
+}

--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -106,12 +106,54 @@ extension EditorTextView {
         }
     }
 
+    // MARK: - Checkbox Attachment
+
+    /// Creates an NSTextAttachment with a circle icon for checkbox rendering.
+    /// Unchecked: gray outlined circle. Checked: filled yellow circle with checkmark.
+    private func checkboxAttachment(checked: Bool) -> NSTextAttachment {
+        let fontSize = bodyFont.pointSize
+        let image = NSImage(size: NSSize(width: fontSize, height: fontSize), flipped: true) { bounds in
+            let inset: CGFloat = 1.0
+            let circleRect = bounds.insetBy(dx: inset, dy: inset)
+            let path = NSBezierPath(ovalIn: circleRect)
+
+            if checked {
+                NSColor.systemYellow.setFill()
+                path.fill()
+                // Checkmark
+                let check = NSBezierPath()
+                check.lineWidth = max(1.5, fontSize * 0.1)
+                check.lineCapStyle = .round
+                check.lineJoinStyle = .round
+                let cx = bounds.midX, cy = bounds.midY
+                let r = circleRect.width / 2
+                check.move(to: NSPoint(x: cx - r * 0.35, y: cy + r * 0.05))
+                check.line(to: NSPoint(x: cx - r * 0.08, y: cy + r * 0.35))
+                check.line(to: NSPoint(x: cx + r * 0.38, y: cy - r * 0.30))
+                NSColor.white.setStroke()
+                check.stroke()
+            } else {
+                NSColor.secondaryLabelColor.setStroke()
+                path.lineWidth = max(1.5, fontSize * 0.08)
+                path.stroke()
+            }
+            return true
+        }
+
+        let attachment = NSTextAttachment()
+        attachment.image = image
+        // Vertically center the circle relative to the text baseline
+        attachment.bounds = CGRect(x: 0, y: -fontSize * 0.15,
+                                   width: fontSize, height: fontSize)
+        return attachment
+    }
+
     // MARK: - List Marker Styling
 
     /// Applies custom non-active styling to a list item's delimiter range.
-    /// - Unordered bullet: accent-colored `-`/`*`/`+`, dimmed space
-    /// - Unchecked checkbox: dimmed `- `, secondary-label `[ ]`
-    /// - Checked checkbox: dimmed `- `, accent-colored `[x]`
+    /// - Unordered bullet: dimmed
+    /// - Unchecked checkbox: circle icon (Apple Notes style)
+    /// - Checked checkbox: filled circle icon (Apple Notes style)
     /// - Ordered: all dimmed
     private func styleListDelimiter(
         _ result: NSMutableAttributedString,
@@ -120,73 +162,56 @@ extension EditorTextView {
         ordered: Bool,
         checkbox: SyntaxHighlighter.Span.Kind.CheckboxState?
     ) {
-        if ordered {
+        if ordered || checkbox == nil {
+            // Ordered lists and plain bullets: dim everything
             result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
             return
         }
 
+        guard let checkbox = checkbox else { return }
+
         let nsDelim = (markdown as NSString).substring(with: dr) as NSString
 
-        if let checkbox = checkbox {
-            // --- Checkbox item: find [ ] or [x] within delimiter ---
-            let bracketOpen = nsDelim.range(of: "[")
-            guard bracketOpen.location != NSNotFound else {
-                result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
-                return
-            }
-            let afterOpen = NSRange(location: bracketOpen.upperBound,
-                                     length: nsDelim.length - bracketOpen.upperBound)
-            let bracketClose = nsDelim.range(of: "]", options: [], range: afterOpen)
-            guard bracketClose.location != NSNotFound else {
-                result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
-                return
-            }
-
-            let cbRange = NSRange(
-                location: dr.location + bracketOpen.location,
-                length: bracketClose.upperBound - bracketOpen.location
-            )
-
-            // Dim everything before `[`
-            if bracketOpen.location > 0 {
-                let before = NSRange(location: dr.location, length: bracketOpen.location)
-                result.addAttribute(.foregroundColor, value: syntaxDimColor, range: before)
-            }
-            // Color the checkbox
-            let cbColor: NSColor = checkbox == .checked ? accentColor : .secondaryLabelColor
-            result.addAttribute(.foregroundColor, value: cbColor, range: cbRange)
-            // Dim everything after `]`
-            let afterEnd = cbRange.upperBound
-            if afterEnd < dr.upperBound {
-                let after = NSRange(location: afterEnd, length: dr.upperBound - afterEnd)
-                result.addAttribute(.foregroundColor, value: syntaxDimColor, range: after)
-            }
-        } else {
-            // --- Plain unordered bullet: color the marker character ---
-            for i in 0..<nsDelim.length {
-                let ch = nsDelim.character(at: i)
-                // 0x2D = '-', 0x2A = '*', 0x2B = '+'
-                guard ch == 0x2D || ch == 0x2A || ch == 0x2B else { continue }
-
-                // Dim leading whitespace
-                if i > 0 {
-                    let ws = NSRange(location: dr.location, length: i)
-                    result.addAttribute(.foregroundColor, value: syntaxDimColor, range: ws)
-                }
-                // Accent-color the bullet character
-                let bullet = NSRange(location: dr.location + i, length: 1)
-                result.addAttribute(.foregroundColor, value: accentColor, range: bullet)
-                // Dim trailing characters (space)
-                let after = dr.location + i + 1
-                if after < dr.upperBound {
-                    let trailing = NSRange(location: after, length: dr.upperBound - after)
-                    result.addAttribute(.foregroundColor, value: syntaxDimColor, range: trailing)
-                }
-                return
-            }
-
-            // Fallback: dim everything
+        // --- Checkbox item: replace [ ]/[x] with circle icon ---
+        let bracketOpen = nsDelim.range(of: "[")
+        guard bracketOpen.location != NSNotFound else {
             result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
+            return
+        }
+        let afterOpen = NSRange(location: bracketOpen.upperBound,
+                                 length: nsDelim.length - bracketOpen.upperBound)
+        let bracketClose = nsDelim.range(of: "]", options: [], range: afterOpen)
+        guard bracketClose.location != NSNotFound else {
+            result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
+            return
+        }
+
+        let cbStart = dr.location + bracketOpen.location
+        let cbEnd = dr.location + bracketClose.upperBound
+
+        // Dim everything before `[` (the "- " prefix)
+        if bracketOpen.location > 0 {
+            let before = NSRange(location: dr.location, length: bracketOpen.location)
+            result.addAttribute(.foregroundColor, value: syntaxDimColor, range: before)
+        }
+
+        // Place circle attachment on `[` character
+        let attachment = checkboxAttachment(checked: checkbox == .checked)
+        result.addAttribute(.attachment, value: attachment,
+                            range: NSRange(location: cbStart, length: 1))
+
+        // Hide remaining checkbox characters (` ]`/`x]`) with zero-width + clear
+        let hideStart = cbStart + 1
+        if hideStart < cbEnd {
+            let hideRange = NSRange(location: hideStart, length: cbEnd - hideStart)
+            result.addAttribute(.font, value: hiddenFont, range: hideRange)
+            result.addAttribute(.foregroundColor, value: NSColor.clear, range: hideRange)
+        }
+
+        // Dim everything after `]` (trailing space)
+        if cbEnd < dr.upperBound {
+            let after = NSRange(location: cbEnd, length: dr.upperBound - cbEnd)
+            result.addAttribute(.foregroundColor, value: syntaxDimColor, range: after)
         }
     }
 

--- a/Tests/MarkdownEditorTests/BlockStylingTests.swift
+++ b/Tests/MarkdownEditorTests/BlockStylingTests.swift
@@ -195,7 +195,7 @@ struct BlockStylingNonActiveTests {
 
     // MARK: - Bullet Lists
 
-    @Test("Non-active list item has raw text, accent-colored bullet, indent")
+    @Test("Non-active list item has raw text, dimmed marker, indent")
     @MainActor func nonActiveBulletList() {
         let editor = makeEditor()
         editor.loadContent("- apples\nother")
@@ -204,11 +204,9 @@ struct BlockStylingNonActiveTests {
         // Text unchanged
         let text = displayText(for: 0, in: editor)
         #expect(text == "- apples")
-        // Bullet `-` is accent-colored (not dimmed)
+        // Bullet `-` is dimmed
         let delimColor = fgColor(at: 0, in: editor)
-        #expect(delimColor == editor.accentColor)
-        // Trailing space is dimmed
-        #expect(fgColor(at: 1, in: editor) == NSColor.tertiaryLabelColor)
+        #expect(delimColor == NSColor.tertiaryLabelColor)
         // Has indent
         let a = attrs(at: 0, in: editor)
         let ps = a[.paragraphStyle] as? NSParagraphStyle
@@ -232,7 +230,7 @@ struct BlockStylingNonActiveTests {
 
     // MARK: - Todo Lists
 
-    @Test("Non-active - [ ] has dimmed prefix, secondary-label checkbox")
+    @Test("Non-active - [ ] has dimmed prefix, circle attachment on [")
     @MainActor func nonActiveTodoUnchecked() {
         let editor = makeEditor()
         editor.loadContent("- [ ] task\nother")
@@ -242,11 +240,16 @@ struct BlockStylingNonActiveTests {
         #expect(text == "- [ ] task")
         // "- " prefix (offsets 0-1) is dimmed
         #expect(fgColor(at: 0, in: editor) == NSColor.tertiaryLabelColor)
-        // "[ ]" (offsets 2-4) has secondary label color
-        #expect(fgColor(at: 2, in: editor) == NSColor.secondaryLabelColor)
+        // "[" (offset 2) has a text attachment (circle icon)
+        let a = attrs(at: 2, in: editor)
+        #expect(a[.attachment] is NSTextAttachment)
+        // " ]" (offsets 3-4) are hidden
+        let hiddenA = attrs(at: 3, in: editor)
+        let hiddenF = hiddenA[.font] as? NSFont
+        #expect(hiddenF != nil && hiddenF!.pointSize < 1.0)
     }
 
-    @Test("Non-active - [x] has dimmed prefix, accent-colored checkbox, strikethrough content")
+    @Test("Non-active - [x] has dimmed prefix, filled circle attachment, strikethrough content")
     @MainActor func nonActiveTodoChecked() {
         let editor = makeEditor()
         editor.loadContent("- [x] done\nother")
@@ -256,16 +259,21 @@ struct BlockStylingNonActiveTests {
         #expect(text == "- [x] done")
         // "- " prefix (offsets 0-1) is dimmed
         #expect(fgColor(at: 0, in: editor) == NSColor.tertiaryLabelColor)
-        // "[x]" (offsets 2-4) has accent color
-        #expect(fgColor(at: 2, in: editor) == editor.accentColor)
+        // "[" (offset 2) has a text attachment (filled circle icon)
+        let a = attrs(at: 2, in: editor)
+        #expect(a[.attachment] is NSTextAttachment)
+        // "x]" (offsets 3-4) are hidden
+        let hiddenA = attrs(at: 3, in: editor)
+        let hiddenF = hiddenA[.font] as? NSFont
+        #expect(hiddenF != nil && hiddenF!.pointSize < 1.0)
         // Content "done" should have strikethrough
-        let a = attrs(at: 6, in: editor)
-        #expect(a[.strikethroughStyle] as? Int == NSUnderlineStyle.single.rawValue)
+        let ca = attrs(at: 6, in: editor)
+        #expect(ca[.strikethroughStyle] as? Int == NSUnderlineStyle.single.rawValue)
     }
 
     // MARK: - Multi-Level Lists
 
-    @Test("Non-active nested bullet (2 spaces) has accent-colored marker")
+    @Test("Non-active nested bullet (2 spaces) has dimmed marker")
     @MainActor func nonActiveNestedBullet() {
         let editor = makeEditor()
         editor.loadContent("  - nested\nother")
@@ -273,11 +281,11 @@ struct BlockStylingNonActiveTests {
 
         let text = displayText(for: 0, in: editor)
         #expect(text == "  - nested")
-        // The `-` at offset 2 is accent-colored
-        #expect(fgColor(at: 2, in: editor) == editor.accentColor)
+        // The `-` at offset 2 is dimmed
+        #expect(fgColor(at: 2, in: editor) == NSColor.tertiaryLabelColor)
     }
 
-    @Test("Non-active deeply-indented bullet (4 spaces) has accent-colored marker")
+    @Test("Non-active deeply-indented bullet (4 spaces) has dimmed marker")
     @MainActor func nonActiveDeeplyNestedBullet() {
         let editor = makeEditor()
         editor.loadContent("    - deep\nother")
@@ -285,8 +293,8 @@ struct BlockStylingNonActiveTests {
 
         let text = displayText(for: 0, in: editor)
         #expect(text == "    - deep")
-        // The `-` at offset 4 is accent-colored
-        #expect(fgColor(at: 4, in: editor) == editor.accentColor)
+        // The `-` at offset 4 is dimmed
+        #expect(fgColor(at: 4, in: editor) == NSColor.tertiaryLabelColor)
     }
 
     // MARK: - Blockquotes

--- a/Tests/MarkdownEditorTests/EditorRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/EditorRenderingTests.swift
@@ -311,51 +311,49 @@ struct EditorStylingTests {
         #expect(hasTextBlock)
     }
 
-    @Test("List bullet marker is accent-colored, never hidden")
-    @MainActor func listMarkerAccent() {
+    @Test("List bullet marker is dimmed, never hidden")
+    @MainActor func listMarkerDimmed() {
         let editor = makeEditor()
         let styled = editor.styleBlock("- hello")
-        // The `-` is accent-colored (not dimmed, not hidden)
-        let a = styled.attributes(at: 0, effectiveRange: nil)
-        let color = a[.foregroundColor] as? NSColor
-        #expect(color == editor.accentColor)
+        // The `-` is dimmed (not hidden)
+        #expect(isDimmed(at: 0, in: styled))
         #expect(!isHidden(at: 0, in: styled))
     }
 
-    @Test("Unchecked checkbox [ ] has secondary label color")
-    @MainActor func uncheckedCheckboxColor() {
+    @Test("Unchecked checkbox [ ] has circle attachment")
+    @MainActor func uncheckedCheckboxAttachment() {
         let editor = makeEditor()
         let styled = editor.styleBlock("- [ ] task")
         // "- " at 0-1 is dimmed
         #expect(isDimmed(at: 0, in: styled))
-        // "[ ]" at 2-4 has secondary label color
+        // "[" at 2 has a text attachment
         let a = styled.attributes(at: 2, effectiveRange: nil)
-        let color = a[.foregroundColor] as? NSColor
-        #expect(color == NSColor.secondaryLabelColor)
+        #expect(a[.attachment] is NSTextAttachment)
+        // " ]" at 3-4 are hidden
+        #expect(isHidden(at: 3, in: styled))
     }
 
-    @Test("Checked checkbox [x] has accent color")
-    @MainActor func checkedCheckboxColor() {
+    @Test("Checked checkbox [x] has circle attachment")
+    @MainActor func checkedCheckboxAttachment() {
         let editor = makeEditor()
         let styled = editor.styleBlock("- [x] done")
         // "- " at 0-1 is dimmed
         #expect(isDimmed(at: 0, in: styled))
-        // "[x]" at 2-4 has accent color
+        // "[" at 2 has a text attachment
         let a = styled.attributes(at: 2, effectiveRange: nil)
-        let color = a[.foregroundColor] as? NSColor
-        #expect(color == editor.accentColor)
+        #expect(a[.attachment] is NSTextAttachment)
+        // "x]" at 3-4 are hidden
+        #expect(isHidden(at: 3, in: styled))
     }
 
-    @Test("Nested bullet (2 spaces) has accent-colored marker")
-    @MainActor func nestedBulletAccent() {
+    @Test("Nested bullet (2 spaces) has dimmed marker")
+    @MainActor func nestedBulletDimmed() {
         let editor = makeEditor()
         let styled = editor.styleBlock("  - nested")
         // Leading spaces have base text color (not part of delimiter)
         #expect(!isDimmed(at: 0, in: styled))
-        // The `-` at offset 2 is accent-colored
-        let a = styled.attributes(at: 2, effectiveRange: nil)
-        let color = a[.foregroundColor] as? NSColor
-        #expect(color == editor.accentColor)
+        // The `-` at offset 2 is dimmed
+        #expect(isDimmed(at: 2, in: styled))
     }
 
     @Test("List items have hanging indent paragraph style")

--- a/Tests/MarkdownEditorTests/TestHelpers.swift
+++ b/Tests/MarkdownEditorTests/TestHelpers.swift
@@ -8,7 +8,7 @@ import AppKit
 /// mirroring the setup in main.swift.
 @MainActor
 func makeEditor() -> EditorTextView {
-    let textStorage = NSTextStorage()
+    let textStorage = EditorTextStorage()
     let layoutManager = NSLayoutManager()
     textStorage.addLayoutManager(layoutManager)
     let textContainer = NSTextContainer(


### PR DESCRIPTION
## Summary
- Todo checkboxes rendered as circle icons (Apple Notes style): gray outlined circle for unchecked, filled yellow circle with checkmark for checked
- Bullet and ordered list markers reverted to uniform dimmed color (no accent)
- Added `EditorTextStorage` subclass that preserves `.attachment` attributes on non-FFFC characters

## Test plan
- [x] All 372 tests pass
- [ ] Verify unchecked `- [ ]` shows gray circle icon
- [ ] Verify checked `- [x]` shows yellow filled circle with checkmark
- [ ] Verify bullet `-` markers are dimmed, not accent-colored
- [ ] Verify cursor entering a checkbox block reveals raw `[ ]`/`[x]` text

🤖 Generated with [Claude Code](https://claude.com/claude-code)