### PR TITLE
Add titlebar separator line

### DIFF
--- a/Sources/MarkdownEditor/Document.swift
+++ b/Sources/MarkdownEditor/Document.swift
@@ -64,9 +64,9 @@ class Document: NSDocument {
 
         // Empty toolbar gives the titlebar extra height (roomy traffic lights).
         let toolbar = NSToolbar(identifier: "MainToolbar")
-        toolbar.showsBaselineSeparator = false
         window.toolbar = toolbar
         window.toolbarStyle = .unified
+        window.titlebarSeparatorStyle = .line
 
         // Build the text system chain:
         //   NSTextStorage → NSLayoutManager → NSTextContainer → NSTextView


### PR DESCRIPTION
## Summary
- Set `window.titlebarSeparatorStyle = .line` to draw a separator between the titlebar and editor content
- Remove unused `showsBaselineSeparator` (ignored by `.unified` toolbar style)

## Test plan
- [x] All 384 tests pass
- [ ] Visual: thin horizontal line visible below the titlebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)