### PR TITLE
Fix nested list hanging indent (hide leading whitespace)

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -239,6 +239,20 @@ extension EditorTextView {
                     } else {
                         firstLineIndent = markerStart
                     }
+                    // Hide the leading indentation — the indent is provided entirely
+                    // by the paragraph style. swift-markdown's list-item delimiter
+                    // range starts at the marker and excludes this whitespace, so
+                    // without hiding it here those spaces render visibly and push the
+                    // first line right, breaking its alignment with the hanging
+                    // (wrapped-line) indent. (The deep-indent rescue parser already
+                    // includes the whitespace in its delimiter, so this is a no-op
+                    // there.)
+                    let wsLen = leadingWS.count
+                    if wsLen > 0 {
+                        let lead = NSRange(location: 0, length: wsLen)
+                        result.addAttribute(.font, value: hiddenFont, range: lead)
+                        result.addAttribute(.foregroundColor, value: NSColor.clear, range: lead)
+                    }
                 }
                 // Apply paragraph style from position 0 — NSTextView uses the paragraph
                 // style from the first character of a paragraph.

--- a/Tests/MarkdownEditorTests/EditorRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/EditorRenderingTests.swift
@@ -446,6 +446,31 @@ struct EditorStylingTests {
         #expect(abs(child!.firstLineHeadIndent - parent!.headIndent) < 1.0)
     }
 
+    @Test("Nested item hides leading whitespace so first line aligns with hanging indent")
+    @MainActor func nestedHangingIndentAligns() {
+        let editor = makeEditor()
+        editor.listIndentUnit = 2
+        // A 2-space item is parsed by swift-markdown (walker path), whose
+        // delimiter range starts at the marker and excludes the leading
+        // indentation. That whitespace must still be hidden, or the visible
+        // spaces push the first line right and break its alignment with the
+        // wrapped-line (hanging) indent.
+        let styled = editor.styleBlock("  - [ ] wraps onto the next line")
+        // Leading spaces (offsets 0,1) are hidden: near-zero font + clear color.
+        for i in 0..<2 {
+            let a = styled.attributes(at: i, effectiveRange: nil)
+            #expect((a[.font] as? NSFont).map { $0.pointSize < 1.0 } == true)
+            #expect(a[.foregroundColor] as? NSColor == NSColor.clear)
+        }
+        // First-line content lands at the hanging indent: firstLineHeadIndent
+        // plus one marker slot (icon + space) equals headIndent.
+        let ps = styled.attribute(.paragraphStyle, at: styled.length - 1, effectiveRange: nil) as? NSParagraphStyle
+        #expect(ps != nil)
+        let spaceWidth = (" " as NSString).size(withAttributes: [.font: editor.bodyFont]).width
+        let slot = editor.bodyFont.pointSize + spaceWidth
+        #expect(abs((ps!.firstLineHeadIndent + slot) - ps!.headIndent) < 1.0)
+    }
+
     @Test("Ordered list keeps its number and dims it")
     @MainActor func orderedListDimmed() {
         let editor = makeEditor()


### PR DESCRIPTION
## What

Follow-up to #62. In a nested list, a **parent** item's wrapped (hanging) lines didn't line up under its own content — while deeper, rescued levels did.

**Cause:** swift-markdown's `ListItem.range` starts at the marker (`-`), so the walker's delimiter range *excludes* the leading indentation. `styleListDelimiter` only styles the delimiter, so for items swift-markdown parses directly (the shallow, non-rescued levels) those leading spaces rendered **visibly**. The visible spaces pushed the first line right, while `headIndent` (where wrapped lines hang) was computed assuming the whitespace was hidden — so the first line and the wrapped lines didn't match.

**Fix:** hide the leading whitespace in the inactive list-item branch (the indent comes entirely from the paragraph style). The deep-indent rescue parser already folds the whitespace into its delimiter, so this is a no-op there.

## Tests

New test asserts the leading spaces are hidden and that `firstLineHeadIndent + one marker slot == headIndent` for a walker-path (2-space) item. Full suite: **455 tests pass**. Verified visually — parent wrapped lines now hang exactly under their content at every level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)