### PR TITLE
Themeable LaTeX source coloring

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -72,6 +72,48 @@ extension EditorTextView {
         return ps
     }
 
+    /// Colors raw LaTeX source: operators/commands (`_`, `^`, `\sum`, `\cdot`,
+    /// i.e. a backslash followed by letters) in the theme's math-operator color,
+    /// and numbers in the math-number color. Other characters keep their color.
+    private func colorMathSource(_ result: NSMutableAttributedString, range: NSRange) {
+        guard range.length > 0, range.upperBound <= result.length else { return }
+        let ns = result.string as NSString
+        let opColor = theme.mathOperatorColor
+        let numColor = theme.mathNumberColor
+        let backslash: unichar = 0x5C, underscore: unichar = 0x5F, caret: unichar = 0x5E
+
+        func isAlpha(_ c: unichar) -> Bool { (c >= 0x41 && c <= 0x5A) || (c >= 0x61 && c <= 0x7A) }
+        func isDigit(_ c: unichar) -> Bool { c >= 0x30 && c <= 0x39 }
+
+        var i = range.location
+        let end = range.upperBound
+        while i < end {
+            let c = ns.character(at: i)
+            if c == backslash {
+                // Command: backslash + following letters (\sum, \cdot). A
+                // backslash before a non-letter (\,, \{) colors just the pair.
+                var j = i + 1
+                while j < end, isAlpha(ns.character(at: j)) { j += 1 }
+                let cmdEnd = j > i + 1 ? j : min(i + 2, end)
+                result.addAttribute(.foregroundColor, value: opColor,
+                                    range: NSRange(location: i, length: cmdEnd - i))
+                i = cmdEnd
+            } else if c == underscore || c == caret {
+                result.addAttribute(.foregroundColor, value: opColor,
+                                    range: NSRange(location: i, length: 1))
+                i += 1
+            } else if isDigit(c) {
+                var j = i + 1
+                while j < end, isDigit(ns.character(at: j)) { j += 1 }
+                result.addAttribute(.foregroundColor, value: numColor,
+                                    range: NSRange(location: i, length: j - i))
+                i = j
+            } else {
+                i += 1
+            }
+        }
+    }
+
     /// Centered paragraph style for display math. The vertical padding is applied
     /// only to the attachment's (first) line — a multi-line `$$…$$` block is
     /// several paragraphs in the text storage (its hidden inner lines), so
