### PR TITLE
Add View menu with a Typewriter Mode toggle

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -283,9 +283,15 @@ public class EditorTextView: NSTextView {
 
     // MARK: - Typewriter Scroll
 
+    /// When true (the default), edits and cursor moves keep the current line
+    /// vertically centered (typewriter scrolling). When false, scrolling is left
+    /// to the normal "keep the cursor visible" behavior. Toggled from View menu.
+    public var typewriterModeEnabled: Bool = true
+
     /// Scrolls the view so the cursor's line fragment is vertically centered
     /// in the visible area.
     private func scrollCursorToCenter() {
+        guard typewriterModeEnabled else { return }
         guard let lm = layoutManager,
               let scrollView = enclosingScrollView else { return }
 

--- a/Sources/md/Document.swift
+++ b/Sources/md/Document.swift
@@ -107,6 +107,7 @@ class Document: NSDocument {
         editor.isHorizontallyResizable = false
         editor.autoresizingMask = [.width]
         editor.textContainerInset = NSSize(width: 24, height: 18)
+        editor.typewriterModeEnabled = AppDelegate.typewriterModeEnabled()
         editor.document = self
 
         let statusBarHeight: CGFloat = 22

--- a/Sources/md/main.swift
+++ b/Sources/md/main.swift
@@ -3,9 +3,19 @@ import MarkdownEditorCore
 
 // --- App Delegate -----------------------------------------------------------
 
-class AppDelegate: NSObject, NSApplicationDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 
     var settingsWindowController: SettingsWindowController?
+
+    // MARK: - Typewriter Mode (persisted)
+
+    static let typewriterModeKey = "EditorTypewriterMode"
+
+    /// Whether typewriter scrolling is enabled. Defaults to on (the historical
+    /// behavior) when nothing has been saved yet.
+    static func typewriterModeEnabled(_ defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: typewriterModeKey) as? Bool ?? true
+    }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         setupMenuBar()
@@ -50,6 +60,25 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
         settingsWindowController?.showWindow(nil)
         settingsWindowController?.window?.makeKeyAndOrderFront(nil)
+    }
+
+    // MARK: - View
+
+    /// Toggles typewriter scrolling, persists the choice, and applies it to every
+    /// open document immediately.
+    @MainActor @objc func toggleTypewriterMode(_ sender: Any?) {
+        let newValue = !AppDelegate.typewriterModeEnabled()
+        UserDefaults.standard.set(newValue, forKey: AppDelegate.typewriterModeKey)
+        for case let doc as Document in NSDocumentController.shared.documents {
+            doc.editor?.typewriterModeEnabled = newValue
+        }
+    }
+
+    @MainActor func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        if menuItem.action == #selector(toggleTypewriterMode(_:)) {
+            menuItem.state = AppDelegate.typewriterModeEnabled() ? .on : .off
+        }
+        return true
     }
 
     // MARK: - Open Document
@@ -177,6 +206,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         editMenuItem.submenu = editMenu
         mainMenu.addItem(editMenuItem)
+
+        // View menu
+        let viewMenuItem = NSMenuItem()
+        let viewMenu = NSMenu(title: "View")
+
+        let typewriterItem = viewMenu.addItem(
+            withTitle: "Typewriter Mode",
+            action: #selector(AppDelegate.toggleTypewriterMode(_:)),
+            keyEquivalent: "")
+        typewriterItem.state = AppDelegate.typewriterModeEnabled() ? .on : .off
+
+        viewMenuItem.submenu = viewMenu
+        mainMenu.addItem(viewMenuItem)
 
         NSApplication.shared.mainMenu = mainMenu
     }

--- a/Tests/MarkdownEditorTests/EditorFeatureTests.swift
+++ b/Tests/MarkdownEditorTests/EditorFeatureTests.swift
@@ -293,6 +293,15 @@ struct FontIntegrationTests {
 @Suite("Integration — Appearance")
 struct AppearanceIntegrationTests {
 
+    @Test("Typewriter mode defaults on and is toggleable")
+    @MainActor func typewriterModeToggle() {
+        let editor = makeEditor()
+        // Default preserves the historical always-centered behavior.
+        #expect(editor.typewriterModeEnabled == true)
+        editor.typewriterModeEnabled = false
+        #expect(editor.typewriterModeEnabled == false)
+    }
+
     @Test("Editor background uses textBackgroundColor")
     @MainActor func editorBackground() {
         let editor = makeEditor()


### PR DESCRIPTION
## Summary

Adds a **View** menu to the menu bar with a checkable **Typewriter Mode** item. Typewriter scrolling (keeping the current line vertically centered) was hardcoded on; it can now be toggled off and on.

## Behavior
- The choice is **persisted** (UserDefaults, default **on** — preserves prior behavior) and applied **immediately to all open documents**.
- When off, normal "keep the cursor visible" scrolling takes over.
- The menu item's checkmark reflects the current state via `validateMenuItem`.

## Changes
- `EditorTextView.typewriterModeEnabled` (Core) — `scrollCursorToCenter()` no-ops when off.
- `Document` seeds each editor from the persisted setting.
- `AppDelegate` builds the View menu, toggles/persists the setting, and drives the checkmark.
- One Core regression test (default-on + settable).

## Verification
`swift build` clean; full suite **461 pass** (460 + 1 new). The menu/scroll behavior itself is GUI and not unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)