### PR TITLE
Normalize line endings on load, preserve original on save

### DIFF
--- a/Sources/MarkdownEditor/Document.swift
+++ b/Sources/MarkdownEditor/Document.swift
@@ -237,7 +237,13 @@ class Document: NSDocument {
     // MARK: - Writing
 
     override func data(ofType typeName: String) throws -> Data {
-        let text = editor?.rawSource ?? ""
+        // The buffer is always LF; restore the file's original line ending on
+        // write so opening, then saving, doesn't silently rewrite every line.
+        let normalized = editor?.rawSource ?? ""
+        let ending = editor?.originalLineEnding ?? .lf
+        let text = ending == .lf
+            ? normalized
+            : normalized.replacingOccurrences(of: "\n", with: ending.string)
         guard let data = text.data(using: .utf8) else {
             throw NSError(domain: NSOSStatusErrorDomain, code: -1,
                           userInfo: [NSLocalizedDescriptionKey: "Could not encode text as UTF-8"])

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -35,6 +35,9 @@ public class EditorTextView: NSTextView {
     // MARK: - State (internal for @testable import)
 
     public var rawSource: String = ""
+    /// Line ending of the most recently loaded content. The buffer itself is
+    /// always LF; this is remembered so saves preserve the file's style.
+    public var originalLineEnding: LineEnding = .lf
     var blocks: [Block] = []
     var activeBlockIndex: Int? = nil
     var isUpdating = false
@@ -271,7 +274,10 @@ public class EditorTextView: NSTextView {
 
     /// Replace the editor's content. Used by NSDocument on file open.
     public func loadContent(_ content: String) {
-        rawSource = content
+        // Remember the file's line ending, then normalize the buffer to LF so
+        // block parsing and rendering never see a stray `\r`.
+        originalLineEnding = LineEnding.detect(in: content)
+        rawSource = LineEnding.normalize(content)
         blocks = BlockParser.parse(rawSource)
         undoStack.removeAll()
         redoStack.removeAll()

--- a/Sources/MarkdownEditorCore/LineEnding.swift
+++ b/Sources/MarkdownEditorCore/LineEnding.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// A file's line-ending style. The editor always keeps its buffer in LF
+/// internally (so `BlockParser`'s `\n` split is clean and no stray `\r`
+/// characters leak into block content); the original style is remembered so
+/// it can be written back on save without silently changing the user's file.
+public enum LineEnding: String, Sendable {
+    case lf    // "\n"
+    case crlf  // "\r\n"
+    case cr    // "\r"
+
+    /// The literal character sequence for this line ending.
+    public var string: String {
+        switch self {
+        case .lf:   return "\n"
+        case .crlf: return "\r\n"
+        case .cr:   return "\r"
+        }
+    }
+
+    /// Short label for display in the status bar.
+    public var displayName: String {
+        switch self {
+        case .lf:   return "LF"
+        case .crlf: return "CRLF"
+        case .cr:   return "CR"
+        }
+    }
+
+    /// Detects the line ending used in `text`. CRLF is checked before CR/LF
+    /// because it contains both. Defaults to `.lf` when there are no breaks.
+    public static func detect(in text: String) -> LineEnding {
+        if text.contains("\r\n") { return .crlf }
+        if text.contains("\r")   { return .cr }
+        return .lf
+    }
+
+    /// Converts every line ending in `text` to LF (`\n`).
+    public static func normalize(_ text: String) -> String {
+        text.replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+    }
+}

--- a/Tests/MarkdownEditorTests/EditorDocumentTests.swift
+++ b/Tests/MarkdownEditorTests/EditorDocumentTests.swift
@@ -30,6 +30,42 @@ struct EditorDocumentLoadingTests {
         #expect(editor.blocks[2].content == "line three")
     }
 
+    @Test("loadContent normalizes CRLF to LF in the buffer")
+    @MainActor func loadContentNormalizesCRLF() {
+        let editor = makeEditor()
+        editor.loadContent("line one\r\nline two")
+        #expect(editor.rawSource == "line one\nline two")
+        #expect(editor.originalLineEnding == .crlf)
+    }
+
+    @Test("loadContent normalizes lone CR to LF in the buffer")
+    @MainActor func loadContentNormalizesCR() {
+        let editor = makeEditor()
+        editor.loadContent("line one\rline two")
+        #expect(editor.rawSource == "line one\nline two")
+        #expect(editor.originalLineEnding == .cr)
+    }
+
+    @Test("loadContent records LF for an LF file")
+    @MainActor func loadContentRecordsLF() {
+        let editor = makeEditor()
+        editor.loadContent("a\nb")
+        #expect(editor.originalLineEnding == .lf)
+    }
+
+    // The consistency bug this fix targets: a CRLF file used to leave a stray
+    // `\r` glued to each block's content because BlockParser splits on `\n`.
+    @Test("CRLF blocks have no stray carriage return in content")
+    @MainActor func crlfBlocksHaveNoStrayCR() {
+        let editor = makeEditor()
+        editor.loadContent("alpha\r\nbeta\r\ngamma")
+        #expect(editor.blocks.count == 3)
+        #expect(editor.blocks[0].content == "alpha")
+        #expect(editor.blocks[1].content == "beta")
+        #expect(editor.blocks[2].content == "gamma")
+        #expect(!editor.blocks.contains { $0.content.contains("\r") })
+    }
+
     @Test("loadContent clears undo/redo stacks")
     @MainActor func loadContentClearsUndo() {
         let editor = makeEditor()

--- a/Tests/MarkdownEditorTests/LineEndingTests.swift
+++ b/Tests/MarkdownEditorTests/LineEndingTests.swift
@@ -1,0 +1,69 @@
+import Testing
+import Foundation
+@testable import MarkdownEditorCore
+
+// MARK: - LineEnding
+
+@Suite("LineEnding — Detection")
+struct LineEndingDetectionTests {
+
+    @Test("LF text detects as .lf")
+    func detectsLF() {
+        #expect(LineEnding.detect(in: "a\nb\nc") == .lf)
+    }
+
+    @Test("CRLF text detects as .crlf")
+    func detectsCRLF() {
+        #expect(LineEnding.detect(in: "a\r\nb\r\nc") == .crlf)
+    }
+
+    @Test("Lone CR text detects as .cr")
+    func detectsCR() {
+        #expect(LineEnding.detect(in: "a\rb\rc") == .cr)
+    }
+
+    @Test("Mixed content prefers CRLF when present")
+    func mixedPrefersCRLF() {
+        #expect(LineEnding.detect(in: "a\r\nb\nc") == .crlf)
+    }
+
+    @Test("Text with no breaks defaults to .lf")
+    func noBreaksDefaultsLF() {
+        #expect(LineEnding.detect(in: "single line") == .lf)
+        #expect(LineEnding.detect(in: "") == .lf)
+    }
+}
+
+@Suite("LineEnding — Normalization")
+struct LineEndingNormalizationTests {
+
+    @Test("CRLF normalizes to LF")
+    func normalizeCRLF() {
+        #expect(LineEnding.normalize("a\r\nb\r\nc") == "a\nb\nc")
+    }
+
+    @Test("Lone CR normalizes to LF")
+    func normalizeCR() {
+        #expect(LineEnding.normalize("a\rb\rc") == "a\nb\nc")
+    }
+
+    @Test("Mixed endings all normalize to LF")
+    func normalizeMixed() {
+        #expect(LineEnding.normalize("a\r\nb\rc\nd") == "a\nb\nc\nd")
+    }
+
+    @Test("Pure LF is unchanged")
+    func normalizeLFUnchanged() {
+        #expect(LineEnding.normalize("a\nb\nc") == "a\nb\nc")
+    }
+
+    @Test("string and displayName round-trip the cases")
+    func stringAndDisplay() {
+        #expect(LineEnding.lf.string == "\n")
+        #expect(LineEnding.crlf.string == "\r\n")
+        #expect(LineEnding.cr.string == "\r")
+        #expect(LineEnding.lf.displayName == "LF")
+        #expect(LineEnding.crlf.displayName == "CRLF")
+        #expect(LineEnding.cr.displayName == "CR")
+    }
+}


### PR DESCRIPTION
A CRLF (or lone-CR) file kept its raw bytes in the buffer, but `BlockParser` splits on `\n` only — so a stray `\r` stayed glued to the end of every block's content and leaked into parsing and rendering.

- Normalize all line endings to LF on load so the buffer is always LF and block parsing is clean.
- Remember the file's original ending (`LineEnding` enum) and write it back on save, so opening then saving never silently rewrites every line.
- New documents default to LF.

Tests: +14 (401 total passing), including a regression test asserting CRLF blocks carry no stray `\r`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)