### PR TITLE
Force .md extension for new-file saves

### DIFF
--- a/Sources/MarkdownEditor/Document.swift
+++ b/Sources/MarkdownEditor/Document.swift
@@ -48,6 +48,18 @@ class Document: NSDocument {
         "md"
     }
 
+    // `fileNameExtension(forType:…)` alone isn't enough: for an untitled save
+    // the panel still seeds its name field from the markdown UTI's preferred
+    // extension (".markdown"). Force the default name to end in ".md" and let
+    // the user type any other extension if they really want one.
+    override func prepareSavePanel(_ savePanel: NSSavePanel) -> Bool {
+        savePanel.allowedContentTypes = []
+        savePanel.allowsOtherFileTypes = true
+        let base = (savePanel.nameFieldStringValue as NSString).deletingPathExtension
+        savePanel.nameFieldStringValue = (base.isEmpty ? "Untitled" : base) + ".md"
+        return true
+    }
+
     // MARK: - Window Setup
 
     override func makeWindowControllers() {


### PR DESCRIPTION
## Problem
Saving a brand-new (untitled) document still defaulted the file extension to `.markdown`, despite the existing `fileNameExtension(forType:saveOperation:)` override returning `"md"`. For an untitled save, NSDocument seeds the save panel's name field from the `net.daringfireball.markdown` UTI's *preferred* extension (`.markdown`), bypassing that override.

## Fix
Add a `prepareSavePanel(_:)` override that forces the default name to end in `.md` (and allows other typed extensions via `allowsOtherFileTypes`).

## Verification
- `swift build` ✓
- `swift test` — 439 tests pass ✓
- Manual (GUI): New doc → ⌘S → name field shows `Untitled.md`. *(Needs your eyes — save-panel behavior isn't unit-testable; the app target has no test coverage.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)