### PR TITLE
Align active list items with rendered items at every depth

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -219,40 +219,39 @@ extension EditorTextView {
                 let leadingWS = markerStr.prefix(while: { $0 == " " || $0 == "\t" })
                 let spaceWidth = (" " as NSString).size(withAttributes: [.font: bodyFont]).width
                 let slotWidth = bodyFont.pointSize + spaceWidth
+                let depth = listDepth(leadingWhitespace: String(leadingWS))
+                let markerStart = listPadding + CGFloat(depth) * slotWidth
+                let contentIndent = markerStart + slotWidth
+                // The visible marker text ("- ", "1. ", "- [ ] "), without the
+                // leading whitespace (which we hide below).
+                let markerText = String(markerStr.dropFirst(leadingWS.count))
+                let markerWidth = (markerText as NSString).size(withAttributes: [.font: bodyFont]).width
                 let firstLineIndent: CGFloat
-                let contentIndent: CGFloat
-                if cursorInToken {
-                    // Active (editing): show raw; let the leading whitespace
-                    // provide the indent so the source reads naturally.
-                    firstLineIndent = listPadding
-                    contentIndent = listPadding
+                if cursorInToken || ordered {
+                    // Active item, OR an ordered marker: right-align the marker into
+                    // its slot so the content begins at `contentIndent` — the same
+                    // place as the rendered (inactive) form. This keeps the active
+                    // item aligned with the rest of the list at every depth (and
+                    // clicking into an item doesn't shift its text), while leaving
+                    // the raw "- " / "1." / "- [ ]" marker visible and editable.
+                    // Wrapped lines hang at contentIndent via headIndent.
+                    firstLineIndent = max(2, contentIndent - markerWidth)
                 } else {
-                    let depth = listDepth(leadingWhitespace: String(leadingWS))
-                    let markerStart = listPadding + CGFloat(depth) * slotWidth
-                    contentIndent = markerStart + slotWidth
-                    if ordered {
-                        // Right-align the "N." into the slot so its content lands
-                        // at contentIndent (also aligns multi-digit numbers).
-                        let numText = String(markerStr.dropFirst(leadingWS.count))
-                        let numWidth = (numText as NSString).size(withAttributes: [.font: bodyFont]).width
-                        firstLineIndent = max(2, contentIndent - numWidth)
-                    } else {
-                        firstLineIndent = markerStart
-                    }
-                    // Hide the leading indentation — the indent is provided entirely
-                    // by the paragraph style. swift-markdown's list-item delimiter
-                    // range starts at the marker and excludes this whitespace, so
-                    // without hiding it here those spaces render visibly and push the
-                    // first line right, breaking its alignment with the hanging
-                    // (wrapped-line) indent. (The deep-indent rescue parser already
-                    // includes the whitespace in its delimiter, so this is a no-op
-                    // there.)
-                    let wsLen = leadingWS.count
-                    if wsLen > 0 {
-                        let lead = NSRange(location: 0, length: wsLen)
-                        result.addAttribute(.font, value: hiddenFont, range: lead)
-                        result.addAttribute(.foregroundColor, value: NSColor.clear, range: lead)
-                    }
+                    // Inactive bullet/checkbox: the marker icon sits at markerStart.
+                    firstLineIndent = markerStart
+                }
+                // Hide the leading indentation — the indent is provided entirely by
+                // the paragraph style. swift-markdown's list-item delimiter range
+                // starts at the marker and excludes this whitespace, so without
+                // hiding it here those spaces render visibly and push the first line
+                // right, breaking alignment with the hanging (wrapped-line) indent.
+                // (The deep-indent rescue parser already includes the whitespace in
+                // its delimiter; the delimiter styling below avoids re-showing it.)
+                let wsLen = leadingWS.count
+                if wsLen > 0 {
+                    let lead = NSRange(location: 0, length: wsLen)
+                    result.addAttribute(.font, value: hiddenFont, range: lead)
+                    result.addAttribute(.foregroundColor, value: NSColor.clear, range: lead)
                 }
                 // Apply paragraph style from position 0 — NSTextView uses the paragraph
                 // style from the first character of a paragraph.
@@ -486,7 +485,19 @@ extension EditorTextView {
                 } else if case .listItem(let ordered, let checkbox) = span.kind {
                     // List markers: custom styling when non-active, dimmed when active
                     if cursorInToken {
-                        result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
+                        // Dim the visible marker, but skip any leading whitespace in
+                        // the delimiter range — it was hidden during content styling
+                        // and dimming it here would re-show it (the rescue parser's
+                        // delimiter includes that whitespace).
+                        let nsDelim = (markdown as NSString).substring(with: dr) as NSString
+                        let firstNonWS = nsDelim.rangeOfCharacter(
+                            from: CharacterSet(charactersIn: " \t").inverted)
+                        let mStart = dr.location +
+                            (firstNonWS.location == NSNotFound ? dr.length : firstNonWS.location)
+                        if mStart < dr.upperBound {
+                            result.addAttribute(.foregroundColor, value: syntaxDimColor,
+                                                range: NSRange(location: mStart, length: dr.upperBound - mStart))
+                        }
                     } else {
                         styleListDelimiter(result, markdown: markdown,
                                            delimiterRange: dr, ordered: ordered,

--- a/Tests/MarkdownEditorTests/EditorRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/EditorRenderingTests.swift
@@ -471,6 +471,68 @@ struct EditorStylingTests {
         #expect(abs((ps!.firstLineHeadIndent + slot) - ps!.headIndent) < 1.0)
     }
 
+    // MARK: - Active list item alignment
+
+    /// The paragraph style of the (only) paragraph in a styled block.
+    @MainActor private func listPS(_ editor: EditorTextView, _ s: String, cursor: Int?) -> NSParagraphStyle? {
+        let st = editor.styleBlock(s, cursorPosition: cursor)
+        return st.attribute(.paragraphStyle, at: st.length - 1, effectiveRange: nil) as? NSParagraphStyle
+    }
+
+    @Test("Active list item shares the rendered item's content indent")
+    @MainActor func activeContentIndentMatchesInactive() {
+        let editor = makeEditor()
+        // Cursor inside the item makes it active (raw marker shown).
+        for marker in ["- item", "1. item", "- [ ] item"] {
+            let active = listPS(editor, marker, cursor: 4)
+            let inactive = listPS(editor, marker, cursor: nil)
+            #expect(active != nil && inactive != nil)
+            // Content (hanging indent) is identical whether active or not, so the
+            // text doesn't shift when you click into the item.
+            #expect(abs(active!.headIndent - inactive!.headIndent) < 0.5)
+            // The raw marker is right-aligned into its slot (first line < content).
+            #expect(active!.firstLineHeadIndent < active!.headIndent)
+        }
+    }
+
+    @Test("Active list marker stays visible and editable (not hidden)")
+    @MainActor func activeMarkerVisible() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("- hello", cursorPosition: 3)
+        // The `-` marker is shown (dimmed), not replaced by an attachment nor
+        // hidden with the near-zero clear font.
+        #expect(styled.attribute(.attachment, at: 0, effectiveRange: nil) == nil)
+        let f = styled.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        #expect((f?.pointSize ?? 0) >= 1.0)
+        #expect(isDimmed(at: 0, in: styled))           // marker is dimmed, visible
+        #expect(styled.string == "- hello")            // raw text intact (editable)
+    }
+
+    @Test("Active nested item aligns with its depth (leading whitespace hidden)")
+    @MainActor func activeNestedAligns() {
+        let editor = makeEditor()
+        editor.listIndentUnit = 2
+        // A nested item, active. Its content indent must match the rendered
+        // (inactive) nested item at the same depth — not collapse to top level.
+        let active = listPS(editor, "  - child", cursor: 6)
+        let inactive = listPS(editor, "  - child", cursor: nil)
+        #expect(active != nil && inactive != nil)
+        #expect(abs(active!.headIndent - inactive!.headIndent) < 0.5)
+
+        // And the active nested item is deeper than an active top-level item.
+        let topLevel = listPS(editor, "- top", cursor: 3)
+        #expect(active!.headIndent > topLevel!.headIndent + 1.0)
+
+        // Leading whitespace (offsets 0,1) is hidden so the indent comes from the
+        // paragraph style, not the visible spaces.
+        let styled = editor.styleBlock("  - child", cursorPosition: 6)
+        for i in 0..<2 {
+            let a = styled.attributes(at: i, effectiveRange: nil)
+            #expect((a[.font] as? NSFont).map { $0.pointSize < 1.0 } == true)
+            #expect(a[.foregroundColor] as? NSColor == NSColor.clear)
+        }
+    }
+
     @Test("Ordered list keeps its number and dims it")
     @MainActor func orderedListDimmed() {
         let editor = makeEditor()


### PR DESCRIPTION
## Problem

When the cursor entered a list item (showing the raw `- `/`1.`/`- [ ]` marker for editing), the item fell out of alignment with its rendered siblings. Three coupled issues:

1. **Marker offset** — active marker sat at a flat `listPadding`, left of the rendered `•`/number slot.
2. **No hanging indent** — active `contentIndent` was also `listPadding`, so wrapped lines collapsed to the far-left margin instead of hanging under the content.
3. **Depth ignored** — nested active items used raw leading-space width instead of `depth × slotWidth`, so they didn't line up with rendered siblings.

## Fix

Active items now use the **same depth-aware slot as rendered items**, and the raw marker is **right-aligned into its slot** (the technique the inactive *ordered* case already used) so content begins at the identical `contentIndent`. Leading whitespace is hidden (indent comes from the paragraph style); the active marker dimming skips that whitespace so it isn't re-shown. The `- `/`1.`/`- [ ]` marker stays visible, dimmed, and editable.

This is the **active-side counterpart of PR #64** (the inactive nested hanging-indent fix), which had left the active branch on the old flat-padding path.

## Result (firstLineHeadIndent, contentIndent)

| Item | Before | After |
|---|---|---|
| L0 `- 05/05` rendered | (16.0, 36.4) | (16.0, 36.4) |
| L0 `- Dinner` **active** | (16.0, **16.0**) | (26.4, **36.4**) |
| L1 `  - Arrive` **active** | (≈8, ≈8) | (46.8, **56.9**) |
| L0 `1. item` **active** | (16.0, 16.0) | (18.7, **36.4**) |
| L0 `- [ ] todo` **active** | (16.0, 16.0) | (4.1, **36.4**) |

Active content indent now equals the rendered item's at every depth — clicking into an item no longer shifts its text, and wrapped lines hang correctly.

## Tests

3 new regression tests: content-indent parity across bullet/ordered/checkbox markers, marker stays visible & editable (not hidden/attachment), and nested active depth aligns with leading whitespace hidden. Full suite: **460 pass**.

> Edge note: a wide active checkbox marker pokes slightly left of the marker column so its content still aligns — content alignment is prioritized over marker-column purity.
> Not visually verified in the app (computer-use unavailable); covered by numeric tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)