### PR TITLE
Un-indent empty list lines before removing marker

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+ListContinuation.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+ListContinuation.swift
@@ -74,10 +74,16 @@ extension EditorTextView {
                 replaceRange.length += 1
             }
             insertText("\n" + next, replacementRange: replaceRange)
+        } else if !indent.isEmpty {
+            // Indented empty list line → un-indent one level
+            let maxRemove = (Self.indentUnit as NSString).length
+            let leading = indent.prefix(while: { $0 == " " }).count
+            let remove = indent.hasPrefix("\t") ? 1 : min(leading, maxRemove)
+            let dedented = String(block.content.dropFirst(remove))
+            insertText(dedented, replacementRange: block.range)
         } else {
-            // Empty list line → remove the marker, leaving a blank line
-            let blockRange = block.range
-            insertText("", replacementRange: blockRange)
+            // Root-level empty list line → remove the marker entirely
+            insertText("", replacementRange: block.range)
         }
     }
 }

--- a/Tests/MarkdownEditorTests/ListContinuationTests.swift
+++ b/Tests/MarkdownEditorTests/ListContinuationTests.swift
@@ -96,6 +96,36 @@ struct ListContinuationTests {
         #expect(editor.rawSource == "- [ ] task\n")
     }
 
+    // MARK: - Un-indent on Empty Line
+
+    @Test("Enter on indented empty bullet un-indents one level")
+    @MainActor func enterUnindentsIndentedBullet() {
+        let editor = makeEditor()
+        editor.loadContent("- hello\n  - ")
+        // Cursor at end (offset 12)
+        editor.setSelectedRange(NSRange(location: 12, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "- hello\n- ")
+    }
+
+    @Test("Enter on doubly-indented empty bullet un-indents one level")
+    @MainActor func enterUnindentsDoublyIndented() {
+        let editor = makeEditor()
+        editor.loadContent("    - ")
+        editor.setSelectedRange(NSRange(location: 6, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "  - ")
+    }
+
+    @Test("Enter on indented empty todo un-indents one level")
+    @MainActor func enterUnindentsTodo() {
+        let editor = makeEditor()
+        editor.loadContent("- task\n  - [ ] ")
+        editor.setSelectedRange(NSRange(location: 15, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "- task\n- [ ] ")
+    }
+
     // MARK: - Non-List Lines
 
     @Test("Enter on non-list line does normal newline")


### PR DESCRIPTION
## Summary
- Enter on an indented empty list line now un-indents one level (removes 2 spaces)
- Only removes the marker entirely when already at root level
- Matches standard editor behavior (VS Code, Obsidian, etc.)

## Test plan
- [x] All 387 tests pass (3 new un-indent tests)
- [ ] Manual: indent a bullet with Tab, clear text, press Enter → un-indents
- [ ] Manual: press Enter again on root-level empty bullet → marker removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)