### PR TITLE
GitHub/Obsidian callouts (> [!type])

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-.DS_Store
+# Test files
+test-files/
+
+# Build & Dev stuff
 /.build
 /build
 /Packages
@@ -7,6 +10,7 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
-todo.md
-test_math.md
+
+# Misc
+.DS_Store
 CLAUDE.md

--- a/Sources/MarkdownEditorCore/BlockParser.swift
+++ b/Sources/MarkdownEditorCore/BlockParser.swift
@@ -90,11 +90,13 @@ public enum BlockParser {
                 continue
             }
 
-            // Detect a callout: a block-quote line whose content is `[!type]`
-            // (a known type). Merge it with the following block-quote lines so the
-            // whole callout is one block and renders with one continuous colored
-            // bar (a plain block quote stays split per line, as before).
-            if isCalloutOpener(lines[i]) {
+            // Merge a run of consecutive block-quote lines (`>`) into one block.
+            // This covers callouts and plain multi-line block quotes alike. It is
+            // also required for editing: each block becomes a single NSTextBlock
+            // (one "table cell"), and NSTextView refuses to delete at the boundary
+            // between two adjacent cells — so per-line block-quote cells made the
+            // marker characters undeletable. One cell per quote avoids that.
+            if isBlockquoteLine(lines[i]) {
                 var merged = [lines[i]]
                 i += 1
                 while i < lines.count && isBlockquoteLine(lines[i]) {
@@ -137,17 +139,6 @@ public enum BlockParser {
     /// then `>`).
     private static func isBlockquoteLine(_ line: String) -> Bool {
         return line.drop(while: { $0 == " " }).first == ">"
-    }
-
-    /// Returns true if the line opens a callout: a block-quote line whose content
-    /// after `>` is a known `[!type]` marker.
-    private static func isCalloutOpener(_ line: String) -> Bool {
-        let afterIndent = line.drop(while: { $0 == " " })
-        guard afterIndent.first == ">" else { return false }
-        let content = afterIndent.dropFirst().drop(while: { $0 == " " })
-        guard let marker = Callout.parseMarker(String(content)),
-              Callout.style(for: marker.type) != nil else { return false }
-        return true
     }
 
     /// Returns true if the line contains a pipe character (potential table row).

--- a/Sources/MarkdownEditorCore/BlockParser.swift
+++ b/Sources/MarkdownEditorCore/BlockParser.swift
@@ -90,6 +90,21 @@ public enum BlockParser {
                 continue
             }
 
+            // Detect a callout: a block-quote line whose content is `[!type]`
+            // (a known type). Merge it with the following block-quote lines so the
+            // whole callout is one block and renders with one continuous colored
+            // bar (a plain block quote stays split per line, as before).
+            if isCalloutOpener(lines[i]) {
+                var merged = [lines[i]]
+                i += 1
+                while i < lines.count && isBlockquoteLine(lines[i]) {
+                    merged.append(lines[i])
+                    i += 1
+                }
+                result.append(merged.joined(separator: "\n"))
+                continue
+            }
+
             // Detect table: header row followed by separator row
             if i + 1 < lines.count && isTableRow(lines[i]) && isTableSeparator(lines[i + 1]) {
                 var merged = [lines[i]]
@@ -116,6 +131,23 @@ public enum BlockParser {
         let trimmed = line.drop(while: { $0 == " " })
         guard trimmed.hasPrefix("$$") else { return nil }
         return trimmed.dropFirst(2).contains("$$")
+    }
+
+    /// Returns true if the line is a block-quote line (optional leading spaces
+    /// then `>`).
+    private static func isBlockquoteLine(_ line: String) -> Bool {
+        return line.drop(while: { $0 == " " }).first == ">"
+    }
+
+    /// Returns true if the line opens a callout: a block-quote line whose content
+    /// after `>` is a known `[!type]` marker.
+    private static func isCalloutOpener(_ line: String) -> Bool {
+        let afterIndent = line.drop(while: { $0 == " " })
+        guard afterIndent.first == ">" else { return false }
+        let content = afterIndent.dropFirst().drop(while: { $0 == " " })
+        guard let marker = Callout.parseMarker(String(content)),
+              Callout.style(for: marker.type) != nil else { return false }
+        return true
     }
 
     /// Returns true if the line contains a pipe character (potential table row).

--- a/Sources/MarkdownEditorCore/Callout.swift
+++ b/Sources/MarkdownEditorCore/Callout.swift
@@ -37,6 +37,10 @@ public struct CalloutStyle: Sendable, Equatable {
     public let borderEdges: Edges
     public let borderWidth: CGFloat
 
+    /// Per-symbol vertical nudge (points) for the icon, since SF Symbols differ
+    /// in internal optical centering. Negative lowers the icon.
+    public let iconBaselineNudge: CGFloat
+
     public init(symbolName: String,
                 colorHex: String,
                 darkColorHex: String? = nil,
@@ -46,7 +50,8 @@ public struct CalloutStyle: Sendable, Equatable {
                 darkBackgroundColorHex: String? = nil,
                 backgroundAlpha: CGFloat = 0.08,
                 borderEdges: Edges = [],
-                borderWidth: CGFloat = 3) {
+                borderWidth: CGFloat = 3,
+                iconBaselineNudge: CGFloat = 0) {
         self.symbolName = symbolName
         self.colorHex = colorHex
         self.darkColorHex = darkColorHex
@@ -57,6 +62,7 @@ public struct CalloutStyle: Sendable, Equatable {
         self.backgroundAlpha = backgroundAlpha
         self.borderEdges = borderEdges
         self.borderWidth = borderWidth
+        self.iconBaselineNudge = iconBaselineNudge
     }
 
     /// The accent hex for the given appearance.
@@ -94,13 +100,13 @@ public enum Callout {
 
         // note → same blue as info; tip → same teal as abstract (Obsidian-style).
         add(CalloutStyle(symbolName: "pencil.tip",               colorHex: "#086DDD"), "note")
-        add(CalloutStyle(symbolName: "lightbulb",                colorHex: "#00BFBC"), "tip", "hint")
+        add(CalloutStyle(symbolName: "flame",                    colorHex: "#00BFBC"), "tip", "hint")
         add(CalloutStyle(symbolName: "exclamationmark.bubble",   colorHex: "#8250DF", darkColorHex: "#A371F7"), "important")
         add(CalloutStyle(symbolName: "exclamationmark.triangle", colorHex: "#EC7500"), "warning", "attention")
         add(CalloutStyle(symbolName: "exclamationmark.octagon",  colorHex: "#CF222E", darkColorHex: "#F85149"), "caution")
 
         // Obsidian's other defaults (closest color + SF Symbol), with aliases.
-        add(CalloutStyle(symbolName: "list.bullet.clipboard", colorHex: "#00BFBC"), "abstract", "summary", "tldr")
+        add(CalloutStyle(symbolName: "list.bullet.clipboard", colorHex: "#00BFBC", iconBaselineNudge: 1.0), "abstract", "summary", "tldr")
         add(CalloutStyle(symbolName: "info.circle",           colorHex: "#086DDD"), "info")
         // checkmark.circle.dotted isn't available before macOS 15; circle.dashed
         // is the closest "to-do / pending" look.
@@ -109,7 +115,7 @@ public enum Callout {
         add(CalloutStyle(symbolName: "questionmark.circle",   colorHex: "#EC7500"), "question", "help", "faq")
         add(CalloutStyle(symbolName: "xmark",                 colorHex: "#E93147"), "failure", "fail", "missing")
         add(CalloutStyle(symbolName: "bolt",                  colorHex: "#E93147"), "danger", "error")
-        add(CalloutStyle(symbolName: "ant",                   colorHex: "#E93147"), "bug")
+        add(CalloutStyle(symbolName: "ladybug",               colorHex: "#E93147"), "bug")
         add(CalloutStyle(symbolName: "list.bullet",           colorHex: "#7852EE"), "example")
         add(CalloutStyle(symbolName: "quote.bubble",          colorHex: "#9E9E9E"), "quote", "cite")
         return m

--- a/Sources/MarkdownEditorCore/Callout.swift
+++ b/Sources/MarkdownEditorCore/Callout.swift
@@ -92,9 +92,9 @@ public enum Callout {
         var m: [String: CalloutStyle] = [:]
         func add(_ style: CalloutStyle, _ names: String...) { for n in names { m[n] = style } }
 
-        // GitHub types (icons per request; GitHub light/dark accents).
-        add(CalloutStyle(symbolName: "pencil.line",              colorHex: "#0969DA", darkColorHex: "#1F6FEB"), "note")
-        add(CalloutStyle(symbolName: "lightbulb.max",            colorHex: "#1A7F37", darkColorHex: "#3FB950"), "tip", "hint")
+        // note → same blue as info; tip → same teal as abstract (Obsidian-style).
+        add(CalloutStyle(symbolName: "pencil.tip",               colorHex: "#086DDD"), "note")
+        add(CalloutStyle(symbolName: "lightbulb",                colorHex: "#00BFBC"), "tip", "hint")
         add(CalloutStyle(symbolName: "exclamationmark.bubble",   colorHex: "#8250DF", darkColorHex: "#A371F7"), "important")
         add(CalloutStyle(symbolName: "exclamationmark.triangle", colorHex: "#9A6700", darkColorHex: "#D29922"), "warning", "attention")
         add(CalloutStyle(symbolName: "exclamationmark.octagon",  colorHex: "#CF222E", darkColorHex: "#F85149"), "caution")
@@ -102,10 +102,12 @@ public enum Callout {
         // Obsidian's other defaults (closest color + SF Symbol), with aliases.
         add(CalloutStyle(symbolName: "list.bullet.clipboard", colorHex: "#00BFBC"), "abstract", "summary", "tldr")
         add(CalloutStyle(symbolName: "info.circle",           colorHex: "#086DDD"), "info")
-        add(CalloutStyle(symbolName: "checkmark.circle",      colorHex: "#086DDD"), "todo")
-        add(CalloutStyle(symbolName: "checkmark.seal",        colorHex: "#08B94E"), "success", "check", "done")
+        // checkmark.circle.dotted isn't available before macOS 15; circle.dotted
+        // is the closest "to-do / pending" look.
+        add(CalloutStyle(symbolName: "circle.dotted",         colorHex: "#086DDD"), "todo")
+        add(CalloutStyle(symbolName: "checkmark",             colorHex: "#08B94E"), "success", "check", "done")
         add(CalloutStyle(symbolName: "questionmark.circle",   colorHex: "#EC7500"), "question", "help", "faq")
-        add(CalloutStyle(symbolName: "xmark.circle",          colorHex: "#E93147"), "failure", "fail", "missing")
+        add(CalloutStyle(symbolName: "xmark",                 colorHex: "#E93147"), "failure", "fail", "missing")
         add(CalloutStyle(symbolName: "bolt",                  colorHex: "#E93147"), "danger", "error")
         add(CalloutStyle(symbolName: "ant",                   colorHex: "#E93147"), "bug")
         add(CalloutStyle(symbolName: "list.bullet",           colorHex: "#7852EE"), "example")

--- a/Sources/MarkdownEditorCore/Callout.swift
+++ b/Sources/MarkdownEditorCore/Callout.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Visual style for a callout type. Fields are plain and serializable so the
+/// mapping can later be overridden from user settings (custom color / icon).
+/// `symbolName` is an SF Symbol; `colorHex` is an "#RRGGBB" string resolved to
+/// an `NSColor` at render time.
+public struct CalloutStyle: Sendable, Equatable {
+    public let symbolName: String
+    public let colorHex: String
+
+    public init(symbolName: String, colorHex: String) {
+        self.symbolName = symbolName
+        self.colorHex = colorHex
+    }
+}
+
+/// GitHub-flavored callouts (a.k.a. admonitions): a block quote whose first line
+/// is `[!type]` (case-insensitive), e.g.
+///
+///     > [!note]
+///     > Body text.
+///
+/// swift-markdown has no native support for this syntax — it parses the quote as
+/// a plain `BlockQuote`, and its `BlockDirective` feature is the unrelated DocC
+/// `@name { … }` form — so we detect the `[!type]` marker ourselves on top of the
+/// existing block-quote span.
+public enum Callout {
+
+    /// Default type → style map (lowercased keys), mirroring GitHub's five
+    /// built-in callouts. Designed to be merged with user overrides later.
+    public static let defaultStyles: [String: CalloutStyle] = [
+        "note":      CalloutStyle(symbolName: "info.circle.fill",              colorHex: "#0969DA"),
+        "tip":       CalloutStyle(symbolName: "lightbulb.fill",                colorHex: "#1A7F37"),
+        "important": CalloutStyle(symbolName: "exclamationmark.bubble.fill",   colorHex: "#8250DF"),
+        "warning":   CalloutStyle(symbolName: "exclamationmark.triangle.fill", colorHex: "#9A6700"),
+        "caution":   CalloutStyle(symbolName: "exclamationmark.octagon.fill",  colorHex: "#CF222E"),
+    ]
+
+    /// The style for `type` (case-insensitive), or `nil` if it isn't a known
+    /// callout type — in which case the block stays a plain block quote, matching
+    /// GitHub. `overrides` lets a future settings layer supply custom types/styles.
+    public static func style(for type: String,
+                             overrides: [String: CalloutStyle] = [:]) -> CalloutStyle? {
+        let key = type.lowercased()
+        return overrides[key] ?? defaultStyles[key]
+    }
+
+    /// A matched `[!type]` marker, with UTF-16 ranges relative to the scanned
+    /// first-line string.
+    public struct Marker: Equatable {
+        public let type: String          // lowercased
+        public let openBracket: NSRange  // "[!"
+        public let typeRange: NSRange    // the type word
+        public let closeBracket: NSRange // "]"
+    }
+
+    /// Matches a callout marker `[!type]` at the start of `firstLine` (a block
+    /// quote's first line, after its `> `). Returns the lowercased type and the
+    /// component ranges, or `nil` if there's no marker.
+    public static func parseMarker(_ firstLine: String) -> Marker? {
+        let ns = firstLine as NSString
+        guard let m = markerRegex.firstMatch(
+            in: firstLine, options: [],
+            range: NSRange(location: 0, length: ns.length)) else { return nil }
+        let typeRange = m.range(at: 1)
+        let type = ns.substring(with: typeRange).lowercased()
+        return Marker(
+            type: type,
+            openBracket: NSRange(location: typeRange.location - 2, length: 2),
+            typeRange: typeRange,
+            closeBracket: NSRange(location: typeRange.upperBound, length: 1)
+        )
+    }
+
+    /// `[!type]` at the very start of the line (optional leading spaces). The
+    /// type is one or more letters/digits/`-`/`_` beginning with a letter.
+    private static let markerRegex = try! NSRegularExpression(
+        pattern: #"^[ \t]*\[!([A-Za-z][A-Za-z0-9_-]*)\]"#)
+}

--- a/Sources/MarkdownEditorCore/Callout.swift
+++ b/Sources/MarkdownEditorCore/Callout.swift
@@ -96,7 +96,7 @@ public enum Callout {
         add(CalloutStyle(symbolName: "pencil.tip",               colorHex: "#086DDD"), "note")
         add(CalloutStyle(symbolName: "lightbulb",                colorHex: "#00BFBC"), "tip", "hint")
         add(CalloutStyle(symbolName: "exclamationmark.bubble",   colorHex: "#8250DF", darkColorHex: "#A371F7"), "important")
-        add(CalloutStyle(symbolName: "exclamationmark.triangle", colorHex: "#9A6700", darkColorHex: "#D29922"), "warning", "attention")
+        add(CalloutStyle(symbolName: "exclamationmark.triangle", colorHex: "#EC7500"), "warning", "attention")
         add(CalloutStyle(symbolName: "exclamationmark.octagon",  colorHex: "#CF222E", darkColorHex: "#F85149"), "caution")
 
         // Obsidian's other defaults (closest color + SF Symbol), with aliases.

--- a/Sources/MarkdownEditorCore/Callout.swift
+++ b/Sources/MarkdownEditorCore/Callout.swift
@@ -45,7 +45,7 @@ public struct CalloutStyle: Sendable, Equatable {
                 backgroundColorHex: String? = nil,
                 darkBackgroundColorHex: String? = nil,
                 backgroundAlpha: CGFloat = 0.08,
-                borderEdges: Edges = .left,
+                borderEdges: Edges = [],
                 borderWidth: CGFloat = 3) {
         self.symbolName = symbolName
         self.colorHex = colorHex
@@ -84,16 +84,34 @@ public struct CalloutStyle: Sendable, Equatable {
 /// existing block-quote span.
 public enum Callout {
 
-    /// Default type → style map (lowercased keys), mirroring GitHub's five
-    /// built-in callouts (with light + dark accents). Designed to be merged with
+    /// Default type → style map (lowercased keys). GitHub's five built-in types
+    /// keep their accents; the rest are Obsidian's default callouts mapped to the
+    /// closest color + SF Symbol (with their aliases). Designed to be merged with
     /// user overrides.
-    public static let defaultStyles: [String: CalloutStyle] = [
-        "note":      CalloutStyle(symbolName: "info.circle.fill",              colorHex: "#0969DA", darkColorHex: "#1F6FEB"),
-        "tip":       CalloutStyle(symbolName: "lightbulb.fill",                colorHex: "#1A7F37", darkColorHex: "#3FB950"),
-        "important": CalloutStyle(symbolName: "exclamationmark.bubble.fill",   colorHex: "#8250DF", darkColorHex: "#A371F7"),
-        "warning":   CalloutStyle(symbolName: "exclamationmark.triangle.fill", colorHex: "#9A6700", darkColorHex: "#D29922"),
-        "caution":   CalloutStyle(symbolName: "exclamationmark.octagon.fill",  colorHex: "#CF222E", darkColorHex: "#F85149"),
-    ]
+    public static let defaultStyles: [String: CalloutStyle] = {
+        var m: [String: CalloutStyle] = [:]
+        func add(_ style: CalloutStyle, _ names: String...) { for n in names { m[n] = style } }
+
+        // GitHub types (icons per request; GitHub light/dark accents).
+        add(CalloutStyle(symbolName: "pencil.line",              colorHex: "#0969DA", darkColorHex: "#1F6FEB"), "note")
+        add(CalloutStyle(symbolName: "lightbulb.max",            colorHex: "#1A7F37", darkColorHex: "#3FB950"), "tip", "hint")
+        add(CalloutStyle(symbolName: "exclamationmark.bubble",   colorHex: "#8250DF", darkColorHex: "#A371F7"), "important")
+        add(CalloutStyle(symbolName: "exclamationmark.triangle", colorHex: "#9A6700", darkColorHex: "#D29922"), "warning", "attention")
+        add(CalloutStyle(symbolName: "exclamationmark.octagon",  colorHex: "#CF222E", darkColorHex: "#F85149"), "caution")
+
+        // Obsidian's other defaults (closest color + SF Symbol), with aliases.
+        add(CalloutStyle(symbolName: "list.bullet.clipboard", colorHex: "#00BFBC"), "abstract", "summary", "tldr")
+        add(CalloutStyle(symbolName: "info.circle",           colorHex: "#086DDD"), "info")
+        add(CalloutStyle(symbolName: "checkmark.circle",      colorHex: "#086DDD"), "todo")
+        add(CalloutStyle(symbolName: "checkmark.seal",        colorHex: "#08B94E"), "success", "check", "done")
+        add(CalloutStyle(symbolName: "questionmark.circle",   colorHex: "#EC7500"), "question", "help", "faq")
+        add(CalloutStyle(symbolName: "xmark.circle",          colorHex: "#E93147"), "failure", "fail", "missing")
+        add(CalloutStyle(symbolName: "bolt",                  colorHex: "#E93147"), "danger", "error")
+        add(CalloutStyle(symbolName: "ant",                   colorHex: "#E93147"), "bug")
+        add(CalloutStyle(symbolName: "list.bullet",           colorHex: "#7852EE"), "example")
+        add(CalloutStyle(symbolName: "quote.bubble",          colorHex: "#9E9E9E"), "quote", "cite")
+        return m
+    }()
 
     /// The style for `type` (case-insensitive), or `nil` if it isn't a known
     /// callout type — in which case the block stays a plain block quote, matching

--- a/Sources/MarkdownEditorCore/Callout.swift
+++ b/Sources/MarkdownEditorCore/Callout.swift
@@ -1,16 +1,74 @@
 import Foundation
 
-/// Visual style for a callout type. Fields are plain and serializable so the
-/// mapping can later be overridden from user settings (custom color / icon).
-/// `symbolName` is an SF Symbol; `colorHex` is an "#RRGGBB" string resolved to
-/// an `NSColor` at render time.
+/// Visual style for a callout type. Fields are plain and serializable (hex
+/// strings, enums) so the mapping can be overridden from user settings — custom
+/// color, icon, border, background. Colors are resolved to `NSColor` at render
+/// time, picking the dark variant under a dark appearance when one is provided.
 public struct CalloutStyle: Sendable, Equatable {
-    public let symbolName: String
-    public let colorHex: String
 
-    public init(symbolName: String, colorHex: String) {
+    /// Which edges of the callout draw a border.
+    public struct Edges: OptionSet, Sendable, Equatable {
+        public let rawValue: Int
+        public init(rawValue: Int) { self.rawValue = rawValue }
+        public static let left   = Edges(rawValue: 1 << 0)
+        public static let top    = Edges(rawValue: 1 << 1)
+        public static let right  = Edges(rawValue: 1 << 2)
+        public static let bottom = Edges(rawValue: 1 << 3)
+        public static let all: Edges = [.left, .top, .right, .bottom]
+    }
+
+    /// SF Symbol name for the icon.
+    public let symbolName: String
+    /// Accent color (icon + title); border/background default to it.
+    public let colorHex: String
+    /// Accent under a dark appearance (defaults to `colorHex`).
+    public let darkColorHex: String?
+
+    /// Explicit border color (defaults to the accent).
+    public let borderColorHex: String?
+    public let darkBorderColorHex: String?
+    /// Explicit background color (defaults to the accent at `backgroundAlpha`).
+    public let backgroundColorHex: String?
+    public let darkBackgroundColorHex: String?
+    /// Alpha used for the derived background when no explicit background is set.
+    public let backgroundAlpha: CGFloat
+
+    /// Which edges draw a border, and how thick.
+    public let borderEdges: Edges
+    public let borderWidth: CGFloat
+
+    public init(symbolName: String,
+                colorHex: String,
+                darkColorHex: String? = nil,
+                borderColorHex: String? = nil,
+                darkBorderColorHex: String? = nil,
+                backgroundColorHex: String? = nil,
+                darkBackgroundColorHex: String? = nil,
+                backgroundAlpha: CGFloat = 0.08,
+                borderEdges: Edges = .left,
+                borderWidth: CGFloat = 3) {
         self.symbolName = symbolName
         self.colorHex = colorHex
+        self.darkColorHex = darkColorHex
+        self.borderColorHex = borderColorHex
+        self.darkBorderColorHex = darkBorderColorHex
+        self.backgroundColorHex = backgroundColorHex
+        self.darkBackgroundColorHex = darkBackgroundColorHex
+        self.backgroundAlpha = backgroundAlpha
+        self.borderEdges = borderEdges
+        self.borderWidth = borderWidth
+    }
+
+    /// The accent hex for the given appearance.
+    public func accentHex(dark: Bool) -> String { (dark ? darkColorHex : nil) ?? colorHex }
+    /// The border hex for the given appearance (falls back to the accent).
+    public func resolvedBorderHex(dark: Bool) -> String {
+        (dark ? darkBorderColorHex : nil) ?? borderColorHex ?? accentHex(dark: dark)
+    }
+    /// An explicit background hex for the given appearance, if any (else the
+    /// renderer derives one from the accent at `backgroundAlpha`).
+    public func explicitBackgroundHex(dark: Bool) -> String? {
+        (dark ? darkBackgroundColorHex : nil) ?? backgroundColorHex
     }
 }
 
@@ -27,13 +85,14 @@ public struct CalloutStyle: Sendable, Equatable {
 public enum Callout {
 
     /// Default type → style map (lowercased keys), mirroring GitHub's five
-    /// built-in callouts. Designed to be merged with user overrides later.
+    /// built-in callouts (with light + dark accents). Designed to be merged with
+    /// user overrides.
     public static let defaultStyles: [String: CalloutStyle] = [
-        "note":      CalloutStyle(symbolName: "info.circle.fill",              colorHex: "#0969DA"),
-        "tip":       CalloutStyle(symbolName: "lightbulb.fill",                colorHex: "#1A7F37"),
-        "important": CalloutStyle(symbolName: "exclamationmark.bubble.fill",   colorHex: "#8250DF"),
-        "warning":   CalloutStyle(symbolName: "exclamationmark.triangle.fill", colorHex: "#9A6700"),
-        "caution":   CalloutStyle(symbolName: "exclamationmark.octagon.fill",  colorHex: "#CF222E"),
+        "note":      CalloutStyle(symbolName: "info.circle.fill",              colorHex: "#0969DA", darkColorHex: "#1F6FEB"),
+        "tip":       CalloutStyle(symbolName: "lightbulb.fill",                colorHex: "#1A7F37", darkColorHex: "#3FB950"),
+        "important": CalloutStyle(symbolName: "exclamationmark.bubble.fill",   colorHex: "#8250DF", darkColorHex: "#A371F7"),
+        "warning":   CalloutStyle(symbolName: "exclamationmark.triangle.fill", colorHex: "#9A6700", darkColorHex: "#D29922"),
+        "caution":   CalloutStyle(symbolName: "exclamationmark.octagon.fill",  colorHex: "#CF222E", darkColorHex: "#F85149"),
     ]
 
     /// The style for `type` (case-insensitive), or `nil` if it isn't a known
@@ -43,6 +102,14 @@ public enum Callout {
                              overrides: [String: CalloutStyle] = [:]) -> CalloutStyle? {
         let key = type.lowercased()
         return overrides[key] ?? defaultStyles[key]
+    }
+
+    /// The displayed title for a callout: the custom title if the header line has
+    /// one after `[!type]`, otherwise the capitalized type name — so `[!note]`
+    /// and `[!NOTE]` both render as "Note".
+    public static func title(type: String, customTitle: String) -> String {
+        let trimmed = customTitle.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? type.capitalized : trimmed
     }
 
     /// A matched `[!type]` marker, with UTF-16 ranges relative to the scanned

--- a/Sources/MarkdownEditorCore/Callout.swift
+++ b/Sources/MarkdownEditorCore/Callout.swift
@@ -102,9 +102,9 @@ public enum Callout {
         // Obsidian's other defaults (closest color + SF Symbol), with aliases.
         add(CalloutStyle(symbolName: "list.bullet.clipboard", colorHex: "#00BFBC"), "abstract", "summary", "tldr")
         add(CalloutStyle(symbolName: "info.circle",           colorHex: "#086DDD"), "info")
-        // checkmark.circle.dotted isn't available before macOS 15; circle.dotted
+        // checkmark.circle.dotted isn't available before macOS 15; circle.dashed
         // is the closest "to-do / pending" look.
-        add(CalloutStyle(symbolName: "circle.dotted",         colorHex: "#086DDD"), "todo")
+        add(CalloutStyle(symbolName: "circle.dashed",         colorHex: "#086DDD"), "todo")
         add(CalloutStyle(symbolName: "checkmark",             colorHex: "#08B94E"), "success", "check", "done")
         add(CalloutStyle(symbolName: "questionmark.circle",   colorHex: "#EC7500"), "question", "help", "faq")
         add(CalloutStyle(symbolName: "xmark",                 colorHex: "#E93147"), "failure", "fail", "missing")

--- a/Sources/MarkdownEditorCore/EditorTextView+BlockquoteContinuation.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+BlockquoteContinuation.swift
@@ -1,0 +1,46 @@
+import AppKit
+
+// MARK: - Block-quote / Callout Continuation on Enter
+//
+// Pressing Return inside a block quote (including a callout) repeats the quote
+// prefix on the next line — `> ` — so the quote/callout keeps going, the same
+// way list items auto-continue. Pressing Return on an *empty* quote line removes
+// the prefix and breaks out of the quote.
+
+extension EditorTextView {
+
+    /// Leading indent + `>` + an optional single space, at the start of a line.
+    private static let blockquotePrefixRegex = try! NSRegularExpression(
+        pattern: #"^[ \t]*>[ \t]?"#
+    )
+
+    /// Continues a block quote / callout on Return. Returns true if it handled
+    /// the newline.
+    func handleBlockquoteNewline(at location: Int) -> Bool {
+        let ns = rawSource as NSString
+        guard location <= ns.length else { return false }
+
+        // The line containing the cursor (without its trailing newline).
+        let lineRange = ns.lineRange(for: NSRange(location: location, length: 0))
+        var lineEnd = lineRange.upperBound
+        if lineEnd > lineRange.location, ns.character(at: lineEnd - 1) == 0x0A { lineEnd -= 1 }
+        let lineStart = lineRange.location
+        let line = ns.substring(with: NSRange(location: lineStart, length: lineEnd - lineStart))
+        let lineNS = line as NSString
+
+        guard let m = Self.blockquotePrefixRegex.firstMatch(
+            in: line, range: NSRange(location: 0, length: lineNS.length)) else { return false }
+
+        let prefix = lineNS.substring(with: m.range)
+        let hasContent = m.range.length < lineNS.length
+
+        if hasContent {
+            // Continue the quote: newline + the same `> ` prefix.
+            insertText("\n" + prefix, replacementRange: NSRange(location: location, length: 0))
+        } else {
+            // Empty quote line → break out by removing the prefix.
+            insertText("", replacementRange: NSRange(location: lineStart, length: lineEnd - lineStart))
+        }
+        return true
+    }
+}

--- a/Sources/MarkdownEditorCore/EditorTextView+CalloutRendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+CalloutRendering.swift
@@ -1,0 +1,128 @@
+import AppKit
+
+// MARK: - Callout Rendering
+//
+// A callout is a block quote whose first line is `[!type]` (case-insensitive).
+// swift-markdown gives us a plain `.blockquote` span; here we detect the marker
+// on the first line and render it with a colored left bar + faint tint, an SF
+// Symbol icon, and a colored type label — hiding the `[ ! ]` brackets when the
+// item is rendered, and showing the raw marker (dimmed) when it's being edited.
+
+extension EditorTextView {
+
+    /// A detected callout on a block-quote span, with marker ranges already
+    /// mapped to absolute offsets within the block string.
+    struct CalloutInfo {
+        let marker: Callout.Marker
+        let style: CalloutStyle
+    }
+
+    /// Returns callout info if `span` (a `.blockquote`) begins with a known
+    /// `[!type]` marker on its first line, else `nil` (a plain block quote).
+    func calloutInfo(forBlockquote span: SyntaxHighlighter.Span, markdown: String) -> CalloutInfo? {
+        // The first `> ` delimiter — the smallest-location one — opens line 1.
+        guard let firstDelim = span.delimiterRanges.min(by: { $0.location < $1.location })
+        else { return nil }
+        let ns = markdown as NSString
+        let contentStart = firstDelim.upperBound
+        let blockEnd = min(span.fullRange.upperBound, ns.length)
+        guard contentStart < blockEnd else { return nil }
+
+        let searchRange = NSRange(location: contentStart, length: blockEnd - contentStart)
+        let nl = ns.range(of: "\n", options: [], range: searchRange)
+        let lineEnd = nl.location == NSNotFound ? blockEnd : nl.location
+        let firstLine = ns.substring(with: NSRange(location: contentStart, length: lineEnd - contentStart))
+
+        guard let rel = Callout.parseMarker(firstLine),
+              let style = Callout.style(for: rel.type) else { return nil }
+
+        func abs(_ r: NSRange) -> NSRange { NSRange(location: r.location + contentStart, length: r.length) }
+        let marker = Callout.Marker(type: rel.type,
+                                    openBracket: abs(rel.openBracket),
+                                    typeRange: abs(rel.typeRange),
+                                    closeBracket: abs(rel.closeBracket))
+        return CalloutInfo(marker: marker, style: style)
+    }
+
+    /// Applies callout styling to a block-quote span detected as a callout.
+    /// `active` shows the raw marker (dimmed, editable); otherwise the marker is
+    /// rendered as an icon + colored type label with the brackets hidden.
+    func styleCalloutContent(_ result: NSMutableAttributedString,
+                             span: SyntaxHighlighter.Span,
+                             info: CalloutInfo,
+                             active: Bool) {
+        guard span.fullRange.upperBound <= result.length else { return }
+        let color = NSColor(hex: info.style.colorHex) ?? accentColor
+
+        // Colored left bar + faint tint behind the whole callout.
+        result.addAttribute(.paragraphStyle, value: calloutParagraphStyle(color: color),
+                            range: span.fullRange)
+
+        let m = info.marker
+        if active {
+            // Editing: keep the raw "[!type]" visible but dimmed.
+            let full = NSRange(location: m.openBracket.location,
+                               length: m.closeBracket.upperBound - m.openBracket.location)
+            if full.upperBound <= result.length {
+                result.addAttribute(.foregroundColor, value: syntaxDimColor, range: full)
+            }
+            return
+        }
+
+        // Rendered: icon replaces "[", hide "!" and "]", color the type label.
+        if let icon = calloutIconAttachment(symbolName: info.style.symbolName, color: color),
+           m.openBracket.location < result.length {
+            result.addAttribute(.attachment, value: icon,
+                                range: NSRange(location: m.openBracket.location, length: 1))
+        }
+        hideCalloutRange(result, NSRange(location: m.openBracket.location + 1, length: 1)) // "!"
+        if m.typeRange.upperBound <= result.length {
+            let bold = NSFontManager.shared.convert(bodyFont, toHaveTrait: .boldFontMask)
+            result.addAttribute(.foregroundColor, value: color, range: m.typeRange)
+            result.addAttribute(.font, value: bold, range: m.typeRange)
+        }
+        hideCalloutRange(result, m.closeBracket) // "]"
+    }
+
+    private func hideCalloutRange(_ result: NSMutableAttributedString, _ r: NSRange) {
+        guard r.upperBound <= result.length else { return }
+        result.addAttribute(.font, value: hiddenFont, range: r)
+        result.addAttribute(.foregroundColor, value: NSColor.clear, range: r)
+    }
+
+    /// Paragraph style for a callout: a thick colored left bar and a faint tint
+    /// of the same color behind the block.
+    private func calloutParagraphStyle(color: NSColor) -> NSParagraphStyle {
+        let ps = NSMutableParagraphStyle()
+        ps.lineSpacing = bodyParagraphStyle.lineSpacing
+        ps.paragraphSpacing = bodyParagraphStyle.paragraphSpacing
+
+        let block = NSTextBlock()
+        block.setContentWidth(100, type: .percentageValueType)
+        let leftEdge = NSRectEdge(rawValue: 0)!
+        block.setWidth(3, type: .absoluteValueType, for: .border, edge: leftEdge)
+        block.setBorderColor(color, for: leftEdge)
+        block.setWidth(8, type: .absoluteValueType, for: .padding, edge: leftEdge)
+        block.backgroundColor = color.withAlphaComponent(0.08)
+        ps.textBlocks = [block]
+        return ps
+    }
+
+    /// An SF Symbol icon attachment tinted to the callout color, sized to the
+    /// body font with a small trailing gap before the label. `nil` if the symbol
+    /// can't be resolved.
+    private func calloutIconAttachment(symbolName: String, color: NSColor) -> NSTextAttachment? {
+        let pointSize = bodyFont.pointSize
+        let config = NSImage.SymbolConfiguration(pointSize: pointSize, weight: .semibold)
+            .applying(NSImage.SymbolConfiguration(paletteColors: [color]))
+        guard let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?
+            .withSymbolConfiguration(config) else { return nil }
+
+        let attachment = NSTextAttachment()
+        attachment.image = image
+        let gap = pointSize * 0.35
+        attachment.bounds = CGRect(x: 0, y: -pointSize * 0.12,
+                                   width: image.size.width + gap, height: image.size.height)
+        return attachment
+    }
+}

--- a/Sources/MarkdownEditorCore/EditorTextView+CalloutRendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+CalloutRendering.swift
@@ -91,7 +91,8 @@ extension EditorTextView {
         result.addAttribute(.font, value: hiddenFont, range: header)
         result.addAttribute(.foregroundColor, value: NSColor.clear, range: header)
         if let att = calloutHeaderAttachment(symbolName: info.style.symbolName,
-                                             title: info.title, color: c.accent) {
+                                             title: info.title, color: c.accent,
+                                             iconNudge: info.style.iconBaselineNudge) {
             result.addAttribute(.attachment, value: att,
                                 range: NSRange(location: header.location, length: 1))
         }
@@ -116,6 +117,14 @@ extension EditorTextView {
         }
         return (accent, border, background)
     }
+
+    // MARK: Padding constants (shared by the box and the header image)
+
+    /// Top breathing room — baked into the header image so it's part of the
+    /// header *line* (clickable text space), not dead block padding.
+    private var calloutTopPad: CGFloat { bodyFont.pointSize * 0.8 }
+    /// Bottom breathing room (kept as block padding; slightly less, to balance).
+    private var calloutBottomPad: CGFloat { bodyFont.pointSize * 0.65 }
 
     // MARK: Paragraph style (border / background / padding)
 
@@ -148,14 +157,14 @@ extension EditorTextView {
         // shared hidden `> ` already provides the indent — rather than sitting
         // further right. (A block quote's left inset is its 2pt border; matching
         // that here keeps callouts and quotes aligned.)
-        let topPad = bodyFont.pointSize * 0.8
-        let bottomPad = bodyFont.pointSize * 0.65   // slightly less, to balance
+        // Top padding lives in the header image (clickable text space); only the
+        // bottom padding is block padding here.
         let leftPad: CGFloat = 2
         let rightPad: CGFloat = 10
-        block.setWidth(topPad, type: .absoluteValueType, for: .padding, edge: top)
-        block.setWidth(bottomPad, type: .absoluteValueType, for: .padding, edge: bottom)
+        block.setWidth(calloutBottomPad, type: .absoluteValueType, for: .padding, edge: bottom)
         block.setWidth(leftPad, type: .absoluteValueType, for: .padding, edge: left)
         block.setWidth(rightPad, type: .absoluteValueType, for: .padding, edge: right)
+        _ = top   // (top padding intentionally omitted — see header image)
 
         ps.textBlocks = [block]
         return ps
@@ -166,7 +175,8 @@ extension EditorTextView {
     /// Draws "icon  Title" into one image, tinted to the callout color. Returns
     /// `nil` if the SF Symbol can't be resolved (the caller then leaves the raw
     /// marker text visible).
-    private func calloutHeaderAttachment(symbolName: String, title: String, color: NSColor) -> NSTextAttachment? {
+    private func calloutHeaderAttachment(symbolName: String, title: String, color: NSColor,
+                                         iconNudge: CGFloat) -> NSTextAttachment? {
         let pointSize = bodyFont.pointSize
         let symConfig = NSImage.SymbolConfiguration(pointSize: pointSize, weight: .semibold)
             .applying(NSImage.SymbolConfiguration(paletteColors: [color]))
@@ -180,23 +190,31 @@ extension EditorTextView {
 
         let gap = pointSize * 0.3
         let symW = symbol.size.width, symH = symbol.size.height
-        let height = ceil(max(symH, titleSize.height))
+        let contentHeight = ceil(max(symH, titleSize.height))
         let width = ceil(symW + gap + titleSize.width)
+        // The image is taller than its content: the extra `calloutTopPad` sits on
+        // top, so the callout's top breathing room is part of this (clickable)
+        // header line rather than dead block padding above it.
+        let topPad = ceil(calloutTopPad)
+        let height = contentHeight + topPad
 
         let image = NSImage(size: NSSize(width: width, height: height), flipped: false) { _ in
-            let titleY = (height - titleSize.height) / 2
+            // Draw the content in the bottom `contentHeight` band; leave `topPad`
+            // empty above it.
+            let titleY = (contentHeight - titleSize.height) / 2
             titleStr.draw(at: NSPoint(x: symW + gap, y: titleY))
             // Center the icon on the title's cap height (its optical middle) rather
-            // than the full line box, so tall-glyph symbols (e.g. the lightbulb)
-            // don't sit high.
+            // than the full line box, so tall-glyph symbols don't sit high.
             let baseline = titleY + abs(titleFont.descender)
             let capCenter = baseline + titleFont.capHeight / 2
-            symbol.draw(in: NSRect(x: 0, y: capCenter - symH / 2, width: symW, height: symH))
+            symbol.draw(in: NSRect(x: 0, y: capCenter - symH / 2 + iconNudge, width: symW, height: symH))
             return true
         }
 
         let attachment = NSTextAttachment()
         attachment.image = image
+        // The content's bottom stays on the text baseline (as before); the extra
+        // `topPad` extends the image (and the line fragment) upward.
         attachment.bounds = CGRect(x: 0, y: -pointSize * 0.15, width: width, height: height)
         return attachment
     }

--- a/Sources/MarkdownEditorCore/EditorTextView+CalloutRendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+CalloutRendering.swift
@@ -4,23 +4,27 @@ import AppKit
 //
 // A callout is a block quote whose first line is `[!type]` (case-insensitive).
 // swift-markdown gives us a plain `.blockquote` span; here we detect the marker
-// on the first line and render it with a colored left bar + faint tint, an SF
-// Symbol icon, and a colored type label — hiding the `[ ! ]` brackets when the
-// item is rendered, and showing the raw marker (dimmed) when it's being edited.
+// and render the header line as an icon + title image (hiding the raw
+// `[!type] …` source), with a customizable colored border + tinted background.
+// Colors resolve per light/dark appearance. While the cursor is inside the
+// callout the raw, editable marker is shown instead.
 
 extension EditorTextView {
 
-    /// A detected callout on a block-quote span, with marker ranges already
-    /// mapped to absolute offsets within the block string.
+    /// A detected callout on a block-quote span, with ranges mapped to absolute
+    /// offsets within the block string.
     struct CalloutInfo {
         let marker: Callout.Marker
         let style: CalloutStyle
+        /// `[ '[' … end-of-first-line )` — replaced by the icon+title image.
+        let headerRange: NSRange
+        /// Capitalized type name, or the custom title if the header has one.
+        let title: String
     }
 
     /// Returns callout info if `span` (a `.blockquote`) begins with a known
     /// `[!type]` marker on its first line, else `nil` (a plain block quote).
     func calloutInfo(forBlockquote span: SyntaxHighlighter.Span, markdown: String) -> CalloutInfo? {
-        // The first `> ` delimiter — the smallest-location one — opens line 1.
         guard let firstDelim = span.delimiterRanges.min(by: { $0.location < $1.location })
         else { return nil }
         let ns = markdown as NSString
@@ -34,95 +38,154 @@ extension EditorTextView {
         let firstLine = ns.substring(with: NSRange(location: contentStart, length: lineEnd - contentStart))
 
         guard let rel = Callout.parseMarker(firstLine),
-              let style = Callout.style(for: rel.type) else { return nil }
+              let style = Callout.style(for: rel.type, overrides: calloutStyleOverrides) else { return nil }
 
         func abs(_ r: NSRange) -> NSRange { NSRange(location: r.location + contentStart, length: r.length) }
         let marker = Callout.Marker(type: rel.type,
                                     openBracket: abs(rel.openBracket),
                                     typeRange: abs(rel.typeRange),
                                     closeBracket: abs(rel.closeBracket))
-        return CalloutInfo(marker: marker, style: style)
+
+        let titleStart = marker.closeBracket.upperBound
+        let customRaw = titleStart < lineEnd
+            ? ns.substring(with: NSRange(location: titleStart, length: lineEnd - titleStart)) : ""
+        let title = Callout.title(type: marker.type, customTitle: customRaw)
+        let headerRange = NSRange(location: marker.openBracket.location,
+                                  length: lineEnd - marker.openBracket.location)
+
+        return CalloutInfo(marker: marker, style: style, headerRange: headerRange, title: title)
     }
 
-    /// Applies callout styling to a block-quote span detected as a callout.
-    /// `active` shows the raw marker (dimmed, editable); otherwise the marker is
-    /// rendered as an icon + colored type label with the brackets hidden.
+    /// Applies callout styling. `active` shows the raw marker (dimmed, editable);
+    /// otherwise the header is replaced by an icon + title image.
     func styleCalloutContent(_ result: NSMutableAttributedString,
                              span: SyntaxHighlighter.Span,
                              info: CalloutInfo,
                              active: Bool) {
         guard span.fullRange.upperBound <= result.length else { return }
-        let color = NSColor(hex: info.style.colorHex) ?? accentColor
+        let c = resolvedCalloutColors(info.style)
 
-        // Colored left bar + faint tint behind the whole callout.
-        result.addAttribute(.paragraphStyle, value: calloutParagraphStyle(color: color),
+        result.addAttribute(.paragraphStyle,
+                            value: calloutParagraphStyle(borderColor: c.border,
+                                                         backgroundColor: c.background,
+                                                         edges: info.style.borderEdges,
+                                                         borderWidth: info.style.borderWidth),
                             range: span.fullRange)
 
         let m = info.marker
         if active {
-            // Editing: keep the raw "[!type]" visible but dimmed.
-            let full = NSRange(location: m.openBracket.location,
-                               length: m.closeBracket.upperBound - m.openBracket.location)
-            if full.upperBound <= result.length {
-                result.addAttribute(.foregroundColor, value: syntaxDimColor, range: full)
+            // Editing: dim the raw "[!type]" marker; the custom title (if any)
+            // stays as normal, editable text.
+            let markerFull = NSRange(location: m.openBracket.location,
+                                     length: m.closeBracket.upperBound - m.openBracket.location)
+            if markerFull.upperBound <= result.length {
+                result.addAttribute(.foregroundColor, value: syntaxDimColor, range: markerFull)
             }
             return
         }
 
-        // Rendered: icon replaces "[", hide "!" and "]", color the type label.
-        if let icon = calloutIconAttachment(symbolName: info.style.symbolName, color: color),
-           m.openBracket.location < result.length {
-            result.addAttribute(.attachment, value: icon,
-                                range: NSRange(location: m.openBracket.location, length: 1))
+        // Rendered: hide the whole header, draw an icon + title image on the first
+        // character.
+        let header = info.headerRange
+        guard header.length > 0, header.upperBound <= result.length else { return }
+        result.addAttribute(.font, value: hiddenFont, range: header)
+        result.addAttribute(.foregroundColor, value: NSColor.clear, range: header)
+        if let att = calloutHeaderAttachment(symbolName: info.style.symbolName,
+                                             title: info.title, color: c.accent) {
+            result.addAttribute(.attachment, value: att,
+                                range: NSRange(location: header.location, length: 1))
         }
-        hideCalloutRange(result, NSRange(location: m.openBracket.location + 1, length: 1)) // "!"
-        if m.typeRange.upperBound <= result.length {
-            let bold = NSFontManager.shared.convert(bodyFont, toHaveTrait: .boldFontMask)
-            result.addAttribute(.foregroundColor, value: color, range: m.typeRange)
-            result.addAttribute(.font, value: bold, range: m.typeRange)
-        }
-        hideCalloutRange(result, m.closeBracket) // "]"
     }
 
-    private func hideCalloutRange(_ result: NSMutableAttributedString, _ r: NSRange) {
-        guard r.upperBound <= result.length else { return }
-        result.addAttribute(.font, value: hiddenFont, range: r)
-        result.addAttribute(.foregroundColor, value: NSColor.clear, range: r)
+    // MARK: Colors (appearance-aware)
+
+    private var isDarkAppearance: Bool {
+        effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
     }
 
-    /// Paragraph style for a callout: a thick colored left bar and a faint tint
-    /// of the same color behind the block.
-    private func calloutParagraphStyle(color: NSColor) -> NSParagraphStyle {
+    private func resolvedCalloutColors(_ style: CalloutStyle)
+        -> (accent: NSColor, border: NSColor, background: NSColor) {
+        let dark = isDarkAppearance
+        let accent = NSColor(hex: style.accentHex(dark: dark)) ?? accentColor
+        let border = NSColor(hex: style.resolvedBorderHex(dark: dark)) ?? accent
+        let background: NSColor
+        if let bgHex = style.explicitBackgroundHex(dark: dark), let bg = NSColor(hex: bgHex) {
+            background = bg
+        } else {
+            background = accent.withAlphaComponent(style.backgroundAlpha)
+        }
+        return (accent, border, background)
+    }
+
+    // MARK: Paragraph style (border / background / padding)
+
+    private func calloutParagraphStyle(borderColor: NSColor, backgroundColor: NSColor,
+                                       edges: CalloutStyle.Edges, borderWidth: CGFloat) -> NSParagraphStyle {
         let ps = NSMutableParagraphStyle()
         ps.lineSpacing = bodyParagraphStyle.lineSpacing
         ps.paragraphSpacing = bodyParagraphStyle.paragraphSpacing
 
+        // One block instance shared across the callout's lines renders as a single
+        // continuous box, so borders/background/padding wrap the whole callout
+        // (padding only at the outer top/bottom, not between lines).
         let block = NSTextBlock()
         block.setContentWidth(100, type: .percentageValueType)
-        let leftEdge = NSRectEdge(rawValue: 0)!
-        block.setWidth(3, type: .absoluteValueType, for: .border, edge: leftEdge)
-        block.setBorderColor(color, for: leftEdge)
-        block.setWidth(8, type: .absoluteValueType, for: .padding, edge: leftEdge)
-        block.backgroundColor = color.withAlphaComponent(0.08)
+        block.backgroundColor = backgroundColor
+
+        let left   = NSRectEdge(rawValue: 0)!   // minX
+        let top     = NSRectEdge(rawValue: 1)!  // minY (top, flipped text coords)
+        let right  = NSRectEdge(rawValue: 2)!   // maxX
+        let bottom = NSRectEdge(rawValue: 3)!   // maxY
+        let edgeMap: [(CalloutStyle.Edges, NSRectEdge)] =
+            [(.left, left), (.top, top), (.right, right), (.bottom, bottom)]
+        for (e, rectEdge) in edgeMap where edges.contains(e) {
+            block.setWidth(borderWidth, type: .absoluteValueType, for: .border, edge: rectEdge)
+            block.setBorderColor(borderColor, for: rectEdge)
+        }
+
+        // Breathing room: vertical (item) + horizontal padding.
+        let vPad = bodyFont.pointSize * 0.45
+        let hPad: CGFloat = 10
+        block.setWidth(vPad, type: .absoluteValueType, for: .padding, edge: top)
+        block.setWidth(vPad, type: .absoluteValueType, for: .padding, edge: bottom)
+        block.setWidth(hPad, type: .absoluteValueType, for: .padding, edge: left)
+        block.setWidth(hPad, type: .absoluteValueType, for: .padding, edge: right)
+
         ps.textBlocks = [block]
         return ps
     }
 
-    /// An SF Symbol icon attachment tinted to the callout color, sized to the
-    /// body font with a small trailing gap before the label. `nil` if the symbol
-    /// can't be resolved.
-    private func calloutIconAttachment(symbolName: String, color: NSColor) -> NSTextAttachment? {
+    // MARK: Header image (icon + title)
+
+    /// Draws "icon  Title" into one image, tinted to the callout color. Returns
+    /// `nil` if the SF Symbol can't be resolved (the caller then leaves the raw
+    /// marker text visible).
+    private func calloutHeaderAttachment(symbolName: String, title: String, color: NSColor) -> NSTextAttachment? {
         let pointSize = bodyFont.pointSize
-        let config = NSImage.SymbolConfiguration(pointSize: pointSize, weight: .semibold)
+        let symConfig = NSImage.SymbolConfiguration(pointSize: pointSize, weight: .semibold)
             .applying(NSImage.SymbolConfiguration(paletteColors: [color]))
-        guard let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?
-            .withSymbolConfiguration(config) else { return nil }
+        guard let symbol = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?
+            .withSymbolConfiguration(symConfig) else { return nil }
+
+        let titleFont = NSFontManager.shared.convert(bodyFont, toHaveTrait: .boldFontMask)
+        let titleAttrs: [NSAttributedString.Key: Any] = [.font: titleFont, .foregroundColor: color]
+        let titleStr = NSAttributedString(string: title, attributes: titleAttrs)
+        let titleSize = titleStr.size()
+
+        let gap = pointSize * 0.3
+        let symW = symbol.size.width, symH = symbol.size.height
+        let height = ceil(max(symH, titleSize.height))
+        let width = ceil(symW + gap + titleSize.width)
+
+        let image = NSImage(size: NSSize(width: width, height: height), flipped: false) { _ in
+            symbol.draw(in: NSRect(x: 0, y: (height - symH) / 2, width: symW, height: symH))
+            titleStr.draw(at: NSPoint(x: symW + gap, y: (height - titleSize.height) / 2))
+            return true
+        }
 
         let attachment = NSTextAttachment()
         attachment.image = image
-        let gap = pointSize * 0.35
-        attachment.bounds = CGRect(x: 0, y: -pointSize * 0.12,
-                                   width: image.size.width + gap, height: image.size.height)
+        attachment.bounds = CGRect(x: 0, y: -pointSize * 0.15, width: width, height: height)
         return attachment
     }
 }

--- a/Sources/MarkdownEditorCore/EditorTextView+CalloutRendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+CalloutRendering.swift
@@ -183,8 +183,14 @@ extension EditorTextView {
         let width = ceil(symW + gap + titleSize.width)
 
         let image = NSImage(size: NSSize(width: width, height: height), flipped: false) { _ in
-            symbol.draw(in: NSRect(x: 0, y: (height - symH) / 2, width: symW, height: symH))
-            titleStr.draw(at: NSPoint(x: symW + gap, y: (height - titleSize.height) / 2))
+            let titleY = (height - titleSize.height) / 2
+            titleStr.draw(at: NSPoint(x: symW + gap, y: titleY))
+            // Center the icon on the title's cap height (its optical middle) rather
+            // than the full line box, so tall-glyph symbols (e.g. the lightbulb)
+            // don't sit high.
+            let baseline = titleY + abs(titleFont.descender)
+            let capCenter = baseline + titleFont.capHeight / 2
+            symbol.draw(in: NSRect(x: 0, y: capCenter - symH / 2, width: symW, height: symH))
             return true
         }
 

--- a/Sources/MarkdownEditorCore/EditorTextView+CalloutRendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+CalloutRendering.swift
@@ -148,11 +148,12 @@ extension EditorTextView {
         // shared hidden `> ` already provides the indent — rather than sitting
         // further right. (A block quote's left inset is its 2pt border; matching
         // that here keeps callouts and quotes aligned.)
-        let vPad = bodyFont.pointSize * 0.8
+        let topPad = bodyFont.pointSize * 0.8
+        let bottomPad = bodyFont.pointSize * 0.65   // slightly less, to balance
         let leftPad: CGFloat = 2
         let rightPad: CGFloat = 10
-        block.setWidth(vPad, type: .absoluteValueType, for: .padding, edge: top)
-        block.setWidth(vPad, type: .absoluteValueType, for: .padding, edge: bottom)
+        block.setWidth(topPad, type: .absoluteValueType, for: .padding, edge: top)
+        block.setWidth(bottomPad, type: .absoluteValueType, for: .padding, edge: bottom)
         block.setWidth(leftPad, type: .absoluteValueType, for: .padding, edge: left)
         block.setWidth(rightPad, type: .absoluteValueType, for: .padding, edge: right)
 

--- a/Sources/MarkdownEditorCore/EditorTextView+CalloutRendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+CalloutRendering.swift
@@ -143,13 +143,18 @@ extension EditorTextView {
             block.setBorderColor(borderColor, for: rectEdge)
         }
 
-        // Breathing room: vertical (item) + horizontal padding.
-        let vPad = bodyFont.pointSize * 0.45
-        let hPad: CGFloat = 10
+        // Breathing room: generous vertical padding. The left padding is kept
+        // small so the callout's text lines up with a plain block quote's — the
+        // shared hidden `> ` already provides the indent — rather than sitting
+        // further right. (A block quote's left inset is its 2pt border; matching
+        // that here keeps callouts and quotes aligned.)
+        let vPad = bodyFont.pointSize * 0.8
+        let leftPad: CGFloat = 2
+        let rightPad: CGFloat = 10
         block.setWidth(vPad, type: .absoluteValueType, for: .padding, edge: top)
         block.setWidth(vPad, type: .absoluteValueType, for: .padding, edge: bottom)
-        block.setWidth(hPad, type: .absoluteValueType, for: .padding, edge: left)
-        block.setWidth(hPad, type: .absoluteValueType, for: .padding, edge: right)
+        block.setWidth(leftPad, type: .absoluteValueType, for: .padding, edge: left)
+        block.setWidth(rightPad, type: .absoluteValueType, for: .padding, edge: right)
 
         ps.textBlocks = [block]
         return ps

--- a/Sources/MarkdownEditorCore/EditorTextView+ListContinuation.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+ListContinuation.swift
@@ -56,17 +56,23 @@ extension EditorTextView {
 
     public override func insertNewline(_ sender: Any?) {
         let sel = selectedRange()
-        guard sel.length == 0,
-              let blockIdx = blockIndexForRawOffset(sel.location),
-              blockIdx < blocks.count else {
+        guard sel.length == 0 else {
             super.insertNewline(sender)
             return
         }
+        if handleListNewline(sel) { return }
+        if handleBlockquoteNewline(at: sel.location) { return }
+        super.insertNewline(sender)
+    }
+
+    /// List continuation. Returns true if it handled the newline.
+    private func handleListNewline(_ sel: NSRange) -> Bool {
+        guard let blockIdx = blockIndexForRawOffset(sel.location),
+              blockIdx < blocks.count else { return false }
 
         let block = blocks[blockIdx]
         guard let (indent, marker, hasContent) = parseListMarker(block.content) else {
-            super.insertNewline(sender)
-            return
+            return false
         }
 
         if hasContent {
@@ -91,5 +97,6 @@ extension EditorTextView {
             // Root-level empty list line → remove the marker entirely
             insertText("", replacementRange: block.range)
         }
+        return true
     }
 }

--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -201,11 +201,18 @@ extension EditorTextView {
 
             case .blockquote:
                 guard span.fullRange.upperBound <= result.length else { continue }
-                // Paragraph style must cover fullRange so the first character of each
-                // paragraph (the `> ` delimiter) carries the NSTextBlock border.
-                // NSTextView uses the paragraph style from the first char of a paragraph.
-                result.addAttribute(.paragraphStyle, value: blockquoteParagraphStyle(), range: span.fullRange)
-                result.addAttribute(.foregroundColor, value: NSColor.secondaryLabelColor, range: span.contentRange)
+                // A block quote whose first line is `[!type]` is a callout
+                // (GitHub-flavored) — render it with an icon, colored label, and
+                // colored bar instead of the plain quote styling.
+                if let callout = calloutInfo(forBlockquote: span, markdown: markdown) {
+                    styleCalloutContent(result, span: span, info: callout, active: cursorInToken)
+                } else {
+                    // Paragraph style must cover fullRange so the first character of each
+                    // paragraph (the `> ` delimiter) carries the NSTextBlock border.
+                    // NSTextView uses the paragraph style from the first char of a paragraph.
+                    result.addAttribute(.paragraphStyle, value: blockquoteParagraphStyle(), range: span.fullRange)
+                    result.addAttribute(.foregroundColor, value: NSColor.secondaryLabelColor, range: span.contentRange)
+                }
 
             case .listItem(let ordered, let checkbox):
                 guard span.fullRange.upperBound <= result.length else { continue }

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -281,8 +281,14 @@ public class EditorTextView: NSTextView {
         if newActiveIndex != activeBlockIndex && !pendingRecompose {
             pendingRecompose = true
             DispatchQueue.main.async { [weak self] in
-                guard let self = self, !self.isUpdating else { return }
+                guard let self = self else { return }
+                // Always clear the flag first. If we bail out below (a recompose is
+                // mid-flight and will set the active block itself), leaving it set
+                // would permanently wedge active-block switching — the cursor could
+                // never re-activate a block, so e.g. a callout would stay rendered
+                // with un-editable zero-width marker characters.
                 self.pendingRecompose = false
+                guard !self.isUpdating else { return }
 
                 let currentSel = self.selectedRange()
                 let rawStart = currentSel.location

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -78,6 +78,11 @@ public class EditorTextView: NSTextView {
 
     public var theme: EditorTheme = .load()
 
+    /// User overrides for callout styles, keyed by lowercased type. Lets a
+    /// settings layer customize a built-in type's color / icon / border /
+    /// background (or add new types). Empty by default (GitHub styles).
+    public var calloutStyleOverrides: [String: CalloutStyle] = [:]
+
     // MARK: - Derived Visual Properties
 
     var accentColor: NSColor { theme.accentColor }

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -247,8 +247,19 @@ public class EditorTextView: NSTextView {
         let sel = selectedRange()
         let cursorRaw = min(sel.location, (rawSource as NSString).length)
 
+        let previousBlockCount = blocks.count
         blocks = BlockParser.parse(rawSource, previous: blocks)
         recalcDisplayRanges()
+
+        // If the number of blocks changed, an edit split or merged blocks (e.g. a
+        // callout/code fence/quote gaining or losing lines). Incremental recompose
+        // only restyles the active block, so a neighbor whose meaning changed —
+        // such as a former callout body line left with a stale background — would
+        // keep its old styling. Do a full recompose to keep the document correct.
+        if blocks.count != previousBlockCount {
+            recompose(cursorInRaw: cursorRaw)
+            return
+        }
 
         let newBlockIndex = blockIndexForRawOffset(cursorRaw)
         if newBlockIndex != activeBlockIndex {

--- a/Tests/MarkdownEditorTests/BlockParserTests.swift
+++ b/Tests/MarkdownEditorTests/BlockParserTests.swift
@@ -24,16 +24,20 @@ struct BlockParserTests {
         #expect(blocks[2].content == "after")
     }
 
-    @Test("A plain block quote stays split per line (unchanged)")
-    func plainQuoteNotMerged() {
-        let blocks = BlockParser.parse("> a\n> b")
-        #expect(blocks.count == 2)
+    @Test("Consecutive block-quote lines merge into one block")
+    func blockquoteLinesMerge() {
+        // One NSTextBlock per quote (vs one per line) avoids the NSTextView
+        // table-cell deletion restriction at per-line boundaries.
+        let blocks = BlockParser.parse("> a\n> b\n\nafter")
+        #expect(blocks.count == 3)
+        #expect(blocks[0].content == "> a\n> b")
+        #expect(blocks[2].content == "after")
     }
 
-    @Test("An unknown [!type] is not treated as a callout opener")
-    func unknownCalloutNotMerged() {
+    @Test("An unknown [!type] still merges as a plain block quote")
+    func unknownCalloutMergesAsQuote() {
         let blocks = BlockParser.parse("> [!bogus]\n> b")
-        #expect(blocks.count == 2)
+        #expect(blocks.count == 1)
     }
 
     @Test("Single line produces one block")
@@ -351,27 +355,24 @@ struct BlockParserTests {
         #expect(blocks[0].range == NSRange(location: 0, length: (text as NSString).length))
     }
 
-    // MARK: - Blockquotes (each line is its own block)
+    // MARK: - Blockquotes (consecutive lines merge into one block)
 
-    @Test("Consecutive blockquote lines are separate blocks")
-    func blockquoteSeparateBlocks() {
+    @Test("Consecutive blockquote lines merge into one block")
+    func blockquoteMergedBlock() {
         let text = "> line1\n> line2\n> line3"
         let blocks = BlockParser.parse(text)
-        #expect(blocks.count == 3)
-        #expect(blocks[0].content == "> line1")
-        #expect(blocks[1].content == "> line2")
-        #expect(blocks[2].content == "> line3")
+        #expect(blocks.count == 1)
+        #expect(blocks[0].content == "> line1\n> line2\n> line3")
     }
 
     @Test("Blockquote between paragraphs")
     func blockquoteBetweenParagraphs() {
         let text = "above\n> line1\n> line2\nbelow"
         let blocks = BlockParser.parse(text)
-        #expect(blocks.count == 4)
+        #expect(blocks.count == 3)
         #expect(blocks[0].content == "above")
-        #expect(blocks[1].content == "> line1")
-        #expect(blocks[2].content == "> line2")
-        #expect(blocks[3].content == "below")
+        #expect(blocks[1].content == "> line1\n> line2")
+        #expect(blocks[2].content == "below")
     }
 
     @Test("Single blockquote line is one block")
@@ -382,12 +383,12 @@ struct BlockParserTests {
         #expect(blocks[0].content == "> just one")
     }
 
-    @Test("Blockquote line range covers single line")
+    @Test("A merged blockquote's range spans all its lines")
     func blockquoteRange() {
         let text = "> a\n> b"
         let blocks = BlockParser.parse(text)
-        #expect(blocks[0].range == NSRange(location: 0, length: 3))
-        #expect(blocks[1].range == NSRange(location: 4, length: 3))
+        #expect(blocks.count == 1)
+        #expect(blocks[0].range == NSRange(location: 0, length: 7))
     }
 
     @Test("Non-consecutive blockquotes are separate blocks")

--- a/Tests/MarkdownEditorTests/BlockParserTests.swift
+++ b/Tests/MarkdownEditorTests/BlockParserTests.swift
@@ -15,6 +15,27 @@ struct BlockParserTests {
         #expect(blocks[0].range == NSRange(location: 0, length: 0))
     }
 
+    @Test("A callout merges its block-quote lines into one block")
+    func calloutMerges() {
+        let blocks = BlockParser.parse("> [!note]\n> line one\n> line two\n\nafter")
+        // The three `>` lines form one callout block; blank + "after" follow.
+        #expect(blocks.count == 3)
+        #expect(blocks[0].content == "> [!note]\n> line one\n> line two")
+        #expect(blocks[2].content == "after")
+    }
+
+    @Test("A plain block quote stays split per line (unchanged)")
+    func plainQuoteNotMerged() {
+        let blocks = BlockParser.parse("> a\n> b")
+        #expect(blocks.count == 2)
+    }
+
+    @Test("An unknown [!type] is not treated as a callout opener")
+    func unknownCalloutNotMerged() {
+        let blocks = BlockParser.parse("> [!bogus]\n> b")
+        #expect(blocks.count == 2)
+    }
+
     @Test("Single line produces one block")
     func singleLine() {
         let blocks = BlockParser.parse("hello")

--- a/Tests/MarkdownEditorTests/BlockStylingTests.swift
+++ b/Tests/MarkdownEditorTests/BlockStylingTests.swift
@@ -131,15 +131,15 @@ struct BlockStylingActiveTests {
         #expect(delimColor == NSColor.tertiaryLabelColor)
     }
 
-    @Test("Active blockquote line shows its raw text")
+    @Test("Active blockquote shows its raw text")
     @MainActor func activeBlockquoteLine() {
         let editor = makeEditor()
         editor.loadContent("> line1\n> line2\nother")
         activateBlock(0, in: editor)
 
-        // Each > line is its own block now
+        // Consecutive `>` lines merge into one block.
         let text = displayText(for: 0, in: editor)
-        #expect(text == "> line1")
+        #expect(text == "> line1\n> line2")
     }
 }
 
@@ -333,23 +333,17 @@ struct BlockStylingNonActiveTests {
         #expect(!ps2!.textBlocks.isEmpty)
     }
 
-    @Test("Non-active consecutive blockquote lines: each > hidden independently")
+    @Test("Non-active merged blockquote hides each > delimiter")
     @MainActor func nonActiveConsecutiveBlockquoteLines() {
         let editor = makeEditor()
-        // Each > line is its own block; activate the last block
+        // Consecutive `>` lines merge into one block; "other" is the next block.
         editor.loadContent("> line1\n> line2\nother")
-        activateBlock(2, in: editor)
+        activateBlock(1, in: editor)   // activate "other"; the quote stays rendered
 
-        // Block 0: "> line1", > hidden
-        let text0 = displayText(for: 0, in: editor)
-        #expect(text0 == "> line1")
-        #expect(fgColor(at: 0, in: editor) == NSColor.clear)
-
-        // Block 1: "> line2", > hidden
-        let text1 = displayText(for: 1, in: editor)
-        #expect(text1 == "> line2")
-        let b1 = editor.displayRanges[1].location
-        #expect(fgColor(at: b1, in: editor) == NSColor.clear)
+        #expect(displayText(for: 0, in: editor) == "> line1\n> line2")
+        // Both lines' `>` delimiters are hidden (clear, width-preserved).
+        #expect(fgColor(at: 0, in: editor) == NSColor.clear)   // line1 `>`
+        #expect(fgColor(at: 8, in: editor) == NSColor.clear)   // line2 `>`
     }
 
     @Test("Non-active blockquote line has text block style")

--- a/Tests/MarkdownEditorTests/BlockquoteContinuationTests.swift
+++ b/Tests/MarkdownEditorTests/BlockquoteContinuationTests.swift
@@ -1,0 +1,61 @@
+import Testing
+import AppKit
+@testable import MarkdownEditorCore
+
+@Suite("EditorTextView — Block-quote / Callout Continuation")
+struct BlockquoteContinuationTests {
+
+    @Test("Enter at the end of a callout body line continues with '> '")
+    @MainActor func continueCalloutBody() {
+        let editor = makeEditor()
+        editor.loadContent("> [!note]\n> body")
+        editor.setSelectedRange(NSRange(location: (editor.rawSource as NSString).length, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "> [!note]\n> body\n> ")
+    }
+
+    @Test("Enter after the callout header continues with '> '")
+    @MainActor func continueCalloutHeader() {
+        let editor = makeEditor()
+        editor.loadContent("> [!note]")
+        editor.setSelectedRange(NSRange(location: 9, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "> [!note]\n> ")
+    }
+
+    @Test("Enter on an empty quote line breaks out of the callout")
+    @MainActor func breakOutOnEmpty() {
+        let editor = makeEditor()
+        editor.loadContent("> [!note]\n> ")
+        editor.setSelectedRange(NSRange(location: 12, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "> [!note]\n")
+    }
+
+    @Test("Plain block quotes continue too")
+    @MainActor func continuePlainQuote() {
+        let editor = makeEditor()
+        editor.loadContent("> quote")
+        editor.setSelectedRange(NSRange(location: 7, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "> quote\n> ")
+    }
+
+    @Test("Non-quote lines get a normal newline")
+    @MainActor func normalNewline() {
+        let editor = makeEditor()
+        editor.loadContent("hello")
+        editor.setSelectedRange(NSRange(location: 5, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "hello\n")
+    }
+
+    @Test("Indented quote keeps its indentation")
+    @MainActor func indentedQuote() {
+        let editor = makeEditor()
+        editor.loadContent("  > note")
+        editor.setSelectedRange(NSRange(location: 8, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "  > note\n  > ")
+    }
+}

--- a/Tests/MarkdownEditorTests/BlockquoteDeletionTests.swift
+++ b/Tests/MarkdownEditorTests/BlockquoteDeletionTests.swift
@@ -1,0 +1,56 @@
+import Testing
+import AppKit
+@testable import MarkdownEditorCore
+
+/// Regression: characters in a callout / block quote must stay deletable.
+///
+/// Each rendered block becomes one NSTextBlock ("table cell"), and NSTextView
+/// refuses `deleteBackward` at the boundary between two adjacent cells. When
+/// block-quote lines were split per line, deleting toward a line end silently
+/// did nothing. Merging a quote's lines into one block (one cell) fixes it —
+/// this test runs the real, laid-out delete path in a window to catch it.
+@Suite("Block-quote / callout deletion")
+struct BlockquoteDeletionTests {
+
+    @MainActor private func windowed() -> EditorTextView {
+        let e = makeEditor()
+        let win = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 400, height: 400),
+                           styleMask: [.titled], backing: .buffered, defer: false)
+        let scroll = NSScrollView(frame: win.contentLayoutRect)
+        scroll.documentView = e
+        win.contentView = scroll
+        win.makeFirstResponder(e)
+        return e
+    }
+
+    @Test("Deleting through a multi-line callout's header keeps working")
+    @MainActor func deleteThroughCalloutHeader() {
+        let e = windowed()
+        e.loadContent("> [!note]\n> hi\n> there")
+        e.setSelectedRange(NSRange(location: 9, length: 0))   // end of "> [!note]"
+        e.recompose(cursorInRaw: 9)
+        e.layoutManager?.ensureLayout(for: e.textContainer!)
+
+        // Delete the whole "[!note]" marker, one char at a time.
+        for _ in 0..<7 {
+            let before = e.rawSource
+            e.deleteBackward(nil)
+            e.layoutManager?.ensureLayout(for: e.textContainer!)
+            #expect(e.rawSource != before)   // every press must remove a character
+        }
+        #expect(e.rawSource == "> \n> hi\n> there")
+    }
+
+    @Test("Deleting at a plain multi-line quote's internal line end works")
+    @MainActor func deleteAtQuoteLineEnd() {
+        let e = windowed()
+        e.loadContent("> aaa\n> bbb")
+        e.setSelectedRange(NSRange(location: 5, length: 0))   // end of "> aaa"
+        e.recompose(cursorInRaw: 5)
+        e.layoutManager?.ensureLayout(for: e.textContainer!)
+        let before = e.rawSource
+        e.deleteBackward(nil)
+        #expect(e.rawSource != before)
+        #expect(e.rawSource == "> aa\n> bbb")
+    }
+}

--- a/Tests/MarkdownEditorTests/CalloutRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/CalloutRenderingTests.swift
@@ -5,12 +5,11 @@ import AppKit
 @Suite("Callout — rendering")
 struct CalloutRenderingTests {
 
-    private let noteHex = Callout.defaultStyles["note"]!.colorHex
     private let leftEdge = NSRectEdge(rawValue: 0)!
 
     // "> [!note]…"  indices: 0'>' 1' ' 2'[' 3'!' 4'n' 5'o' 6't' 7'e' 8']'
 
-    @Test("Rendered callout: header replaced by an image, source hidden, colored bar")
+    @Test("Rendered callout: header replaced by an image, source hidden, tinted bg, no border")
     @MainActor func rendered() {
         let editor = makeEditor()
         let styled = editor.styleBlock("> [!note]\n> body")
@@ -22,10 +21,11 @@ struct CalloutRenderingTests {
         // The raw "[!note]" header is hidden (near-zero font + clear) — its title
         // is drawn inside the image instead.
         for i in 3...8 { #expect(isHidden(at: i, in: styled)) }
-        // The left bar is the callout color.
-        let ps = styled.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
-        #expect(ps?.textBlocks.first?.borderColor(for: leftEdge)?.hexString
-                == NSColor(hex: noteHex)?.hexString)
+        // A tinted background marks the callout; no border by default.
+        let block = styled.attribute(.paragraphStyle, at: 0, effectiveRange: nil)
+            .flatMap { ($0 as? NSParagraphStyle)?.textBlocks.first }
+        #expect(block?.backgroundColor != nil)
+        #expect(block?.borderColor(for: leftEdge) == nil)
     }
 
     @Test("Unknown type stays a plain block quote")
@@ -44,15 +44,14 @@ struct CalloutRenderingTests {
         #expect(!isHidden(at: 2, in: styled))   // "[" visible (dimmed), editable
     }
 
-    @Test("The colored bar covers the callout's body lines too")
-    @MainActor func barCoversBody() {
+    @Test("The tinted background covers the callout's body lines too")
+    @MainActor func backgroundCoversBody() {
         let editor = makeEditor()
         let styled = editor.styleBlock("> [!note]\n> body line")
         let bodyIdx = (styled.string as NSString).range(of: "body").location
         #expect(bodyIdx != NSNotFound)
         let ps = styled.attribute(.paragraphStyle, at: bodyIdx, effectiveRange: nil) as? NSParagraphStyle
-        #expect(ps?.textBlocks.first?.borderColor(for: leftEdge)?.hexString
-                == NSColor(hex: noteHex)?.hexString)
+        #expect(ps?.textBlocks.first?.backgroundColor != nil)
     }
 
     @Test("Custom title text is hidden (drawn in the header image)")

--- a/Tests/MarkdownEditorTests/CalloutRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/CalloutRenderingTests.swift
@@ -10,37 +10,33 @@ struct CalloutRenderingTests {
 
     // "> [!note]…"  indices: 0'>' 1' ' 2'[' 3'!' 4'n' 5'o' 6't' 7'e' 8']'
 
-    @Test("Rendered callout: icon, hidden brackets, colored bold label, colored bar")
+    @Test("Rendered callout: header replaced by an image, source hidden, colored bar")
     @MainActor func rendered() {
         let editor = makeEditor()
         let styled = editor.styleBlock("> [!note]\n> body")
 
-        // Icon attachment replaces "[".
-        #expect(styled.attribute(.attachment, at: 2, effectiveRange: nil) is NSTextAttachment)
-        // "!" and "]" are hidden (near-zero font + clear).
-        #expect(isHidden(at: 3, in: styled))
-        #expect(isHidden(at: 8, in: styled))
-        // The type label "note" is colored and bold.
-        let fg = styled.attribute(.foregroundColor, at: 4, effectiveRange: nil) as? NSColor
-        #expect(fg?.hexString == NSColor(hex: noteHex)?.hexString)
-        let f = styled.attribute(.font, at: 4, effectiveRange: nil) as? NSFont
-        #expect(f.map { NSFontManager.shared.traits(of: $0).contains(.boldFontMask) } == true)
+        // The header image sits on "[".
+        let att = styled.attribute(.attachment, at: 2, effectiveRange: nil) as? NSTextAttachment
+        #expect(att != nil)
+        #expect(att?.image != nil)
+        // The raw "[!note]" header is hidden (near-zero font + clear) — its title
+        // is drawn inside the image instead.
+        for i in 3...8 { #expect(isHidden(at: i, in: styled)) }
         // The left bar is the callout color.
         let ps = styled.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
-        let block = ps?.textBlocks.first
-        #expect(block?.borderColor(for: leftEdge)?.hexString == NSColor(hex: noteHex)?.hexString)
+        #expect(ps?.textBlocks.first?.borderColor(for: leftEdge)?.hexString
+                == NSColor(hex: noteHex)?.hexString)
     }
 
     @Test("Unknown type stays a plain block quote")
     @MainActor func unknownPlain() {
         let editor = makeEditor()
         let styled = editor.styleBlock("> [!bogus]\n> body")
-        // No icon; the literal "[!bogus]" stays visible.
         #expect(styled.attribute(.attachment, at: 2, effectiveRange: nil) == nil)
         #expect(!isHidden(at: 3, in: styled))
     }
 
-    @Test("Active callout shows the raw marker, no icon")
+    @Test("Active callout shows the raw marker, no image")
     @MainActor func activeRaw() {
         let editor = makeEditor()
         let styled = editor.styleBlock("> [!note]\n> body", cursorPosition: 4)
@@ -52,8 +48,6 @@ struct CalloutRenderingTests {
     @MainActor func barCoversBody() {
         let editor = makeEditor()
         let styled = editor.styleBlock("> [!note]\n> body line")
-        // Pick a character on the body line and confirm it carries the same
-        // colored bar as the header line.
         let bodyIdx = (styled.string as NSString).range(of: "body").location
         #expect(bodyIdx != NSNotFound)
         let ps = styled.attribute(.paragraphStyle, at: bodyIdx, effectiveRange: nil) as? NSParagraphStyle
@@ -61,13 +55,31 @@ struct CalloutRenderingTests {
                 == NSColor(hex: noteHex)?.hexString)
     }
 
-    @Test("Case-insensitive type renders as a callout")
-    @MainActor func caseInsensitiveRenders() {
+    @Test("Custom title text is hidden (drawn in the header image)")
+    @MainActor func customTitleHidden() {
         let editor = makeEditor()
-        let styled = editor.styleBlock("> [!TIP]\n> body")
-        #expect(styled.attribute(.attachment, at: 2, effectiveRange: nil) is NSTextAttachment)
-        let tipHex = Callout.defaultStyles["tip"]!.colorHex
-        let fg = styled.attribute(.foregroundColor, at: 4, effectiveRange: nil) as? NSColor
-        #expect(fg?.hexString == NSColor(hex: tipHex)?.hexString)
+        let styled = editor.styleBlock("> [!note] My Title\n> body")
+        // "My Title" (after the marker) is part of the hidden header.
+        let r = (styled.string as NSString).range(of: "My Title")
+        #expect(r.location != NSNotFound)
+        #expect(isHidden(at: r.location, in: styled))
+    }
+
+    @Test("Style overrides change the bar color and border edges")
+    @MainActor func overridesApplied() {
+        let editor = makeEditor()
+        editor.calloutStyleOverrides = [
+            "note": CalloutStyle(symbolName: "star.fill", colorHex: "#112233",
+                                 borderEdges: .all, borderWidth: 2)
+        ]
+        let styled = editor.styleBlock("> [!note]\n> body")
+        let block = styled.attribute(.paragraphStyle, at: 0, effectiveRange: nil)
+            .flatMap { ($0 as? NSParagraphStyle)?.textBlocks.first }
+        #expect(block?.borderColor(for: leftEdge)?.hexString == NSColor(hex: "#112233")?.hexString)
+        // All four edges now have a border.
+        let top = NSRectEdge(rawValue: 1)!, right = NSRectEdge(rawValue: 2)!, bottom = NSRectEdge(rawValue: 3)!
+        #expect(block?.borderColor(for: top) != nil)
+        #expect(block?.borderColor(for: right) != nil)
+        #expect(block?.borderColor(for: bottom) != nil)
     }
 }

--- a/Tests/MarkdownEditorTests/CalloutRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/CalloutRenderingTests.swift
@@ -44,6 +44,22 @@ struct CalloutRenderingTests {
         #expect(!isHidden(at: 2, in: styled))   // "[" visible (dimmed), editable
     }
 
+    @Test("Callout's left inset does not exceed a plain block quote's")
+    @MainActor func leftInsetNotLargerThanBlockquote() {
+        let editor = makeEditor()
+        let left = leftEdge
+        func leftInset(_ s: String) -> CGFloat {
+            let st = editor.styleBlock(s)
+            guard let b = (st.attribute(.paragraphStyle, at: 0, effectiveRange: nil)
+                as? NSParagraphStyle)?.textBlocks.first else { return -1 }
+            return b.width(for: .border, edge: left) + b.width(for: .padding, edge: left)
+        }
+        let callout = leftInset("> [!note]\n> x")
+        let quote = leftInset("> x")
+        #expect(callout > 0 && quote > 0)
+        #expect(callout <= quote + 0.01)
+    }
+
     @Test("The tinted background covers the callout's body lines too")
     @MainActor func backgroundCoversBody() {
         let editor = makeEditor()

--- a/Tests/MarkdownEditorTests/CalloutRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/CalloutRenderingTests.swift
@@ -1,0 +1,73 @@
+import Testing
+import AppKit
+@testable import MarkdownEditorCore
+
+@Suite("Callout — rendering")
+struct CalloutRenderingTests {
+
+    private let noteHex = Callout.defaultStyles["note"]!.colorHex
+    private let leftEdge = NSRectEdge(rawValue: 0)!
+
+    // "> [!note]…"  indices: 0'>' 1' ' 2'[' 3'!' 4'n' 5'o' 6't' 7'e' 8']'
+
+    @Test("Rendered callout: icon, hidden brackets, colored bold label, colored bar")
+    @MainActor func rendered() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("> [!note]\n> body")
+
+        // Icon attachment replaces "[".
+        #expect(styled.attribute(.attachment, at: 2, effectiveRange: nil) is NSTextAttachment)
+        // "!" and "]" are hidden (near-zero font + clear).
+        #expect(isHidden(at: 3, in: styled))
+        #expect(isHidden(at: 8, in: styled))
+        // The type label "note" is colored and bold.
+        let fg = styled.attribute(.foregroundColor, at: 4, effectiveRange: nil) as? NSColor
+        #expect(fg?.hexString == NSColor(hex: noteHex)?.hexString)
+        let f = styled.attribute(.font, at: 4, effectiveRange: nil) as? NSFont
+        #expect(f.map { NSFontManager.shared.traits(of: $0).contains(.boldFontMask) } == true)
+        // The left bar is the callout color.
+        let ps = styled.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        let block = ps?.textBlocks.first
+        #expect(block?.borderColor(for: leftEdge)?.hexString == NSColor(hex: noteHex)?.hexString)
+    }
+
+    @Test("Unknown type stays a plain block quote")
+    @MainActor func unknownPlain() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("> [!bogus]\n> body")
+        // No icon; the literal "[!bogus]" stays visible.
+        #expect(styled.attribute(.attachment, at: 2, effectiveRange: nil) == nil)
+        #expect(!isHidden(at: 3, in: styled))
+    }
+
+    @Test("Active callout shows the raw marker, no icon")
+    @MainActor func activeRaw() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("> [!note]\n> body", cursorPosition: 4)
+        #expect(styled.attribute(.attachment, at: 2, effectiveRange: nil) == nil)
+        #expect(!isHidden(at: 2, in: styled))   // "[" visible (dimmed), editable
+    }
+
+    @Test("The colored bar covers the callout's body lines too")
+    @MainActor func barCoversBody() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("> [!note]\n> body line")
+        // Pick a character on the body line and confirm it carries the same
+        // colored bar as the header line.
+        let bodyIdx = (styled.string as NSString).range(of: "body").location
+        #expect(bodyIdx != NSNotFound)
+        let ps = styled.attribute(.paragraphStyle, at: bodyIdx, effectiveRange: nil) as? NSParagraphStyle
+        #expect(ps?.textBlocks.first?.borderColor(for: leftEdge)?.hexString
+                == NSColor(hex: noteHex)?.hexString)
+    }
+
+    @Test("Case-insensitive type renders as a callout")
+    @MainActor func caseInsensitiveRenders() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("> [!TIP]\n> body")
+        #expect(styled.attribute(.attachment, at: 2, effectiveRange: nil) is NSTextAttachment)
+        let tipHex = Callout.defaultStyles["tip"]!.colorHex
+        let fg = styled.attribute(.foregroundColor, at: 4, effectiveRange: nil) as? NSColor
+        #expect(fg?.hexString == NSColor(hex: tipHex)?.hexString)
+    }
+}

--- a/Tests/MarkdownEditorTests/CalloutTests.swift
+++ b/Tests/MarkdownEditorTests/CalloutTests.swift
@@ -72,6 +72,36 @@ struct CalloutStyleTests {
         #expect(Callout.style(for: "bogus") == nil)
     }
 
+    @Test("GitHub types use the requested SF Symbols")
+    func githubIcons() {
+        #expect(Callout.style(for: "note")?.symbolName == "pencil.line")
+        #expect(Callout.style(for: "tip")?.symbolName == "lightbulb.max")
+        #expect(Callout.style(for: "important")?.symbolName == "exclamationmark.bubble")
+        #expect(Callout.style(for: "warning")?.symbolName == "exclamationmark.triangle")
+        #expect(Callout.style(for: "caution")?.symbolName == "exclamationmark.octagon")
+    }
+
+    @Test("Obsidian's default types and aliases all resolve")
+    func obsidianTypes() {
+        let types = ["abstract", "summary", "tldr", "info", "todo", "success", "check",
+                     "done", "question", "help", "faq", "failure", "fail", "missing",
+                     "danger", "error", "bug", "example", "quote", "cite", "hint", "attention"]
+        for t in types { #expect(Callout.style(for: t) != nil, "expected '\(t)' to resolve") }
+    }
+
+    @Test("Aliases share their primary type's style")
+    func aliases() {
+        #expect(Callout.style(for: "summary") == Callout.style(for: "abstract"))
+        #expect(Callout.style(for: "done") == Callout.style(for: "success"))
+        #expect(Callout.style(for: "error") == Callout.style(for: "danger"))
+        #expect(Callout.style(for: "cite") == Callout.style(for: "quote"))
+    }
+
+    @Test("Callouts have no border by default (background only)")
+    func noBorderByDefault() {
+        #expect(Callout.style(for: "note")?.borderEdges == [])
+    }
+
     @Test("Overrides win and can add custom types (customization-ready)")
     func overrides() {
         let custom = CalloutStyle(symbolName: "star.fill", colorHex: "#123456")

--- a/Tests/MarkdownEditorTests/CalloutTests.swift
+++ b/Tests/MarkdownEditorTests/CalloutTests.swift
@@ -1,0 +1,63 @@
+import Testing
+import Foundation
+@testable import MarkdownEditorCore
+
+@Suite("Callout — marker parsing")
+struct CalloutMarkerTests {
+
+    @Test("Parses [!note] into component ranges, lowercased")
+    func basic() {
+        let m = Callout.parseMarker("[!note]")
+        #expect(m?.type == "note")
+        #expect(m?.openBracket == NSRange(location: 0, length: 2))   // "[!"
+        #expect(m?.typeRange == NSRange(location: 2, length: 4))     // "note"
+        #expect(m?.closeBracket == NSRange(location: 6, length: 1))  // "]"
+    }
+
+    @Test("Type matching is case-insensitive")
+    func caseInsensitive() {
+        #expect(Callout.parseMarker("[!NOTE]")?.type == "note")
+        #expect(Callout.parseMarker("[!Tip]")?.type == "tip")
+        #expect(Callout.parseMarker("[!WARNING] title")?.type == "warning")
+    }
+
+    @Test("Allows leading whitespace before the marker")
+    func leadingWhitespace() {
+        let m = Callout.parseMarker("  [!caution]")
+        #expect(m?.type == "caution")
+        #expect(m?.openBracket.location == 2)
+    }
+
+    @Test("Rejects non-markers")
+    func rejects() {
+        #expect(Callout.parseMarker("not a callout") == nil)
+        #expect(Callout.parseMarker("[!]") == nil)            // empty type
+        #expect(Callout.parseMarker("[!note") == nil)         // no closing bracket
+        #expect(Callout.parseMarker("text [!note]") == nil)   // not at the start
+    }
+}
+
+@Suite("Callout — style registry")
+struct CalloutStyleTests {
+
+    @Test("GitHub's five types resolve, case-insensitively")
+    func known() {
+        #expect(Callout.style(for: "note") != nil)
+        #expect(Callout.style(for: "TIP") != nil)
+        #expect(Callout.style(for: "Important") != nil)
+        #expect(Callout.style(for: "warning") != nil)
+        #expect(Callout.style(for: "caution") != nil)
+    }
+
+    @Test("Unknown types are not callouts")
+    func unknown() {
+        #expect(Callout.style(for: "bogus") == nil)
+    }
+
+    @Test("Overrides win and can add custom types (customization-ready)")
+    func overrides() {
+        let custom = CalloutStyle(symbolName: "star.fill", colorHex: "#123456")
+        #expect(Callout.style(for: "FAQ", overrides: ["faq": custom]) == custom)
+        #expect(Callout.style(for: "note", overrides: ["note": custom]) == custom)
+    }
+}

--- a/Tests/MarkdownEditorTests/CalloutTests.swift
+++ b/Tests/MarkdownEditorTests/CalloutTests.swift
@@ -37,6 +37,24 @@ struct CalloutMarkerTests {
     }
 }
 
+@Suite("Callout — title")
+struct CalloutTitleTests {
+
+    @Test("No custom title → capitalized type (note/NOTE both render Note)")
+    func capitalized() {
+        // parseMarker lowercases the type, so both `[!note]` and `[!NOTE]`
+        // arrive here as "note".
+        #expect(Callout.title(type: "note", customTitle: "") == "Note")
+        #expect(Callout.title(type: "warning", customTitle: "   ") == "Warning")
+    }
+
+    @Test("Custom title is used verbatim (trimmed), preserving case")
+    func customTitle() {
+        #expect(Callout.title(type: "note", customTitle: " My Title ") == "My Title")
+        #expect(Callout.title(type: "tip", customTitle: "DON'T") == "DON'T")
+    }
+}
+
 @Suite("Callout — style registry")
 struct CalloutStyleTests {
 
@@ -59,5 +77,28 @@ struct CalloutStyleTests {
         let custom = CalloutStyle(symbolName: "star.fill", colorHex: "#123456")
         #expect(Callout.style(for: "FAQ", overrides: ["faq": custom]) == custom)
         #expect(Callout.style(for: "note", overrides: ["note": custom]) == custom)
+    }
+
+    @Test("Color resolution picks the dark accent under a dark appearance")
+    func darkResolution() {
+        let note = Callout.defaultStyles["note"]!
+        #expect(note.accentHex(dark: false) == "#0969DA")
+        #expect(note.accentHex(dark: true) == "#1F6FEB")
+        // Border falls back to the (appearance-specific) accent when unset.
+        #expect(note.resolvedBorderHex(dark: true) == "#1F6FEB")
+        // No explicit background by default → renderer derives one from the accent.
+        #expect(note.explicitBackgroundHex(dark: false) == nil)
+    }
+
+    @Test("Customizable fields are honored")
+    func customFields() {
+        let s = CalloutStyle(symbolName: "x", colorHex: "#111111",
+                             borderColorHex: "#222222",
+                             backgroundColorHex: "#333333",
+                             borderEdges: [.left, .top], borderWidth: 5)
+        #expect(s.resolvedBorderHex(dark: false) == "#222222")
+        #expect(s.explicitBackgroundHex(dark: false) == "#333333")
+        #expect(s.borderEdges.contains(.top))
+        #expect(s.borderWidth == 5)
     }
 }

--- a/Tests/MarkdownEditorTests/CalloutTests.swift
+++ b/Tests/MarkdownEditorTests/CalloutTests.swift
@@ -75,7 +75,7 @@ struct CalloutStyleTests {
     @Test("Built-in types use the expected SF Symbols")
     func builtinIcons() {
         #expect(Callout.style(for: "note")?.symbolName == "pencil.tip")
-        #expect(Callout.style(for: "tip")?.symbolName == "lightbulb")
+        #expect(Callout.style(for: "tip")?.symbolName == "flame")
         #expect(Callout.style(for: "important")?.symbolName == "exclamationmark.bubble")
         #expect(Callout.style(for: "warning")?.symbolName == "exclamationmark.triangle")
         #expect(Callout.style(for: "caution")?.symbolName == "exclamationmark.octagon")

--- a/Tests/MarkdownEditorTests/CalloutTests.swift
+++ b/Tests/MarkdownEditorTests/CalloutTests.swift
@@ -79,7 +79,7 @@ struct CalloutStyleTests {
         #expect(Callout.style(for: "important")?.symbolName == "exclamationmark.bubble")
         #expect(Callout.style(for: "warning")?.symbolName == "exclamationmark.triangle")
         #expect(Callout.style(for: "caution")?.symbolName == "exclamationmark.octagon")
-        #expect(Callout.style(for: "todo")?.symbolName == "circle.dotted")
+        #expect(Callout.style(for: "todo")?.symbolName == "circle.dashed")
         #expect(Callout.style(for: "success")?.symbolName == "checkmark")
         #expect(Callout.style(for: "failure")?.symbolName == "xmark")
     }

--- a/Tests/MarkdownEditorTests/CalloutTests.swift
+++ b/Tests/MarkdownEditorTests/CalloutTests.swift
@@ -72,13 +72,23 @@ struct CalloutStyleTests {
         #expect(Callout.style(for: "bogus") == nil)
     }
 
-    @Test("GitHub types use the requested SF Symbols")
-    func githubIcons() {
-        #expect(Callout.style(for: "note")?.symbolName == "pencil.line")
-        #expect(Callout.style(for: "tip")?.symbolName == "lightbulb.max")
+    @Test("Built-in types use the expected SF Symbols")
+    func builtinIcons() {
+        #expect(Callout.style(for: "note")?.symbolName == "pencil.tip")
+        #expect(Callout.style(for: "tip")?.symbolName == "lightbulb")
         #expect(Callout.style(for: "important")?.symbolName == "exclamationmark.bubble")
         #expect(Callout.style(for: "warning")?.symbolName == "exclamationmark.triangle")
         #expect(Callout.style(for: "caution")?.symbolName == "exclamationmark.octagon")
+        #expect(Callout.style(for: "todo")?.symbolName == "circle.dotted")
+        #expect(Callout.style(for: "success")?.symbolName == "checkmark")
+        #expect(Callout.style(for: "failure")?.symbolName == "xmark")
+    }
+
+    @Test("note matches info's color; tip matches abstract's; warning aliases match warning")
+    func colorGroupings() {
+        #expect(Callout.style(for: "note")?.colorHex == Callout.style(for: "info")?.colorHex)
+        #expect(Callout.style(for: "tip")?.colorHex == Callout.style(for: "abstract")?.colorHex)
+        #expect(Callout.style(for: "attention")?.colorHex == Callout.style(for: "warning")?.colorHex)
     }
 
     @Test("Obsidian's default types and aliases all resolve")
@@ -111,13 +121,16 @@ struct CalloutStyleTests {
 
     @Test("Color resolution picks the dark accent under a dark appearance")
     func darkResolution() {
-        let note = Callout.defaultStyles["note"]!
-        #expect(note.accentHex(dark: false) == "#0969DA")
-        #expect(note.accentHex(dark: true) == "#1F6FEB")
+        let important = Callout.defaultStyles["important"]!
+        #expect(important.accentHex(dark: false) == "#8250DF")
+        #expect(important.accentHex(dark: true) == "#A371F7")
         // Border falls back to the (appearance-specific) accent when unset.
-        #expect(note.resolvedBorderHex(dark: true) == "#1F6FEB")
+        #expect(important.resolvedBorderHex(dark: true) == "#A371F7")
         // No explicit background by default → renderer derives one from the accent.
-        #expect(note.explicitBackgroundHex(dark: false) == nil)
+        #expect(important.explicitBackgroundHex(dark: false) == nil)
+        // A type with no dark variant falls back to its light accent.
+        let note = Callout.defaultStyles["note"]!
+        #expect(note.accentHex(dark: true) == note.colorHex)
     }
 
     @Test("Customizable fields are honored")

--- a/Tests/MarkdownEditorTests/CalloutTests.swift
+++ b/Tests/MarkdownEditorTests/CalloutTests.swift
@@ -88,6 +88,7 @@ struct CalloutStyleTests {
     func colorGroupings() {
         #expect(Callout.style(for: "note")?.colorHex == Callout.style(for: "info")?.colorHex)
         #expect(Callout.style(for: "tip")?.colorHex == Callout.style(for: "abstract")?.colorHex)
+        #expect(Callout.style(for: "warning")?.colorHex == Callout.style(for: "question")?.colorHex)
         #expect(Callout.style(for: "attention")?.colorHex == Callout.style(for: "warning")?.colorHex)
     }
 

--- a/Tests/MarkdownEditorTests/RecomposeTests.swift
+++ b/Tests/MarkdownEditorTests/RecomposeTests.swift
@@ -1,0 +1,49 @@
+import Testing
+import AppKit
+@testable import MarkdownEditorCore
+
+/// Edits that change block structure must re-style the whole document, not just
+/// the active block — otherwise a neighbor whose meaning changed keeps stale
+/// styling (the "recompose only renders part of the file" glitch).
+@Suite("Recompose — structural edits")
+struct RecomposeTests {
+
+    @MainActor private func calloutBackground(_ ts: NSTextStorage, at i: Int) -> NSColor? {
+        let ps = ts.attributes(at: i, effectiveRange: nil)[.paragraphStyle] as? NSParagraphStyle
+        return ps?.textBlocks.first?.backgroundColor
+    }
+
+    @Test("Removing a callout marker clears the stale background on its former body")
+    @MainActor func unmergeCalloutClearsBody() {
+        let editor = makeEditor()
+        editor.loadContent("> [!note]\n> body line")
+        // Sanity: the body line starts out with the callout background.
+        let ts = editor.textStorage!
+        #expect(calloutBackground(ts, at: (editor.rawSource as NSString).range(of: "body").location) != nil)
+
+        // Delete "[!note]" — the block un-merges (1 → 2 blocks) and "> body line"
+        // is no longer part of a callout.
+        let mk = (editor.rawSource as NSString).range(of: "[!note]")
+        editor.setSelectedRange(NSRange(location: mk.location, length: 0))
+        editor.insertText("", replacementRange: mk)
+
+        let bodyLoc = (editor.textStorage!.string as NSString).range(of: "body").location
+        #expect(calloutBackground(editor.textStorage!, at: bodyLoc) == nil)
+    }
+
+    @Test("Adding a callout marker styles the lines it absorbs")
+    @MainActor func mergeCalloutStylesAbsorbed() {
+        let editor = makeEditor()
+        // Two plain quote lines (separate blocks, no callout background).
+        editor.loadContent(">\n> absorbed")
+        // Type the marker into the first line, making it a callout opener that
+        // merges the second line in.
+        let firstLineEnd = 1  // after ">"
+        editor.setSelectedRange(NSRange(location: firstLineEnd, length: 0))
+        editor.insertText(" [!note]", replacementRange: NSRange(location: firstLineEnd, length: 0))
+
+        let ts = editor.textStorage!
+        let absorbed = (ts.string as NSString).range(of: "absorbed").location
+        #expect(calloutBackground(ts, at: absorbed) != nil)
+    }
+}


### PR DESCRIPTION
## Summary

Adds GitHub/Obsidian-flavored **callouts** — a block quote whose first line is `[!type]` (case-insensitive) — rendered with an SF Symbol icon, a colored title, and a tinted background box. Includes the GitHub set plus Obsidian's full default set (with aliases), per-appearance colors, a customization hook, and Enter-continuation.

## Highlights
- **Detection**: `[!type]` on a block quote's first line; case-insensitive; unknown types stay plain quotes (GitHub behavior). swift-markdown has no native support (its `BlockDirective` is the unrelated DocC `@name{}` form), so it's layered on the existing block-quote span.
- **Rendering**: icon + capitalized/custom title drawn as a header image (so `[!note]`/`[!NOTE]` both show "Note"); tinted background; no border by default; appearance-aware colors with dark variants for the built-ins. Top padding is baked into the header line so it's clickable text space; left padding matches a plain quote.
- **Types**: note, tip, important, warning, caution (GitHub) + abstract/summary/tldr, info, todo, success/check/done, question/help/faq, failure/fail/missing, danger/error, bug, example, quote/cite, hint, attention (Obsidian), each mapped to the closest color + SF Symbol.
- **Customization**: `CalloutStyle` (icon, colors, border edges/width, per-symbol baseline nudge) + an `EditorTextView.calloutStyleOverrides` hook.
- **Editing**: Enter continues the `> ` prefix (auto-continuation); empty quote line breaks out.

## Notable fixes along the way
- **Full recompose on structural edits** — stale styling on neighbor blocks after a callout split/merge.
- **Block-quote lines now merge into one block** — each block is one `NSTextBlock` ("table cell"), and NSTextView refuses `deleteBackward` at cell boundaries; per-line quote cells made callout marker chars undeletable. Merging (one cell per quote) fixes deletion and renders multi-line quotes with one continuous bar.

## Tests
Full suite **497 pass**, including marker parsing, registry/aliases/overrides, dark-color resolution, rendering, the structural-recompose regressions, and a **windowed deletion regression** that exercises the real laid-out delete path.

## Known limitation
Callout **bottom** padding is still `NSTextBlock` block padding (not text space), so clicking that thin bottom strip doesn't enter the callout. Line metrics add height *above* text, not below, so a clean fix needs more work — tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)