### PR TITLE
Display math ($$…$$) as centered blocks

### DIFF
--- a/Sources/MarkdownEditorCore/BlockParser.swift
+++ b/Sources/MarkdownEditorCore/BlockParser.swift
@@ -71,6 +71,25 @@ public enum BlockParser {
                 continue
             }
 
+            // Detect display-math fence: a line starting with `$$`.
+            if let closedOnSameLine = displayMathClosedOnSameLine(lines[i]) {
+                if closedOnSameLine {
+                    result.append(lines[i])
+                    i += 1
+                    continue
+                }
+                var merged = [lines[i]]
+                i += 1
+                while i < lines.count {
+                    merged.append(lines[i])
+                    let closes = lines[i].contains("$$")
+                    i += 1
+                    if closes { break }
+                }
+                result.append(merged.joined(separator: "\n"))
+                continue
+            }
+
             // Detect table: header row followed by separator row
             if i + 1 < lines.count && isTableRow(lines[i]) && isTableSeparator(lines[i + 1]) {
                 var merged = [lines[i]]
@@ -88,6 +107,15 @@ public enum BlockParser {
         }
 
         return result
+    }
+
+    /// If the line (after optional leading whitespace) starts with `$$`, returns
+    /// whether a second `$$` also appears on the same line (a one-line `$$…$$`
+    /// block). Returns nil when the line is not a display-math opener.
+    private static func displayMathClosedOnSameLine(_ line: String) -> Bool? {
+        let trimmed = line.drop(while: { $0 == " " })
+        guard trimmed.hasPrefix("$$") else { return nil }
+        return trimmed.dropFirst(2).contains("$$")
     }
 
     /// Returns true if the line contains a pipe character (potential table row).

--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -72,6 +72,20 @@ extension EditorTextView {
         return ps
     }
 
