### PR TITLE
Keep IME-composed text visible (fix invisible Chinese/CJK input)

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -186,6 +186,28 @@ public class EditorTextView: NSTextView {
 
     // MARK: - Edit Flow
 
+    /// NSTextView copies the attributes next to the caret into `typingAttributes`.
+    /// When the caret sits beside a hidden delimiter (our near-zero-size
+    /// `hiddenFont` + clear color), newly inserted text inherits that invisible
+    /// font. Regular typing self-heals via `applyBlockStyle` on each keystroke,
+    /// but IME composition (e.g. Pinyin) is deferred while marked — so the
+    /// composing text would render invisibly and input appears broken. Refuse the
+    /// invisible font here so composition is always visible; the block restyle
+    /// still applies the correct final styling on commit.
+    public override var typingAttributes: [NSAttributedString.Key: Any] {
+        get { super.typingAttributes }
+        set {
+            var attrs = newValue
+            if let font = attrs[.font] as? NSFont, font.pointSize < 1.0 {
+                attrs[.font] = bodyFont
+                if (attrs[.foregroundColor] as? NSColor) == .clear {
+                    attrs[.foregroundColor] = foregroundColor
+                }
+            }
+            super.typingAttributes = attrs
+        }
+    }
+
     public override func shouldChangeText(in affectedCharRange: NSRange, replacementString: String?) -> Bool {
         if isUpdating { return false }
         if let replacement = replacementString {

--- a/Tests/MarkdownEditorTests/InternationalInputTests.swift
+++ b/Tests/MarkdownEditorTests/InternationalInputTests.swift
@@ -1,0 +1,98 @@
+import Testing
+import AppKit
+import CoreText
+@testable import MarkdownEditorCore
+
+/// International text and IME input. The body font (a Latin serif) lacks glyphs
+/// for most non-Latin scripts, so display relies on font substitution (see
+/// EditorTextStorage). Composition relies on `typingAttributes` never carrying
+/// the hidden-delimiter font — otherwise IME marked text (Pinyin, Kana, Hangul,
+/// etc.) would compose invisibly with zero width.
+@Suite("International text & IME input")
+struct InternationalInputTests {
+
+    struct Script: Sendable, CustomStringConvertible {
+        let name: String
+        let sample: String
+        var description: String { name }
+    }
+
+    static let scripts: [Script] = [
+        Script(name: "Chinese (Simplified)", sample: "你好世界"),
+        Script(name: "Japanese", sample: "こんにちは日本語"),
+        Script(name: "Korean", sample: "안녕하세요"),
+        Script(name: "Arabic", sample: "مرحبا"),
+        Script(name: "Hindi (Devanagari)", sample: "नमस्ते"),
+        Script(name: "Russian (Cyrillic)", sample: "Привет"),
+        Script(name: "Greek", sample: "Ελληνικά"),
+        Script(name: "Thai", sample: "สวัสดี"),
+        Script(name: "Emoji (ZWJ)", sample: "😀👨‍👩‍👧‍👦"),
+    ]
+
+    private func fontCovers(_ s: String, _ font: NSFont) -> Bool {
+        let chars = Array(s.utf16)
+        var glyphs = [CGGlyph](repeating: 0, count: chars.count)
+        return CTFontGetGlyphsForCharacters(font as CTFont, chars, &glyphs, chars.count)
+    }
+
+    /// Every composed-character sequence in `range` is drawn with a font that can
+    /// actually render it (whether the body font or a substituted fallback).
+    @MainActor
+    private func allGraphemesCovered(_ range: NSRange, in attr: NSAttributedString) -> Bool {
+        let ns = attr.string as NSString
+        var i = range.location
+        while i < range.upperBound {
+            let g = ns.rangeOfComposedCharacterSequence(at: i)
+            let gr = NSRange(location: g.location,
+                             length: min(g.length, range.upperBound - g.location))
+            let s = ns.substring(with: gr)
+            guard let f = attr.attributes(at: gr.location, effectiveRange: nil)[.font] as? NSFont,
+                  fontCovers(s, f) else { return false }
+            i = gr.upperBound
+        }
+        return true
+    }
+
+    @Test("Text in any script is displayed with a covering font", arguments: scripts)
+    @MainActor func displaySubstituted(_ script: Script) {
+        let editor = makeEditor()
+        editor.loadContent(script.sample + " ascii")
+        editor.setSelectedRange(NSRange(location: 0, length: 0))
+        editor.recompose(cursorInRaw: 0)
+        let ts = editor.textStorage!
+        let r = (ts.string as NSString).range(of: script.sample)
+        #expect(r.location != NSNotFound)
+        #expect(allGraphemesCovered(r, in: ts))
+    }
+
+    @Test("IME marked text stays visible for any script", arguments: scripts)
+    @MainActor func imeMarkedTextVisible(_ script: Script) {
+        let editor = makeEditor()
+        editor.loadContent("")
+        editor.setSelectedRange(NSRange(location: 0, length: 0))
+        // Reproduce the bug's trigger: the caret inherited the hidden delimiter
+        // font (near-zero size + clear color).
+        editor.typingAttributes = [.font: editor.hiddenFont,
+                                   .foregroundColor: NSColor.clear]
+
+        // An IME marks the provisional composition string.
+        editor.setMarkedText(script.sample,
+                             selectedRange: NSRange(location: (script.sample as NSString).length, length: 0),
+                             replacementRange: NSRange(location: NSNotFound, length: 0))
+        let ts = editor.textStorage!
+        let markRange = NSRange(location: 0, length: (script.sample as NSString).length)
+
+        // Visible: a real (>1pt) font, not clear, and able to render the script.
+        let markFont = ts.attributes(at: 0, effectiveRange: nil)[.font] as? NSFont
+        #expect((markFont?.pointSize ?? 0) >= 1.0)
+        let markColor = ts.attributes(at: 0, effectiveRange: nil)[.foregroundColor] as? NSColor
+        #expect(markColor != NSColor.clear)
+        #expect(allGraphemesCovered(markRange, in: ts))
+
+        // Commit: the text is present and rendered with covering fonts.
+        editor.insertText(script.sample, replacementRange: editor.markedRange())
+        #expect(editor.rawSource == script.sample)
+        let committed = (editor.textStorage!.string as NSString).range(of: script.sample)
+        #expect(allGraphemesCovered(committed, in: editor.textStorage!))
+    }
+}


### PR DESCRIPTION
## Problem

IME input (Pinyin, Kana, Hangul, and others) could compose **invisibly with zero width** — Chinese characters appeared not to be entered at all.

## Root cause

NSTextView copies the attributes next to the caret into `typingAttributes`. When the caret sits beside a hidden markdown delimiter (the near-zero-size `hiddenFont` + clear color used to hide `*`/`#`/`-`), newly inserted text inherits that invisible font.

- **Regular typing self-heals**: `didChangeText` restyles the block on every keystroke, so the invisible intermediate state is never seen.
- **IME composition is guarded out while marked** (`guard !hasMarkedText()`, added so restyling doesn't abort composition) — so marked text kept the invisible font for the *entire* composition. Font substitution explicitly skips sub-1pt fonts, so it never recovered.

Reproduced in a unit test: with `typingAttributes` holding the hidden font, simulated Pinyin marked text rendered at `fontSize=0.01, clear=true`.

## Fix

Override `typingAttributes` to refuse the invisible hidden-delimiter font, substituting the body font (and restoring a visible color). You should never be "typing" in a 0.01 pt clear font. Composition is now always visible; the block restyle still applies correct final styling on commit. Script-agnostic, and also covers paste and any future input path.

## Tests

New `InternationalInputTests` — parametrized across **Chinese, Japanese, Korean, Arabic, Hindi, Russian, Greek, Thai, and emoji** — verifying both:
- display font substitution (every grapheme drawn with a covering font), and
- IME marked-text visibility through compose → commit.

All 18 cases pass; full suite green (457 functions).

> Note: not verified against the live app — computer-use access was declined. The fix and mechanism are proven by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)