### PR TITLE
Stabilize flaky wide-equation scale-to-fit test

### DIFF
--- a/Tests/MarkdownEditorTests/MathRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/MathRenderingTests.swift
@@ -134,13 +134,19 @@ struct MathFitWidthTests {
     @Test("A very wide equation is scaled down to the text width")
     @MainActor func wideScaled() {
         let editor = makeEditor()
+        // Pin the container width so the usable width is deterministic. With
+        // `widthTracksTextView` it depends on the view's layout state, which
+        // varies between runs and made this assertion flaky.
+        editor.textContainer?.widthTracksTextView = false
+        editor.textContainer?.size = NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
+
         let wide = "$$a_{10}x^{10}+a_9x^9+a_8x^8+a_7x^7+a_6x^6+a_5x^5+a_4x^4+a_3x^3+a_2x^2+a_1x+a_0$$"
         let styled = editor.styleBlock(wide)
         let att = styled.attribute(.attachment, at: 0, effectiveRange: nil) as? NSTextAttachment
         #expect(att != nil)
-        // Scaled to the cap (within a small tolerance), not its much larger natural width.
-        #expect((att?.bounds.width ?? 0) <= cap + 2)
-        #expect((att?.bounds.width ?? 0) >= cap - 12)
+        // The natural width exceeds the usable width, so it scales down to
+        // exactly the cap (500 − 2·5 line-fragment padding).
+        #expect(abs((att?.bounds.width ?? 0) - cap) < 1)
     }
 
     @Test("A normal-width equation is not scaled")


### PR DESCRIPTION
The math test **"A very wide equation is scaled down to the text width"** failed intermittently (~1 in 3 runs).

## Cause
`availableContentWidth` reads `textContainer.containerSize.width`. The test editor uses `widthTracksTextView = true`, so that width is recomputed from the view's layout state — which varies between runs, so the scaled attachment width drifted (e.g. 455 vs 488) and tripped the lower bound.

## Fix
Pin the container to a fixed width (tracking off) in the test so the usable width is deterministic, and assert the scaled width equals the cap exactly (`abs(width - cap) < 1`). Production code is unchanged.

Verified: **8/8** consecutive `swift test` runs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)