### PR TITLE
Ignore local CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ DerivedData/
 .netrc
 todo.md
 test_math.md
+CLAUDE.md


### PR DESCRIPTION
`CLAUDE.md` is a local, per-developer instructions file that shouldn't be tracked. Ignoring it prevents it from being accidentally committed (it was nearly swept into an unrelated commit earlier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)