### PR TITLE
Inline math ($…$) rendering via SwiftMath

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8514d6f5f7c52c78262dab3e606bfc5f385c20edea147c4454a161d9cc34f3ef",
+  "originHash" : "40e40f4c9574618aba68a76f62f318411774fee5f79b7b8b9a18dce6f5c7315f",
   "pins" : [
     {
       "identity" : "swift-cmark",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "7d9a5ce307528578dfa777d505496bd5f544ad94",
         "version" : "0.7.3"
+      }
+    },
+    {
+      "identity" : "swiftmath",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mgriebling/SwiftMath.git",
+      "state" : {
+        "revision" : "fa8244ed032f4a1ade4cb0571bf87d2f1a9fd2d7",
+        "version" : "1.7.3"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -6,12 +6,14 @@ let package = Package(
     platforms: [.macOS(.v13)],
     dependencies: [
         .package(url: "https://github.com/swiftlang/swift-markdown.git", from: "0.5.0"),
+        .package(url: "https://github.com/mgriebling/SwiftMath.git", from: "1.7.0"),
     ],
     targets: [
         .target(
             name: "MarkdownEditorCore",
             dependencies: [
                 .product(name: "Markdown", package: "swift-markdown"),
+                .product(name: "SwiftMath", package: "SwiftMath"),
             ]),
         .executableTarget(
             name: "MarkdownEditor",

--- a/Sources/MarkdownEditorCore/EditorTextView+MathRendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+MathRendering.swift
@@ -1,0 +1,49 @@
+import AppKit
+import SwiftMath
+
+/// Rendered math images are cached so we don't re-rasterize on every keystroke
+/// or recompose. The key encodes everything that affects the pixels: latex,
+/// display vs inline, font size, and the resolved text color (light/dark).
+// NSCache is internally thread-safe; `nonisolated(unsafe)` opts it out of the
+// Swift 6 Sendable check (in practice it's only touched on the main actor).
+nonisolated(unsafe) private let mathImageCache = NSCache<NSString, NSImage>()
+
+extension EditorTextView {
+
+    /// Renders a LaTeX string to an `NSTextAttachment`, or `nil` if SwiftMath
+    /// can't parse it (the caller then shows the raw source instead).
+    func mathAttachment(latex: String, display: Bool) -> NSTextAttachment? {
+        let fontSize = bodyFont.pointSize
+
+        // Resolve the (dynamic) text color against this view's appearance so the
+        // math is rendered in the right shade for light/dark — and so the cache
+        // key differs between the two.
+        var color = foregroundColor
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            color = self.foregroundColor.usingColorSpace(.deviceRGB) ?? self.foregroundColor
+        }
+        let tag = String(format: "%.0f,%.3f,%.3f,%.3f,%.3f", fontSize,
+                         color.redComponent, color.greenComponent,
+                         color.blueComponent, color.alphaComponent)
+        let key = "\(display ? "D" : "I")|\(tag)|\(latex)" as NSString
+
+        let image: NSImage
+        if let cached = mathImageCache.object(forKey: key) {
+            image = cached
+        } else {
+            let math = MTMathImage(latex: latex, fontSize: fontSize,
+                                   textColor: color, labelMode: display ? .display : .text)
+            let (error, rendered) = math.asImage()
+            guard error == nil, let rendered else { return nil }
+            mathImageCache.setObject(rendered, forKey: key)
+            image = rendered
+        }
+
+        let attachment = NSTextAttachment()
+        attachment.image = image
+        // Nudge down so inline math sits roughly on the text baseline.
+        attachment.bounds = CGRect(x: 0, y: -fontSize * 0.2,
+                                   width: image.size.width, height: image.size.height)
+        return attachment
+    }
+}

--- a/Sources/MarkdownEditorCore/EditorTextView+MathRendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+MathRendering.swift
@@ -1,49 +1,71 @@
 import AppKit
 import SwiftMath
 
-/// Rendered math images are cached so we don't re-rasterize on every keystroke
-/// or recompose. The key encodes everything that affects the pixels: latex,
-/// display vs inline, font size, and the resolved text color (light/dark).
+/// A rendered equation: the image plus its typesetting descent, which we need to
+/// sit the math on the surrounding text's baseline.
+private final class MathRender {
+    let image: NSImage
+    let descent: CGFloat
+    init(image: NSImage, descent: CGFloat) {
+        self.image = image
+        self.descent = descent
+    }
+}
+
+/// Rendered math is cached so we don't re-typeset on every keystroke or
+/// recompose. The key encodes everything that affects the pixels/metrics:
+/// latex, display vs inline, font size, and the resolved text color.
 // NSCache is internally thread-safe; `nonisolated(unsafe)` opts it out of the
 // Swift 6 Sendable check (in practice it's only touched on the main actor).
-nonisolated(unsafe) private let mathImageCache = NSCache<NSString, NSImage>()
+nonisolated(unsafe) private let mathRenderCache = NSCache<NSString, MathRender>()
 
 extension EditorTextView {
 
-    /// Renders a LaTeX string to an `NSTextAttachment`, or `nil` if SwiftMath
-    /// can't parse it (the caller then shows the raw source instead).
-    func mathAttachment(latex: String, display: Bool) -> NSTextAttachment? {
-        let fontSize = bodyFont.pointSize
-
+    /// Renders a LaTeX string to an `NSTextAttachment` sized to `fontSize` and
+    /// aligned to the text baseline, or `nil` if SwiftMath can't parse it (the
+    /// caller then shows the raw source instead).
+    func mathAttachment(latex: String, display: Bool, fontSize: CGFloat) -> NSTextAttachment? {
         // Resolve the (dynamic) text color against this view's appearance so the
-        // math is rendered in the right shade for light/dark — and so the cache
-        // key differs between the two.
+        // math renders in the right shade for light/dark — and so the cache key
+        // differs between the two.
         var color = foregroundColor
         effectiveAppearance.performAsCurrentDrawingAppearance {
             color = self.foregroundColor.usingColorSpace(.deviceRGB) ?? self.foregroundColor
         }
-        let tag = String(format: "%.0f,%.3f,%.3f,%.3f,%.3f", fontSize,
+        let tag = String(format: "%.1f,%.3f,%.3f,%.3f,%.3f", fontSize,
                          color.redComponent, color.greenComponent,
                          color.blueComponent, color.alphaComponent)
         let key = "\(display ? "D" : "I")|\(tag)|\(latex)" as NSString
 
-        let image: NSImage
-        if let cached = mathImageCache.object(forKey: key) {
-            image = cached
+        let render: MathRender
+        if let cached = mathRenderCache.object(forKey: key) {
+            render = cached
         } else {
-            let math = MTMathImage(latex: latex, fontSize: fontSize,
-                                   textColor: color, labelMode: display ? .display : .text)
-            let (error, rendered) = math.asImage()
-            guard error == nil, let rendered else { return nil }
-            mathImageCache.setObject(rendered, forKey: key)
-            image = rendered
+            let mode: MTMathUILabelMode = display ? .display : .text
+            let math = MTMathImage(latex: latex, fontSize: fontSize, textColor: color, labelMode: mode)
+            let (error, image) = math.asImage()
+            guard error == nil, let image else { return nil }
+
+            // Typeset once more via a label to read the descent (the distance from
+            // the math baseline to the bottom of the image), used for alignment.
+            let label = MTMathUILabel()
+            label.latex = latex
+            label.fontSize = fontSize
+            label.labelMode = mode
+            label.layout()
+            let descent = label.displayList?.descent ?? 0
+
+            render = MathRender(image: image, descent: descent)
+            mathRenderCache.setObject(render, forKey: key)
         }
 
         let attachment = NSTextAttachment()
-        attachment.image = image
-        // Nudge down so inline math sits roughly on the text baseline.
-        attachment.bounds = CGRect(x: 0, y: -fontSize * 0.2,
-                                   width: image.size.width, height: image.size.height)
+        attachment.image = render.image
+        // Drop the image so its baseline (descent above the image bottom) lands
+        // on the text baseline.
+        attachment.bounds = CGRect(x: 0, y: -render.descent,
+                                   width: render.image.size.width,
+                                   height: render.image.size.height)
         return attachment
     }
 }

--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -478,9 +478,18 @@ extension EditorTextView {
 
             case .math(let display):
                 guard span.fullRange.upperBound <= result.length else { continue }
-                if !cursorInToken {
+                if cursorInToken {
+                    // Active: show the raw LaTeX in monospace (like inline code);
+                    // `$` delimiters are dimmed in the loop below.
+                    result.addAttribute(.font, value: inlineCodeFont, range: span.fullRange)
+                } else {
                     let latex = (markdown as NSString).substring(with: span.contentRange)
-                    if let attachment = mathAttachment(latex: latex, display: display) {
+                    // Size the math to the font already applied at this location, so
+                    // inline math inside a heading matches the heading's size.
+                    let contextFont = result.attribute(.font, at: span.fullRange.location,
+                                                       effectiveRange: nil) as? NSFont ?? bodyFont
+                    if let attachment = mathAttachment(latex: latex, display: display,
+                                                       fontSize: contextFont.pointSize) {
                         // Hide the LaTeX source + closing `$`, show the rendered
                         // image on the opening `$` (which the attachment replaces).
                         let hideStart = span.contentRange.location
@@ -491,11 +500,11 @@ extension EditorTextView {
                         result.addAttribute(.attachment, value: attachment,
                                             range: NSRange(location: span.fullRange.location, length: 1))
                     } else {
-                        // Invalid LaTeX: surface the raw source tinted, don't hide.
+                        // Invalid LaTeX: surface the raw source in monospace, tinted.
+                        result.addAttribute(.font, value: inlineCodeFont, range: span.fullRange)
                         result.addAttribute(.foregroundColor, value: NSColor.systemRed, range: span.fullRange)
                     }
                 }
-                // Active: raw LaTeX shown; `$` delimiters dimmed in the loop below.
 
             case .lineBreak:
                 break  // Delimiter handling done below

--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -100,6 +100,10 @@ extension EditorTextView {
             return true
         case .listItem, .table, .codeBlock, .thematicBreak:
             return false
+        case .math(let display):
+            // Inline math hides its `$` like other inline tokens; display math
+            // is block-level and handled specially.
+            return !display
         }
     }
 
@@ -472,6 +476,27 @@ extension EditorTextView {
                     result.addAttribute(.foregroundColor, value: NSColor.clear, range: span.fullRange)
                 }
 
+            case .math(let display):
+                guard span.fullRange.upperBound <= result.length else { continue }
+                if !cursorInToken {
+                    let latex = (markdown as NSString).substring(with: span.contentRange)
+                    if let attachment = mathAttachment(latex: latex, display: display) {
+                        // Hide the LaTeX source + closing `$`, show the rendered
+                        // image on the opening `$` (which the attachment replaces).
+                        let hideStart = span.contentRange.location
+                        let hideLen = span.fullRange.upperBound - hideStart
+                        let hideRange = NSRange(location: hideStart, length: hideLen)
+                        result.addAttribute(.font, value: hiddenFont, range: hideRange)
+                        result.addAttribute(.foregroundColor, value: NSColor.clear, range: hideRange)
+                        result.addAttribute(.attachment, value: attachment,
+                                            range: NSRange(location: span.fullRange.location, length: 1))
+                    } else {
+                        // Invalid LaTeX: surface the raw source tinted, don't hide.
+                        result.addAttribute(.foregroundColor, value: NSColor.systemRed, range: span.fullRange)
+                    }
+                }
+                // Active: raw LaTeX shown; `$` delimiters dimmed in the loop below.
+
             case .lineBreak:
                 break  // Delimiter handling done below
             }
@@ -500,6 +525,12 @@ extension EditorTextView {
                         styleListDelimiter(result, markdown: markdown,
                                            delimiterRange: dr, ordered: ordered,
                                            checkbox: checkbox)
+                    }
+                } else if case .math = span.kind {
+                    // Math: when active, dim the `$`; when not, the attachment and
+                    // source-hiding are already applied in content styling — leave them.
+                    if cursorInToken {
+                        result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
                     }
                 } else if cursorInToken || !isDelimiterHideable(span.kind) {
                     // Visible: dim the delimiters

--- a/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
+++ b/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
@@ -33,6 +33,7 @@ public enum SyntaxHighlighter {
             case table
             case thematicBreak
             case lineBreak
+            case math(display: Bool)
 
             public enum CheckboxState: Equatable, Sendable {
                 case checked, unchecked
@@ -52,6 +53,9 @@ public enum SyntaxHighlighter {
 
         // ==highlight== is not supported by swift-markdown; parse with regex.
         parseHighlight(text, into: &walker.spans)
+
+        // $…$ inline math (display $$…$$ is handled per-block in a later phase).
+        parseMath(text, into: &walker.spans)
 
         // Trailing backslash line break (single-line blocks only).
         parseLineBreak(text, into: &walker.spans)
@@ -87,6 +91,75 @@ public enum SyntaxHighlighter {
                 contentRange: content,
                 delimiterRanges: [openDelim, closeDelim]
             ))
+        }
+    }
+
+    /// Scans for inline `$…$` math. Uses Pandoc-style disambiguation so prose
+    /// like "it cost $5 to $10" is left alone:
+    ///   - the opening `$` is immediately followed by a non-space, non-`$` char,
+    ///   - the closing `$` is immediately preceded by a non-space char and is
+    ///     not followed by a digit,
+    ///   - `\$` is a literal escape, `$$` is skipped (display math, later phase),
+    ///   - inline math never spans a newline.
+    private static func parseMath(_ text: String, into spans: inout [Span]) {
+        let ns = text as NSString
+        let n = ns.length
+        let dollar: unichar = 0x24, backslash: unichar = 0x5C, newline: unichar = 0x0A
+
+        func isSpace(_ c: unichar) -> Bool { c == 0x20 || c == 0x09 }
+        func isDigit(_ c: unichar) -> Bool { c >= 0x30 && c <= 0x39 }
+
+        var i = 0
+        while i < n {
+            let c = ns.character(at: i)
+            if c == backslash { i += 2; continue }   // skip escaped char
+            if c != dollar { i += 1; continue }
+            // Skip display `$$` (handled per-block in a later phase).
+            if i + 1 < n && ns.character(at: i + 1) == dollar { i += 2; continue }
+            // Opening `$`: must be followed by a non-space, non-`$` character.
+            guard i + 1 < n else { break }
+            let next = ns.character(at: i + 1)
+            if isSpace(next) || next == dollar || next == newline { i += 1; continue }
+
+            // Find the closing `$`.
+            var j = i + 1
+            var close = -1
+            while j < n {
+                let cj = ns.character(at: j)
+                if cj == backslash { j += 2; continue }
+                if cj == newline { break }           // inline math stays on one line
+                if cj == dollar {
+                    let prev = ns.character(at: j - 1)
+                    let isDouble = j + 1 < n && ns.character(at: j + 1) == dollar
+                    let nextIsDigit = j + 1 < n && isDigit(ns.character(at: j + 1))
+                    if !isDouble && !isSpace(prev) && !nextIsDigit { close = j; break }
+                }
+                j += 1
+            }
+
+            guard close > i + 1 else { i += 1; continue }
+
+            let full = NSRange(location: i, length: close - i + 1)
+            // Don't match inside code spans.
+            let overlaps = spans.contains { existing in
+                switch existing.kind {
+                case .code, .codeBlock:
+                    return existing.fullRange.location <= full.location
+                        && existing.fullRange.upperBound >= full.upperBound
+                default:
+                    return false
+                }
+            }
+            if !overlaps {
+                spans.append(Span(
+                    kind: .math(display: false),
+                    fullRange: full,
+                    contentRange: NSRange(location: i + 1, length: close - i - 1),
+                    delimiterRanges: [NSRange(location: i, length: 1),
+                                      NSRange(location: close, length: 1)]
+                ))
+            }
+            i = close + 1
         }
     }
 

--- a/Tests/MarkdownEditorTests/MathRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/MathRenderingTests.swift
@@ -24,3 +24,37 @@ struct MathSmokeTests {
         #expect(error != nil)
     }
 }
+
+@Suite("Math — Inline rendering")
+struct InlineMathRenderingTests {
+
+    @Test("Inactive $x^2$ shows an attachment and hides the source")
+    @MainActor func inactiveRendersAttachment() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("$x^2$")           // no cursor → render
+        // Attachment replaces the opening `$`.
+        let attachment = styled.attribute(.attachment, at: 0, effectiveRange: nil)
+        #expect(attachment is NSTextAttachment)
+        // LaTeX source + closing `$` are hidden.
+        #expect(isHidden(at: 1, in: styled))
+        #expect(isHidden(at: 4, in: styled))
+    }
+
+    @Test("Active $x^2$ (cursor inside) shows raw, no attachment")
+    @MainActor func activeShowsRaw() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("$x^2$", cursorPosition: 2)
+        #expect(styled.attribute(.attachment, at: 0, effectiveRange: nil) == nil)
+        #expect(!isHidden(at: 1, in: styled))             // source visible
+    }
+
+    @Test("Invalid LaTeX shows the raw source tinted, no attachment")
+    @MainActor func invalidLatexFallsBack() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("$\\frac{$")
+        #expect(styled.attribute(.attachment, at: 0, effectiveRange: nil) == nil)
+        #expect(!isHidden(at: 1, in: styled))             // raw source shown
+        let color = styled.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+        #expect(color == NSColor.systemRed)
+    }
+}

--- a/Tests/MarkdownEditorTests/MathRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/MathRenderingTests.swift
@@ -1,0 +1,26 @@
+import Testing
+import AppKit
+import SwiftMath
+@testable import MarkdownEditorCore
+
+@Suite("Math — SwiftMath smoke test")
+struct MathSmokeTests {
+
+    @Test("SwiftMath renders a valid expression to a non-nil image")
+    func rendersValidLatex() {
+        let math = MTMathImage(latex: "x^2 + 1", fontSize: 16,
+                               textColor: .labelColor, labelMode: .text)
+        let (error, image) = math.asImage()
+        #expect(error == nil)
+        #expect(image != nil)
+        if let image { #expect(image.size.width > 0 && image.size.height > 0) }
+    }
+
+    @Test("SwiftMath returns an error for invalid LaTeX")
+    func rejectsInvalidLatex() {
+        let math = MTMathImage(latex: "\\frac{", fontSize: 16,
+                               textColor: .labelColor, labelMode: .text)
+        let (error, _) = math.asImage()
+        #expect(error != nil)
+    }
+}

--- a/Tests/MarkdownEditorTests/SyntaxHighlighterTests.swift
+++ b/Tests/MarkdownEditorTests/SyntaxHighlighterTests.swift
@@ -843,3 +843,61 @@ struct LineBreakTests {
         #expect(breaks[0].delimiterRanges == [NSRange(location: 4, length: 1)])
     }
 }
+
+// MARK: - Inline Math
+
+@Suite("SyntaxHighlighter — Inline Math")
+struct InlineMathTests {
+
+    private func mathSpans(_ text: String) -> [SyntaxHighlighter.Span] {
+        SyntaxHighlighter.parse(text).filter {
+            if case .math = $0.kind { return true }; return false
+        }
+    }
+
+    @Test("$x$ produces an inline math span with correct ranges")
+    func basicInline() {
+        let spans = mathSpans("$x$")
+        #expect(spans.count == 1)
+        let s = spans[0]
+        #expect(s.kind == .math(display: false))
+        #expect(s.fullRange == NSRange(location: 0, length: 3))
+        #expect(s.contentRange == NSRange(location: 1, length: 1))
+        #expect(s.delimiterRanges == [NSRange(location: 0, length: 1),
+                                      NSRange(location: 2, length: 1)])
+    }
+
+    @Test("Math in the middle of text has the right offset")
+    func mathInMiddle() {
+        let spans = mathSpans("energy $E=mc^2$ here")
+        #expect(spans.count == 1)
+        #expect(spans[0].fullRange == NSRange(location: 7, length: 8))
+        #expect(spans[0].contentRange == NSRange(location: 8, length: 6))
+    }
+
+    @Test("Prose dollar amounts are not matched")
+    func proseDollarsIgnored() {
+        #expect(mathSpans("it cost $5 to $10 today").isEmpty)
+    }
+
+    @Test("Escaped \\$ is not a delimiter")
+    func escapedDollar() {
+        #expect(mathSpans("price is \\$5 each").isEmpty)
+    }
+
+    @Test("$ inside inline code is not matched")
+    func dollarsInCode() {
+        let spans = mathSpans("`$x$`")
+        #expect(spans.isEmpty)
+    }
+
+    @Test("Display $$…$$ on one line is not treated as inline math (phase 2)")
+    func displayNotInline() {
+        #expect(mathSpans("$$x$$").isEmpty)
+    }
+
+    @Test("Opening $ followed by space is not math")
+    func openFollowedBySpace() {
+        #expect(mathSpans("a $ b $ c").isEmpty)
+    }
+}

--- a/test_math.md
+++ b/test_math.md
@@ -1,0 +1,19 @@
+linear polynomial: $y=mx+b$
+
+matrix: $A=\begin{bmatrix} a&b\\ c&d \end{bmatrix}$
+
+Sum: $\sum_{i=1}^n i = \frac{n(n+1)}{2}$
+
+
+
+I expect $A$ in the line above to align with matrix. And $A$ here to align with the line. 
+
+Also, inline equations that wraps around the window seem to trigger an edge case with recompose. 
+
+## This is a level-2 heading $f(x)=ax^2+bx+c$
+(I am aware the equation will not be bolded along with the heading. However, the equation should be the same size as the font of the heading.)
+
+```
+$f(x)$
+```
+


### PR DESCRIPTION
Adds inline LaTeX math, rendered as image attachments using the editor's word-level model (raw source revealed when the cursor is inside the token).

**Parsing** (`SyntaxHighlighter`): new `Span.Kind.math(display:)` + scan-based `parseMath` with Pandoc-style `$` disambiguation — escaped `\$`, `$$` skipped (display is a later phase), prose like `$5 to $10` left alone, never spans a newline, never matches inside code spans.

**Rendering** (`EditorTextView+MathRendering`, new): `mathAttachment` renders LaTeX to an `NSImage` via SwiftMath, resolving the text color against the view's light/dark appearance, and caches the image with its descent. Returns nil on parse error.

**Integration** (`styleBlock`): outside the token → hide source, show the attachment on the opening `$`; inside → raw LaTeX in the monospace code font; invalid LaTeX → raw source tinted red.

**Polish (visually verified):**
- Baseline: math sits on the text baseline (offset by the real typesetting descent, not a guessed constant).
- Size: inline math inside a heading matches the heading's font size.

Stays on plain SwiftMath (no ExtendedSwiftMath) — the baseline/heading fixes only needed SwiftMath's existing `displayList` descent API.

Tests: parser cases + render/active/invalid cases + a SwiftMath smoke test (422 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)