### PR TITLE
Fix todo checkbox hanging indent alignment

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -302,10 +302,19 @@ extension EditorTextView {
 
             case .listItem(let ordered, let checkbox):
                 guard span.fullRange.upperBound <= result.length else { continue }
-                // Measure marker width (including leading whitespace) for hanging indent.
-                // Everything from position 0 to content start is the "marker" area.
+                // Measure marker width for hanging indent. For checkbox items,
+                // measure the VISUAL width (hidden prefix + circle attachment),
+                // not the raw text width.
                 let markerStr = (markdown as NSString).substring(to: span.contentRange.location)
-                let markerWidth = (markerStr as NSString).size(withAttributes: [.font: bodyFont]).width
+                let markerWidth: CGFloat
+                if checkbox != nil {
+                    let leadingWS = markerStr.prefix(while: { $0 == " " || $0 == "\t" })
+                    let wsWidth = (String(leadingWS) as NSString).size(withAttributes: [.font: bodyFont]).width
+                    let spaceWidth = (" " as NSString).size(withAttributes: [.font: bodyFont]).width
+                    markerWidth = wsWidth + bodyFont.pointSize + spaceWidth
+                } else {
+                    markerWidth = (markerStr as NSString).size(withAttributes: [.font: bodyFont]).width
+                }
                 // Apply paragraph style from position 0 — NSTextView uses the paragraph
                 // style from the first character of a paragraph.
                 result.addAttribute(.paragraphStyle, value: listParagraphStyle(markerWidth: markerWidth), range: NSRange(location: 0, length: result.length))

--- a/Tests/MarkdownEditorTests/EditorRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/EditorRenderingTests.swift
@@ -411,6 +411,28 @@ struct EditorStylingTests {
         #expect(wrapped > 0)
     }
 
+    @Test("Checkbox list has narrower hanging indent than raw text width")
+    @MainActor func checkboxHangingIndent() {
+        let editor = makeEditor()
+        let bullet = editor.styleBlock("- hello")
+        let checkbox = editor.styleBlock("- [ ] hello")
+
+        var bulletIndent: CGFloat = 0
+        bullet.enumerateAttribute(.paragraphStyle, in: NSRange(location: 0, length: bullet.length)) { val, _, _ in
+            if let ps = val as? NSParagraphStyle { bulletIndent = ps.headIndent }
+        }
+
+        var cbIndent: CGFloat = 0
+        checkbox.enumerateAttribute(.paragraphStyle, in: NSRange(location: 0, length: checkbox.length)) { val, _, _ in
+            if let ps = val as? NSParagraphStyle { cbIndent = ps.headIndent }
+        }
+
+        // Checkbox indent should be based on visual width (circle + space),
+        // not raw text width of "- [ ] ". It should be comparable to bullet indent.
+        let rawWidth = ("- [ ] " as NSString).size(withAttributes: [.font: editor.bodyFont]).width
+        #expect(cbIndent < editor.listPadding + rawWidth)
+    }
+
     @Test("Table has monospace font and dimmed pipes")
     @MainActor func tableStyling() {
         let editor = makeEditor()


### PR DESCRIPTION
## Summary
- Compute checkbox `markerWidth` from visual width (circle + space) instead of raw text width (`- [ ] ` in bodyFont)
- Fixes wrapped lines being indented too far right for todo items

## Test plan
- [x] All 384 tests pass (1 new checkbox indent test)
- [ ] Visual: todo item wrapped lines align with content start, not far right

🤖 Generated with [Claude Code](https://claude.com/claude-code)