### PR TITLE
Add list continuation on Enter

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+ListContinuation.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+ListContinuation.swift
@@ -1,0 +1,83 @@
+import AppKit
+
+// MARK: - List Continuation on Enter
+
+extension EditorTextView {
+
+    /// Regex that captures a list marker prefix:
+    /// Group 1 = leading whitespace, Group 2 = marker (e.g. "- ", "* ", "1. ", "- [ ] ", "- [x] ")
+    private static let listMarkerRegex = try! NSRegularExpression(
+        pattern: #"^(\s*)([-*+]\s+(?:\[[ xX]\]\s+)?|\d+\.\s+)"#
+    )
+
+    /// If the cursor is on a list line, returns (leadingWhitespace, marker, hasContent).
+    /// `marker` is the bullet/number portion (e.g. "- ", "1. ", "- [ ] ").
+    private func parseListMarker(_ line: String) -> (indent: String, marker: String, hasContent: Bool)? {
+        let ns = line as NSString
+        let range = NSRange(location: 0, length: ns.length)
+        guard let match = Self.listMarkerRegex.firstMatch(in: line, range: range) else {
+            return nil
+        }
+        let indent = ns.substring(with: match.range(at: 1))
+        let marker = ns.substring(with: match.range(at: 2))
+        let prefixLen = match.range.length
+        let hasContent = prefixLen < ns.length
+        return (indent, marker, hasContent)
+    }
+
+    /// Builds the next marker for list continuation.
+    /// - Ordered lists: increments the number (e.g. "1. " → "2. ")
+    /// - Checkbox items: resets to unchecked (e.g. "- [x] " → "- [ ] ")
+    /// - Plain bullets: returns the same marker
+    private func nextMarker(for marker: String) -> String {
+        // Ordered: "1. " → "2. "
+        if let dotRange = marker.range(of: #"^\d+\."#, options: .regularExpression) {
+            let numStr = String(marker[dotRange].dropLast())  // drop the "."
+            if let num = Int(numStr) {
+                return "\(num + 1)." + String(marker[dotRange.upperBound...])
+            }
+        }
+        // Checkbox: replace [x] with [ ]
+        if let cbRange = marker.range(of: "[x]", options: .caseInsensitive) {
+            var next = marker
+            next.replaceSubrange(cbRange, with: "[ ]")
+            return next
+        }
+        return marker
+    }
+
+    // MARK: - Override
+
+    public override func insertNewline(_ sender: Any?) {
+        let sel = selectedRange()
+        guard sel.length == 0,
+              let blockIdx = blockIndexForRawOffset(sel.location),
+              blockIdx < blocks.count else {
+            super.insertNewline(sender)
+            return
+        }
+
+        let block = blocks[blockIdx]
+        guard let (indent, marker, hasContent) = parseListMarker(block.content) else {
+            super.insertNewline(sender)
+            return
+        }
+
+        if hasContent {
+            // Content present → insert newline + next marker.
+            // If splitting mid-line and the next char is a space, consume it
+            // so we don't get a double space after the marker.
+            let next = indent + nextMarker(for: marker)
+            var replaceRange = sel
+            let nsRaw = rawSource as NSString
+            if sel.location < nsRaw.length && nsRaw.character(at: sel.location) == 0x20 {
+                replaceRange.length += 1
+            }
+            insertText("\n" + next, replacementRange: replaceRange)
+        } else {
+            // Empty list line → remove the marker, leaving a blank line
+            let blockRange = block.range
+            insertText("", replacementRange: blockRange)
+        }
+    }
+}