@@ -493,9 +535,10 @@ extension EditorTextView {
             case .math(let display):
                 guard span.fullRange.upperBound <= result.length else { continue }
                 if cursorInToken {
-                    // Active: show the raw LaTeX in monospace (like inline code);
-                    // `$` delimiters are dimmed in the loop below.
+                    // Active: show the raw LaTeX in monospace (like inline code),
+                    // with LaTeX syntax coloring; `$` delimiters dimmed below.
                     result.addAttribute(.font, value: inlineCodeFont, range: span.fullRange)
+                    colorMathSource(result, range: span.contentRange)
                 } else {
                     let latex = (markdown as NSString).substring(with: span.contentRange)
                     // Size the math to the font already applied at this location, so

--- a/Sources/MarkdownEditorCore/EditorTheme.swift
+++ b/Sources/MarkdownEditorCore/EditorTheme.swift
@@ -16,6 +16,10 @@ public struct EditorTheme: Equatable, Sendable {
 
     public var accentHex: String
     public var codeHex: String
+    /// Color for LaTeX operators/commands (`_`, `^`, `\sum`, …) in raw math.
+    public var mathOperatorHex: String
+    /// Color for numbers in raw math.
+    public var mathNumberHex: String
 
     // MARK: - Spacing
 
@@ -23,13 +27,16 @@ public struct EditorTheme: Equatable, Sendable {
     public var paragraphSpacingBefore: CGFloat
 
     public init(fontName: String, fontSize: CGFloat, accentHex: String, codeHex: String,
-                lineSpacing: CGFloat, paragraphSpacingBefore: CGFloat) {
+                lineSpacing: CGFloat, paragraphSpacingBefore: CGFloat,
+                mathOperatorHex: String = "#D70015", mathNumberHex: String = "#C77800") {
         self.fontName = fontName
         self.fontSize = fontSize
         self.accentHex = accentHex
         self.codeHex = codeHex
         self.lineSpacing = lineSpacing
         self.paragraphSpacingBefore = paragraphSpacingBefore
+        self.mathOperatorHex = mathOperatorHex
+        self.mathNumberHex = mathNumberHex
     }
 
     // MARK: - Defaults
@@ -57,6 +64,14 @@ public struct EditorTheme: Equatable, Sendable {
         NSColor(hex: codeHex) ?? .systemRed
     }
 
+    @MainActor public var mathOperatorColor: NSColor {
+        NSColor(hex: mathOperatorHex) ?? .systemRed
+    }
+
+    @MainActor public var mathNumberColor: NSColor {
+        NSColor(hex: mathNumberHex) ?? .systemOrange
+    }
+
     // MARK: - UserDefaults Persistence
 
     private enum Keys {
@@ -64,6 +79,8 @@ public struct EditorTheme: Equatable, Sendable {
         static let fontSize = "EditorFontSize"
         static let accentHex = "EditorAccentHex"
         static let codeHex = "EditorCodeHex"
+        static let mathOperatorHex = "EditorMathOperatorHex"
+        static let mathNumberHex = "EditorMathNumberHex"
         static let lineSpacing = "EditorLineSpacing"
         static let paragraphSpacingBefore = "EditorParagraphSpacingBefore"
     }
@@ -79,6 +96,8 @@ public struct EditorTheme: Equatable, Sendable {
         }()
         let accentHex = d.string(forKey: Keys.accentHex) ?? def.accentHex
         let codeHex = d.string(forKey: Keys.codeHex) ?? def.codeHex
+        let mathOperatorHex = d.string(forKey: Keys.mathOperatorHex) ?? def.mathOperatorHex
+        let mathNumberHex = d.string(forKey: Keys.mathNumberHex) ?? def.mathNumberHex
         let lineSpacing: CGFloat = d.object(forKey: Keys.lineSpacing) != nil
             ? CGFloat(d.float(forKey: Keys.lineSpacing))
             : def.lineSpacing
@@ -92,7 +111,9 @@ public struct EditorTheme: Equatable, Sendable {
             accentHex: accentHex,
             codeHex: codeHex,
             lineSpacing: lineSpacing,
-            paragraphSpacingBefore: paragraphSpacingBefore
+            paragraphSpacingBefore: paragraphSpacingBefore,
+            mathOperatorHex: mathOperatorHex,
+            mathNumberHex: mathNumberHex
         )
     }
 
@@ -102,6 +123,8 @@ public struct EditorTheme: Equatable, Sendable {
         d.set(Float(fontSize), forKey: Keys.fontSize)
         d.set(accentHex, forKey: Keys.accentHex)
         d.set(codeHex, forKey: Keys.codeHex)
+        d.set(mathOperatorHex, forKey: Keys.mathOperatorHex)
+        d.set(mathNumberHex, forKey: Keys.mathNumberHex)
         d.set(Float(lineSpacing), forKey: Keys.lineSpacing)
         d.set(Float(paragraphSpacingBefore), forKey: Keys.paragraphSpacingBefore)
     }

--- a/Tests/MarkdownEditorTests/EditorThemeTests.swift
+++ b/Tests/MarkdownEditorTests/EditorThemeTests.swift
@@ -1,0 +1,36 @@
+import Testing
+import AppKit
+@testable import MarkdownEditorCore
+
+@Suite("EditorTheme — Math colors")
+struct EditorThemeMathColorTests {
+
+    @Test("Default math colors are red (operators) and orange (numbers)")
+    @MainActor func defaults() {
+        let t = EditorTheme.default
+        #expect(t.mathOperatorHex == "#D70015")
+        #expect(t.mathNumberHex == "#C77800")
+        #expect(t.mathOperatorColor == NSColor(hex: "#D70015"))
+        #expect(t.mathNumberColor == NSColor(hex: "#C77800"))
+    }
+
+    @Test("Custom math hex resolves to the matching color")
+    @MainActor func customHex() {
+        let t = EditorTheme(fontName: "Helvetica", fontSize: 14,
+                            accentHex: "#000000", codeHex: "#000000",
+                            lineSpacing: 0, paragraphSpacingBefore: 0,
+                            mathOperatorHex: "#112233", mathNumberHex: "#445566")
+        #expect(t.mathOperatorColor == NSColor(hex: "#112233"))
+        #expect(t.mathNumberColor == NSColor(hex: "#445566"))
+    }
+
+    @Test("An invalid hex falls back to a system color, not a crash")
+    @MainActor func invalidHexFallback() {
+        let t = EditorTheme(fontName: "Helvetica", fontSize: 14,
+                            accentHex: "#000000", codeHex: "#000000",
+                            lineSpacing: 0, paragraphSpacingBefore: 0,
+                            mathOperatorHex: "nonsense", mathNumberHex: "")
+        #expect(t.mathOperatorColor == NSColor.systemRed)
+        #expect(t.mathNumberColor == NSColor.systemOrange)
+    }
+}

--- a/Tests/MarkdownEditorTests/MathRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/MathRenderingTests.swift
@@ -59,6 +59,41 @@ struct InlineMathRenderingTests {
     }
 }
 
+@Suite("Math — Source coloring")
+struct MathSourceColoringTests {
+
+    @MainActor private func color(_ s: NSAttributedString, at i: Int) -> String? {
+        (s.attribute(.foregroundColor, at: i, effectiveRange: nil) as? NSColor)?.hexString
+    }
+
+    @Test("Active math colors _, ^ as operators and digits as numbers")
+    @MainActor func operatorsAndNumbers() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("$x_1^2$", cursorPosition: 3)   // active
+        let op = editor.theme.mathOperatorColor.hexString
+        let num = editor.theme.mathNumberColor.hexString
+        // $0 x1 _2 13 ^4 25 $6
+        #expect(color(styled, at: 2) == op)    // _
+        #expect(color(styled, at: 3) == num)   // 1
+        #expect(color(styled, at: 4) == op)    // ^
+        #expect(color(styled, at: 5) == num)   // 2
+        #expect(color(styled, at: 1) != op)    // x is neither
+        #expect(color(styled, at: 1) != num)
+    }
+
+    @Test("Active math colors a backslash command as an operator")
+    @MainActor func backslashCommand() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("$\\alpha+1$", cursorPosition: 2)
+        let op = editor.theme.mathOperatorColor.hexString
+        let num = editor.theme.mathNumberColor.hexString
+        // $0 \1 a2 l3 p4 h5 a6 +7 18 $9
+        #expect(color(styled, at: 1) == op)    // backslash
+        #expect(color(styled, at: 4) == op)    // inside \alpha
+        #expect(color(styled, at: 8) == num)   // 1
+    }
+}
+
 @Suite("Math — Display rendering")
 struct DisplayMathRenderingTests {
 


### PR DESCRIPTION
When a math token is active (cursor inside), the raw LaTeX shows in monospace — now syntax-colored like a lightweight LaTeX highlighter:

- `_`, `^`, and `\command` (backslash + letters) → math-operator color (default red)
- numbers → math-number color (default orange)
- everything else keeps its color

The two colors live in `EditorTheme` (persisted, themeable) with sensible defaults; a Settings UI to change them is a later pass (per request).

Visually verified against the reference screenshot. Tests: theme defaults/derivation + active-math coloring (437 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)