### PR TITLE
Fix flaky math fit-width test via isolated theme defaults

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -71,6 +71,11 @@ public class EditorTextView: NSTextView {
 
     // MARK: - Theme (user-configurable visual settings)
 
+    /// The UserDefaults domain backing theme persistence. Defaults to the
+    /// shared `.standard` store; tests override it to isolate from the real
+    /// domain (and from each other under parallel execution).
+    public var themeDefaults: UserDefaults = .standard
+
     public var theme: EditorTheme = .load()
 
     // MARK: - Derived Visual Properties
@@ -100,7 +105,7 @@ public class EditorTextView: NSTextView {
     /// Apply a new theme, persist it, and recompose.
     public func applyTheme(_ newTheme: EditorTheme) {
         theme = newTheme
-        theme.save()
+        theme.save(to: themeDefaults)
         typingAttributes = baseAttributes
         recompose(cursorInRaw: currentCursorInRaw())
     }

--- a/Sources/MarkdownEditorCore/EditorTheme.swift
+++ b/Sources/MarkdownEditorCore/EditorTheme.swift
@@ -85,8 +85,8 @@ public struct EditorTheme: Equatable, Sendable {
         static let paragraphSpacingBefore = "EditorParagraphSpacingBefore"
     }
 
-    public static func load() -> EditorTheme {
-        let d = UserDefaults.standard
+    public static func load(from defaults: UserDefaults = .standard) -> EditorTheme {
+        let d = defaults
         let def = EditorTheme.default
 
         let fontName = d.string(forKey: Keys.fontName) ?? def.fontName
@@ -117,8 +117,8 @@ public struct EditorTheme: Equatable, Sendable {
         )
     }
 
-    public func save() {
-        let d = UserDefaults.standard
+    public func save(to defaults: UserDefaults = .standard) {
+        let d = defaults
         d.set(fontName, forKey: Keys.fontName)
         d.set(Float(fontSize), forKey: Keys.fontSize)
         d.set(accentHex, forKey: Keys.accentHex)

--- a/Tests/MarkdownEditorTests/EditorFeatureTests.swift
+++ b/Tests/MarkdownEditorTests/EditorFeatureTests.swift
@@ -259,10 +259,13 @@ struct FontIntegrationTests {
         theme.lineSpacing = 8
         editor.applyTheme(theme)
 
-        let savedName = UserDefaults.standard.string(forKey: "EditorFontName")
-        let savedSize = UserDefaults.standard.float(forKey: "EditorFontSize")
-        let savedAccent = UserDefaults.standard.string(forKey: "EditorAccentHex")
-        let savedSpacing = UserDefaults.standard.float(forKey: "EditorLineSpacing")
+        // Read from the editor's own (isolated) defaults domain, where
+        // applyTheme persists — see makeEditor.
+        let d = editor.themeDefaults
+        let savedName = d.string(forKey: "EditorFontName")
+        let savedSize = d.float(forKey: "EditorFontSize")
+        let savedAccent = d.string(forKey: "EditorAccentHex")
+        let savedSpacing = d.float(forKey: "EditorLineSpacing")
         #expect(savedName == "Courier")
         #expect(savedSize == 14)
         #expect(savedAccent == "#FF0000")

--- a/Tests/MarkdownEditorTests/MathRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/MathRenderingTests.swift
@@ -134,9 +134,14 @@ struct MathFitWidthTests {
     @Test("A very wide equation is scaled down to the text width")
     @MainActor func wideScaled() {
         let editor = makeEditor()
-        // Pin the container width so the usable width is deterministic. With
-        // `widthTracksTextView` it depends on the view's layout state, which
-        // varies between runs and made this assertion flaky.
+        // Pin the font size so the equation is reliably wider than the cap
+        // regardless of the default theme: at 24pt its natural width (~780)
+        // comfortably exceeds the 490 cap, so the scale-down branch must run.
+        var theme = editor.theme
+        theme.fontSize = 24
+        editor.theme = theme
+
+        // Pin the container width so the usable width is exactly 500 − 2·5 = 490.
         editor.textContainer?.widthTracksTextView = false
         editor.textContainer?.size = NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
 

--- a/Tests/MarkdownEditorTests/TestHelpers.swift
+++ b/Tests/MarkdownEditorTests/TestHelpers.swift
@@ -16,10 +16,21 @@ func makeEditor() -> EditorTextView {
     )
     textContainer.widthTracksTextView = true
     layoutManager.addTextContainer(textContainer)
-    return EditorTextView(
+    let editor = EditorTextView(
         frame: NSRect(x: 0, y: 0, width: 500, height: 300),
         textContainer: textContainer
     )
+    // Isolate theme persistence. EditorTextView loads/saves its theme via
+    // UserDefaults; without isolation, tests that call `applyTheme` write font
+    // sizes into the shared `.standard` domain, and under parallel execution
+    // those leak into other editors (this caused the math fit-width flake).
+    // Give each editor its own empty domain.
+    let suite = "MarkdownEditorTests.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suite)!
+    defaults.removePersistentDomain(forName: suite)
+    editor.themeDefaults = defaults
+    editor.theme = .load(from: defaults)
+    return editor
 }
 
 // MARK: - Input Simulation


### PR DESCRIPTION
## Problem

The test **"A very wide equation is scaled down to the text width"** (`MathFitWidthTests`) failed ~1 in 3 full `swift test` runs, with the attachment width not matching the 490 cap (one observed value: 455). PR #61's container-width pin did not fix it.

## Root cause

Not container width, the `mathRenderCache`, or SwiftMath nondeterminism — those were constant every run (`maxW=490`, `containerW=500`, `lfp=5.0`). The real cause is **shared-state pollution via `UserDefaults.standard`**:

- `EditorTextView` loads/saves its theme through `UserDefaults.standard`.
- The `applyTheme` tests persist font sizes (12/18/20/24…) into that shared domain.
- Under swift-testing's parallel execution, whichever size was written last leaked into other editors.
- The math test passes that size straight to SwiftMath (`fontSize: contextFont.pointSize`), so the equation's natural width varied **455–780**. When it landed below the 490 cap, the scale-down branch never ran and the assertion failed.

Instrumentation confirmed `fontSize` swinging 14→24pt across runs (always 24 in isolation), with natural width tracking it linearly (~32.5 px/pt).

## Fix

**Systemic (mirrors `StatusBarPrefs`):**
- `EditorTheme.load(from:)` / `save(to:)` take a `UserDefaults` argument (default `.standard`).
- `EditorTextView` gains an injectable `themeDefaults` (default `.standard`); `applyTheme` persists to it.
- `makeEditor()` gives each test editor its own empty `UserDefaults` domain, so no test can pollute another (or the real domain).
- The "Theme persists to UserDefaults" test reads back from the editor's own domain.

**Test-level:** pin the font size in the fit-width test so the equation is reliably wider than the cap regardless of the default theme.

## Verification

- `swift build` (full package incl. app target) succeeds — API changes are backward-compatible via default params.
- **20/20 full `swift test` runs pass** (was ~1-in-3 failing).
- The assertion is not weakened: the equation is still genuinely over-wide and still must scale to exactly the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)