### PR TITLE
Clean up compiler warnings

### DIFF
--- a/Sources/MarkdownEditor/main.swift
+++ b/Sources/MarkdownEditor/main.swift
@@ -132,11 +132,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let editMenu = NSMenu(title: "Edit")
 
         editMenu.addItem(withTitle: "Undo",
-                         action: Selector(("undo:")),
+                         action: #selector(EditorTextView.undo(_:)),
                          keyEquivalent: "z")
 
         let redoItem = editMenu.addItem(withTitle: "Redo",
-                                        action: Selector(("redo:")),
+                                        action: #selector(EditorTextView.redo(_:)),
                                         keyEquivalent: "z")
         redoItem.keyEquivalentModifierMask = [.command, .shift]
 

--- a/Sources/MarkdownEditorCore/EditorTextView+Undo.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Undo.swift
@@ -8,11 +8,11 @@ import AppKit
 
 extension EditorTextView {
 
-    @objc func undo(_ sender: Any?) {
+    @objc public func undo(_ sender: Any?) {
         performUndo()
     }
 
-    @objc func redo(_ sender: Any?) {
+    @objc public func redo(_ sender: Any?) {
         performRedo()
     }
 

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -245,7 +245,7 @@ public class EditorTextView: NSTextView {
     /// Scrolls the view so the cursor's line fragment is vertically centered
     /// in the visible area.
     private func scrollCursorToCenter() {
-        guard let lm = layoutManager, let container = textContainer,
+        guard let lm = layoutManager,
               let scrollView = enclosingScrollView else { return }
 
         let sel = selectedRange()


### PR DESCRIPTION
Silences the three build warnings:

- `EditorTextView.swift` `scrollCursorToCenter`: removed the unused `container` binding from the `guard`.
- `main.swift` Edit menu: replaced `Selector(("undo:"))` / `Selector(("redo:"))` with `#selector(EditorTextView.undo(_:))` / `#selector(EditorTextView.redo(_:))`. Those `@objc` methods are now `public` so the app target can reference them.

`swift build` is warning-free; `swift test` — 439 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)