### PR TITLE
Follow links on cmd+click

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -1,5 +1,12 @@
 import AppKit
 
+extension NSAttributedString.Key {
+    /// Stores a link's destination (URL string) on its visible text so a
+    /// cmd+click can follow it. Kept separate from the system `.link` attribute
+    /// to avoid NSTextView's built-in link styling/cursor behavior.
+    static let editorLinkURL = NSAttributedString.Key("EditorLinkURL")
+}
+
 // MARK: - Word-Level Styling
 //
 // All blocks are styled the same way: content gets rich text attributes,
@@ -341,10 +348,13 @@ extension EditorTextView {
                 let heading = NSFontManager.shared.convert(sized, toHaveTrait: .boldFontMask)
                 result.addAttribute(.font, value: heading, range: span.fullRange)
 
-            case .link:
+            case .link(let destination):
                 guard span.contentRange.upperBound <= result.length else { continue }
                 result.addAttribute(.foregroundColor, value: accentColor, range: span.contentRange)
                 result.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: span.contentRange)
+                if !destination.isEmpty {
+                    result.addAttribute(.editorLinkURL, value: destination, range: span.contentRange)
+                }
 
             case .image:
                 guard span.contentRange.upperBound <= result.length else { continue }

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -264,6 +264,39 @@ public class EditorTextView: NSTextView {
         scrollView.reflectScrolledClipView(scrollView.contentView)
     }
 
+    // MARK: - Link Following
+
+    /// Cmd+click on a link's text follows it; any other click edits normally.
+    public override func mouseDown(with event: NSEvent) {
+        if event.modifierFlags.contains(.command), let url = linkURL(at: event) {
+            NSWorkspace.shared.open(url)
+            return
+        }
+        super.mouseDown(with: event)
+    }
+
+    /// The destination URL of the link under a mouse event, or nil if the click
+    /// doesn't land directly on link text.
+    private func linkURL(at event: NSEvent) -> URL? {
+        guard let lm = layoutManager, let container = textContainer,
+              let storage = textStorage, storage.length > 0 else { return nil }
+
+        var point = convert(event.locationInWindow, from: nil)
+        point.x -= textContainerOrigin.x
+        point.y -= textContainerOrigin.y
+
+        let glyphIndex = lm.glyphIndex(for: point, in: container)
+        // Reject clicks past the end of a line (which still resolve to a glyph).
+        let glyphRect = lm.boundingRect(forGlyphRange: NSRange(location: glyphIndex, length: 1), in: container)
+        guard glyphRect.contains(point) else { return nil }
+
+        let charIndex = lm.characterIndexForGlyph(at: glyphIndex)
+        guard charIndex < storage.length,
+              let dest = storage.attribute(.editorLinkURL, at: charIndex, effectiveRange: nil) as? String
+        else { return nil }
+        return URL(string: dest)
+    }
+
     // MARK: - Helpers
 
     func currentCursorInRaw() -> Int {

--- a/Tests/MarkdownEditorTests/EditorRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/EditorRenderingTests.swift
@@ -217,6 +217,17 @@ struct EditorStylingTests {
         #expect(underline != nil)
     }
 
+    @Test("Link text carries its destination URL for cmd+click")
+    @MainActor func linkCarriesURL() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("[text](https://example.com)")
+        // "text" is at positions 1-4; the URL attribute should cover it.
+        let dest = styled.attribute(.editorLinkURL, at: 1, effectiveRange: nil) as? String
+        #expect(dest == "https://example.com")
+        // The delimiters/destination source carry no URL attribute.
+        #expect(styled.attribute(.editorLinkURL, at: 0, effectiveRange: nil) == nil)
+    }
+
     @Test("Image delimiters are hidden when cursor is outside")
     @MainActor func imageDelimitersHidden() {
         let editor = makeEditor()


### PR DESCRIPTION
## Feature
⌘+Click on a Markdown link's text now opens its destination in the default handler (browser, etc.). A normal click still places the cursor / edits.

## Implementation
- Rendering: stash the link destination on the visible link text via a custom `.editorLinkURL` attribute (deliberately *not* the system `.link` attribute, to avoid NSTextView's built-in link styling and cursor changes).
- `EditorTextView.mouseDown(with:)`: when ⌘ is held and the click lands directly on link-text glyphs, resolve the `.editorLinkURL` at that character and `NSWorkspace.shared.open(url)`; otherwise fall through to `super`.

## Verification
- `swift build` ✓
- `swift test` — **440** tests pass (added "Link text carries its destination URL for cmd+click") ✓
- Manual (GUI): ⌘-click `[text](https://example.com)` opens the URL; plain click edits. *(Needs your eyes for the actual click behavior.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)