### PR TITLE
Reduce status bar bottom padding

### DIFF
--- a/Sources/MarkdownEditor/Document.swift
+++ b/Sources/MarkdownEditor/Document.swift
@@ -93,7 +93,7 @@ class Document: NSDocument {
         editor.textContainerInset = NSSize(width: 24, height: 18)
         editor.document = self
 
-        let statusBarHeight: CGFloat = 24
+        let statusBarHeight: CGFloat = 18
         let contentBounds = window.contentView!.bounds
 
         let scrollView = NSScrollView(frame: NSRect(


### PR DESCRIPTION
## Summary
- Reduce status bar height from 24pt to 18pt

## Test plan
- [x] All 386 tests pass
- [ ] Visual: less gap at the bottom of the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)