### PR TITLE
Polish todo checkbox rendering

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -130,9 +130,13 @@ extension EditorTextView {
                 NSColor.white.setStroke()
                 check.stroke()
             } else {
-                NSColor.secondaryLabelColor.setStroke()
-                path.lineWidth = max(1.5, fontSize * 0.08)
-                path.stroke()
+                let lw = max(1.5, fontSize * 0.08)
+                // Inset the stroke path so its outer edge matches the filled circle's edge.
+                let strokeRect = circleRect.insetBy(dx: lw / 2, dy: lw / 2)
+                let strokePath = NSBezierPath(ovalIn: strokeRect)
+                strokePath.lineWidth = lw
+                NSColor.tertiaryLabelColor.setStroke()
+                strokePath.stroke()
             }
             return true
         }
@@ -186,10 +190,11 @@ extension EditorTextView {
         let cbStart = dr.location + bracketOpen.location
         let cbEnd = dr.location + bracketClose.upperBound
 
-        // Dim everything before `[` (the "- " prefix)
+        // Hide everything before `[` (the "- " prefix) — zero-width + clear
         if bracketOpen.location > 0 {
             let before = NSRange(location: dr.location, length: bracketOpen.location)
-            result.addAttribute(.foregroundColor, value: syntaxDimColor, range: before)
+            result.addAttribute(.font, value: hiddenFont, range: before)
+            result.addAttribute(.foregroundColor, value: NSColor.clear, range: before)
         }
 
         // Place circle attachment on `[` character

--- a/Tests/MarkdownEditorTests/BlockStylingTests.swift
+++ b/Tests/MarkdownEditorTests/BlockStylingTests.swift
@@ -238,8 +238,8 @@ struct BlockStylingNonActiveTests {
 
         let text = displayText(for: 0, in: editor)
         #expect(text == "- [ ] task")
-        // "- " prefix (offsets 0-1) is dimmed
-        #expect(fgColor(at: 0, in: editor) == NSColor.tertiaryLabelColor)
+        // "- " prefix (offsets 0-1) is hidden (zero-width + clear)
+        #expect(isHidden(at: 0, in: editor.textStorage!))
         // "[" (offset 2) has a text attachment (circle icon)
         let a = attrs(at: 2, in: editor)
         #expect(a[.attachment] is NSTextAttachment)
@@ -257,8 +257,8 @@ struct BlockStylingNonActiveTests {
 
         let text = displayText(for: 0, in: editor)
         #expect(text == "- [x] done")
-        // "- " prefix (offsets 0-1) is dimmed
-        #expect(fgColor(at: 0, in: editor) == NSColor.tertiaryLabelColor)
+        // "- " prefix (offsets 0-1) is hidden (zero-width + clear)
+        #expect(isHidden(at: 0, in: editor.textStorage!))
         // "[" (offset 2) has a text attachment (filled circle icon)
         let a = attrs(at: 2, in: editor)
         #expect(a[.attachment] is NSTextAttachment)

--- a/Tests/MarkdownEditorTests/EditorRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/EditorRenderingTests.swift
@@ -324,8 +324,8 @@ struct EditorStylingTests {
     @MainActor func uncheckedCheckboxAttachment() {
         let editor = makeEditor()
         let styled = editor.styleBlock("- [ ] task")
-        // "- " at 0-1 is dimmed
-        #expect(isDimmed(at: 0, in: styled))
+        // "- " at 0-1 is hidden (zero-width + clear)
+        #expect(isHidden(at: 0, in: styled))
         // "[" at 2 has a text attachment
         let a = styled.attributes(at: 2, effectiveRange: nil)
         #expect(a[.attachment] is NSTextAttachment)
@@ -337,8 +337,8 @@ struct EditorStylingTests {
     @MainActor func checkedCheckboxAttachment() {
         let editor = makeEditor()
         let styled = editor.styleBlock("- [x] done")
-        // "- " at 0-1 is dimmed
-        #expect(isDimmed(at: 0, in: styled))
+        // "- " at 0-1 is hidden (zero-width + clear)
+        #expect(isHidden(at: 0, in: styled))
         // "[" at 2 has a text attachment
         let a = styled.attributes(at: 2, effectiveRange: nil)
         #expect(a[.attachment] is NSTextAttachment)


### PR DESCRIPTION
## Summary
- Dim unchecked circle: `tertiaryLabelColor` instead of `secondaryLabelColor`
- Hide `- ` prefix before checkbox (zero-width + clear) instead of dimming it
- Fix circle radii: inset unchecked stroke path so outer edge matches filled circle size

## Test plan
- [x] All 372 tests pass
- [ ] Visual: unchecked circle is dimmer (tertiary label color)
- [ ] Visual: no `- ` visible before checkbox circles
- [ ] Visual: checked and unchecked circles are the same size

🤖 Generated with [Claude Code](https://claude.com/claude-code)