### PR TITLE
Render emoji (font substitution) + guard restyle during IME composition

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextStorage.swift
+++ b/Sources/MarkdownEditorCore/EditorTextStorage.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CoreText
 
 /// A text storage subclass that preserves `.attachment` attributes on
 /// any character, not just the object replacement character (\u{FFFC}).
@@ -37,9 +38,65 @@ public class EditorTextStorage: NSTextStorage {
     }
 
     override public func fixAttributes(in range: NSRange) {
-        // Skip default attribute fixing. The editor sets all attributes
-        // explicitly for every character, so no automatic fixing is needed.
-        // This preserves .attachment attributes on non-FFFC characters
-        // (used for checkbox circle icons).
+        // We deliberately skip the framework's default attribute fixing because
+        // it strips .attachment from non-FFFC characters — and the editor places
+        // marker icons (bullet dot, checkbox circle, math image) on real
+        // characters like "-", "[", "$".
+        //
+        // But one part of fixing is still needed: font substitution. The body
+        // font (a serif/mono) has no glyphs for emoji, CJK, etc.; without
+        // substitution those render as missing-glyph boxes. So we do font
+        // fixing ourselves, leaving every other attribute (attachments included)
+        // untouched.
+        fixFontSubstitution(in: range)
+    }
+
+    /// Replaces the font on any character the run's font cannot render with a
+    /// fallback font that can (e.g. Apple Color Emoji), preserving the original
+    /// size. Substitutions are computed first, then applied, so we never mutate
+    /// the attribute we're enumerating mid-pass.
+    private func fixFontSubstitution(in range: NSRange) {
+        guard range.length > 0, range.upperBound <= backing.length else { return }
+        let ns = backing.string as NSString
+        var fixes: [(NSRange, NSFont)] = []
+
+        backing.enumerateAttribute(.font, in: range, options: []) { value, runRange, _ in
+            // Skip the tiny hidden-delimiter font — those chars are invisible
+            // and are plain ASCII delimiters the base font already covers.
+            guard let font = value as? NSFont, font.pointSize > 1.0 else { return }
+
+            // Fast path: does the font cover the whole run?
+            let runChars = Array(ns.substring(with: runRange).utf16)
+            var runGlyphs = [CGGlyph](repeating: 0, count: runChars.count)
+            if CTFontGetGlyphsForCharacters(font as CTFont, runChars, &runGlyphs, runChars.count) {
+                return
+            }
+
+            // Substitute per composed-character sequence so we never split a
+            // grapheme (emoji ZWJ sequences, skin-tone modifiers, é, …).
+            var i = runRange.location
+            let end = runRange.upperBound
+            while i < end {
+                let seq = ns.rangeOfComposedCharacterSequence(at: i)
+                let seqRange = NSRange(location: seq.location,
+                                       length: min(seq.length, end - seq.location))
+                let seqStr = ns.substring(with: seqRange)
+                let seqChars = Array(seqStr.utf16)
+                var seqGlyphs = [CGGlyph](repeating: 0, count: seqChars.count)
+                let covered = CTFontGetGlyphsForCharacters(
+                    font as CTFont, seqChars, &seqGlyphs, seqChars.count)
+                if !covered {
+                    let substitute = CTFontCreateForString(
+                        font as CTFont, seqStr as CFString,
+                        CFRange(location: 0, length: seqChars.count)) as NSFont
+                    fixes.append((seqRange, substitute))
+                }
+                i = seqRange.upperBound
+            }
+        }
+
+        for (r, f) in fixes {
+            backing.addAttribute(.font, value: f, range: r)
+        }
     }
 }

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -194,6 +194,12 @@ public class EditorTextView: NSTextView {
     public override func didChangeText() {
         super.didChangeText()
         guard !isUpdating, !isUndoRedoing else { return }
+        // While an input method is composing (marked text — e.g. emoji search,
+        // accent/IME entry), the storage holds provisional text. Re-styling it
+        // (setAttributes over the marked range) interferes with the composition
+        // and can abort it, so defer all syncing/restyling until the IME commits
+        // — which fires didChangeText again with no marked text.
+        guard !hasMarkedText() else { return }
         syncRawSourceFromDisplay()
         applyBlockStyle()
         document?.updateChangeCount(.changeDone)
@@ -222,6 +228,8 @@ public class EditorTextView: NSTextView {
 
     @objc private func selectionDidChange(_ notification: Notification) {
         guard !isUpdating else { return }
+        // Don't restyle while an input method is composing (see didChangeText).
+        guard !hasMarkedText() else { return }
 
         let sel = selectedRange()
         let rawOffset = sel.location

--- a/Tests/MarkdownEditorTests/EmojiRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/EmojiRenderingTests.swift
@@ -1,0 +1,89 @@
+import Testing
+import AppKit
+import CoreText
+@testable import MarkdownEditorCore
+
+/// The body font (a serif/mono) has no glyphs for emoji. EditorTextStorage
+/// disables the framework's attribute fixing (to preserve marker attachments),
+/// so it must perform font substitution itself — otherwise emoji render as
+/// missing-glyph boxes even though the text is stored correctly.
+@Suite("Emoji — font substitution")
+struct EmojiRenderingTests {
+
+    private func fontCovers(_ s: String, _ font: NSFont) -> Bool {
+        let chars = Array(s.utf16)
+        var glyphs = [CGGlyph](repeating: 0, count: chars.count)
+        return CTFontGetGlyphsForCharacters(font as CTFont, chars, &glyphs, chars.count)
+    }
+
+    @MainActor private func renderedFont(for emoji: String, in source: String) -> NSFont? {
+        let editor = makeEditor()
+        editor.loadContent(source)
+        editor.setSelectedRange(NSRange(location: 0, length: 0))
+        editor.recompose(cursorInRaw: 0)
+        let ts = editor.textStorage!
+        let r = (ts.string as NSString).range(of: emoji)
+        guard r.location != NSNotFound else { return nil }
+        return ts.attributes(at: r.location, effectiveRange: nil)[.font] as? NSFont
+    }
+
+    @Test("Body font lacks emoji glyphs (precondition)")
+    @MainActor func bodyFontLacksEmoji() {
+        let editor = makeEditor()
+        #expect(fontCovers("A", editor.bodyFont))
+        #expect(!fontCovers("😀", editor.bodyFont))
+    }
+
+    @Test("A plain emoji is given a font that can draw it")
+    @MainActor func plainEmojiSubstituted() {
+        let font = renderedFont(for: "😀", in: "hello 😀 world")
+        #expect(font != nil)
+        if let font { #expect(fontCovers("😀", font)) }
+    }
+
+    @Test("A ZWJ family emoji is substituted as one unit")
+    @MainActor func zwjEmojiSubstituted() {
+        let font = renderedFont(for: "👨‍👩‍👧‍👦", in: "family 👨‍👩‍👧‍👦 here")
+        #expect(font != nil)
+        if let font { #expect(fontCovers("👨‍👩‍👧‍👦", font)) }
+    }
+
+    @Test("A skin-tone emoji is substituted")
+    @MainActor func skinToneEmojiSubstituted() {
+        let font = renderedFont(for: "👍🏽", in: "nice 👍🏽")
+        #expect(font != nil)
+        if let font { #expect(fontCovers("👍🏽", font)) }
+    }
+
+    @Test("Emoji inside bold are substituted and still bold-rendered")
+    @MainActor func emojiInBold() {
+        let font = renderedFont(for: "😀", in: "**bold 😀**")
+        #expect(font != nil)
+        if let font { #expect(fontCovers("😀", font)) }
+    }
+
+    @Test("ASCII text keeps the body font")
+    @MainActor func asciiKeepsBodyFont() {
+        let editor = makeEditor()
+        editor.loadContent("plain ascii 😀")
+        editor.setSelectedRange(NSRange(location: 0, length: 0))
+        editor.recompose(cursorInRaw: 0)
+        let font = editor.textStorage!.attributes(at: 0, effectiveRange: nil)[.font] as? NSFont
+        #expect(font?.fontName == editor.bodyFont.fontName)
+    }
+
+    @Test("Emoji survive char-by-char typing")
+    @MainActor func emojiTypedRoundTrips() {
+        let editor = makeEditor()
+        editor.loadContent("")
+        editor.setSelectedRange(NSRange(location: 0, length: 0))
+        for ch in "a😀b" {
+            editor.insertText(String(ch), replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
+        #expect(editor.rawSource == "a😀b")
+        let r = (editor.textStorage!.string as NSString).range(of: "😀")
+        let font = editor.textStorage!.attributes(at: r.location, effectiveRange: nil)[.font] as? NSFont
+        #expect(font != nil)
+        if let font { #expect(fontCovers("😀", font)) }
+    }
+}


### PR DESCRIPTION
## What

Emoji didn't render in the editor — but the cause wasn't encoding (the data layer round-trips every emoji correctly). The real cause:

`EditorTextStorage.fixAttributes` was overridden to a **complete no-op** so the framework wouldn't strip `.attachment` from non-FFFC characters (marker icons live on real chars like `-`, `[`, `$`). That also disabled **font substitution**: the serif/mono body font has no emoji glyphs, so emoji rendered as missing-glyph boxes (□) despite being stored correctly.

### Fix 1 — font substitution
`fixAttributes` now does font substitution itself: for any character its run-font can't draw, it substitutes a covering font (Apple Color Emoji) **per composed-character sequence** (ZWJ families, skin-tone modifiers, flags stay whole), leaving attachments and all other attributes untouched.

### Fix 2 — IME guard (latent bug)
`didChangeText`/`selectionDidChange` re-style the active block on every edit. While an input method holds marked text, `setAttributes` over the marked range can abort composition. Both paths now bail on `hasMarkedText()` and defer until the IME commits.

## Tests

New `EmojiRenderingTests` (7 tests): plain, ZWJ family, skin-tone emoji all get a covering font; ASCII keeps the body font; emoji-in-bold and char-by-char typing round-trip. Full suite: **454 tests pass**. Verified visually in headings, bullets, bold/italic/code, and blockquotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)