### PR TITLE
Fix deep-nested ordered list alignment + dim bullet dots

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+ListRendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+ListRendering.swift
@@ -96,7 +96,8 @@ extension EditorTextView {
         let image = NSImage(size: NSSize(width: fontSize, height: fontSize), flipped: true) { bounds in
             let r = fontSize * 0.13                 // small dot
             let dot = NSRect(x: bounds.midX - r, y: bounds.midY - r, width: 2 * r, height: 2 * r)
-            NSColor.secondaryLabelColor.setFill()
+            // Match the dim used for numbered-list markers (syntaxDimColor).
+            NSColor.tertiaryLabelColor.setFill()
             NSBezierPath(ovalIn: dot).fill()
             return true
         }

--- a/Sources/MarkdownEditorCore/SyntaxHighlighter+CustomParsers.swift
+++ b/Sources/MarkdownEditorCore/SyntaxHighlighter+CustomParsers.swift
@@ -153,9 +153,11 @@ extension SyntaxHighlighter {
     }
 
     /// Detects list items with deep indentation (4+ spaces or tabs) that
-    /// swift-markdown parses as indented code instead of list items.
+    /// swift-markdown parses as indented code instead of list items. Group 2 is
+    /// the marker — an unordered bullet (`-`/`*`/`+`) or an ordered number
+    /// (`1.`/`1)`), so nested ordered lists are rescued too.
     static let indentedListRegex = try! NSRegularExpression(
-        pattern: #"^([\t ]*\t[\t ]*|[ ]{4,})([-*+])\s"#
+        pattern: #"^([\t ]*\t[\t ]*|[ ]{4,})([-*+]|\d{1,9}[.)])\s"#
     )
 
     /// Matches a GFM task-list checkbox at the start of list-item content:
@@ -182,20 +184,27 @@ extension SyntaxHighlighter {
         let full = NSRange(location: 0, length: nsText.length)
         let markerEnd = match.range(at: 0).upperBound  // end of "    - "
 
+        // An ordered marker (1./1)) starts with a digit; a bullet (-/*/+) doesn't.
+        let marker = nsText.substring(with: match.range(at: 2))
+        let ordered = marker.first?.isNumber ?? false
+
         // Detect a GFM task-list checkbox following the marker ("[ ] "/"[x] ").
         // swift-markdown skips these on deeply-indented lines (it treats the
         // whole line as code), so we parse the checkbox ourselves — otherwise
-        // task items nested beyond level 2 render without a circle.
+        // task items nested beyond level 2 render without a circle. Only the
+        // unordered `- [ ]` form is supported.
         var checkbox: Span.Kind.CheckboxState? = nil
         var delimEnd = markerEnd
-        let afterMarker = nsText.substring(from: markerEnd) as NSString
-        if let cb = checkboxRegex.firstMatch(
-            in: afterMarker as String,
-            range: NSRange(location: 0, length: afterMarker.length)
-        ) {
-            let stateChar = afterMarker.substring(with: cb.range(at: 1))
-            checkbox = (stateChar == "x" || stateChar == "X") ? .checked : .unchecked
-            delimEnd = markerEnd + cb.range(at: 0).length
+        if !ordered {
+            let afterMarker = nsText.substring(from: markerEnd) as NSString
+            if let cb = checkboxRegex.firstMatch(
+                in: afterMarker as String,
+                range: NSRange(location: 0, length: afterMarker.length)
+            ) {
+                let stateChar = afterMarker.substring(with: cb.range(at: 1))
+                checkbox = (stateChar == "x" || stateChar == "X") ? .checked : .unchecked
+                delimEnd = markerEnd + cb.range(at: 0).length
+            }
         }
 
         let delim = NSRange(location: 0, length: delimEnd)
@@ -208,7 +217,7 @@ extension SyntaxHighlighter {
         }
 
         spans.append(Span(
-            kind: .listItem(ordered: false, checkbox: checkbox),
+            kind: .listItem(ordered: ordered, checkbox: checkbox),
             fullRange: full,
             contentRange: content,
             delimiterRanges: [delim]

--- a/Tests/MarkdownEditorTests/SyntaxHighlighterTests.swift
+++ b/Tests/MarkdownEditorTests/SyntaxHighlighterTests.swift
@@ -535,6 +535,45 @@ struct ListItemTests {
         }
     }
 
+    @Test("Indented ordered item (4 spaces) produces an ordered listItem span")
+    func indentedOrderedFourSpaces() {
+        let spans = SyntaxHighlighter.parse("    1. hello")
+        let items = spans.filter { if case .listItem = $0.kind { return true }; return false }
+        #expect(items.count == 1)
+        if case .listItem(let ordered, _) = items[0].kind {
+            #expect(ordered == true)
+        } else {
+            #expect(Bool(false), "Expected listItem")
+        }
+        // Should NOT also produce a codeBlock span.
+        let codeBlocks = spans.filter { if case .codeBlock = $0.kind { return true }; return false }
+        #expect(codeBlocks.count == 0)
+    }
+
+    @Test("Deeply indented ordered item (8 spaces, paren) is ordered")
+    func deeplyIndentedOrderedParen() {
+        let spans = SyntaxHighlighter.parse("        2) deep")
+        let items = spans.filter { if case .listItem = $0.kind { return true }; return false }
+        #expect(items.count == 1)
+        if case .listItem(let ordered, _) = items[0].kind {
+            #expect(ordered == true)
+        } else {
+            #expect(Bool(false), "Expected listItem")
+        }
+    }
+
+    @Test("Tab-indented ordered item is ordered")
+    func tabIndentedOrdered() {
+        let spans = SyntaxHighlighter.parse("\t1. tabbed")
+        let items = spans.filter { if case .listItem = $0.kind { return true }; return false }
+        #expect(items.count == 1)
+        if case .listItem(let ordered, _) = items[0].kind {
+            #expect(ordered == true)
+        } else {
+            #expect(Bool(false), "Expected listItem")
+        }
+    }
+
     @Test("Indented todo content excludes the checkbox delimiter")
     func indentedTodoContentRange() {
         let text = "    - [ ] task"


### PR DESCRIPTION
## What

Two list-rendering fixes:

1. **Deep-nested ordered lists now align at every level.** swift-markdown parses any line indented ≥4 spaces (or a tab) as *indented code*; the `parseIndentedListItem` rescue is what restores list styling, but it only matched unordered bullets (`[-*+]`). Ordered items therefore lost their `listItem` span the moment their indent hit 4 spaces — "beyond level 2" in a 2-space document — and rendered with **no** indentation. The rescue regex now also matches ordered markers (`\d{1,9}[.)]`) and tags the span `ordered: true`.

2. **Bullet dots dimmed to match numbered markers.** Dots drew with `secondaryLabelColor`; numbers use `syntaxDimColor` (`tertiaryLabelColor`). Dots now use the same shade.

## Tests

Adds parser regression tests for 4-space, 8-space, and tab-indented ordered items. Full suite: **454 tests pass**. Verified visually to 5 nesting levels (ordered + bullets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)