### PR TITLE
Scale over-wide equations to fit the text width

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+MathRendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+MathRendering.swift
@@ -61,11 +61,30 @@ extension EditorTextView {
 
         let attachment = NSTextAttachment()
         attachment.image = render.image
+
+        var width = render.image.size.width
+        var height = render.image.size.height
+        var descent = render.descent
+        // Interim until SwiftMath line-wrapping ships: if the equation is wider
+        // than the text area, scale it down to fit (otherwise leave it natural
+        // size). The baseline descent scales with it.
+        let maxWidth = availableContentWidth
+        if maxWidth > 0, width > maxWidth {
+            let scale = maxWidth / width
+            width *= scale
+            height *= scale
+            descent *= scale
+        }
         // Drop the image so its baseline (descent above the image bottom) lands
         // on the text baseline.
-        attachment.bounds = CGRect(x: 0, y: -render.descent,
-                                   width: render.image.size.width,
-                                   height: render.image.size.height)
+        attachment.bounds = CGRect(x: 0, y: -descent, width: width, height: height)
         return attachment
+    }
+
+    /// The usable text width for one line — the text container minus its line
+    /// fragment padding on both sides. Used to cap over-wide equations.
+    private var availableContentWidth: CGFloat {
+        guard let container = textContainer else { return 0 }
+        return container.containerSize.width - 2 * container.lineFragmentPadding
     }
 }

--- a/Tests/MarkdownEditorTests/MathRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/MathRenderingTests.swift
@@ -124,3 +124,32 @@ struct DisplayMathRenderingTests {
         #expect(!isHidden(at: 2, in: styled))             // source visible
     }
 }
+
+@Suite("Math — Fit to width")
+struct MathFitWidthTests {
+
+    // The test editor's container is 500 wide; usable width ≈ 500 − 2·5 padding.
+    private let cap: CGFloat = 490
+
+    @Test("A very wide equation is scaled down to the text width")
+    @MainActor func wideScaled() {
+        let editor = makeEditor()
+        let wide = "$$a_{10}x^{10}+a_9x^9+a_8x^8+a_7x^7+a_6x^6+a_5x^5+a_4x^4+a_3x^3+a_2x^2+a_1x+a_0$$"
+        let styled = editor.styleBlock(wide)
+        let att = styled.attribute(.attachment, at: 0, effectiveRange: nil) as? NSTextAttachment
+        #expect(att != nil)
+        // Scaled to the cap (within a small tolerance), not its much larger natural width.
+        #expect((att?.bounds.width ?? 0) <= cap + 2)
+        #expect((att?.bounds.width ?? 0) >= cap - 12)
+    }
+
+    @Test("A normal-width equation is not scaled")
+    @MainActor func normalNotScaled() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("$$x+y$$")
+        let att = styled.attribute(.attachment, at: 0, effectiveRange: nil) as? NSTextAttachment
+        #expect(att != nil)
+        let w = att?.bounds.width ?? 0
+        #expect(w > 0 && w < 200)        // comfortably under the cap
+    }
+}


### PR DESCRIPTION
Interim handling (until SwiftMath's unreleased line-wrapping) for equations wider than the window: when a rendered math image exceeds the usable line width, scale it — and its baseline descent — down to fit, preserving aspect ratio. Equations that already fit are untouched.

`NSTextAttachment` scales the image to its bounds, so this is just a bounds computation; no new dependency or fragile overlay.

**Known limitation:** the fit is computed at compose time, so after a live window resize a wide equation re-fits on the next edit/cursor move rather than instantly.

Visually verified (a wide 11-term polynomial shrinks to fit; `E=mc²` stays natural size). Tests: wide scales to the cap, normal untouched (439 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)