### PR TITLE
Adjust thematic break divider to 1em height

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -57,19 +57,20 @@ extension EditorTextView {
     }
 
     /// Paragraph style for thematic breaks. Uses an NSTextBlock with a
-    /// top border to render a full-width horizontal line.
+    /// top border to render a full-width horizontal line, totaling 1em height.
     private func thematicBreakParagraphStyle() -> NSParagraphStyle {
         let ps = NSMutableParagraphStyle()
-        ps.paragraphSpacing = bodyParagraphStyle.paragraphSpacing
-        ps.paragraphSpacingBefore = bodyParagraphStyle.paragraphSpacingBefore
 
         let block = NSTextBlock()
         block.setContentWidth(100, type: .percentageValueType)
-        // NSMinYEdge (1) = top in flipped coordinates (NSTextView)
-        let topEdge = NSRectEdge(rawValue: 1)!
+        // Center the 1pt border within 1em of vertical space.
+        let halfEm = (bodyFont.pointSize - 1) / 2
+        let topEdge = NSRectEdge(rawValue: 1)!   // NSMinYEdge = top in flipped
+        let bottomEdge = NSRectEdge(rawValue: 3)! // NSMaxYEdge = bottom in flipped
         block.setWidth(1, type: .absoluteValueType, for: .border, edge: topEdge)
         block.setBorderColor(.separatorColor, for: topEdge)
-        block.setWidth(4, type: .absoluteValueType, for: .padding, edge: topEdge)
+        block.setWidth(halfEm, type: .absoluteValueType, for: .margin, edge: topEdge)
+        block.setWidth(halfEm, type: .absoluteValueType, for: .margin, edge: bottomEdge)
         ps.textBlocks = [block]
 
         return ps


### PR DESCRIPTION
## Summary
- Thematic break (`---`/`***`) divider now takes 1em of vertical height
- Border line centered within the 1em space using equal top/bottom margins on NSTextBlock
- Paragraph spacing removed from divider style so block margins alone control height

## Test plan
- [x] All 372 tests pass
- [ ] Verify `---` divider renders as a thin horizontal line taking ~1em of vertical space

🤖 Generated with [Claude Code](https://claude.com/claude-code)