### PR TITLE
Docs: add file-level headers to remaining files

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+Composition.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Composition.swift
@@ -1,6 +1,13 @@
 import AppKit
 
 // MARK: - Display Composition & Coordinate Mapping
+//
+// `recompose` rebuilds the whole text storage by styling every block and
+// joining them; `recomposeIncremental` re-styles only the block(s) the cursor
+// moved between, which is what runs on most edits. Because the text storage
+// always equals the raw source (word-level rendering, no string stripping),
+// the display↔raw coordinate mapping is the identity — the conversion helpers
+// exist so call sites read clearly and stay correct if that ever changes.
 
 extension EditorTextView {
 

--- a/Sources/MarkdownEditorCore/EditorTextView+Indentation.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Indentation.swift
@@ -1,6 +1,11 @@
 import AppKit
 
 // MARK: - Tab / Shift-Tab List Indentation
+//
+// Tab / Shift-Tab change the nesting of list items by adding or removing one
+// indent unit of leading whitespace. They apply to every list block the
+// selection touches (so a whole sub-list can be indented at once) and only kick
+// in on list lines — elsewhere Tab inserts a literal tab as usual.
 
 extension EditorTextView {
 

--- a/Sources/MarkdownEditorCore/EditorTextView+ListContinuation.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+ListContinuation.swift
@@ -1,6 +1,12 @@
 import AppKit
 
 // MARK: - List Continuation on Enter
+//
+// Pressing Return inside a list item starts the next item automatically: it
+// repeats the same indent and a fresh marker (the next number for ordered
+// lists, an empty checkbox for task lists, the same bullet otherwise). Pressing
+// Return on an *empty* item instead removes the marker and breaks out of the
+// list, matching the behavior of most note editors.
 
 extension EditorTextView {
 

--- a/Sources/md/SettingsWindow.swift
+++ b/Sources/md/SettingsWindow.swift
@@ -2,6 +2,10 @@ import AppKit
 import CoreText
 import MarkdownEditorCore
 
+/// The Settings window (⌘,). Lets the user pick the body font and size, accent
+/// and code colors, and line / paragraph spacing, with a live preview. Changes
+/// are written into an `EditorTheme`, persisted, and applied to every open
+/// editor so the document updates immediately.
 class SettingsWindowController: NSWindowController {
 
     private var fontPopup: NSPopUpButton!


### PR DESCRIPTION
Documentation polish for the "comprehensive comments and documentation" task. **Comments only — no code changes.**

Added explanatory file headers to the files that only had a bare `// MARK:` line (or none):
- `EditorTextView+Indentation.swift` — Tab/Shift-Tab list nesting
- `EditorTextView+Composition.swift` — full vs incremental recompose + identity coordinate mapping
- `EditorTextView+ListContinuation.swift` — Return continues / exits a list
- `SettingsWindow.swift` — what the Settings window configures and how it applies

Most other files already had good headers (BlockParser, Block, LineEnding, StatusBarPrefs, EditorTheme, EditorTextStorage, DocumentController, the EditorTextView class doc), so they were left as-is.

`swift build` ✓. *(The pre-existing wide-equation flake is the only test blip; unrelated to these comment edits.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)