### PR TITLE
Add cell padding to rendered tables

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -340,14 +340,17 @@ extension EditorTextView {
                     }
                 } else {
                     // Non-active: bold header, hidden pipes, column-width alignment
-                    // via kern, drawn vertical + horizontal borders via TableRowTextBlock.
+                    // via kern, drawn vertical + horizontal borders via TableRowTextBlock,
+                    // with cell padding for breathing room.
                     let tableNS = (result.string as NSString)
                     let tableStr = tableNS.substring(with: span.fullRange)
                     let lines = tableStr.components(separatedBy: "\n")
 
                     let boldFont = NSFontManager.shared.convert(bodyFont, toHaveTrait: .boldFontMask)
+                    let cellHPad = bodyFont.pointSize * 0.3
+                    let cellVPad = bodyFont.pointSize * 0.15
 
-                    // --- Compute column widths (max cell width per column) ---
+                    // --- Compute column widths (max cell width + horizontal padding) ---
                     let headerCells = splitTableRow(lines[0])
                     let numCols = headerCells.count
                     guard numCols > 0 else { break }
@@ -361,6 +364,10 @@ extension EditorTextView {
                             colWidths[ci] = max(colWidths[ci], w)
                         }
                     }
+                    // Add horizontal padding to each column (space after cell text).
+                    for ci in 0..<numCols {
+                        colWidths[ci] += 2 * cellHPad
+                    }
 
                     // Column-border X offsets (between columns) and total width.
                     var borderXOffsets: [CGFloat] = []
@@ -370,6 +377,11 @@ extension EditorTextView {
                         if ci < numCols - 1 { borderXOffsets.append(cumX) }
                     }
                     let totalWidth = cumX
+
+                    let leftEdge  = NSRectEdge(rawValue: 0)!
+                    let rightEdge = NSRectEdge(rawValue: 2)!
+                    let edge1     = NSRectEdge(rawValue: 1)!
+                    let edge3     = NSRectEdge(rawValue: 3)!
 
                     // --- Style each row ---
                     var lineOffset = span.fullRange.location
@@ -388,10 +400,20 @@ extension EditorTextView {
                         ps.lineSpacing = 0
                         let block = TableRowTextBlock()
                         block.verticalLineXOffsets = borderXOffsets
+                        block.contentLeftOffset = cellHPad
                         block.setContentWidth(totalWidth, type: .absoluteValueType)
+                        // Left/right padding so text doesn't touch the table edge.
+                        block.setWidth(cellHPad, type: .absoluteValueType, for: .padding, edge: leftEdge)
+                        block.setWidth(cellHPad, type: .absoluteValueType, for: .padding, edge: rightEdge)
+                        // Vertical padding for breathing room between rows.
+                        block.setWidth(cellVPad, type: .absoluteValueType, for: .padding, edge: edge1)
+                        block.setWidth(cellVPad, type: .absoluteValueType, for: .padding, edge: edge3)
                         if i == 1 {
                             block.drawHorizontalLine = true
                             block.heightOverride = 4
+                            // Separator needs no vertical padding.
+                            block.setWidth(0, type: .absoluteValueType, for: .padding, edge: edge1)
+                            block.setWidth(0, type: .absoluteValueType, for: .padding, edge: edge3)
                         }
                         ps.textBlocks = [block]
                         result.addAttribute(.paragraphStyle, value: ps, range: lineRange)
@@ -578,8 +600,11 @@ private class ThematicBreakTextBlock: NSTextBlock {
 /// continuous column borders.
 private class TableRowTextBlock: NSTextBlock {
 
-    /// X offsets (from block left edge) where vertical border lines are drawn.
+    /// X offsets (from content area left edge) where vertical border lines are drawn.
     var verticalLineXOffsets: [CGFloat] = []
+
+    /// Offset from frameRect.minX to the content area (= left padding).
+    var contentLeftOffset: CGFloat = 0
 
     /// Whether to draw a horizontal hairline centered in the row (separator).
     var drawHorizontalLine = false
@@ -609,11 +634,12 @@ private class TableRowTextBlock: NSTextBlock {
         layoutManager: NSLayoutManager
     ) {
         NSColor.separatorColor.setStroke()
+        let baseX = frameRect.minX + contentLeftOffset
 
         // Vertical borders at column boundaries
         for xOffset in verticalLineXOffsets {
             let path = NSBezierPath()
-            let x = round(frameRect.minX + xOffset) + 0.5
+            let x = round(baseX + xOffset) + 0.5
             path.move(to: NSPoint(x: x, y: frameRect.minY))
             path.line(to: NSPoint(x: x, y: frameRect.maxY))
             path.lineWidth = 1

--- a/test.md
+++ b/test.md
@@ -41,12 +41,12 @@ Nest lists
 - [x] File save/open
   - [ ] NSDocuments integration
 - [x] Syntax highlighting in the active block — polish, not blocking
-- [ ] Typewriter scroll
+- [x] Typewriter scroll
 - [ ] Highlight active block
 - [ ] Title bar
   - [ ] Toggle between edit and reading mode
   - [ ] Togge between monospace and other
-- [ ] Status bar: Character/word count
+- [x] Status bar: Character/word count, line number, cursor position
 - [ ] Performance: Lazy loading for larger / more mathy files 
 
 #### Markdown support
@@ -87,15 +87,15 @@ Refer to the implementation of [Swift Markdown Engine](https://github.com/nodes-
   - [ ] Built-in: iA, old letters, typewriter, serif, code, native
   - [ ] Custom theme (see full customization)
 - [ ] Active block highlighting: wiggly (not fully straight) highlighter style by line
-- [ ] Title bar: Add horizontal line to divide content and bar
-- [ ] List: Automatic add list item upon new line in a list environment
-- [ ] List: Un-indent current line when upon new line on a empty line
+- [x] Title bar: Add horizontal line to divide content and bar
+- [x] List: Automatic add list item upon new line in a list environment
+- [x] List: Un-indent current line when upon new line on a empty line
 
 ### Bugs
 
 - [x] List indentation: ` -` has less indentation than `-` (which has rendered indentation). Render indentation for all `-` at the beginning of the line, even after whitespace. 
-- [ ] Unmatched * and _ should not be hidden
-- [ ] Todo list indentation: Align beginning of list marker with first character in upper-level text
+- [x] Unmatched * and _ should not be hidden
+- [x] Todo list indentation: Align beginning of list marker with first character in upper-level text
 
 
 ### Maybes


### PR DESCRIPTION
## Summary
- Add horizontal cell padding by increasing column widths by `2 × cellHPad` (kern absorbs the extra)
- Add vertical cell padding via `NSTextBlock.setWidth(.padding)` on each row's TextBlock
- Separator row gets no vertical padding (stays collapsed as a thin hairline)
- Vertical border lines offset by `contentLeftOffset` to align with padded content area
- Restore 7 checked-off todo items in test.md

## Test plan
- [x] All 387 tests pass
- [ ] Manual: verify table cells have visible breathing room

🤖 Generated with [Claude Code](https://claude.com/claude-code)