### PR TITLE
Default saves to .md, drop format popup and Save As…

### DIFF
--- a/Sources/MarkdownEditor/Document.swift
+++ b/Sources/MarkdownEditor/Document.swift
@@ -35,13 +35,17 @@ class Document: NSDocument {
         return readableTypes.contains(name)
     }
 
+    // A single writable type keeps the save panel from showing a file-format
+    // popup. Everything we write is markdown, so there's nothing to choose.
     override func writableTypes(for saveOperation: NSDocument.SaveOperationType) -> [String] {
-        switch saveOperation {
-        case .saveAsOperation, .saveToOperation:
-            ["net.daringfireball.markdown", "public.plain-text"]
-        default:
-            ["net.daringfireball.markdown"]
-        }
+        ["net.daringfireball.markdown"]
+    }
+
+    // The `net.daringfireball.markdown` UTI prefers the ".markdown" extension;
+    // force ".md" instead, which is what people actually expect.
+    override func fileNameExtension(forType typeName: String,
+                                    saveOperation: NSDocument.SaveOperationType) -> String? {
+        "md"
     }
 
     // MARK: - Window Setup

--- a/Sources/MarkdownEditor/main.swift
+++ b/Sources/MarkdownEditor/main.swift
@@ -114,11 +114,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                          action: #selector(NSDocument.save(_:)),
                          keyEquivalent: "s")
 
-        let saveAsItem = fileMenu.addItem(withTitle: "Save As\u{2026}",
-                                          action: #selector(NSDocument.saveAs(_:)),
-                                          keyEquivalent: "s")
-        saveAsItem.keyEquivalentModifierMask = [.command, .shift]
-
         fileMenu.addItem(NSMenuItem.separator())
 
         fileMenu.addItem(withTitle: "Rename\u{2026}",


### PR DESCRIPTION
Simplifies the save flow:

- The save panel offered a "markdown / plain text" format popup (two `writableTypes`) and defaulted to `.markdown`. Now returns a single writable type (popup gone) and overrides `fileNameExtension(forType:saveOperation:)` to `md`.
- Removes the redundant **Save As…** menu item — with one type and a fixed extension there's nothing for it to disambiguate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)