+    /// Centered paragraph style for display math. Spacing is intentionally zero:
+    /// a multi-line `$$…$$` block is several paragraphs in the text storage (its
+    /// hidden inner lines), so per-paragraph spacing would multiply into a large
+    /// gap. Breathing room comes from the blank lines authors put around display
+    /// math, like fenced code.
+    private func displayMathParagraphStyle() -> NSParagraphStyle {
+        let ps = NSMutableParagraphStyle()
+        ps.alignment = .center
+        ps.lineSpacing = 0
+        ps.paragraphSpacing = 0
+        ps.paragraphSpacingBefore = 0
+        return ps
+    }
+
     /// Paragraph style with a left border for blockquotes.
     private func blockquoteParagraphStyle() -> NSParagraphStyle {
         let ps = NSMutableParagraphStyle()
@@ -488,17 +502,24 @@ extension EditorTextView {
                     // inline math inside a heading matches the heading's size.
                     let contextFont = result.attribute(.font, at: span.fullRange.location,
                                                        effectiveRange: nil) as? NSFont ?? bodyFont
-                    if let attachment = mathAttachment(latex: latex, display: display,
+                    if let attachment = mathAttachment(latex: latex.trimmingCharacters(in: .whitespacesAndNewlines),
+                                                       display: display,
                                                        fontSize: contextFont.pointSize) {
-                        // Hide the LaTeX source + closing `$`, show the rendered
-                        // image on the opening `$` (which the attachment replaces).
-                        let hideStart = span.contentRange.location
+                        // Show the rendered image on the first `$` (which the
+                        // attachment replaces) and hide everything after it — the
+                        // rest of the opening delimiter, the source, and the close.
+                        let hideStart = span.fullRange.location + 1
                         let hideLen = span.fullRange.upperBound - hideStart
                         let hideRange = NSRange(location: hideStart, length: hideLen)
                         result.addAttribute(.font, value: hiddenFont, range: hideRange)
                         result.addAttribute(.foregroundColor, value: NSColor.clear, range: hideRange)
                         result.addAttribute(.attachment, value: attachment,
                                             range: NSRange(location: span.fullRange.location, length: 1))
+                        // Display math sits centered on its own line.
+                        if display {
+                            result.addAttribute(.paragraphStyle, value: displayMathParagraphStyle(),
+                                                range: span.fullRange)
+                        }
                     } else {
                         // Invalid LaTeX: surface the raw source in monospace, tinted.
                         result.addAttribute(.font, value: inlineCodeFont, range: span.fullRange)

--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -72,17 +72,17 @@ extension EditorTextView {
         return ps
     }
 
-    /// Centered paragraph style for display math. Spacing is intentionally zero:
-    /// a multi-line `$$…$$` block is several paragraphs in the text storage (its
-    /// hidden inner lines), so per-paragraph spacing would multiply into a large
-    /// gap. Breathing room comes from the blank lines authors put around display
-    /// math, like fenced code.
-    private func displayMathParagraphStyle() -> NSParagraphStyle {
+    /// Centered paragraph style for display math. The vertical padding is applied
+    /// only to the attachment's (first) line — a multi-line `$$…$$` block is
+    /// several paragraphs in the text storage (its hidden inner lines), so
+    /// padding every paragraph would multiply into a huge gap.
+    private func displayMathParagraphStyle(padded: Bool) -> NSParagraphStyle {
         let ps = NSMutableParagraphStyle()
         ps.alignment = .center
         ps.lineSpacing = 0
-        ps.paragraphSpacing = 0
-        ps.paragraphSpacingBefore = 0
+        let pad = padded ? bodyFont.pointSize * 0.9 : 0
+        ps.paragraphSpacingBefore = pad
+        ps.paragraphSpacing = pad
         return ps
     }
 
@@ -515,10 +515,22 @@ extension EditorTextView {
                         result.addAttribute(.foregroundColor, value: NSColor.clear, range: hideRange)
                         result.addAttribute(.attachment, value: attachment,
                                             range: NSRange(location: span.fullRange.location, length: 1))
-                        // Display math sits centered on its own line.
+                        // Display math sits centered on its own line, with
+                        // vertical padding on the (first) line that carries the
+                        // attachment image.
                         if display {
-                            result.addAttribute(.paragraphStyle, value: displayMathParagraphStyle(),
+                            let fullStr = result.string as NSString
+                            result.addAttribute(.paragraphStyle,
+                                                value: displayMathParagraphStyle(padded: false),
                                                 range: span.fullRange)
+                            let nl = fullStr.range(of: "\n", options: [], range: span.fullRange)
+                            let firstLine = nl.location == NSNotFound
+                                ? span.fullRange
+                                : NSRange(location: span.fullRange.location,
+                                          length: nl.location - span.fullRange.location + 1)
+                            result.addAttribute(.paragraphStyle,
+                                                value: displayMathParagraphStyle(padded: true),
+                                                range: firstLine)
                         }
                     } else {
                         // Invalid LaTeX: surface the raw source in monospace, tinted.

--- a/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
+++ b/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
@@ -54,7 +54,9 @@ public enum SyntaxHighlighter {
         // ==highlight== is not supported by swift-markdown; parse with regex.
         parseHighlight(text, into: &walker.spans)
 
-        // $…$ inline math (display $$…$$ is handled per-block in a later phase).
+        // $$…$$ display math (the block is pre-merged by BlockParser), then
+        // $…$ inline math.
+        parseDisplayMath(text, into: &walker.spans)
         parseMath(text, into: &walker.spans)
 
         // Trailing backslash line break (single-line blocks only).
@@ -92,6 +94,29 @@ public enum SyntaxHighlighter {
                 delimiterRanges: [openDelim, closeDelim]
             ))
         }
+    }
+
+    /// Recognizes a whole block as `$$…$$` display math. `BlockParser` has
+    /// already merged a multi-line `$$ … $$` run into a single block, so here we
+    /// only need to confirm the block opens and closes with `$$`.
+    private static func parseDisplayMath(_ text: String, into spans: inout [Span]) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("$$"), trimmed.hasSuffix("$$"), trimmed.count >= 4 else { return }
+
+        let ns = text as NSString
+        let open = ns.range(of: "$$")
+        let close = ns.range(of: "$$", options: .backwards)
+        guard open.location != NSNotFound, close.location != NSNotFound,
+              close.location >= open.location + 2 else { return }
+
+        let full = NSRange(location: open.location, length: close.upperBound - open.location)
+        let content = NSRange(location: open.upperBound, length: close.location - open.upperBound)
+        spans.append(Span(
+            kind: .math(display: true),
+            fullRange: full,
+            contentRange: content,
+            delimiterRanges: [open, close]
+        ))
     }
 
     /// Scans for inline `$…$` math. Uses Pandoc-style disambiguation so prose
@@ -140,10 +165,10 @@ public enum SyntaxHighlighter {
             guard close > i + 1 else { i += 1; continue }
 
             let full = NSRange(location: i, length: close - i + 1)
-            // Don't match inside code spans.
+            // Don't match inside code spans or a display-math block.
             let overlaps = spans.contains { existing in
                 switch existing.kind {
-                case .code, .codeBlock:
+                case .code, .codeBlock, .math(display: true):
                     return existing.fullRange.location <= full.location
                         && existing.fullRange.upperBound >= full.upperBound
                 default:

--- a/Tests/MarkdownEditorTests/BlockParserTests.swift
+++ b/Tests/MarkdownEditorTests/BlockParserTests.swift
@@ -290,6 +290,39 @@ struct BlockParserTests {
         #expect(blocks[0].content.contains("a\nb\nc"))
     }
 
+    @Test("Multi-line $$ display math merges into a single block")
+    func displayMathMerge() {
+        let text = "$$\nx = y\n$$"
+        let blocks = BlockParser.parse(text)
+        #expect(blocks.count == 1)
+        #expect(blocks[0].content == "$$\nx = y\n$$")
+    }
+
+    @Test("One-line $$…$$ stays a single block")
+    func displayMathOneLine() {
+        let blocks = BlockParser.parse("$$ x = y $$")
+        #expect(blocks.count == 1)
+        #expect(blocks[0].content == "$$ x = y $$")
+    }
+
+    @Test("Display math between paragraphs splits correctly")
+    func displayMathBetweenParagraphs() {
+        let text = "above\n$$\nx\n$$\nbelow"
+        let blocks = BlockParser.parse(text)
+        #expect(blocks.count == 3)
+        #expect(blocks[0].content == "above")
+        #expect(blocks[1].content == "$$\nx\n$$")
+        #expect(blocks[2].content == "below")
+    }
+
+    @Test("Display math opener with content on the same line")
+    func displayMathOpenerWithContent() {
+        let text = "$$ x +\ny $$"
+        let blocks = BlockParser.parse(text)
+        #expect(blocks.count == 1)
+        #expect(blocks[0].content == "$$ x +\ny $$")
+    }
+
     @Test("Code fence range covers full text")
     func codeFenceRange() {
         let text = "```\nhello\n```"

--- a/Tests/MarkdownEditorTests/MathRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/MathRenderingTests.swift
@@ -58,3 +58,34 @@ struct InlineMathRenderingTests {
         #expect(color == NSColor.systemRed)
     }
 }
+
+@Suite("Math — Display rendering")
+struct DisplayMathRenderingTests {
+
+    @Test("Inactive $$…$$ shows an attachment and hides the source")
+    @MainActor func inactiveRendersAttachment() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("$$x+y$$")
+        // Attachment replaces the first `$`.
+        #expect(styled.attribute(.attachment, at: 0, effectiveRange: nil) is NSTextAttachment)
+        // The second `$` of the opening delimiter is hidden too.
+        #expect(isHidden(at: 1, in: styled))
+        #expect(isHidden(at: 2, in: styled))             // content
+    }
+
+    @Test("Display math is centered")
+    @MainActor func displayIsCentered() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("$$x+y$$")
+        let ps = styled.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        #expect(ps?.alignment == .center)
+    }
+
+    @Test("Active $$…$$ (cursor inside) shows raw, no attachment")
+    @MainActor func activeShowsRaw() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("$$x+y$$", cursorPosition: 3)
+        #expect(styled.attribute(.attachment, at: 0, effectiveRange: nil) == nil)
+        #expect(!isHidden(at: 2, in: styled))             // source visible
+    }
+}

--- a/Tests/MarkdownEditorTests/SyntaxHighlighterTests.swift
+++ b/Tests/MarkdownEditorTests/SyntaxHighlighterTests.swift
@@ -891,13 +891,54 @@ struct InlineMathTests {
         #expect(spans.isEmpty)
     }
 
-    @Test("Display $$…$$ on one line is not treated as inline math (phase 2)")
-    func displayNotInline() {
-        #expect(mathSpans("$$x$$").isEmpty)
+    @Test("$$x$$ on one line is display math, not inline")
+    func singleLineDisplay() {
+        let spans = mathSpans("$$x$$")
+        #expect(spans.count == 1)
+        #expect(spans[0].kind == .math(display: true))
+        #expect(spans[0].contentRange == NSRange(location: 2, length: 1))
     }
 
     @Test("Opening $ followed by space is not math")
     func openFollowedBySpace() {
         #expect(mathSpans("a $ b $ c").isEmpty)
+    }
+}
+
+// MARK: - Display Math
+
+@Suite("SyntaxHighlighter — Display Math")
+struct DisplayMathTests {
+
+    private func mathSpans(_ text: String) -> [SyntaxHighlighter.Span] {
+        SyntaxHighlighter.parse(text).filter {
+            if case .math = $0.kind { return true }; return false
+        }
+    }
+
+    @Test("Multi-line $$…$$ block produces a display-math span")
+    func multiLineDisplay() {
+        let text = "$$\nx = y\n$$"
+        let spans = mathSpans(text)
+        #expect(spans.count == 1)
+        #expect(spans[0].kind == .math(display: true))
+        // full range spans the opening $$ through the closing $$.
+        #expect(spans[0].fullRange == NSRange(location: 0, length: (text as NSString).length))
+        // content is the text between the delimiters (newlines included).
+        let content = (text as NSString).substring(with: spans[0].contentRange)
+        #expect(content == "\nx = y\n")
+    }
+
+    @Test("Display delimiters are the two $$")
+    func displayDelimiters() {
+        let spans = mathSpans("$$a$$")
+        #expect(spans.count == 1)
+        #expect(spans[0].delimiterRanges == [NSRange(location: 0, length: 2),
+                                             NSRange(location: 3, length: 2)])
+    }
+
+    @Test("A normal paragraph is not display math")
+    func paragraphNotDisplay() {
+        #expect(mathSpans("just a paragraph").isEmpty)
     }
 }


### PR DESCRIPTION
Phase 2 of math support — block-level display equations.

- `BlockParser` merges a `$$`-fenced run into one block (like code fences); one-line `$$…$$` stays a single block.
- `SyntaxHighlighter.parseDisplayMath` recognizes a block opening/closing with `$$` as `.math(display: true)`; the inline scanner skips inside it.
- `styleBlock` renders display math in SwiftMath display mode, centered on its own line, with vertical padding applied only to the attachment's line (so a multi-line block's hidden inner lines don't compound the gap). Cursor-inside shows raw LaTeX in monospace.

Reuses the Phase-1 attachment + baseline machinery. Visually verified (integral, matrix, E=mc²). 432 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)