### PR TITLE
Fix duplicate launch window + make Open panel reliably visible

### DIFF
--- a/Sources/md/main.swift
+++ b/Sources/md/main.swift
@@ -10,14 +10,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         setupMenuBar()
 
-        // Open file from command-line argument.
-        // (NSDocumentController automatically opens an untitled document on launch,
-        //  so we only need to act when a file path is provided.)
+        // Open file from command-line argument. When a file is given,
+        // `applicationShouldOpenUntitledFile` suppresses the otherwise-automatic
+        // blank document, so we don't end up with two windows.
         let args = CommandLine.arguments
         if args.count > 1 {
             let url = URL(fileURLWithPath: args[1])
             NSDocumentController.shared.openDocument(withContentsOf: url, display: true) { _, _, _ in }
         }
+    }
+
+    // Auto-open a blank document on launch only when no file was passed on the
+    // command line (otherwise the file arg + the blank doc make two windows).
+    func applicationShouldOpenUntitledFile(_ sender: NSApplication) -> Bool {
+        CommandLine.arguments.count <= 1
     }
 
     func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
@@ -55,7 +61,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
         panel.canChooseFiles = true
-        panel.begin { response in
+
+        let complete: (NSApplication.ModalResponse) -> Void = { response in
             guard response == .OK, let url = panel.url else { return }
             NSDocumentController.shared.openDocument(
                 withContentsOf: url, display: true
@@ -64,6 +71,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     NSAlert(error: error).runModal()
                 }
             }
+        }
+
+        // Attach the panel to the front window as a sheet so it's always visible
+        // — a free-floating panel can open off-screen or behind the window
+        // (the app's windows can launch off-screen), which looks like a hang.
+        NSApp.activate(ignoringOtherApps: true)
+        if let window = NSApp.keyWindow ?? NSApp.mainWindow {
+            panel.beginSheetModal(for: window, completionHandler: complete)
+        } else {
+            panel.begin(completionHandler: complete)
         }
     }
 


### PR DESCRIPTION
Two related document/launch fixes in `Sources/md/main.swift`.

## 1. Double window on launch-with-file
Launching `md somefile.md` showed the file **and** a blank `Untitled` window: the file was opened manually in `applicationDidFinishLaunching`, while AppKit *also* auto-opened an untitled document.

**Fix:** implement `applicationShouldOpenUntitledFile` → return `false` when a file arg is present (still opens a blank doc on a plain launch). Verified: launching with a file now shows only the file's window.

## 2. "Stuck after Open"
I couldn't reproduce a hard hang (the app stays responsive — process is in `S` sleep, not beach-balling). The most likely cause: the app's windows can launch off-screen here, and the **free-floating** `NSOpenPanel.begin` could appear off-screen/behind the window, so the menu closes with no visible panel — looking stuck.

**Fix:** present the Open panel as a **sheet** on the front window (`beginSheetModal(for:)`) after `NSApp.activate`, falling back to `begin` only when there's no window. Verified: the panel now reports `onscreen = true`, attached to the document window.

## Notes
- There's a separate **off-screen** 500×500 untitled window present in all launch modes (even before this change); it isn't created by app code (only Document 400×500 and Settings 400×340 windows exist) — likely AppKit state restoration. It's off-screen/invisible here and unrelated to the reported "Untitled" doc. Flagging in case it shows on a real display.

## Verification
- `swift build` ✓ / `swift test` — 444 pass ✓
- Manual (screen-capture): single doc window on launch-with-file; Open panel onscreen as a sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)