### PR TITLE
Change default font to Iowan Old Style

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTheme.swift
+++ b/Sources/MarkdownEditorCore/EditorTheme.swift
@@ -35,7 +35,7 @@ public struct EditorTheme: Equatable, Sendable {
     // MARK: - Defaults
 
     public static let `default` = EditorTheme(
-        fontName: "Hoefler Text",
+        fontName: "Iowan Old Style",
         fontSize: 16,
         accentHex: "#3366E6",
         codeHex: "#8A2425",


### PR DESCRIPTION
## Summary
- Change default font from Hoefler Text to Iowan Old Style

## Test plan
- [x] All 384 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)