### PR TITLE
Add checkbox click-to-toggle

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -170,6 +170,50 @@ public class EditorTextView: NSTextView {
         recompose(cursorInRaw: currentCursorInRaw())
     }
 
+    // MARK: - Checkbox Toggle
+
+    public override func mouseDown(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+        let charIndex = characterIndexForInsertion(at: point)
+
+        // Check if the click landed on a checkbox attachment
+        if charIndex < textStorage!.length,
+           textStorage!.attribute(.attachment, at: charIndex, effectiveRange: nil) is NSTextAttachment {
+            // Find the `[ ]` or `[x]` pattern at this position in rawSource
+            let nsRaw = rawSource as NSString
+            if charIndex < nsRaw.length {
+                let ch = nsRaw.character(at: charIndex)
+                // The attachment is placed on `[`
+                if ch == 0x5B { // '['
+                    let remaining = nsRaw.length - charIndex
+                    if remaining >= 3 {
+                        let snippet = nsRaw.substring(with: NSRange(location: charIndex, length: 3))
+                        if snippet == "[ ]" || snippet == "[x]" || snippet == "[X]" {
+                            // Record undo
+                            undoStack.append(UndoSnapshot(rawSource: rawSource, cursorInRaw: selectedRange().location))
+                            redoStack.removeAll()
+                            lastEditType = .other
+                            lastEditBlockIndex = nil
+
+                            // Toggle
+                            let replacement = snippet == "[ ]" ? "[x]" : "[ ]"
+                            rawSource = nsRaw.replacingCharacters(
+                                in: NSRange(location: charIndex, length: 3),
+                                with: replacement
+                            )
+                            blocks = BlockParser.parse(rawSource, previous: blocks)
+                            recompose(cursorInRaw: selectedRange().location)
+                            document?.updateChangeCount(.changeDone)
+                            return
+                        }
+                    }
+                }
+            }
+        }
+
+        super.mouseDown(with: event)
+    }
+
     // MARK: - Edit Flow
 
     public override func shouldChangeText(in affectedCharRange: NSRange, replacementString: String?) -> Bool {

--- a/Tests/MarkdownEditorTests/ListContinuationTests.swift
+++ b/Tests/MarkdownEditorTests/ListContinuationTests.swift
@@ -149,3 +149,32 @@ struct ListContinuationTests {
         #expect(editor.rawSource == "- hello\n- world")
     }
 }
+
+// MARK: - Checkbox Toggle (rawSource mutation)
+
+@Suite("EditorTextView — Checkbox Toggle")
+struct CheckboxToggleTests {
+
+    @Test("Toggling [ ] to [x] in rawSource works")
+    @MainActor func toggleUncheckedToChecked() {
+        let editor = makeEditor()
+        editor.loadContent("- [ ] task")
+        // Simulate what mouseDown does: find [ ] at offset 2 and toggle
+        let nsRaw = editor.rawSource as NSString
+        #expect(nsRaw.substring(with: NSRange(location: 2, length: 3)) == "[ ]")
+        editor.rawSource = nsRaw.replacingCharacters(
+            in: NSRange(location: 2, length: 3), with: "[x]")
+        #expect(editor.rawSource == "- [x] task")
+    }
+
+    @Test("Toggling [x] to [ ] in rawSource works")
+    @MainActor func toggleCheckedToUnchecked() {
+        let editor = makeEditor()
+        editor.loadContent("- [x] done")
+        let nsRaw = editor.rawSource as NSString
+        #expect(nsRaw.substring(with: NSRange(location: 2, length: 3)) == "[x]")
+        editor.rawSource = nsRaw.replacingCharacters(
+            in: NSRange(location: 2, length: 3), with: "[ ]")
+        #expect(editor.rawSource == "- [ ] done")
+    }
+}


### PR DESCRIPTION
## Summary
- Override `mouseDown` to detect clicks on checkbox circle attachments
- Clicking toggles between `[ ]` and `[x]` in the raw source
- Records undo snapshot before toggling
- Updates the document dirty state

## Test plan
- [x] All 388 tests pass (2 new toggle tests)
- [ ] Manual: click unchecked circle → toggles to checked (filled yellow)
- [ ] Manual: click checked circle → toggles to unchecked (outline)
- [ ] Manual: undo after toggle restores previous state

🤖 Generated with [Claude Code](https://claude.com/claude-code)