--- a/Tests/MarkdownEditorTests/ListContinuationTests.swift
+++ b/Tests/MarkdownEditorTests/ListContinuationTests.swift
@@ -1,0 +1,121 @@
+import Testing
+import AppKit
+@testable import MarkdownEditorCore
+
+// MARK: - List Continuation on Enter
+
+@Suite("EditorTextView — List Continuation")
+struct ListContinuationTests {
+
+    // MARK: - Unordered Lists
+
+    @Test("Enter after bullet item inserts new bullet")
+    @MainActor func enterAfterBullet() {
+        let editor = makeEditor()
+        editor.loadContent("- hello")
+        // Place cursor at end
+        editor.setSelectedRange(NSRange(location: 7, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "- hello\n- ")
+    }
+
+    @Test("Enter after * bullet inserts new * bullet")
+    @MainActor func enterAfterStarBullet() {
+        let editor = makeEditor()
+        editor.loadContent("* hello")
+        editor.setSelectedRange(NSRange(location: 7, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "* hello\n* ")
+    }
+
+    @Test("Enter on empty bullet line removes marker")
+    @MainActor func enterOnEmptyBullet() {
+        let editor = makeEditor()
+        editor.loadContent("- hello\n- ")
+        // Cursor at end of "- " (offset 10)
+        editor.setSelectedRange(NSRange(location: 10, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "- hello\n")
+    }
+
+    @Test("Enter preserves indentation level")
+    @MainActor func enterPreservesIndent() {
+        let editor = makeEditor()
+        editor.loadContent("  - nested")
+        editor.setSelectedRange(NSRange(location: 10, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "  - nested\n  - ")
+    }
+
+    // MARK: - Ordered Lists
+
+    @Test("Enter after ordered item increments number")
+    @MainActor func enterAfterOrdered() {
+        let editor = makeEditor()
+        editor.loadContent("1. first")
+        editor.setSelectedRange(NSRange(location: 8, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "1. first\n2. ")
+    }
+
+    @Test("Enter on empty ordered line removes marker")
+    @MainActor func enterOnEmptyOrdered() {
+        let editor = makeEditor()
+        editor.loadContent("1. first\n2. ")
+        editor.setSelectedRange(NSRange(location: 12, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "1. first\n")
+    }
+
+    // MARK: - Checkbox Lists
+
+    @Test("Enter after unchecked todo inserts new unchecked todo")
+    @MainActor func enterAfterUncheckedTodo() {
+        let editor = makeEditor()
+        editor.loadContent("- [ ] task")
+        editor.setSelectedRange(NSRange(location: 10, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "- [ ] task\n- [ ] ")
+    }
+
+    @Test("Enter after checked todo inserts new unchecked todo")
+    @MainActor func enterAfterCheckedTodo() {
+        let editor = makeEditor()
+        editor.loadContent("- [x] done")
+        editor.setSelectedRange(NSRange(location: 10, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "- [x] done\n- [ ] ")
+    }
+
+    @Test("Enter on empty todo line removes marker")
+    @MainActor func enterOnEmptyTodo() {
+        let editor = makeEditor()
+        editor.loadContent("- [ ] task\n- [ ] ")
+        editor.setSelectedRange(NSRange(location: 17, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "- [ ] task\n")
+    }
+
+    // MARK: - Non-List Lines
+
+    @Test("Enter on non-list line does normal newline")
+    @MainActor func enterOnNonListLine() {
+        let editor = makeEditor()
+        editor.loadContent("hello")
+        editor.setSelectedRange(NSRange(location: 5, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "hello\n")
+    }
+
+    // MARK: - Mid-Line Enter
+
+    @Test("Enter mid-line splits and continues list")
+    @MainActor func enterMidLine() {
+        let editor = makeEditor()
+        editor.loadContent("- hello world")
+        // Cursor after "hello" (offset 7)
+        editor.setSelectedRange(NSRange(location: 7, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "- hello\n- world")
+    }
+}


### PR DESCRIPTION
## Summary
- Override `insertNewline` to auto-continue list items when pressing Enter
- Supports unordered (`-`, `*`, `+`), ordered (auto-increments number), and checkboxes (resets to unchecked)
- Empty list line Enter removes the marker (exits list mode)
- Mid-line Enter splits content and continues the list
- Preserves indentation level for nested lists

## Test plan
- [x] All 383 tests pass (11 new list continuation tests)
- [ ] Manual: type `- hello`, press Enter → new `- ` appears
- [ ] Manual: press Enter on empty `- ` → marker removed
- [ ] Manual: `1. first` + Enter → `2. ` appears
- [ ] Manual: `- [x] done` + Enter → `- [ ] ` appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)