### PR TITLE
Recompose redesign: dirty-set styling, TextKit 2, lazy rendering, incremental parse

### DIFF
--- a/Sources/MarkdownEditorCore/Block.swift
+++ b/Sources/MarkdownEditorCore/Block.swift
@@ -32,11 +32,17 @@ public struct Block: Identifiable, Sendable {
     public var content: String
     public var range: NSRange
     public var kind: BlockKind
+    /// Whether the text storage currently holds this block's full styling.
+    /// False = the block is pending lazy styling (base attributes, or stale
+    /// styling scheduled for the drain). Maintained by the recompose engine.
+    public var isStyled: Bool
 
-    public init(id: UUID = UUID(), content: String, range: NSRange, kind: BlockKind = .paragraph) {
+    public init(id: UUID = UUID(), content: String, range: NSRange,
+                kind: BlockKind = .paragraph, isStyled: Bool = false) {
         self.id = id
         self.content = content
         self.range = range
         self.kind = kind
+        self.isStyled = isStyled
     }
 }

--- a/Sources/MarkdownEditorCore/Block.swift
+++ b/Sources/MarkdownEditorCore/Block.swift
@@ -1,22 +1,42 @@
 import Foundation
 
+/// What a block *is* at the line/merge level. Advisory metadata captured
+/// during parsing — used by the recompose engine (e.g. restyling every list
+/// block when the document's indent unit changes) and available to future
+/// outline/folding features. Styling itself still derives from the block's
+/// content, not from this tag.
+public enum BlockKind: Equatable, Sendable {
+    case paragraph
+    case heading(level: Int)
+    case quoteRun(isCallout: Bool)
+    case fence
+    case mathDisplay
+    case table
+    case listItem
+    case thematicBreak
+    case blank
+}
+
 /// A Block is one paragraph of markdown — the unit of rendering.
 ///
 /// Blocks are separated by newlines (`\n`).  Each block carries:
 ///   - `id`:       stable UUID so we can track which block the cursor is in
 ///   - `content`:  the raw markdown text of this paragraph
 ///   - `range`:    the character range within the full document string
+///   - `kind`:     advisory classification (see `BlockKind`)
 ///
 /// The editor renders every block as rich text *except* the one containing
 /// the cursor, which stays as raw markdown so the user can edit it.
 public struct Block: Identifiable, Sendable {
-    public let id: UUID
+    public var id: UUID
     public var content: String
     public var range: NSRange
+    public var kind: BlockKind
 
-    public init(id: UUID = UUID(), content: String, range: NSRange) {
+    public init(id: UUID = UUID(), content: String, range: NSRange, kind: BlockKind = .paragraph) {
         self.id = id
         self.content = content
         self.range = range
+        self.kind = kind
     }
 }

--- a/Sources/MarkdownEditorCore/BlockParser.swift
+++ b/Sources/MarkdownEditorCore/BlockParser.swift
@@ -4,33 +4,36 @@ import Foundation
 /// across re-parses so the "active block" doesn't jump around.
 ///
 /// Strategy:
-///   1. Split the raw string on single newlines (`\n`) to get paragraphs.
+///   1. Split the raw string on single newlines (`\n`) to get paragraphs,
+///      tagging each with its `BlockKind`.
 ///   2. Compute each paragraph's `NSRange` within the full string.
-///   3. Match new paragraphs to previous blocks by content equality to
-///      preserve UUIDs.  Unmatched paragraphs get fresh UUIDs.
+///   3. Preserve UUIDs positionally: blocks in the unchanged prefix and
+///      suffix (by content equality from both ends) keep their previous IDs;
+///      the changed window in between gets fresh ones. The window is also the
+///      exact set of blocks whose styling may have changed — the dirty set
+///      the recompose engine restyles.
 public enum BlockParser {
 
     public static func parse(_ text: String, previous: [Block] = []) -> [Block] {
+        parseWithDiff(text, previous: previous).blocks
+    }
+
+    /// Parses `text` and returns the blocks plus the changed window: the range
+    /// of indices (in the new list) outside the unchanged prefix/suffix.
+    public static func parseWithDiff(
+        _ text: String, previous: [Block] = []
+    ) -> (blocks: [Block], changed: Range<Int>) {
         let nsText = text as NSString
         let paragraphs = splitParagraphs(text)
 
-        var available = previous
         var blocks: [Block] = []
+        blocks.reserveCapacity(paragraphs.count)
         var cursor = 0
 
-        for para in paragraphs {
+        for (para, kind) in paragraphs {
             let length = (para as NSString).length
             let range = NSRange(location: cursor, length: length)
-
-            let id: UUID
-            if let idx = available.firstIndex(where: { $0.content == para }) {
-                id = available[idx].id
-                available.remove(at: idx)
-            } else {
-                id = UUID()
-            }
-
-            blocks.append(Block(id: id, content: para, range: range))
+            blocks.append(Block(content: para, range: range, kind: kind))
 
             // Advance past this paragraph.
             cursor = range.upperBound
@@ -40,18 +43,43 @@ public enum BlockParser {
             }
         }
 
-        return blocks
+        let changed = assignIdentity(old: previous, new: &blocks)
+        return (blocks, changed)
+    }
+
+    /// Positional prefix/suffix diff: scans content equality from the front
+    /// and the back, copies old IDs onto the matches, and returns the changed
+    /// window in new-list indices. O(unchanged + changed); never matches a
+    /// block across the edit (no cross-document ID stealing).
+    static func assignIdentity(old: [Block], new: inout [Block]) -> Range<Int> {
+        var prefix = 0
+        while prefix < old.count && prefix < new.count
+            && old[prefix].content == new[prefix].content {
+            new[prefix].id = old[prefix].id
+            prefix += 1
+        }
+
+        var suffix = 0
+        let maxSuffix = min(old.count, new.count) - prefix  // overlap clamp
+        while suffix < maxSuffix
+            && old[old.count - 1 - suffix].content == new[new.count - 1 - suffix].content {
+            new[new.count - 1 - suffix].id = old[old.count - 1 - suffix].id
+            suffix += 1
+        }
+
+        return prefix ..< (new.count - suffix)
     }
 
     // MARK: - Helpers
 
     /// Splits text into paragraphs on single newlines, merging fenced code blocks
-    /// and table rows into single multi-line blocks.
-    private static func splitParagraphs(_ text: String) -> [String] {
-        if text.isEmpty { return [""] }
+    /// and table rows into single multi-line blocks. Each paragraph is tagged
+    /// with its `BlockKind`.
+    private static func splitParagraphs(_ text: String) -> [(content: String, kind: BlockKind)] {
+        if text.isEmpty { return [("", .blank)] }
 
         let lines = text.components(separatedBy: "\n")
-        var result: [String] = []
+        var result: [(content: String, kind: BlockKind)] = []
         var i = 0
 
         while i < lines.count {
@@ -67,14 +95,14 @@ public enum BlockParser {
                         break
                     }
                 }
-                result.append(merged.joined(separator: "\n"))
+                result.append((merged.joined(separator: "\n"), .fence))
                 continue
             }
 
             // Detect display-math fence: a line starting with `$$`.
             if let closedOnSameLine = displayMathClosedOnSameLine(lines[i]) {
                 if closedOnSameLine {
-                    result.append(lines[i])
+                    result.append((lines[i], .mathDisplay))
                     i += 1
                     continue
                 }
@@ -86,7 +114,7 @@ public enum BlockParser {
                     i += 1
                     if closes { break }
                 }
-                result.append(merged.joined(separator: "\n"))
+                result.append((merged.joined(separator: "\n"), .mathDisplay))
                 continue
             }
 
@@ -97,13 +125,14 @@ public enum BlockParser {
             // between two adjacent cells — so per-line block-quote cells made the
             // marker characters undeletable. One cell per quote avoids that.
             if isBlockquoteLine(lines[i]) {
+                let isCallout = quoteRunOpensCallout(lines[i])
                 var merged = [lines[i]]
                 i += 1
                 while i < lines.count && isBlockquoteLine(lines[i]) {
                     merged.append(lines[i])
                     i += 1
                 }
-                result.append(merged.joined(separator: "\n"))
+                result.append((merged.joined(separator: "\n"), .quoteRun(isCallout: isCallout)))
                 continue
             }
 
@@ -115,15 +144,61 @@ public enum BlockParser {
                     merged.append(lines[i])
                     i += 1
                 }
-                result.append(merged.joined(separator: "\n"))
+                result.append((merged.joined(separator: "\n"), .table))
                 continue
             }
 
-            result.append(lines[i])
+            result.append((lines[i], classifyLine(lines[i])))
             i += 1
         }
 
         return result
+    }
+
+    // MARK: - Line Classification
+
+    /// Classifies a single (non-merged) line. Advisory: see `BlockKind`.
+    private static func classifyLine(_ line: String) -> BlockKind {
+        if line.allSatisfy({ $0 == " " || $0 == "\t" }) { return .blank }
+        let trimmed = line.drop(while: { $0 == " " })
+        let hashes = trimmed.prefix(while: { $0 == "#" }).count
+        if (1...6).contains(hashes),
+           trimmed.count == hashes || trimmed.dropFirst(hashes).first == " " {
+            return .heading(level: hashes)
+        }
+        if isThematicBreakLine(line) { return .thematicBreak }
+        if isListLine(line) { return .listItem }
+        return .paragraph
+    }
+
+    /// Returns true if the line is a bullet (`- `, `* `, `+ `) or ordered
+    /// (`1. `, `1) `) list item, with any leading-space indent.
+    static func isListLine(_ line: String) -> Bool {
+        let trimmed = line.drop(while: { $0 == " " })
+        if trimmed.hasPrefix("- ") || trimmed.hasPrefix("* ") || trimmed.hasPrefix("+ ") {
+            return true
+        }
+        let digits = trimmed.prefix(while: { $0.isNumber })
+        guard !digits.isEmpty else { return false }
+        let rest = trimmed.dropFirst(digits.count)
+        return rest.hasPrefix(". ") || rest.hasPrefix(") ")
+    }
+
+    /// Returns true for a thematic break: 3+ of the same `-`/`*`/`_` character
+    /// and nothing else but spaces.
+    private static func isThematicBreakLine(_ line: String) -> Bool {
+        let stripped = line.filter { $0 != " " && $0 != "\t" }
+        guard stripped.count >= 3, let first = stripped.first,
+              first == "-" || first == "*" || first == "_" else { return false }
+        return stripped.allSatisfy { $0 == first }
+    }
+
+    /// Returns true if the first line of a quote run opens a callout
+    /// (`> [!type]`, known or unknown type).
+    private static func quoteRunOpensCallout(_ firstLine: String) -> Bool {
+        let trimmed = firstLine.drop(while: { $0 == " " })
+        guard trimmed.first == ">" else { return false }
+        return Callout.parseMarker(String(trimmed.dropFirst())) != nil
     }
 
     /// If the line (after optional leading whitespace) starts with `$$`, returns

--- a/Sources/MarkdownEditorCore/BlockParser.swift
+++ b/Sources/MarkdownEditorCore/BlockParser.swift
@@ -47,6 +47,112 @@ public enum BlockParser {
         return (blocks, changed)
     }
 
+    /// Re-parses only the lines affected by an edit, splicing the untouched
+    /// prefix and (shifted) suffix of the previous parse around the re-split
+    /// window — O(edit), not O(document).
+    ///
+    /// The window starts one block before the first affected block: every
+    /// merge rule needs at most that much left context (quote-run adjacency
+    /// and the table header+separator lookahead are single-step; an unclosed
+    /// fence/math opener further up would already contain the edit inside its
+    /// merged block). Downstream, the re-split continues until a produced
+    /// block boundary lands on an old block start at/after the edit's end —
+    /// from there the old parse is provably identical, because a block's
+    /// parse depends only on its own and following lines.
+    ///
+    /// Returns nil when the inputs don't allow it (caller falls back to the
+    /// full parse).
+    public static func incrementalParse(
+        text: String,
+        old: [Block],
+        editedOldRange: NSRange,
+        delta: Int
+    ) -> (blocks: [Block], changed: Range<Int>)? {
+        guard !old.isEmpty else { return nil }
+        let newLength = (text as NSString).length
+        let oldLength = newLength - delta
+        guard editedOldRange.location >= 0,
+              editedOldRange.upperBound <= oldLength else { return nil }
+
+        guard let firstAffected = blockIndex(in: old, forOffset: editedOldRange.location)
+        else { return nil }
+
+        let windowStartIndex = max(0, firstAffected - 1)
+        let windowStartOffset = old[windowStartIndex].range.location
+        let editEndNew = editedOldRange.upperBound + delta
+
+        var buf = LineBuffer(text, from: windowStartOffset)
+        var window: [Block] = []
+        var cursor = windowStartOffset   // new-coords offset of the next block
+        var lineIndex = 0
+        var suffixStart: Int? = nil      // old block index to splice from
+
+        while true {
+            // Resync probe at this block boundary (not at the initial one).
+            if cursor > windowStartOffset && cursor >= editEndNew {
+                let oldOffset = cursor - delta
+                if let j = blockIndex(in: old, forOffset: oldOffset),
+                   old[j].range.location == oldOffset,
+                   oldOffset >= editedOldRange.upperBound {
+                    suffixStart = j
+                    break
+                }
+            }
+
+            guard let (content, kind, next) = consumeBlock(&buf, at: lineIndex) else {
+                break   // end of document: the window runs to the end
+            }
+            let length = (content as NSString).length
+            window.append(Block(content: content,
+                                range: NSRange(location: cursor, length: length),
+                                kind: kind))
+            lineIndex = next
+            cursor += length
+            // Skip the `\n` separator if another line follows; otherwise this
+            // was the document's final block — stop before re-probing (the
+            // boundary we'd probe is the block we just consumed).
+            if buf.line(at: next) != nil { cursor += 1 } else { break }
+        }
+
+        // Trim unchanged leading window blocks (the lookback block usually
+        // re-parses identically): preserve their identity and styling, and
+        // keep the changed window tight.
+        let spliceLimit = suffixStart ?? old.count
+        var keep = 0
+        while keep < window.count, windowStartIndex + keep < spliceLimit,
+              old[windowStartIndex + keep].content == window[keep].content {
+            window[keep].id = old[windowStartIndex + keep].id
+            window[keep].isStyled = old[windowStartIndex + keep].isStyled
+            keep += 1
+        }
+
+        var blocks = Array(old[0..<windowStartIndex])
+        blocks.append(contentsOf: window)
+        if let s = suffixStart {
+            for j in s..<old.count {
+                var b = old[j]
+                b.range.location += delta
+                blocks.append(b)
+            }
+        }
+
+        return (blocks, (windowStartIndex + keep) ..< (windowStartIndex + window.count))
+    }
+
+    /// Binary search over sorted, adjacent block ranges — the same
+    /// inclusive-upper-bound semantics as the editor's lookup (an offset at a
+    /// block's trailing separator maps to that block; past-end clamps to last).
+    private static func blockIndex(in blocks: [Block], forOffset offset: Int) -> Int? {
+        guard !blocks.isEmpty else { return nil }
+        var lo = 0
+        var hi = blocks.count - 1
+        while lo < hi {
+            let mid = (lo + hi) / 2
+            if blocks[mid].range.upperBound < offset { lo = mid + 1 } else { hi = mid }
+        }
+        return lo
+    }
+
     /// Positional prefix/suffix diff: scans content equality from the front
     /// and the back, copies old IDs onto the matches, and returns the changed
     /// window in new-list indices. O(unchanged + changed); never matches a
@@ -74,86 +180,128 @@ public enum BlockParser {
 
     // MARK: - Helpers
 
+    /// Lazily materializes the `\n`-separated line segments of a text starting
+    /// at a given UTF-16 offset. `components(separatedBy: "\n")` semantics:
+    /// number of segments = number of newlines + 1, so a trailing `\n` yields
+    /// a final empty segment. Both the full and incremental parses consume
+    /// lines through this buffer, so they cannot diverge.
+    struct LineBuffer {
+        private let ns: NSString
+        private(set) var lines: [String] = []
+        private var nextOffset: Int
+        private var exhausted = false
+
+        init(_ text: String, from offset: Int = 0) {
+            self.ns = text as NSString
+            self.nextOffset = offset
+        }
+
+        /// The line at index `i` (buffer-relative), fetching as needed.
+        /// Returns nil past the end of the text.
+        mutating func line(at i: Int) -> String? {
+            while lines.count <= i && !exhausted {
+                fetchNext()
+            }
+            return i < lines.count ? lines[i] : nil
+        }
+
+        private mutating func fetchNext() {
+            guard !exhausted else { return }
+            let remaining = NSRange(location: nextOffset, length: ns.length - nextOffset)
+            let nl = ns.range(of: "\n", options: [], range: remaining)
+            if nl.location == NSNotFound {
+                lines.append(ns.substring(with: remaining))
+                exhausted = true
+            } else {
+                lines.append(ns.substring(
+                    with: NSRange(location: nextOffset, length: nl.location - nextOffset)))
+                nextOffset = nl.upperBound
+                if nextOffset == ns.length {
+                    // Trailing newline: one final empty segment.
+                    lines.append("")
+                    exhausted = true
+                }
+            }
+        }
+    }
+
+    /// Consumes one block starting at line `i`, merging multi-line constructs
+    /// (fences, display math, quote runs, tables). Returns the block's
+    /// content/kind and the index of the line after it.
+    static func consumeBlock(_ buf: inout LineBuffer, at i: Int)
+        -> (content: String, kind: BlockKind, next: Int)? {
+        guard let first = buf.line(at: i) else { return nil }
+
+        // Detect opening code fence
+        if let fence = codeFenceInfo(first) {
+            var merged = [first]
+            var j = i + 1
+            while let line = buf.line(at: j) {
+                merged.append(line)
+                j += 1
+                if isClosingFence(line, char: fence.char, count: fence.count) {
+                    break
+                }
+            }
+            return (merged.joined(separator: "\n"), .fence, j)
+        }
+
+        // Detect display-math fence: a line starting with `$$`.
+        if let closedOnSameLine = displayMathClosedOnSameLine(first) {
+            if closedOnSameLine {
+                return (first, .mathDisplay, i + 1)
+            }
+            var merged = [first]
+            var j = i + 1
+            while let line = buf.line(at: j) {
+                merged.append(line)
+                j += 1
+                if line.contains("$$") { break }
+            }
+            return (merged.joined(separator: "\n"), .mathDisplay, j)
+        }
+
+        // Merge a run of consecutive block-quote lines (`>`) into one block.
+        // This covers callouts and plain multi-line block quotes alike, and
+        // gives the editor one styling/activation unit per quote.
+        if isBlockquoteLine(first) {
+            let isCallout = quoteRunOpensCallout(first)
+            var merged = [first]
+            var j = i + 1
+            while let line = buf.line(at: j), isBlockquoteLine(line) {
+                merged.append(line)
+                j += 1
+            }
+            return (merged.joined(separator: "\n"), .quoteRun(isCallout: isCallout), j)
+        }
+
+        // Detect table: header row followed by separator row
+        if isTableRow(first), let second = buf.line(at: i + 1), isTableSeparator(second) {
+            var merged = [first]
+            var j = i + 1
+            while let line = buf.line(at: j), isTableRow(line) || isTableSeparator(line) {
+                merged.append(line)
+                j += 1
+            }
+            return (merged.joined(separator: "\n"), .table, j)
+        }
+
+        return (first, classifyLine(first), i + 1)
+    }
+
     /// Splits text into paragraphs on single newlines, merging fenced code blocks
     /// and table rows into single multi-line blocks. Each paragraph is tagged
     /// with its `BlockKind`.
     private static func splitParagraphs(_ text: String) -> [(content: String, kind: BlockKind)] {
         if text.isEmpty { return [("", .blank)] }
 
-        let lines = text.components(separatedBy: "\n")
+        var buf = LineBuffer(text)
         var result: [(content: String, kind: BlockKind)] = []
         var i = 0
-
-        while i < lines.count {
-            // Detect opening code fence
-            if let fence = codeFenceInfo(lines[i]) {
-                var merged = [lines[i]]
-                i += 1
-                while i < lines.count {
-                    let line = lines[i]
-                    merged.append(line)
-                    i += 1
-                    if isClosingFence(line, char: fence.char, count: fence.count) {
-                        break
-                    }
-                }
-                result.append((merged.joined(separator: "\n"), .fence))
-                continue
-            }
-
-            // Detect display-math fence: a line starting with `$$`.
-            if let closedOnSameLine = displayMathClosedOnSameLine(lines[i]) {
-                if closedOnSameLine {
-                    result.append((lines[i], .mathDisplay))
-                    i += 1
-                    continue
-                }
-                var merged = [lines[i]]
-                i += 1
-                while i < lines.count {
-                    merged.append(lines[i])
-                    let closes = lines[i].contains("$$")
-                    i += 1
-                    if closes { break }
-                }
-                result.append((merged.joined(separator: "\n"), .mathDisplay))
-                continue
-            }
-
-            // Merge a run of consecutive block-quote lines (`>`) into one block.
-            // This covers callouts and plain multi-line block quotes alike. It is
-            // also required for editing: each block becomes a single NSTextBlock
-            // (one "table cell"), and NSTextView refuses to delete at the boundary
-            // between two adjacent cells — so per-line block-quote cells made the
-            // marker characters undeletable. One cell per quote avoids that.
-            if isBlockquoteLine(lines[i]) {
-                let isCallout = quoteRunOpensCallout(lines[i])
-                var merged = [lines[i]]
-                i += 1
-                while i < lines.count && isBlockquoteLine(lines[i]) {
-                    merged.append(lines[i])
-                    i += 1
-                }
-                result.append((merged.joined(separator: "\n"), .quoteRun(isCallout: isCallout)))
-                continue
-            }
-
-            // Detect table: header row followed by separator row
-            if i + 1 < lines.count && isTableRow(lines[i]) && isTableSeparator(lines[i + 1]) {
-                var merged = [lines[i]]
-                i += 1
-                while i < lines.count && (isTableRow(lines[i]) || isTableSeparator(lines[i])) {
-                    merged.append(lines[i])
-                    i += 1
-                }
-                result.append((merged.joined(separator: "\n"), .table))
-                continue
-            }
-
-            result.append((lines[i], classifyLine(lines[i])))
-            i += 1
+        while let (content, kind, next) = consumeBlock(&buf, at: i) {
+            result.append((content, kind))
+            i = next
         }
-
         return result
     }
 

--- a/Sources/MarkdownEditorCore/BlockParser.swift
+++ b/Sources/MarkdownEditorCore/BlockParser.swift
@@ -56,6 +56,7 @@ public enum BlockParser {
         while prefix < old.count && prefix < new.count
             && old[prefix].content == new[prefix].content {
             new[prefix].id = old[prefix].id
+            new[prefix].isStyled = old[prefix].isStyled
             prefix += 1
         }
 
@@ -64,6 +65,7 @@ public enum BlockParser {
         while suffix < maxSuffix
             && old[old.count - 1 - suffix].content == new[new.count - 1 - suffix].content {
             new[new.count - 1 - suffix].id = old[old.count - 1 - suffix].id
+            new[new.count - 1 - suffix].isStyled = old[old.count - 1 - suffix].isStyled
             suffix += 1
         }
 

--- a/Sources/MarkdownEditorCore/EditorTextStorage.swift
+++ b/Sources/MarkdownEditorCore/EditorTextStorage.swift
@@ -1,12 +1,12 @@
 import AppKit
 import CoreText
 
-/// A text storage subclass that preserves `.attachment` attributes on
-/// any character, not just the object replacement character (\u{FFFC}).
+/// A text storage subclass whose `fixAttributes` does font substitution only.
 ///
-/// Standard NSTextStorage strips attachments from non-FFFC characters
-/// during `fixAttributes`. This subclass skips attribute fixing since
-/// the editor explicitly manages all attributes for every character.
+/// The editor explicitly manages every attribute on every character (custom
+/// keys like `.blockDecoration` / `.fragmentOverlay` included), so the
+/// framework's default attribute "fixing" has nothing useful to add — and
+/// historically it stripped attributes the renderer depended on.
 public class EditorTextStorage: NSTextStorage {
     private let backing = NSMutableAttributedString()
 
@@ -38,10 +38,9 @@ public class EditorTextStorage: NSTextStorage {
     }
 
     override public func fixAttributes(in range: NSRange) {
-        // We deliberately skip the framework's default attribute fixing because
-        // it strips .attachment from non-FFFC characters — and the editor places
-        // marker icons (bullet dot, checkbox circle, math image) on real
-        // characters like "-", "[", "$".
+        // We deliberately skip the framework's default attribute fixing — the
+        // editor manages all attributes itself, and the default pass has a
+        // history of stripping what the renderer depends on.
         //
         // But one part of fixing is still needed: font substitution. The body
         // font (a serif/mono) has no glyphs for emoji, CJK, etc.; without

--- a/Sources/MarkdownEditorCore/EditorTextStorage.swift
+++ b/Sources/MarkdownEditorCore/EditorTextStorage.swift
@@ -10,6 +10,48 @@ import CoreText
 public class EditorTextStorage: NSTextStorage {
     private let backing = NSMutableAttributedString()
 
+    /// The accumulated string mutation since the last consume, expressed as
+    /// "this range of the OLD string was replaced, shifting lengths by
+    /// `delta`". Multiple mutations coalesce into the conservative hull.
+    /// This is the single funnel for all string edits (typing, paste, IME),
+    /// so the incremental block parser can re-split only the affected lines.
+    public struct PendingEdit {
+        public var oldRange: NSRange
+        public var delta: Int
+    }
+    public private(set) var pendingEdit: PendingEdit?
+
+    /// Returns and clears the accumulated edit.
+    public func consumePendingEdit() -> PendingEdit? {
+        defer { pendingEdit = nil }
+        return pendingEdit
+    }
+
+    /// Drops accumulated-edit tracking. Programmatic whole-document
+    /// replacements (recompose after load/undo/indent) call this — they
+    /// re-parse from scratch themselves.
+    public func clearPendingEdit() {
+        pendingEdit = nil
+    }
+
+    /// Coalesces a new edit (given in CURRENT-string coordinates) into the
+    /// pending edit (kept in OLD-string coordinates).
+    private func accumulateEdit(currentRange r: NSRange, delta d: Int) {
+        guard var p = pendingEdit else {
+            pendingEdit = PendingEdit(oldRange: r, delta: d)
+            return
+        }
+        // Map the new edit's bounds back to old-string coordinates and take
+        // the hull. Positions at/after the previous edit's replacement shift
+        // back by the previous delta; the max() keeps positions inside or
+        // before it clamped to the previous old range.
+        let start = min(p.oldRange.location, r.location)
+        let end = max(p.oldRange.upperBound, r.upperBound - p.delta)
+        p.oldRange = NSRange(location: start, length: max(0, end - start))
+        p.delta += d
+        pendingEdit = p
+    }
+
     override public var string: String { backing.string }
 
     override public func attributes(
@@ -19,15 +61,18 @@ public class EditorTextStorage: NSTextStorage {
     }
 
     override public func replaceCharacters(in range: NSRange, with str: String) {
+        let delta = (str as NSString).length - range.length
+        accumulateEdit(currentRange: range, delta: delta)
         backing.replaceCharacters(in: range, with: str)
-        edited(.editedCharacters, range: range,
-               changeInLength: (str as NSString).length - range.length)
+        edited(.editedCharacters, range: range, changeInLength: delta)
     }
 
     override public func replaceCharacters(in range: NSRange, with attrString: NSAttributedString) {
+        let delta = attrString.length - range.length
+        accumulateEdit(currentRange: range, delta: delta)
         backing.replaceCharacters(in: range, with: attrString)
         edited([.editedCharacters, .editedAttributes], range: range,
-               changeInLength: attrString.length - range.length)
+               changeInLength: delta)
     }
 
     override public func setAttributes(

--- a/Sources/MarkdownEditorCore/EditorTextView+CalloutRendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+CalloutRendering.swift
@@ -65,12 +65,28 @@ extension EditorTextView {
         guard span.fullRange.upperBound <= result.length else { return }
         let c = resolvedCalloutColors(info.style)
 
-        result.addAttribute(.paragraphStyle,
-                            value: calloutParagraphStyle(borderColor: c.border,
-                                                         backgroundColor: c.background,
-                                                         edges: info.style.borderEdges,
-                                                         borderWidth: info.style.borderWidth),
+        // The box is drawn by DecoratedTextLayoutFragment behind every
+        // paragraph of the callout; the fragments tile into one continuous box.
+        result.addAttribute(
+            .blockDecoration,
+            value: BlockDecoration(.box(background: c.background,
+                                        borderColor: c.border,
+                                        borderEdges: info.style.borderEdges,
+                                        borderWidth: info.style.borderWidth)),
+            range: span.fullRange)
+        result.addAttribute(.paragraphStyle, value: calloutParagraphStyle(),
                             range: span.fullRange)
+        // Bottom breathing room: paragraph spacing on the last line. The box
+        // covers it (it's inside the last fragment's frame), and clicks there
+        // resolve to the callout's last line — no dead zone.
+        let ns = result.string as NSString
+        var lastLineStart = span.fullRange.location
+        let nl = ns.range(of: "\n", options: .backwards,
+                          range: span.fullRange)
+        if nl.location != NSNotFound { lastLineStart = nl.upperBound }
+        result.addAttribute(.paragraphStyle, value: calloutParagraphStyle(isLastLine: true),
+                            range: NSRange(location: lastLineStart,
+                                           length: span.fullRange.upperBound - lastLineStart))
 
         let m = info.marker
         if active {
@@ -84,17 +100,30 @@ extension EditorTextView {
             return
         }
 
-        // Rendered: hide the whole header, draw an icon + title image on the first
-        // character.
+        // Rendered: hide the whole header, draw an icon + title image at the
+        // first character via a fragment overlay.
         let header = info.headerRange
         guard header.length > 0, header.upperBound <= result.length else { return }
         result.addAttribute(.font, value: hiddenFont, range: header)
         result.addAttribute(.foregroundColor, value: NSColor.clear, range: header)
-        if let att = calloutHeaderAttachment(symbolName: info.style.symbolName,
-                                             title: info.title, color: c.accent,
-                                             iconNudge: info.style.iconBaselineNudge) {
-            result.addAttribute(.attachment, value: att,
-                                range: NSRange(location: header.location, length: 1))
+        if let overlay = calloutHeaderOverlay(symbolName: info.style.symbolName,
+                                              title: info.title, color: c.accent,
+                                              iconNudge: info.style.iconBaselineNudge) {
+            applyOverlay(overlay, anchor: NSRange(location: header.location, length: 1),
+                         in: result)
+            // Top breathing room: a raised minimum line height on the header
+            // line — still clickable text space, the box covers it.
+            let ns = result.string as NSString
+            let nl = ns.range(of: "\n", options: [], range: span.fullRange)
+            let headerLineEnd = nl.location == NSNotFound ? span.fullRange.upperBound : nl.location
+            let headerLine = NSRange(location: span.fullRange.location,
+                                     length: headerLineEnd - span.fullRange.location)
+            let headerIsLastLine = nl.location == NSNotFound
+            result.addAttribute(
+                .paragraphStyle,
+                value: calloutParagraphStyle(isLastLine: headerIsLastLine,
+                                             minimumLineHeight: overlay.bounds.height + calloutTopPad),
+                range: headerLine)
         }
     }
 
@@ -126,57 +155,35 @@ extension EditorTextView {
     /// Bottom breathing room (kept as block padding; slightly less, to balance).
     private var calloutBottomPad: CGFloat { bodyFont.pointSize * 0.65 }
 
-    // MARK: Paragraph style (border / background / padding)
+    // MARK: Paragraph style (text insets; the box itself is a BlockDecoration)
 
-    private func calloutParagraphStyle(borderColor: NSColor, backgroundColor: NSColor,
-                                       edges: CalloutStyle.Edges, borderWidth: CGFloat) -> NSParagraphStyle {
+    /// Text insets the NSTextBlock padding used to provide. The left inset is
+    /// kept small so the callout's text lines up with a plain block quote's —
+    /// the quote's 2pt bar inset matches this 2pt — and the top breathing room
+    /// lives in the header image (clickable text space). The bottom breathing
+    /// room is the last line's paragraph spacing: it's inside the last
+    /// fragment's frame, so the drawn box covers it and clicks there land on
+    /// the callout's last line.
+    private func calloutParagraphStyle(isLastLine: Bool = false,
+                                       minimumLineHeight: CGFloat = 0) -> NSParagraphStyle {
         let ps = NSMutableParagraphStyle()
         ps.lineSpacing = bodyParagraphStyle.lineSpacing
-        ps.paragraphSpacing = bodyParagraphStyle.paragraphSpacing
-
-        // One block instance shared across the callout's lines renders as a single
-        // continuous box, so borders/background/padding wrap the whole callout
-        // (padding only at the outer top/bottom, not between lines).
-        let block = NSTextBlock()
-        block.setContentWidth(100, type: .percentageValueType)
-        block.backgroundColor = backgroundColor
-
-        let left   = NSRectEdge(rawValue: 0)!   // minX
-        let top     = NSRectEdge(rawValue: 1)!  // minY (top, flipped text coords)
-        let right  = NSRectEdge(rawValue: 2)!   // maxX
-        let bottom = NSRectEdge(rawValue: 3)!   // maxY
-        let edgeMap: [(CalloutStyle.Edges, NSRectEdge)] =
-            [(.left, left), (.top, top), (.right, right), (.bottom, bottom)]
-        for (e, rectEdge) in edgeMap where edges.contains(e) {
-            block.setWidth(borderWidth, type: .absoluteValueType, for: .border, edge: rectEdge)
-            block.setBorderColor(borderColor, for: rectEdge)
-        }
-
-        // Breathing room: generous vertical padding. The left padding is kept
-        // small so the callout's text lines up with a plain block quote's — the
-        // shared hidden `> ` already provides the indent — rather than sitting
-        // further right. (A block quote's left inset is its 2pt border; matching
-        // that here keeps callouts and quotes aligned.)
-        // Top padding lives in the header image (clickable text space); only the
-        // bottom padding is block padding here.
-        let leftPad: CGFloat = 2
-        let rightPad: CGFloat = 10
-        block.setWidth(calloutBottomPad, type: .absoluteValueType, for: .padding, edge: bottom)
-        block.setWidth(leftPad, type: .absoluteValueType, for: .padding, edge: left)
-        block.setWidth(rightPad, type: .absoluteValueType, for: .padding, edge: right)
-        _ = top   // (top padding intentionally omitted — see header image)
-
-        ps.textBlocks = [block]
+        ps.firstLineHeadIndent = 2
+        ps.headIndent = 2
+        ps.tailIndent = -10
+        ps.paragraphSpacing = isLastLine ? calloutBottomPad : 0
+        ps.minimumLineHeight = minimumLineHeight
         return ps
     }
 
     // MARK: Header image (icon + title)
 
-    /// Draws "icon  Title" into one image, tinted to the callout color. Returns
-    /// `nil` if the SF Symbol can't be resolved (the caller then leaves the raw
-    /// marker text visible).
-    private func calloutHeaderAttachment(symbolName: String, title: String, color: NSColor,
-                                         iconNudge: CGFloat) -> NSTextAttachment? {
+    /// Draws "icon  Title" into one image, tinted to the callout color, and
+    /// wraps it in a `FragmentOverlay`. Returns `nil` if the SF Symbol can't
+    /// be resolved. The top breathing room is NOT in the image — the caller
+    /// raises the header line's minimum line height instead.
+    private func calloutHeaderOverlay(symbolName: String, title: String, color: NSColor,
+                                      iconNudge: CGFloat) -> FragmentOverlay? {
         let pointSize = bodyFont.pointSize
         let symConfig = NSImage.SymbolConfiguration(pointSize: pointSize, weight: .semibold)
             .applying(NSImage.SymbolConfiguration(paletteColors: [color]))
@@ -192,15 +199,8 @@ extension EditorTextView {
         let symW = symbol.size.width, symH = symbol.size.height
         let contentHeight = ceil(max(symH, titleSize.height))
         let width = ceil(symW + gap + titleSize.width)
-        // The image is taller than its content: the extra `calloutTopPad` sits on
-        // top, so the callout's top breathing room is part of this (clickable)
-        // header line rather than dead block padding above it.
-        let topPad = ceil(calloutTopPad)
-        let height = contentHeight + topPad
 
-        let image = NSImage(size: NSSize(width: width, height: height), flipped: false) { _ in
-            // Draw the content in the bottom `contentHeight` band; leave `topPad`
-            // empty above it.
+        let image = NSImage(size: NSSize(width: width, height: contentHeight), flipped: false) { _ in
             let titleY = (contentHeight - titleSize.height) / 2
             titleStr.draw(at: NSPoint(x: symW + gap, y: titleY))
             // Center the icon on the title's cap height (its optical middle) rather
@@ -211,11 +211,8 @@ extension EditorTextView {
             return true
         }
 
-        let attachment = NSTextAttachment()
-        attachment.image = image
-        // The content's bottom stays on the text baseline (as before); the extra
-        // `topPad` extends the image (and the line fragment) upward.
-        attachment.bounds = CGRect(x: 0, y: -pointSize * 0.15, width: width, height: height)
-        return attachment
+        return FragmentOverlay(image: image,
+                               bounds: CGRect(x: 0, y: -pointSize * 0.15,
+                                              width: width, height: contentHeight))
     }
 }

--- a/Sources/MarkdownEditorCore/EditorTextView+Composition.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Composition.swift
@@ -31,6 +31,8 @@ extension EditorTextView {
                              with: NSAttributedString(string: rawSource,
                                                       attributes: baseAttributes))
         ts.endEditing()
+        // Whole-document replacement; blocks are re-parsed by our callers.
+        (ts as? EditorTextStorage)?.clearPendingEdit()
         isUpdating = false
 
         for i in blocks.indices { blocks[i].isStyled = false }

--- a/Sources/MarkdownEditorCore/EditorTextView+Composition.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Composition.swift
@@ -126,12 +126,16 @@ extension EditorTextView {
 
     /// Incremental recompose: only re-styles the old and new active blocks.
     /// Used when the cursor moves between blocks without changing content.
-    func recomposeIncremental(cursorInRaw: Int, selectionInRaw: NSRange? = nil) {
+    /// `settingSelection` is false when the caller already owns the caret (a
+    /// user-driven cursor move) — re-setting it would trigger AppKit's
+    /// scroll-the-selection-into-view, fighting typewriter centering.
+    func recomposeIncremental(cursorInRaw: Int, selectionInRaw: NSRange? = nil,
+                              settingSelection: Bool = true) {
         var dirty = IndexSet()
         if let oldIdx = activeBlockIndex, oldIdx < blocks.count { dirty.insert(oldIdx) }
         if let newIdx = blockIndexForRawOffset(cursorInRaw) { dirty.insert(newIdx) }
         recomposeDirty(dirty, cursorInRaw: cursorInRaw,
-                       selectionInRaw: selectionInRaw, settingSelection: true)
+                       selectionInRaw: selectionInRaw, settingSelection: settingSelection)
     }
 
     /// Restyles every block in place (attribute-only). For theme and

--- a/Sources/MarkdownEditorCore/EditorTextView+Composition.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Composition.swift
@@ -74,49 +74,85 @@ extension EditorTextView {
         isUpdating = false
     }
 
-    /// Incremental recompose: only re-styles the old and new active blocks.
-    /// Used when the cursor moves between blocks without changing content.
-    func recomposeIncremental(cursorInRaw: Int, selectionInRaw: NSRange? = nil) {
+    /// Dirty-set recompose: restyles exactly the given block indexes in place.
+    /// Attribute-only — the storage string is never touched. This is the
+    /// single styling path for edits, activation changes, and theme /
+    /// appearance refreshes; `recompose` (string-replacing) remains only for
+    /// paths that rebuild `rawSource` (load, undo, indent).
+    ///
+    /// `settingSelection` is true for selection-driven and whole-document
+    /// callers (preserving the old recompose behavior); the edit path leaves
+    /// the caret where NSTextView already placed it to avoid re-entrant
+    /// selection notifications.
+    func recomposeDirty(
+        _ dirty: IndexSet,
+        cursorInRaw: Int,
+        selectionInRaw: NSRange? = nil,
+        settingSelection: Bool = false
+    ) {
         guard let ts = textStorage else { return }
 
         isUpdating = true
 
-        let oldActiveIndex = activeBlockIndex
         let newActiveIndex = blockIndexForRawOffset(cursorInRaw)
         activeBlockIndex = newActiveIndex
 
+        let nsString = ts.string as NSString
         ts.beginEditing()
+        for idx in dirty where idx < blocks.count {
+            let cursorInBlock: Int? = (idx == newActiveIndex)
+                ? max(0, cursorInRaw - blocks[idx].range.location) : nil
+            restyleBlock(idx, cursorInBlock: cursorInBlock)
 
-        // Re-style old active block (hide all inline delimiters)
-        if let oldIdx = oldActiveIndex, oldIdx < blocks.count {
-            restyleBlock(oldIdx, cursorInBlock: nil)
+            // Full recompose resets separator newlines to base attributes as
+            // a side effect of rebuilding the whole string; do the same for
+            // dirty blocks so stale paragraph styles can't linger on the `\n`
+            // after e.g. a former callout.
+            let sep = blocks[idx].range.upperBound
+            if sep < nsString.length && nsString.character(at: sep) == 0x0A {
+                ts.setAttributes(baseAttributes, range: NSRange(location: sep, length: 1))
+            }
         }
-
-        // Re-style new active block (show delimiters at cursor)
-        if let newIdx = newActiveIndex, newIdx < blocks.count {
-            let cursorInBlock = max(0, cursorInRaw - blocks[newIdx].range.location)
-            restyleBlock(newIdx, cursorInBlock: cursorInBlock)
-        }
-
         ts.endEditing()
 
         displayRanges = blocks.map { $0.range }
 
-        if let rawSel = selectionInRaw, rawSel.length > 0 {
-            let len = ts.length
-            let displaySel = NSRange(
-                location: min(rawSel.location, len),
-                length: max(0, min(rawSel.upperBound, len) - min(rawSel.location, len))
-            )
-            setSelectedRange(displaySel)
-        } else {
-            let clamped = min(cursorInRaw, ts.length)
-            setSelectedRange(NSRange(location: clamped, length: 0))
+        if settingSelection {
+            if let rawSel = selectionInRaw, rawSel.length > 0 {
+                let len = ts.length
+                let displaySel = NSRange(
+                    location: min(rawSel.location, len),
+                    length: max(0, min(rawSel.upperBound, len) - min(rawSel.location, len))
+                )
+                setSelectedRange(displaySel)
+            } else {
+                let clamped = min(cursorInRaw, ts.length)
+                setSelectedRange(NSRange(location: clamped, length: 0))
+            }
         }
 
         typingAttributes = baseAttributes
 
         isUpdating = false
+    }
+
+    /// Incremental recompose: only re-styles the old and new active blocks.
+    /// Used when the cursor moves between blocks without changing content.
+    func recomposeIncremental(cursorInRaw: Int, selectionInRaw: NSRange? = nil) {
+        var dirty = IndexSet()
+        if let oldIdx = activeBlockIndex, oldIdx < blocks.count { dirty.insert(oldIdx) }
+        if let newIdx = blockIndexForRawOffset(cursorInRaw) { dirty.insert(newIdx) }
+        recomposeDirty(dirty, cursorInRaw: cursorInRaw,
+                       selectionInRaw: selectionInRaw, settingSelection: true)
+    }
+
+    /// Restyles every block in place (attribute-only). For theme and
+    /// appearance changes: the string is unchanged but every attribute
+    /// derives from the new theme/appearance.
+    func recomposeAllDirty() {
+        recomposeDirty(IndexSet(blocks.indices),
+                       cursorInRaw: currentCursorInRaw(),
+                       settingSelection: true)
     }
 
     /// Recalculates displayRanges from current blocks.

--- a/Sources/MarkdownEditorCore/EditorTextView+Composition.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Composition.swift
@@ -16,62 +16,26 @@ extension EditorTextView {
     // Text storage content = rawSource, always.
     // Styling is attribute-only; the string never changes during recompose.
 
-    /// Full recompose: replaces the entire text storage. Used for initial load,
-    /// content changes (undo/redo, loadContent), font/appearance changes.
+    /// Full recompose: replaces the entire text storage with `rawSource` in
+    /// base attributes, then styles via the dirty flush — viewport-first when
+    /// the editor is in a scroll view, everything synchronously otherwise.
+    /// Used when rawSource was rebuilt (initial load, undo/redo, indent) and
+    /// for content changes that bypass the edit path.
     func recompose(cursorInRaw: Int, selectionInRaw: NSRange? = nil) {
+        guard let ts = textStorage else { return }
+
         isUpdating = true
-
-        activeBlockIndex = blockIndexForRawOffset(cursorInRaw)
-
-        // Build styled attributed string from rawSource.
-        let composed = NSMutableAttributedString(string: rawSource, attributes: baseAttributes)
-
-        for (i, block) in blocks.enumerated() {
-            guard block.range.upperBound <= composed.length else { continue }
-
-            let cursorInBlock: Int?
-            if i == activeBlockIndex {
-                cursorInBlock = max(0, cursorInRaw - block.range.location)
-            } else {
-                cursorInBlock = nil
-            }
-
-            let styled = styleBlock(block.content, cursorPosition: cursorInBlock)
-
-            styled.enumerateAttributes(
-                in: NSRange(location: 0, length: styled.length), options: []
-            ) { attrs, range, _ in
-                let tsRange = NSRange(
-                    location: range.location + block.range.location,
-                    length: range.length
-                )
-                guard tsRange.upperBound <= composed.length else { return }
-                composed.setAttributes(attrs, range: tsRange)
-            }
-        }
-
-        let fullRange = NSRange(location: 0, length: textStorage!.length)
-        textStorage?.beginEditing()
-        textStorage?.replaceCharacters(in: fullRange, with: composed)
-        textStorage?.endEditing()
-
-        displayRanges = blocks.map { $0.range }
-
-        if let rawSel = selectionInRaw, rawSel.length > 0 {
-            let len = textStorage!.length
-            let displaySel = NSRange(
-                location: min(rawSel.location, len),
-                length: max(0, min(rawSel.upperBound, len) - min(rawSel.location, len))
-            )
-            setSelectedRange(displaySel)
-        } else {
-            let clamped = min(cursorInRaw, textStorage!.length)
-            setSelectedRange(NSRange(location: clamped, length: 0))
-        }
-
-        typingAttributes = baseAttributes
-
+        let fullRange = NSRange(location: 0, length: ts.length)
+        ts.beginEditing()
+        ts.replaceCharacters(in: fullRange,
+                             with: NSAttributedString(string: rawSource,
+                                                      attributes: baseAttributes))
+        ts.endEditing()
         isUpdating = false
+
+        for i in blocks.indices { blocks[i].isStyled = false }
+        recomposeDirty(IndexSet(blocks.indices), cursorInRaw: cursorInRaw,
+                       selectionInRaw: selectionInRaw, settingSelection: true)
     }
 
     /// Dirty-set recompose: restyles exactly the given block indexes in place.
@@ -97,12 +61,28 @@ extension EditorTextView {
         let newActiveIndex = blockIndexForRawOffset(cursorInRaw)
         activeBlockIndex = newActiveIndex
 
+        // Lazy rendering: a LARGE dirty set (load, theme change, a fence
+        // absorbing half the document) is restyled synchronously only near
+        // the viewport; the rest goes to the idle drain / scroll promotion.
+        // Small sets — every normal interaction — are styled in full, so
+        // user-visible state transitions are never deferred. Without a
+        // scroll view (headless), everything is synchronous.
+        var syncSet = dirty
+        if dirty.count > 8, let bounds = syncStylingBlockRange() {
+            syncSet = dirty.filteredIndexSet { bounds.contains($0) }
+            if let active = newActiveIndex, dirty.contains(active) {
+                syncSet.insert(active)
+            }
+        }
+        let deferred = dirty.subtracting(syncSet)
+
         let nsString = ts.string as NSString
         ts.beginEditing()
-        for idx in dirty where idx < blocks.count {
+        for idx in syncSet where idx < blocks.count {
             let cursorInBlock: Int? = (idx == newActiveIndex)
                 ? max(0, cursorInRaw - blocks[idx].range.location) : nil
             restyleBlock(idx, cursorInBlock: cursorInBlock)
+            blocks[idx].isStyled = true
 
             // Full recompose resets separator newlines to base attributes as
             // a side effect of rebuilding the whole string; do the same for
@@ -114,6 +94,10 @@ extension EditorTextView {
             }
         }
         ts.endEditing()
+
+        for idx in deferred where idx < blocks.count {
+            blocks[idx].isStyled = false
+        }
 
         displayRanges = blocks.map { $0.range }
 
@@ -134,6 +118,8 @@ extension EditorTextView {
         typingAttributes = baseAttributes
 
         isUpdating = false
+
+        if !deferred.isEmpty { scheduleProgressiveStyling() }
     }
 
     /// Incremental recompose: only re-styles the old and new active blocks.
@@ -150,9 +136,34 @@ extension EditorTextView {
     /// appearance changes: the string is unchanged but every attribute
     /// derives from the new theme/appearance.
     func recomposeAllDirty() {
+        for i in blocks.indices { blocks[i].isStyled = false }
         recomposeDirty(IndexSet(blocks.indices),
                        cursorInRaw: currentCursorInRaw(),
                        settingSelection: true)
+    }
+
+    /// The block-index window to style synchronously: the TextKit 2 viewport
+    /// plus a margin, or — before any layout exists (fresh load) — a window
+    /// around the active block. Returns nil without a scroll view (headless):
+    /// callers then style everything synchronously.
+    func syncStylingBlockRange() -> ClosedRange<Int>? {
+        guard enclosingScrollView != nil, !blocks.isEmpty,
+              let tlm = textLayoutManager else { return nil }
+
+        if let viewport = tlm.textViewportLayoutController.viewportRange {
+            let docStart = tlm.documentRange.location
+            let start = tlm.offset(from: docStart, to: viewport.location)
+            let end = tlm.offset(from: docStart, to: viewport.endLocation)
+            if let s = blockIndexForRawOffset(start),
+               let e = blockIndexForRawOffset(max(start, end)) {
+                let margin = max(16, e - s + 1)
+                return max(0, s - margin) ... min(blocks.count - 1, e + margin)
+            }
+        }
+        // No viewport yet (first layout hasn't happened): style a generous
+        // window around the cursor; the drain and scroll promotion cover the rest.
+        let anchor = activeBlockIndex ?? 0
+        return max(0, anchor - 200) ... min(blocks.count - 1, anchor + 200)
     }
 
     /// Recalculates displayRanges from current blocks.

--- a/Sources/MarkdownEditorCore/EditorTextView+Composition.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Composition.swift
@@ -129,13 +129,23 @@ extension EditorTextView {
     //
     // With text storage = rawSource, display offset = raw offset (identity).
 
+    /// Binary search over the (sorted, adjacent) block ranges. An offset at a
+    /// block's `upperBound` — the trailing `\n` separator — belongs to that
+    /// block; offsets past the last block clamp to it.
     func blockIndexForRawOffset(_ rawOffset: Int) -> Int? {
-        for (i, block) in blocks.enumerated() {
-            if rawOffset >= block.range.location && rawOffset <= block.range.upperBound {
-                return i
+        guard !blocks.isEmpty else { return nil }
+        var lo = 0
+        var hi = blocks.count - 1
+        // First block whose inclusive upper bound reaches the offset.
+        while lo < hi {
+            let mid = (lo + hi) / 2
+            if blocks[mid].range.upperBound < rawOffset {
+                lo = mid + 1
+            } else {
+                hi = mid
             }
         }
-        return blocks.isEmpty ? nil : blocks.count - 1
+        return lo
     }
 
     func displayOffsetToRawOffset(_ displayOffset: Int) -> Int {

--- a/Sources/MarkdownEditorCore/EditorTextView+Indentation.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Indentation.swift
@@ -90,6 +90,7 @@ extension EditorTextView {
             }
         }
         rawSource = parts.joined(separator: blockSeparator)
+        rebuildListIndentState()
 
         // Cursor in startBlock shifts by 1 indent; rawEnd in endBlock
         // shifts by (endBlock - startBlock + 1) indents (one per block).
@@ -146,6 +147,7 @@ extension EditorTextView {
             }
         }
         rawSource = parts.joined(separator: blockSeparator)
+        rebuildListIndentState()
 
         // Adjust rawStart (in startBlock).  No blocks before startBlock
         // were modified, so its start position is unchanged.

--- a/Sources/MarkdownEditorCore/EditorTextView+LazyStyling.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+LazyStyling.swift
@@ -1,0 +1,118 @@
+import AppKit
+
+// MARK: - Lazy Styling: idle drain + scroll promotion
+//
+// The dirty flush styles only blocks near the viewport synchronously and
+// leaves the rest marked `isStyled == false` (base attributes after a load,
+// or briefly-stale styling after an offscreen structural change). Two
+// mechanisms converge the document:
+//
+// - The idle drain: time-budgeted main-thread slices restyling unstyled
+//   blocks until none remain, so document height settles and offscreen
+//   content is ready before the user gets there.
+// - Scroll promotion: when the clip view scrolls, unstyled blocks entering
+//   the viewport window are styled synchronously so the user never sees raw
+//   base-attributed text.
+
+extension EditorTextView {
+
+    /// Schedules the idle drain (coalesced; safe to call repeatedly).
+    func scheduleProgressiveStyling() {
+        guard !progressiveStylingScheduled else { return }
+        progressiveStylingScheduled = true
+        DispatchQueue.main.async { [weak self] in
+            self?.progressiveStylingScheduled = false
+            self?.drainStylingSlice()
+        }
+    }
+
+    /// Restyles unstyled blocks for ~6 ms, then reschedules itself if any
+    /// remain. Reads current state each slice, so edits/undo/load between
+    /// slices are naturally accommodated. Internal so tests can drive the
+    /// drain synchronously.
+    func drainStylingSlice() {
+        guard let ts = textStorage else { return }
+        guard !isUpdating else { scheduleProgressiveStyling(); return }
+        // Restyling marked text aborts IME composition — wait it out.
+        guard !hasMarkedText() else { scheduleProgressiveStyling(); return }
+
+        let start = ContinuousClock.now
+        let budget = Duration.milliseconds(6)
+
+        isUpdating = true
+        let nsString = ts.string as NSString
+        let cursor = selectedRange().location
+        var remaining = false
+        // Explicit pool: styling churns through transient images/attributed
+        // strings, and a caller may run many slices without a run-loop turn.
+        autoreleasepool {
+            ts.beginEditing()
+            // Resume the scan where the last slice stopped (`drainCursor` is a
+            // hint — edits shift indices, the wrap-around pass self-corrects).
+            // Rescanning from 0 each slice made the drain quadratic: deep
+            // slices burned their whole budget skipping styled blocks.
+            let count = blocks.count
+            var scanned = 0
+            var idx = min(drainCursor, max(0, count - 1))
+            while scanned < count {
+                if idx >= count { idx = 0 }
+                if !blocks[idx].isStyled {
+                    let cursorInBlock: Int? = (idx == activeBlockIndex)
+                        ? max(0, cursor - blocks[idx].range.location) : nil
+                    restyleBlock(idx, cursorInBlock: cursorInBlock)
+                    blocks[idx].isStyled = true
+                    let sep = blocks[idx].range.upperBound
+                    if sep < nsString.length && nsString.character(at: sep) == 0x0A {
+                        ts.setAttributes(baseAttributes, range: NSRange(location: sep, length: 1))
+                    }
+                    if ContinuousClock.now - start > budget {
+                        remaining = true
+                        idx += 1
+                        break
+                    }
+                }
+                idx += 1
+                scanned += 1
+            }
+            drainCursor = idx
+            ts.endEditing()
+        }
+        isUpdating = false
+
+        if remaining { scheduleProgressiveStyling() }
+    }
+
+    /// Synchronously styles any unstyled blocks inside the current viewport
+    /// window. Called when the clip view scrolls.
+    func promoteVisibleUnstyledBlocks() {
+        // The bounds-change notification fires before the next layout pass,
+        // so the viewport range is stale at this point — bring it up to date
+        // or promotion would lag one frame behind every scroll.
+        textLayoutManager?.textViewportLayoutController.layoutViewport()
+        guard let bounds = syncStylingBlockRange() else { return }
+        let unstyled = IndexSet(bounds.filter { !blocks[$0].isStyled })
+        guard !unstyled.isEmpty else { return }
+        recomposeDirty(unstyled, cursorInRaw: selectedRange().location)
+    }
+
+    /// Observes clip-view scrolling for promotion. Called from
+    /// `viewDidMoveToWindow`.
+    func installScrollPromotionObserver() {
+        guard let clipView = enclosingScrollView?.contentView else { return }
+        clipView.postsBoundsChangedNotifications = true
+        // viewDidMoveToWindow can fire more than once; keep one observation.
+        NotificationCenter.default.removeObserver(
+            self, name: NSView.boundsDidChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(clipViewBoundsDidChange(_:)),
+            name: NSView.boundsDidChangeNotification,
+            object: clipView
+        )
+    }
+
+    @objc private func clipViewBoundsDidChange(_ note: Notification) {
+        guard !isUpdating else { return }
+        promoteVisibleUnstyledBlocks()
+    }
+}

--- a/Sources/MarkdownEditorCore/EditorTextView+LazyStyling.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+LazyStyling.swift
@@ -82,12 +82,10 @@ extension EditorTextView {
         if remaining { scheduleProgressiveStyling() }
     }
 
-    /// Synchronously styles any unstyled blocks inside the current viewport
-    /// window. Called when the clip view scrolls.
+    /// Styles any unstyled blocks inside the current viewport window. Forces a
+    /// viewport layout first because callers may run before the next layout
+    /// pass (the viewport range would otherwise be stale).
     func promoteVisibleUnstyledBlocks() {
-        // The bounds-change notification fires before the next layout pass,
-        // so the viewport range is stale at this point — bring it up to date
-        // or promotion would lag one frame behind every scroll.
         textLayoutManager?.textViewportLayoutController.layoutViewport()
         guard let bounds = syncStylingBlockRange() else { return }
         let unstyled = IndexSet(bounds.filter { !blocks[$0].isStyled })
@@ -112,7 +110,18 @@ extension EditorTextView {
     }
 
     @objc private func clipViewBoundsDidChange(_ note: Notification) {
-        guard !isUpdating else { return }
-        promoteVisibleUnstyledBlocks()
+        // Promotion forces a viewport layout and may restyle blocks (changing
+        // their heights). Running that synchronously inside the scroll
+        // notification fights the momentum scroll and makes the viewport
+        // bounce. Defer to the next run-loop turn (coalesced), so each scroll
+        // tick just scrolls and styling catches up between ticks.
+        guard !isUpdating, !pendingPromotion else { return }
+        pendingPromotion = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.pendingPromotion = false
+            guard !self.isUpdating else { return }
+            self.promoteVisibleUnstyledBlocks()
+        }
     }
 }

--- a/Sources/MarkdownEditorCore/EditorTextView+ListRendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+ListRendering.swift
@@ -44,9 +44,9 @@ extension EditorTextView {
 
     // MARK: Marker Icons
 
-    /// Creates an NSTextAttachment with a circle icon for checkbox rendering.
+    /// Creates a fragment overlay with a circle icon for checkbox rendering.
     /// Unchecked: gray outlined circle. Checked: filled yellow circle with checkmark.
-    private func checkboxAttachment(checked: Bool) -> NSTextAttachment {
+    private func checkboxOverlay(checked: Bool) -> FragmentOverlay {
         let fontSize = bodyFont.pointSize
         let image = NSImage(size: NSSize(width: fontSize, height: fontSize), flipped: true) { bounds in
             let inset: CGFloat = 1.0
@@ -80,18 +80,16 @@ extension EditorTextView {
             return true
         }
 
-        let attachment = NSTextAttachment()
-        attachment.image = image
         // Vertically center the circle relative to the text baseline
-        attachment.bounds = CGRect(x: 0, y: -fontSize * 0.15,
-                                   width: fontSize, height: fontSize)
-        return attachment
+        return FragmentOverlay(image: image,
+                               bounds: CGRect(x: 0, y: -fontSize * 0.15,
+                                              width: fontSize, height: fontSize))
     }
 
-    /// Creates an attachment with a small filled dot for unordered bullets,
+    /// Creates an overlay with a small filled dot for unordered bullets,
     /// sized to the same box as the checkbox circle so bullet and todo lists
     /// share one indentation (Apple Notes style).
-    private func bulletAttachment() -> NSTextAttachment {
+    private func bulletOverlay() -> FragmentOverlay {
         let fontSize = bodyFont.pointSize
         let image = NSImage(size: NSSize(width: fontSize, height: fontSize), flipped: true) { bounds in
             let r = fontSize * 0.13                 // small dot
@@ -101,11 +99,9 @@ extension EditorTextView {
             NSBezierPath(ovalIn: dot).fill()
             return true
         }
-        let attachment = NSTextAttachment()
-        attachment.image = image
-        attachment.bounds = CGRect(x: 0, y: -fontSize * 0.15,
-                                   width: fontSize, height: fontSize)
-        return attachment
+        return FragmentOverlay(image: image,
+                               bounds: CGRect(x: 0, y: -fontSize * 0.15,
+                                              width: fontSize, height: fontSize))
     }
 
     // MARK: Marker Styling
@@ -156,9 +152,9 @@ extension EditorTextView {
                 result.addAttribute(.font, value: hiddenFont, range: before)
                 result.addAttribute(.foregroundColor, value: NSColor.clear, range: before)
             }
-            // Dot attachment on the bullet character.
-            result.addAttribute(.attachment, value: bulletAttachment(),
-                                range: NSRange(location: markerAbs, length: 1))
+            // Dot overlay on the (hidden) bullet character.
+            applyOverlay(bulletOverlay(), anchor: NSRange(location: markerAbs, length: 1),
+                         in: result)
             // Dim the trailing space(s) after the bullet.
             let afterStart = markerAbs + 1
             if afterStart < dr.upperBound {
@@ -196,10 +192,9 @@ extension EditorTextView {
             result.addAttribute(.foregroundColor, value: NSColor.clear, range: before)
         }
 
-        // Place circle attachment on `[` character
-        let attachment = checkboxAttachment(checked: checkbox == .checked)
-        result.addAttribute(.attachment, value: attachment,
-                            range: NSRange(location: cbStart, length: 1))
+        // Circle overlay on the (hidden) `[` character
+        applyOverlay(checkboxOverlay(checked: checkbox == .checked),
+                     anchor: NSRange(location: cbStart, length: 1), in: result)
 
         // Hide remaining checkbox characters (` ]`/`x]`) with zero-width + clear
         let hideStart = cbStart + 1

--- a/Sources/MarkdownEditorCore/EditorTextView+MathRendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+MathRendering.swift
@@ -21,10 +21,10 @@ nonisolated(unsafe) private let mathRenderCache = NSCache<NSString, MathRender>(
 
 extension EditorTextView {
 
-    /// Renders a LaTeX string to an `NSTextAttachment` sized to `fontSize` and
+    /// Renders a LaTeX string to a `FragmentOverlay` sized to `fontSize` and
     /// aligned to the text baseline, or `nil` if SwiftMath can't parse it (the
     /// caller then shows the raw source instead).
-    func mathAttachment(latex: String, display: Bool, fontSize: CGFloat) -> NSTextAttachment? {
+    func mathOverlay(latex: String, display: Bool, fontSize: CGFloat) -> FragmentOverlay? {
         // Resolve the (dynamic) text color against this view's appearance so the
         // math renders in the right shade for light/dark — and so the cache key
         // differs between the two.
@@ -59,9 +59,6 @@ extension EditorTextView {
             mathRenderCache.setObject(render, forKey: key)
         }
 
-        let attachment = NSTextAttachment()
-        attachment.image = render.image
-
         var width = render.image.size.width
         var height = render.image.size.height
         var descent = render.descent
@@ -77,8 +74,8 @@ extension EditorTextView {
         }
         // Drop the image so its baseline (descent above the image bottom) lands
         // on the text baseline.
-        attachment.bounds = CGRect(x: 0, y: -descent, width: width, height: height)
-        return attachment
+        return FragmentOverlay(image: render.image,
+                               bounds: CGRect(x: 0, y: -descent, width: width, height: height))
     }
 
     /// The usable text width for one line — the text container minus its line
@@ -133,16 +130,19 @@ extension EditorTextView {
     }
 
     /// Centered paragraph style for display math. The vertical padding is applied
-    /// only to the attachment's (first) line — a multi-line `$$…$$` block is
+    /// only to the image's (first) line — a multi-line `$$…$$` block is
     /// several paragraphs in the text storage (its hidden inner lines), so
     /// padding every paragraph would multiply into a huge gap.
-    func displayMathParagraphStyle(padded: Bool) -> NSParagraphStyle {
+    /// `imageHeight` reserves the equation's height on that line: the line's
+    /// own characters are hidden (near-zero), so without it the line collapses.
+    func displayMathParagraphStyle(padded: Bool, imageHeight: CGFloat = 0) -> NSParagraphStyle {
         let ps = NSMutableParagraphStyle()
         ps.alignment = .center
         ps.lineSpacing = 0
         let pad = padded ? bodyFont.pointSize * 0.9 : 0
         ps.paragraphSpacingBefore = pad
         ps.paragraphSpacing = pad
+        ps.minimumLineHeight = imageHeight
         return ps
     }
 }

--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -73,10 +73,13 @@ extension EditorTextView {
         // Force a real line height despite the hidden (0.01pt) dashes.
         ps.minimumLineHeight = lineHeight
         ps.maximumLineHeight = lineHeight
-        // Breathing space above and below — slightly less below, since the line
-        // height already contributes space beneath the centered rule.
-        ps.paragraphSpacingBefore = bodyFont.pointSize * 0.5
-        ps.paragraphSpacing = bodyFont.pointSize * 0.3
+        // Symmetric breathing space. The rule is drawn centered in the
+        // fragment, so paragraphSpacingBefore sits above the line (and the
+        // rule) while paragraphSpacing sits below — equal values keep the
+        // rule visually equidistant from the text on either side.
+        let pad = bodyFont.pointSize * 0.5
+        ps.paragraphSpacingBefore = pad
+        ps.paragraphSpacing = pad
         return ps
     }
 
@@ -440,6 +443,14 @@ extension EditorTextView {
                         applyOverlay(overlay,
                                      anchor: NSRange(location: span.fullRange.location, length: 1),
                                      in: result)
+                        if !display {
+                            // Inline math flows within a text line; reserve the
+                            // line height so a tall equation (e.g. scaled to a
+                            // heading's font) doesn't overlap the line below.
+                            reserveLineHeight(overlay.bounds.height,
+                                              forOverlayAt: span.fullRange.location,
+                                              in: result)
+                        }
                         // Display math sits centered on its own line, with
                         // vertical padding and the image's height reserved on
                         // the (first) line that carries it.

--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -65,7 +65,7 @@ extension EditorTextView {
     /// Paragraph style for thematic breaks. The raw dashes are hidden with a
     /// near-zero font, which would collapse the line — so we force the line to a
     /// full body-line height and add symmetric breathing space above and below.
-    /// A ThematicBreakTextBlock draws the hairline centered in that height.
+    /// A `.horizontalRule` BlockDecoration draws the hairline centered in it.
     private func thematicBreakParagraphStyle() -> NSParagraphStyle {
         let lineHeight = bodyFont.pointSize + theme.lineSpacing
 
@@ -77,28 +77,17 @@ extension EditorTextView {
         // height already contributes space beneath the centered rule.
         ps.paragraphSpacingBefore = bodyFont.pointSize * 0.5
         ps.paragraphSpacing = bodyFont.pointSize * 0.3
-
-        let block = ThematicBreakTextBlock()
-        block.lineHeight = lineHeight
-        block.setContentWidth(100, type: .percentageValueType)
-        ps.textBlocks = [block]
-
         return ps
     }
 
-    /// Paragraph style with a left border for blockquotes.
+    /// Paragraph style for blockquotes: a 2pt text inset matching the width of
+    /// the left bar that the `.leftBar` BlockDecoration draws.
     private func blockquoteParagraphStyle() -> NSParagraphStyle {
         let ps = NSMutableParagraphStyle()
         ps.lineSpacing = bodyParagraphStyle.lineSpacing
         ps.paragraphSpacing = bodyParagraphStyle.paragraphSpacing
-
-        let block = NSTextBlock()
-        block.setContentWidth(100, type: .percentageValueType)
-        let leftEdge = NSRectEdge(rawValue: 0)!
-        block.setWidth(2, type: .absoluteValueType, for: .border, edge: leftEdge)
-        block.setBorderColor(.tertiaryLabelColor, for: leftEdge)
-        ps.textBlocks = [block]
-
+        ps.firstLineHeadIndent = 2
+        ps.headIndent = 2
         return ps
     }
 
@@ -207,10 +196,13 @@ extension EditorTextView {
                 if let callout = calloutInfo(forBlockquote: span, markdown: markdown) {
                     styleCalloutContent(result, span: span, info: callout, active: cursorInToken)
                 } else {
-                    // Paragraph style must cover fullRange so the first character of each
-                    // paragraph (the `> ` delimiter) carries the NSTextBlock border.
-                    // NSTextView uses the paragraph style from the first char of a paragraph.
+                    // Attributes must cover fullRange so the first character of each
+                    // paragraph (the `> ` delimiter) carries the style/decoration —
+                    // the fragment vendor reads the paragraph's first character.
                     result.addAttribute(.paragraphStyle, value: blockquoteParagraphStyle(), range: span.fullRange)
+                    result.addAttribute(.blockDecoration,
+                                        value: BlockDecoration(.leftBar(color: .tertiaryLabelColor, width: 2)),
+                                        range: span.fullRange)
                     result.addAttribute(.foregroundColor, value: NSColor.secondaryLabelColor, range: span.contentRange)
                 }
 
@@ -328,11 +320,6 @@ extension EditorTextView {
                     }
                     let totalWidth = cumX
 
-                    let leftEdge  = NSRectEdge(rawValue: 0)!
-                    let rightEdge = NSRectEdge(rawValue: 2)!
-                    let edge1     = NSRectEdge(rawValue: 1)!
-                    let edge3     = NSRectEdge(rawValue: 3)!
-
                     // --- Style each row ---
                     var lineOffset = span.fullRange.location
                     for (i, line) in lines.enumerated() {
@@ -342,31 +329,34 @@ extension EditorTextView {
 
                         let rowFont: NSFont = (i == 0) ? boldFont : bodyFont
 
-                        // Paragraph style with TableRowTextBlock for borders
+                        // Row geometry via the paragraph style; the borders are
+                        // drawn by a .tableRow BlockDecoration. Vertical padding
+                        // becomes paragraph spacing (row gap = trailing + leading
+                        // spacing = 2*cellVPad, same as the old block padding).
                         let ps = NSMutableParagraphStyle()
-                        ps.paragraphSpacingBefore = (i == 0)
-                            ? bodyParagraphStyle.paragraphSpacingBefore : 0
-                        ps.paragraphSpacing = 0
                         ps.lineSpacing = 0
-                        let block = TableRowTextBlock()
-                        block.verticalLineXOffsets = borderXOffsets
-                        block.contentLeftOffset = cellHPad
-                        block.setContentWidth(totalWidth, type: .absoluteValueType)
-                        // Left/right padding so text doesn't touch the table edge.
-                        block.setWidth(cellHPad, type: .absoluteValueType, for: .padding, edge: leftEdge)
-                        block.setWidth(cellHPad, type: .absoluteValueType, for: .padding, edge: rightEdge)
-                        // Vertical padding for breathing room between rows.
-                        block.setWidth(cellVPad, type: .absoluteValueType, for: .padding, edge: edge1)
-                        block.setWidth(cellVPad, type: .absoluteValueType, for: .padding, edge: edge3)
+                        ps.firstLineHeadIndent = cellHPad
+                        ps.headIndent = cellHPad
                         if i == 1 {
-                            block.drawHorizontalLine = true
-                            block.heightOverride = 4
-                            // Separator needs no vertical padding.
-                            block.setWidth(0, type: .absoluteValueType, for: .padding, edge: edge1)
-                            block.setWidth(0, type: .absoluteValueType, for: .padding, edge: edge3)
+                            // Separator row: its text is hidden; force a thin
+                            // strip and draw the horizontal rule through it.
+                            ps.minimumLineHeight = 4
+                            ps.maximumLineHeight = 4
+                            ps.paragraphSpacingBefore = 0
+                            ps.paragraphSpacing = 0
+                        } else {
+                            ps.paragraphSpacingBefore = cellVPad + ((i == 0)
+                                ? bodyParagraphStyle.paragraphSpacingBefore : 0)
+                            ps.paragraphSpacing = cellVPad
                         }
-                        ps.textBlocks = [block]
                         result.addAttribute(.paragraphStyle, value: ps, range: lineRange)
+                        result.addAttribute(
+                            .blockDecoration,
+                            value: BlockDecoration(.tableRow(columnXOffsets: borderXOffsets,
+                                                             width: totalWidth,
+                                                             leftInset: cellHPad,
+                                                             separator: i == 1)),
+                            range: lineRange)
 
                         if i == 0 {
                             result.addAttribute(.font, value: boldFont, range: lineRange)
@@ -413,8 +403,11 @@ extension EditorTextView {
                     // Active: show raw dashes, dimmed
                     result.addAttribute(.foregroundColor, value: syntaxDimColor, range: span.fullRange)
                 } else {
-                    // Non-active: horizontal line via NSTextBlock, hide raw text
+                    // Non-active: horizontal hairline decoration, hide raw text
                     result.addAttribute(.paragraphStyle, value: thematicBreakParagraphStyle(), range: span.fullRange)
+                    result.addAttribute(.blockDecoration,
+                                        value: BlockDecoration(.horizontalRule(color: .separatorColor)),
+                                        range: span.fullRange)
                     result.addAttribute(.font, value: hiddenFont, range: span.fullRange)
                     result.addAttribute(.foregroundColor, value: NSColor.clear, range: span.fullRange)
                 }
@@ -432,22 +425,24 @@ extension EditorTextView {
                     // inline math inside a heading matches the heading's size.
                     let contextFont = result.attribute(.font, at: span.fullRange.location,
                                                        effectiveRange: nil) as? NSFont ?? bodyFont
-                    if let attachment = mathAttachment(latex: latex.trimmingCharacters(in: .whitespacesAndNewlines),
-                                                       display: display,
-                                                       fontSize: contextFont.pointSize) {
-                        // Show the rendered image on the first `$` (which the
-                        // attachment replaces) and hide everything after it — the
-                        // rest of the opening delimiter, the source, and the close.
+                    if let overlay = mathOverlay(latex: latex.trimmingCharacters(in: .whitespacesAndNewlines),
+                                                 display: display,
+                                                 fontSize: contextFont.pointSize) {
+                        // Draw the rendered image at the first `$` (hidden, with
+                        // kern reserving the image's width) and hide everything
+                        // after it — the rest of the opening delimiter, the
+                        // source, and the close.
                         let hideStart = span.fullRange.location + 1
                         let hideLen = span.fullRange.upperBound - hideStart
                         let hideRange = NSRange(location: hideStart, length: hideLen)
                         result.addAttribute(.font, value: hiddenFont, range: hideRange)
                         result.addAttribute(.foregroundColor, value: NSColor.clear, range: hideRange)
-                        result.addAttribute(.attachment, value: attachment,
-                                            range: NSRange(location: span.fullRange.location, length: 1))
+                        applyOverlay(overlay,
+                                     anchor: NSRange(location: span.fullRange.location, length: 1),
+                                     in: result)
                         // Display math sits centered on its own line, with
-                        // vertical padding on the (first) line that carries the
-                        // attachment image.
+                        // vertical padding and the image's height reserved on
+                        // the (first) line that carries it.
                         if display {
                             let fullStr = result.string as NSString
                             result.addAttribute(.paragraphStyle,
@@ -459,7 +454,8 @@ extension EditorTextView {
                                 : NSRange(location: span.fullRange.location,
                                           length: nl.location - span.fullRange.location + 1)
                             result.addAttribute(.paragraphStyle,
-                                                value: displayMathParagraphStyle(padded: true),
+                                                value: displayMathParagraphStyle(padded: true,
+                                                                                 imageHeight: overlay.bounds.height),
                                                 range: firstLine)
                         }
                     } else {
@@ -574,39 +570,4 @@ extension EditorTextView {
 
 // MARK: - ThematicBreakTextBlock
 
-/// NSTextBlock subclass that renders a full-width horizontal hairline
-/// centered vertically within a block whose height matches body text.
-private class ThematicBreakTextBlock: NSTextBlock {
-
-    /// Target block height (set to bodyFont.pointSize by the caller).
-    var lineHeight: CGFloat = 16
-
-    override func rectForLayout(
-        at startingPosition: CGPoint,
-        in rect: NSRect,
-        textContainer: NSTextContainer,
-        characterRange charRange: NSRange
-    ) -> NSRect {
-        var r = super.rectForLayout(at: startingPosition, in: rect,
-                                    textContainer: textContainer,
-                                    characterRange: charRange)
-        r.size.height = lineHeight
-        return r
-    }
-
-    override func drawBackground(
-        withFrame frameRect: NSRect,
-        in controlView: NSView,
-        characterRange charRange: NSRange,
-        layoutManager: NSLayoutManager
-    ) {
-        NSColor.separatorColor.setStroke()
-        let path = NSBezierPath()
-        let y = round(frameRect.midY) + 0.5
-        path.move(to: NSPoint(x: frameRect.minX, y: y))
-        path.line(to: NSPoint(x: frameRect.maxX, y: y))
-        path.lineWidth = 1
-        path.stroke()
-    }
-}
 

--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -83,6 +83,13 @@ extension EditorTextView {
         return ps
     }
 
+    /// How far below the rule fragment's geometric center to draw the hairline.
+    /// Adjacent text sits at its baseline (low in its line box), so a
+    /// center-drawn rule looks too close to the line above; this nudge brings
+    /// it down to the optical midpoint between the surrounding text. Tuned
+    /// against rendered output (see RenderingRegressionTests / screencapture).
+    var thematicBreakCenterOffset: CGFloat { bodyFont.pointSize * 0.3 }
+
     /// Paragraph style for blockquotes: a 2pt text inset matching the width of
     /// the left bar that the `.leftBar` BlockDecoration draws.
     private func blockquoteParagraphStyle() -> NSParagraphStyle {
@@ -409,7 +416,8 @@ extension EditorTextView {
                     // Non-active: horizontal hairline decoration, hide raw text
                     result.addAttribute(.paragraphStyle, value: thematicBreakParagraphStyle(), range: span.fullRange)
                     result.addAttribute(.blockDecoration,
-                                        value: BlockDecoration(.horizontalRule(color: .separatorColor)),
+                                        value: BlockDecoration(.horizontalRule(color: .separatorColor,
+                                                                               centerOffset: thematicBreakCenterOffset)),
                                         range: span.fullRange)
                     result.addAttribute(.font, value: hiddenFont, range: span.fullRange)
                     result.addAttribute(.foregroundColor, value: NSColor.clear, range: span.fullRange)

--- a/Sources/MarkdownEditorCore/EditorTextView+TableSupport.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+TableSupport.swift
@@ -3,80 +3,14 @@ import AppKit
 // MARK: - Table Rendering Support
 //
 // Helpers used by the `.table` branch of `styleBlock` (in
-// EditorTextView+Rendering.swift) to lay out and draw GFM tables:
-//
-//   - `TableRowTextBlock` draws the column/row border lines behind each row.
-//   - `splitTableRow` / `cellRanges` parse a pipe-delimited row into its cells.
+// EditorTextView+Rendering.swift) to lay out GFM tables:
+// `splitTableRow` / `cellRanges` parse a pipe-delimited row into its cells.
 //
 // A rendered table is a run of consecutive single-line paragraphs (one per
-// table row) that the BlockParser merges into a single block. Each row's
-// paragraph style carries a `TableRowTextBlock`; because every row uses the
-// same column X offsets, the per-row vertical strokes line up into continuous
+// table row) that the BlockParser merges into a single block. Each row
+// carries a `.tableRow` BlockDecoration; because every row uses the same
+// column X offsets, the per-row vertical strokes line up into continuous
 // column borders.
-
-/// `NSTextBlock` subclass for table rows. Each row draws vertical border lines
-/// at column boundaries. The separator row also draws a horizontal hairline.
-/// All rows use the same column offsets so the vertical lines align into
-/// continuous column borders.
-final class TableRowTextBlock: NSTextBlock {
-
-    /// X offsets (from content area left edge) where vertical border lines are drawn.
-    var verticalLineXOffsets: [CGFloat] = []
-
-    /// Offset from frameRect.minX to the content area (= left padding).
-    var contentLeftOffset: CGFloat = 0
-
-    /// Whether to draw a horizontal hairline centered in the row (separator).
-    var drawHorizontalLine = false
-
-    /// Height override for the separator row (collapses to thin strip).
-    var heightOverride: CGFloat?
-
-    override func rectForLayout(
-        at startingPosition: CGPoint,
-        in rect: NSRect,
-        textContainer: NSTextContainer,
-        characterRange charRange: NSRange
-    ) -> NSRect {
-        var r = super.rectForLayout(at: startingPosition, in: rect,
-                                    textContainer: textContainer,
-                                    characterRange: charRange)
-        if let h = heightOverride {
-            r.size.height = h
-        }
-        return r
-    }
-
-    override func drawBackground(
-        withFrame frameRect: NSRect,
-        in controlView: NSView,
-        characterRange charRange: NSRange,
-        layoutManager: NSLayoutManager
-    ) {
-        NSColor.separatorColor.setStroke()
-        let baseX = frameRect.minX + contentLeftOffset
-
-        // Vertical borders at column boundaries
-        for xOffset in verticalLineXOffsets {
-            let path = NSBezierPath()
-            let x = round(baseX + xOffset) + 0.5
-            path.move(to: NSPoint(x: x, y: frameRect.minY))
-            path.line(to: NSPoint(x: x, y: frameRect.maxY))
-            path.lineWidth = 1
-            path.stroke()
-        }
-
-        // Horizontal separator
-        if drawHorizontalLine {
-            let path = NSBezierPath()
-            let y = round(frameRect.midY) + 0.5
-            path.move(to: NSPoint(x: frameRect.minX, y: y))
-            path.line(to: NSPoint(x: frameRect.maxX, y: y))
-            path.lineWidth = 1
-            path.stroke()
-        }
-    }
-}
 
 // MARK: - Table Row Parsing
 

--- a/Sources/MarkdownEditorCore/EditorTextView+TextKit2.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+TextKit2.swift
@@ -287,6 +287,28 @@ extension EditorTextView {
         result.addAttribute(.kern, value: overlay.bounds.width, range: anchor)
         result.addAttribute(.fragmentOverlay, value: overlay, range: anchor)
     }
+
+    /// Reserves vertical room for an overlay taller than the text line that
+    /// carries it. A `FragmentOverlay` only reserves horizontal advance (kern),
+    /// so — unlike the old `NSTextAttachment`, which grew its line fragment —
+    /// a tall image (e.g. inline math scaled to a heading's size) would
+    /// otherwise overlap the line below. Raises the enclosing paragraph's
+    /// `minimumLineHeight` to fit, preserving any other paragraph attributes.
+    func reserveLineHeight(_ height: CGFloat, forOverlayAt location: Int,
+                           in result: NSMutableAttributedString) {
+        guard location < result.length else { return }
+        let ns = result.string as NSString
+        // The enclosing paragraph (between newlines): minimumLineHeight is a
+        // paragraph attribute, and for the heading/inline cases the math sits
+        // on a single line, so this grows exactly the line that needs it.
+        let para = ns.paragraphRange(for: NSRange(location: location, length: 0))
+        let base = (result.attribute(.paragraphStyle, at: location, effectiveRange: nil)
+            as? NSParagraphStyle) ?? bodyParagraphStyle
+        guard height > base.minimumLineHeight else { return }
+        let ps = (base.mutableCopy() as! NSMutableParagraphStyle)
+        ps.minimumLineHeight = height
+        result.addAttribute(.paragraphStyle, value: ps, range: para)
+    }
 }
 
 // MARK: - Stack Construction

--- a/Sources/MarkdownEditorCore/EditorTextView+TextKit2.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+TextKit2.swift
@@ -49,8 +49,12 @@ public final class BlockDecoration: NSObject, @unchecked Sendable {
         /// table's left edge.
         case tableRow(columnXOffsets: [CGFloat], width: CGFloat,
                       leftInset: CGFloat, separator: Bool)
-        /// Horizontal hairline centered across the text column.
-        case horizontalRule(color: NSColor)
+        /// Horizontal hairline across the text column, drawn `centerOffset`
+        /// points below the fragment's vertical center. The offset compensates
+        /// for adjacent text sitting at its baseline (low in its line box), so
+        /// the rule looks equidistant from the text above and below rather
+        /// than hugging the line above it.
+        case horizontalRule(color: NSColor, centerOffset: CGFloat)
     }
 
     public let kind: Kind
@@ -227,10 +231,10 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
             }
             context.strokePath()
 
-        case .horizontalRule(let color):
+        case .horizontalRule(let color, let centerOffset):
             context.setStrokeColor(color.cgColor)
             context.setLineWidth(1)
-            let y = round(point.y + frame.height / 2) + 0.5
+            let y = round(point.y + frame.height / 2 + centerOffset) + 0.5
             context.move(to: CGPoint(x: columnRect.minX, y: y))
             context.addLine(to: CGPoint(x: columnRect.maxX, y: y))
             context.strokePath()

--- a/Sources/MarkdownEditorCore/EditorTextView+TextKit2.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+TextKit2.swift
@@ -8,17 +8,28 @@ import AppKit
 // `NSTextView.layoutManager` or store NSTextBlock/NSTextTable attributes —
 // either silently switches the view back to TextKit 1 for good.
 //
-// Block decorations (callout boxes, quote bars, table borders, thematic
-// breaks) that used to be NSTextBlock subclasses are now drawn by a custom
-// NSTextLayoutFragment: styling stores a `.blockDecoration` attribute on the
-// paragraph, and the layout-manager delegate vends a DecoratedTextLayoutFragment
-// for paragraphs that carry one. Backgrounds tile per paragraph fragment, so a
-// multi-line quote run still renders as one continuous box/bar.
+// Two custom attributes drive a custom layout fragment:
+//
+// - `.blockDecoration` (paragraph-level): callout boxes, quote bars, table
+//   borders, thematic-break rules. Fragment frames tile vertically, so
+//   per-paragraph drawing renders a multi-line quote run as one continuous
+//   box/bar.
+// - `.fragmentOverlay` (character-level): images drawn at a character's
+//   position — callout header (icon + title), rendered math, list bullets and
+//   checkboxes. TextKit 1 rendered `.attachment` over any character; TextKit 2
+//   only honors attachments on U+FFFC, which the storage==rawSource invariant
+//   forbids. Instead the anchor character is hidden, `.kern` reserves the
+//   image's advance width (the same trick the table renderer uses for column
+//   alignment), and the fragment draws the image at the anchor's position.
 
 public extension NSAttributedString.Key {
     /// Paragraph-level decoration drawn behind the text by
     /// `DecoratedTextLayoutFragment`. Value: `BlockDecoration`.
     static let blockDecoration = NSAttributedString.Key("MarkdownEditor.blockDecoration")
+    /// Character-level image drawn at the character's position by
+    /// `DecoratedTextLayoutFragment`. Value: `FragmentOverlay`. The styling
+    /// code pairs it with a hidden anchor glyph plus `.kern` for layout space.
+    static let fragmentOverlay = NSAttributedString.Key("MarkdownEditor.fragmentOverlay")
 }
 
 /// Value object describing what to draw behind a decorated paragraph.
@@ -27,17 +38,18 @@ public extension NSAttributedString.Key {
 public final class BlockDecoration: NSObject, @unchecked Sendable {
 
     public enum Kind: Equatable {
-        /// Filled box across the fragment (callouts), with optional borders.
+        /// Filled box across the text column (callouts), with optional borders.
         case box(background: NSColor, borderColor: NSColor?,
                  borderEdges: CalloutStyle.Edges, borderWidth: CGFloat)
-        /// Vertical bar at the fragment's left edge (plain block quotes).
+        /// Vertical bar just left of the paragraph's text (plain block quotes).
         case leftBar(color: NSColor, width: CGFloat)
-        /// Table-row chrome: vertical column borders (x offsets measured from
-        /// the row's left inset), and a horizontal rule through the separator
-        /// row. `width` is the table's full width.
+        /// Table-row chrome: vertical column borders at text-relative x
+        /// offsets, and a horizontal rule through the separator row. `width`
+        /// is the table's full width; `leftInset` the text's inset from the
+        /// table's left edge.
         case tableRow(columnXOffsets: [CGFloat], width: CGFloat,
                       leftInset: CGFloat, separator: Bool)
-        /// Horizontal hairline centered in the fragment (thematic break).
+        /// Horizontal hairline centered across the text column.
         case horizontalRule(color: NSColor)
     }
 
@@ -62,15 +74,40 @@ public final class BlockDecoration: NSObject, @unchecked Sendable {
     }
 }
 
+/// An image drawn at a character's laid-out position, with attachment-style
+/// bounds: `bounds.origin.y` is the image bottom relative to the text baseline
+/// (negative descends below it).
+public final class FragmentOverlay: NSObject, @unchecked Sendable {
+    public let image: NSImage
+    public let bounds: CGRect
+
+    public init(image: NSImage, bounds: CGRect) {
+        self.image = image
+        self.bounds = bounds
+        super.init()
+    }
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? FragmentOverlay else { return false }
+        return other.image === image && other.bounds == bounds
+    }
+
+    public override var hash: Int { Int(bounds.width) ^ Int(bounds.height) }
+}
+
 /// Layout fragment that draws its paragraph's `BlockDecoration` behind the
-/// text. Fragment frames tile vertically, so per-paragraph drawing of the
-/// same box/bar renders as one continuous shape across a multi-line block.
+/// text and any `FragmentOverlay` images at their characters' positions.
 final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
 
-    let decoration: BlockDecoration
+    let decoration: BlockDecoration?
+    /// Paragraph-relative anchor offsets and their overlays.
+    let overlays: [(offset: Int, overlay: FragmentOverlay)]
 
-    init(textElement: NSTextElement, range: NSTextRange?, decoration: BlockDecoration) {
+    init(textElement: NSTextElement, range: NSTextRange?,
+         decoration: BlockDecoration?,
+         overlays: [(offset: Int, overlay: FragmentOverlay)]) {
         self.decoration = decoration
+        self.overlays = overlays
         super.init(textElement: textElement, range: range)
     }
 
@@ -78,73 +115,126 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
         fatalError("DecoratedTextLayoutFragment does not support coding")
     }
 
+    /// Fragment-local x of the text container's left edge. The fragment's
+    /// frame hugs the laid-out text, so container x = 0 sits at -frame.minX.
+    private var containerLeft: CGFloat { -layoutFragmentFrame.minX }
+
+    private var containerWidth: CGFloat {
+        textLayoutManager?.textContainer?.size.width ?? layoutFragmentFrame.width
+    }
+
     override var renderingSurfaceBounds: CGRect {
-        // The decoration spans the full fragment, which can be wider than the
-        // text's own surface bounds (e.g. a box behind a short line).
-        CGRect(origin: .zero, size: layoutFragmentFrame.size)
-            .union(super.renderingSurfaceBounds)
+        var bounds = super.renderingSurfaceBounds
+        let frame = layoutFragmentFrame
+        if decoration != nil {
+            bounds = bounds.union(CGRect(x: containerLeft - 4, y: 0,
+                                         width: containerWidth + 8, height: frame.height))
+        }
+        for (offset, overlay) in overlays {
+            if let rect = overlayRect(anchorOffset: offset, overlay: overlay) {
+                bounds = bounds.union(rect.insetBy(dx: -2, dy: -2))
+            }
+        }
+        return bounds
     }
 
     override func draw(at point: CGPoint, in context: CGContext) {
         context.saveGState()
-        // Fragment-local (0,0) maps to `point` in the context.
-        let frame = CGRect(origin: point, size: layoutFragmentFrame.size)
+        if let decoration {
+            drawDecoration(decoration, at: point, in: context)
+        }
+        context.restoreGState()
+        super.draw(at: point, in: context)
+        for (offset, overlay) in overlays {
+            guard let rect = overlayRect(anchorOffset: offset, overlay: overlay) else { continue }
+            let drawRect = rect.offsetBy(dx: point.x, dy: point.y)
+            let nsContext = NSGraphicsContext(cgContext: context, flipped: true)
+            NSGraphicsContext.saveGraphicsState()
+            NSGraphicsContext.current = nsContext
+            overlay.image.draw(in: drawRect, from: .zero, operation: .sourceOver,
+                               fraction: 1, respectFlipped: true, hints: nil)
+            NSGraphicsContext.restoreGraphicsState()
+        }
+    }
+
+    /// Fragment-local rect for an overlay image, anchored to the character at
+    /// the given paragraph-relative offset.
+    private func overlayRect(anchorOffset: Int, overlay: FragmentOverlay) -> CGRect? {
+        guard let line = textLineFragments.first(where: {
+            NSLocationInRange(anchorOffset, $0.characterRange)
+        }) ?? textLineFragments.last else { return nil }
+        let anchorX = line.typographicBounds.minX
+            + line.locationForCharacter(at: anchorOffset).x
+        // Baseline (flipped coords): the line's glyph origin sits at its
+        // typographic origin plus the ascent-derived glyph origin.
+        let baselineY = line.typographicBounds.minY + line.glyphOrigin.y
+        return CGRect(x: anchorX + overlay.bounds.minX,
+                      y: baselineY - overlay.bounds.height - overlay.bounds.minY,
+                      width: overlay.bounds.width,
+                      height: overlay.bounds.height)
+    }
+
+    private func drawDecoration(_ decoration: BlockDecoration, at point: CGPoint, in context: CGContext) {
+        let frame = layoutFragmentFrame
+        // Fragment-local rect spanning the full text column for this fragment.
+        let columnRect = CGRect(x: point.x + containerLeft, y: point.y,
+                                width: containerWidth, height: frame.height)
 
         switch decoration.kind {
         case .box(let background, let borderColor, let edges, let borderWidth):
             context.setFillColor(background.cgColor)
-            context.fill(frame)
+            context.fill(columnRect)
             if let borderColor, !edges.isEmpty {
                 context.setFillColor(borderColor.cgColor)
                 if edges.contains(.left) {
-                    context.fill(CGRect(x: frame.minX, y: frame.minY,
-                                        width: borderWidth, height: frame.height))
+                    context.fill(CGRect(x: columnRect.minX, y: columnRect.minY,
+                                        width: borderWidth, height: columnRect.height))
                 }
                 if edges.contains(.right) {
-                    context.fill(CGRect(x: frame.maxX - borderWidth, y: frame.minY,
-                                        width: borderWidth, height: frame.height))
+                    context.fill(CGRect(x: columnRect.maxX - borderWidth, y: columnRect.minY,
+                                        width: borderWidth, height: columnRect.height))
                 }
                 if edges.contains(.top) {
-                    context.fill(CGRect(x: frame.minX, y: frame.minY,
-                                        width: frame.width, height: borderWidth))
+                    context.fill(CGRect(x: columnRect.minX, y: columnRect.minY,
+                                        width: columnRect.width, height: borderWidth))
                 }
                 if edges.contains(.bottom) {
-                    context.fill(CGRect(x: frame.minX, y: frame.maxY - borderWidth,
-                                        width: frame.width, height: borderWidth))
+                    context.fill(CGRect(x: columnRect.minX, y: columnRect.maxY - borderWidth,
+                                        width: columnRect.width, height: borderWidth))
                 }
             }
 
         case .leftBar(let color, let width):
+            // The bar sits immediately left of the text (the paragraph style
+            // insets the text by the bar's width).
             context.setFillColor(color.cgColor)
-            context.fill(CGRect(x: frame.minX, y: frame.minY,
+            context.fill(CGRect(x: point.x - width, y: point.y,
                                 width: width, height: frame.height))
 
         case .tableRow(let xOffsets, let width, let leftInset, let separator):
+            // Offsets are text-relative; the fragment's origin is the text start.
             context.setStrokeColor(NSColor.separatorColor.cgColor)
             context.setLineWidth(1)
             for x in xOffsets {
-                let lineX = round(frame.minX + leftInset + x) + 0.5
-                context.move(to: CGPoint(x: lineX, y: frame.minY))
-                context.addLine(to: CGPoint(x: lineX, y: frame.maxY))
+                let lineX = round(point.x + x) + 0.5
+                context.move(to: CGPoint(x: lineX, y: point.y))
+                context.addLine(to: CGPoint(x: lineX, y: point.y + frame.height))
             }
             if separator {
-                let y = round(frame.midY) + 0.5
-                context.move(to: CGPoint(x: frame.minX, y: y))
-                context.addLine(to: CGPoint(x: frame.minX + width, y: y))
+                let y = round(point.y + frame.height / 2) + 0.5
+                context.move(to: CGPoint(x: point.x - leftInset, y: y))
+                context.addLine(to: CGPoint(x: point.x - leftInset + width, y: y))
             }
             context.strokePath()
 
         case .horizontalRule(let color):
             context.setStrokeColor(color.cgColor)
             context.setLineWidth(1)
-            let y = round(frame.midY) + 0.5
-            context.move(to: CGPoint(x: frame.minX, y: y))
-            context.addLine(to: CGPoint(x: frame.maxX, y: y))
+            let y = round(point.y + frame.height / 2) + 0.5
+            context.move(to: CGPoint(x: columnRect.minX, y: y))
+            context.addLine(to: CGPoint(x: columnRect.maxX, y: y))
             context.strokePath()
         }
-
-        context.restoreGState()
-        super.draw(at: point, in: context)
     }
 }
 
@@ -156,16 +246,46 @@ extension EditorTextView: NSTextLayoutManagerDelegate {
         textLayoutFragmentFor location: NSTextLocation,
         in textElement: NSTextElement
     ) -> NSTextLayoutFragment {
-        if let paragraph = textElement as? NSTextParagraph,
-           paragraph.attributedString.length > 0,
-           let decoration = paragraph.attributedString.attribute(
-               .blockDecoration, at: 0, effectiveRange: nil) as? BlockDecoration {
-            return DecoratedTextLayoutFragment(textElement: textElement,
-                                               range: textElement.elementRange,
-                                               decoration: decoration)
+        guard let paragraph = textElement as? NSTextParagraph,
+              paragraph.attributedString.length > 0 else {
+            return NSTextLayoutFragment(textElement: textElement,
+                                        range: textElement.elementRange)
         }
-        return NSTextLayoutFragment(textElement: textElement,
-                                    range: textElement.elementRange)
+        let str = paragraph.attributedString
+        let decoration = str.attribute(.blockDecoration, at: 0,
+                                       effectiveRange: nil) as? BlockDecoration
+        var overlays: [(offset: Int, overlay: FragmentOverlay)] = []
+        str.enumerateAttribute(.fragmentOverlay,
+                               in: NSRange(location: 0, length: str.length),
+                               options: []) { value, range, _ in
+            if let overlay = value as? FragmentOverlay {
+                overlays.append((range.location, overlay))
+            }
+        }
+        guard decoration != nil || !overlays.isEmpty else {
+            return NSTextLayoutFragment(textElement: textElement,
+                                        range: textElement.elementRange)
+        }
+        return DecoratedTextLayoutFragment(textElement: textElement,
+                                           range: textElement.elementRange,
+                                           decoration: decoration,
+                                           overlays: overlays)
+    }
+}
+
+// MARK: - Overlay Application
+
+extension EditorTextView {
+    /// Renders `overlay` at `anchor` (a single character): hides the anchor
+    /// glyph, reserves the image's advance width with kern so following text
+    /// flows around it, and stores the overlay for the layout fragment to draw.
+    func applyOverlay(_ overlay: FragmentOverlay, anchor: NSRange,
+                      in result: NSMutableAttributedString) {
+        guard anchor.upperBound <= result.length else { return }
+        result.addAttribute(.font, value: hiddenFont, range: anchor)
+        result.addAttribute(.foregroundColor, value: NSColor.clear, range: anchor)
+        result.addAttribute(.kern, value: overlay.bounds.width, range: anchor)
+        result.addAttribute(.fragmentOverlay, value: overlay, range: anchor)
     }
 }
 

--- a/Sources/MarkdownEditorCore/EditorTextView+TextKit2.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+TextKit2.swift
@@ -1,0 +1,191 @@
+import AppKit
+
+// MARK: - TextKit 2 Support
+//
+// The editor runs on TextKit 2 (NSTextLayoutManager): layout is viewport-based
+// — the system only lays out what's on screen, which is what makes large
+// documents tractable. The hard rule that follows: never touch
+// `NSTextView.layoutManager` or store NSTextBlock/NSTextTable attributes —
+// either silently switches the view back to TextKit 1 for good.
+//
+// Block decorations (callout boxes, quote bars, table borders, thematic
+// breaks) that used to be NSTextBlock subclasses are now drawn by a custom
+// NSTextLayoutFragment: styling stores a `.blockDecoration` attribute on the
+// paragraph, and the layout-manager delegate vends a DecoratedTextLayoutFragment
+// for paragraphs that carry one. Backgrounds tile per paragraph fragment, so a
+// multi-line quote run still renders as one continuous box/bar.
+
+public extension NSAttributedString.Key {
+    /// Paragraph-level decoration drawn behind the text by
+    /// `DecoratedTextLayoutFragment`. Value: `BlockDecoration`.
+    static let blockDecoration = NSAttributedString.Key("MarkdownEditor.blockDecoration")
+}
+
+/// Value object describing what to draw behind a decorated paragraph.
+/// Reference type (NSObject) so it lives in attributed strings; value
+/// equality so attribute-run merging and the test oracle behave.
+public final class BlockDecoration: NSObject, @unchecked Sendable {
+
+    public enum Kind: Equatable {
+        /// Filled box across the fragment (callouts), with optional borders.
+        case box(background: NSColor, borderColor: NSColor?,
+                 borderEdges: CalloutStyle.Edges, borderWidth: CGFloat)
+        /// Vertical bar at the fragment's left edge (plain block quotes).
+        case leftBar(color: NSColor, width: CGFloat)
+        /// Table-row chrome: vertical column borders (x offsets measured from
+        /// the row's left inset), and a horizontal rule through the separator
+        /// row. `width` is the table's full width.
+        case tableRow(columnXOffsets: [CGFloat], width: CGFloat,
+                      leftInset: CGFloat, separator: Bool)
+        /// Horizontal hairline centered in the fragment (thematic break).
+        case horizontalRule(color: NSColor)
+    }
+
+    public let kind: Kind
+
+    public init(_ kind: Kind) {
+        self.kind = kind
+    }
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? BlockDecoration else { return false }
+        return kind == other.kind
+    }
+
+    public override var hash: Int {
+        switch kind {
+        case .box: return 1
+        case .leftBar: return 2
+        case .tableRow: return 3
+        case .horizontalRule: return 4
+        }
+    }
+}
+
+/// Layout fragment that draws its paragraph's `BlockDecoration` behind the
+/// text. Fragment frames tile vertically, so per-paragraph drawing of the
+/// same box/bar renders as one continuous shape across a multi-line block.
+final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
+
+    let decoration: BlockDecoration
+
+    init(textElement: NSTextElement, range: NSTextRange?, decoration: BlockDecoration) {
+        self.decoration = decoration
+        super.init(textElement: textElement, range: range)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("DecoratedTextLayoutFragment does not support coding")
+    }
+
+    override var renderingSurfaceBounds: CGRect {
+        // The decoration spans the full fragment, which can be wider than the
+        // text's own surface bounds (e.g. a box behind a short line).
+        CGRect(origin: .zero, size: layoutFragmentFrame.size)
+            .union(super.renderingSurfaceBounds)
+    }
+
+    override func draw(at point: CGPoint, in context: CGContext) {
+        context.saveGState()
+        // Fragment-local (0,0) maps to `point` in the context.
+        let frame = CGRect(origin: point, size: layoutFragmentFrame.size)
+
+        switch decoration.kind {
+        case .box(let background, let borderColor, let edges, let borderWidth):
+            context.setFillColor(background.cgColor)
+            context.fill(frame)
+            if let borderColor, !edges.isEmpty {
+                context.setFillColor(borderColor.cgColor)
+                if edges.contains(.left) {
+                    context.fill(CGRect(x: frame.minX, y: frame.minY,
+                                        width: borderWidth, height: frame.height))
+                }
+                if edges.contains(.right) {
+                    context.fill(CGRect(x: frame.maxX - borderWidth, y: frame.minY,
+                                        width: borderWidth, height: frame.height))
+                }
+                if edges.contains(.top) {
+                    context.fill(CGRect(x: frame.minX, y: frame.minY,
+                                        width: frame.width, height: borderWidth))
+                }
+                if edges.contains(.bottom) {
+                    context.fill(CGRect(x: frame.minX, y: frame.maxY - borderWidth,
+                                        width: frame.width, height: borderWidth))
+                }
+            }
+
+        case .leftBar(let color, let width):
+            context.setFillColor(color.cgColor)
+            context.fill(CGRect(x: frame.minX, y: frame.minY,
+                                width: width, height: frame.height))
+
+        case .tableRow(let xOffsets, let width, let leftInset, let separator):
+            context.setStrokeColor(NSColor.separatorColor.cgColor)
+            context.setLineWidth(1)
+            for x in xOffsets {
+                let lineX = round(frame.minX + leftInset + x) + 0.5
+                context.move(to: CGPoint(x: lineX, y: frame.minY))
+                context.addLine(to: CGPoint(x: lineX, y: frame.maxY))
+            }
+            if separator {
+                let y = round(frame.midY) + 0.5
+                context.move(to: CGPoint(x: frame.minX, y: y))
+                context.addLine(to: CGPoint(x: frame.minX + width, y: y))
+            }
+            context.strokePath()
+
+        case .horizontalRule(let color):
+            context.setStrokeColor(color.cgColor)
+            context.setLineWidth(1)
+            let y = round(frame.midY) + 0.5
+            context.move(to: CGPoint(x: frame.minX, y: y))
+            context.addLine(to: CGPoint(x: frame.maxX, y: y))
+            context.strokePath()
+        }
+
+        context.restoreGState()
+        super.draw(at: point, in: context)
+    }
+}
+
+// MARK: - Fragment Vending
+
+extension EditorTextView: NSTextLayoutManagerDelegate {
+    public nonisolated func textLayoutManager(
+        _ textLayoutManager: NSTextLayoutManager,
+        textLayoutFragmentFor location: NSTextLocation,
+        in textElement: NSTextElement
+    ) -> NSTextLayoutFragment {
+        if let paragraph = textElement as? NSTextParagraph,
+           paragraph.attributedString.length > 0,
+           let decoration = paragraph.attributedString.attribute(
+               .blockDecoration, at: 0, effectiveRange: nil) as? BlockDecoration {
+            return DecoratedTextLayoutFragment(textElement: textElement,
+                                               range: textElement.elementRange,
+                                               decoration: decoration)
+        }
+        return NSTextLayoutFragment(textElement: textElement,
+                                    range: textElement.elementRange)
+    }
+}
+
+// MARK: - Stack Construction
+
+public extension EditorTextView {
+    /// Builds the TextKit 2 text system chain and returns the wired editor:
+    ///   EditorTextStorage → NSTextContentStorage → NSTextLayoutManager
+    ///   → NSTextContainer → EditorTextView
+    static func makeTextKit2(frame: NSRect, containerSize: NSSize) -> EditorTextView {
+        let contentStorage = NSTextContentStorage()
+        contentStorage.textStorage = EditorTextStorage()
+
+        let layoutManager = NSTextLayoutManager()
+        contentStorage.addTextLayoutManager(layoutManager)
+
+        let container = NSTextContainer(size: containerSize)
+        container.widthTracksTextView = true
+        layoutManager.textContainer = container
+
+        return EditorTextView(frame: frame, textContainer: container)
+    }
+}

--- a/Sources/MarkdownEditorCore/EditorTextView+Undo.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Undo.swift
@@ -56,6 +56,7 @@ extension EditorTextView {
     private func restoreSnapshot(_ snapshot: UndoSnapshot) {
         isUndoRedoing = true
         rawSource = snapshot.rawSource
+        rebuildListIndentState()
         blocks = BlockParser.parse(rawSource, previous: blocks)
         recompose(cursorInRaw: snapshot.cursorInRaw)
         isUndoRedoing = false

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -34,13 +34,23 @@ public class EditorTextView: NSTextView {
 
     // MARK: - State (internal for @testable import)
 
-    public var rawSource: String = "" {
-        didSet { listIndentUnit = Self.detectListIndentUnit(rawSource) }
-    }
+    public var rawSource: String = ""
     /// Columns of leading whitespace that make up one list-nesting level,
     /// detected from the document (the smallest indent used, or one tab).
     /// Defaults to 4. Used to map a list item's indentation to a nesting depth.
+    /// Maintained incrementally from `listIndentState` on the edit path;
+    /// rebuilt by the whole-document paths (load, undo, indent).
     public var listIndentUnit: Int = 4
+    /// Histogram of indented-list-line indents (see ListIndentState) backing
+    /// the incremental `listIndentUnit`.
+    var listIndentState = ListIndentState()
+
+    /// Rebuilds the indent histogram from the whole document. O(n) — for the
+    /// paths that rebuilt rawSource anyway; the edit path updates per block.
+    func rebuildListIndentState() {
+        listIndentState = ListIndentState.build(from: rawSource)
+        listIndentUnit = listIndentState.unit
+    }
     /// Line ending of the most recently loaded content. The buffer itself is
     /// always LF; this is remembered so saves preserve the file's style.
     public var originalLineEnding: LineEnding = .lf
@@ -164,6 +174,7 @@ public class EditorTextView: NSTextView {
         typingAttributes = baseAttributes
 
         rawSource = ""
+        rebuildListIndentState()
         blocks = BlockParser.parse(rawSource)
         recompose(cursorInRaw: 0)
 
@@ -281,7 +292,7 @@ public class EditorTextView: NSTextView {
         guard let ts = textStorage else { return }
 
         let oldIndentUnit = listIndentUnit
-        rawSource = ts.string   // didSet recomputes listIndentUnit
+        rawSource = ts.string
         let sel = selectedRange()
         let cursorRaw = min(sel.location, (rawSource as NSString).length)
 
@@ -300,8 +311,20 @@ public class EditorTextView: NSTextView {
             #if DEBUG
             verifyIncrementalParse(newBlocks)
             #endif
+            // Update the indent histogram from exactly the replaced blocks
+            // (old) and their replacements (new) — O(edit), same effect as a
+            // whole-document rescan.
+            let suffixCount = newBlocks.count - changed.upperBound
+            for i in changed.lowerBound ..< (oldCount - suffixCount) {
+                listIndentState.remove(blocks[i].content)
+            }
+            for i in changed {
+                listIndentState.add(newBlocks[i].content)
+            }
+            listIndentUnit = listIndentState.unit
         } else {
             (newBlocks, changed) = BlockParser.parseWithDiff(rawSource, previous: blocks)
+            rebuildListIndentState()
         }
         blocks = newBlocks
 
@@ -368,6 +391,14 @@ public class EditorTextView: NSTextView {
 
     @objc private func selectionDidChange(_ notification: Notification) {
         guard !isUpdating else { return }
+        // NSTextView moves the selection DURING an edit, before didChangeText
+        // runs the sync — at that moment `blocks` still has pre-edit ranges.
+        // Styling here would apply stale ranges/content against the new text,
+        // spilling wrong attributes across block boundaries. The pending edit
+        // is exactly the "storage ahead of blocks" signal; didChangeText's
+        // flush styles the active block anyway.
+        if let storage = textStorage as? EditorTextStorage,
+           storage.pendingEdit != nil { return }
         // Don't restyle while an input method is composing (see didChangeText).
         guard !hasMarkedText() else { return }
 
@@ -543,7 +574,7 @@ public class EditorTextView: NSTextView {
         return minSpaces == Int.max ? 4 : minSpaces
     }
 
-    private static func startsWithListMarker(_ s: Substring) -> Bool {
+    nonisolated static func startsWithListMarker(_ s: Substring) -> Bool {
         guard let first = s.first else { return false }
         if first == "-" || first == "*" || first == "+" {
             return s.dropFirst().first == " "
@@ -565,6 +596,7 @@ public class EditorTextView: NSTextView {
         // block parsing and rendering never see a stray `\r`.
         originalLineEnding = LineEnding.detect(in: content)
         rawSource = LineEnding.normalize(content)
+        rebuildListIndentState()
         blocks = BlockParser.parse(rawSource)
         undoStack.removeAll()
         redoStack.removeAll()

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -287,7 +287,22 @@ public class EditorTextView: NSTextView {
 
         let oldCount = blocks.count
         let oldActive = activeBlockIndex
-        let (newBlocks, changed) = BlockParser.parseWithDiff(rawSource, previous: blocks)
+        // Incremental parse from the storage's accumulated edit — O(edit);
+        // full positional-diff parse as the fallback.
+        let newBlocks: [Block]
+        let changed: Range<Int>
+        if let pending = (ts as? EditorTextStorage)?.consumePendingEdit(),
+           let incremental = BlockParser.incrementalParse(text: rawSource,
+                                                          old: blocks,
+                                                          editedOldRange: pending.oldRange,
+                                                          delta: pending.delta) {
+            (newBlocks, changed) = incremental
+            #if DEBUG
+            verifyIncrementalParse(newBlocks)
+            #endif
+        } else {
+            (newBlocks, changed) = BlockParser.parseWithDiff(rawSource, previous: blocks)
+        }
         blocks = newBlocks
 
         var dirty = IndexSet(integersIn: changed)
@@ -321,6 +336,33 @@ public class EditorTextView: NSTextView {
 
         recomposeDirty(dirty, cursorInRaw: cursorRaw)
     }
+
+    #if DEBUG
+    /// Debug oracle for the incremental parser: every incremental result must
+    /// equal a from-scratch parse (content, ranges, kinds — IDs are allowed
+    /// to differ). Skipped under MD_PERF so measurements stay representative.
+    private func verifyIncrementalParse(_ incremental: [Block]) {
+        guard ProcessInfo.processInfo.environment["MD_PERF"] == nil else { return }
+        let reference = BlockParser.parse(rawSource)
+        guard incremental.count == reference.count else {
+            assertionFailure("""
+            incremental parse diverged: \(incremental.count) blocks \
+            vs \(reference.count) reference
+            """)
+            return
+        }
+        for (a, b) in zip(incremental, reference) {
+            if a.content != b.content || a.range != b.range || a.kind != b.kind {
+                assertionFailure("""
+                incremental parse diverged at \(a.range): \
+                \(String(reflecting: a.content)) [\(a.kind)] vs \
+                \(String(reflecting: b.content)) [\(b.kind)] at \(b.range)
+                """)
+                return
+            }
+        }
+    }
+    #endif
 
     // MARK: - Selection Change Detection
 

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -49,6 +49,11 @@ public class EditorTextView: NSTextView {
     var isUpdating = false
     var displayRanges: [NSRange] = []
     private var pendingRecompose = false
+    /// Coalesces idle-drain scheduling (see EditorTextView+LazyStyling).
+    var progressiveStylingScheduled = false
+    /// Where the idle drain resumes scanning for unstyled blocks (a hint;
+    /// it wraps around and self-corrects after edits shift indices).
+    var drainCursor = 0
 
     // MARK: - Custom Undo/Redo State
 
@@ -197,6 +202,12 @@ public class EditorTextView: NSTextView {
         """)
     }
     #endif
+
+    /// Hook up scroll promotion once the editor lands in its scroll view.
+    public override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        installScrollPromotionObserver()
+    }
 
     // MARK: - Appearance
 
@@ -374,9 +385,14 @@ public class EditorTextView: NSTextView {
     /// The caret line's rect in text-container coordinates (TextKit 2: lays
     /// out only the caret's fragment, positions above are estimated).
     private func caretLineRect() -> CGRect? {
+        lineRect(forCharacterAt: selectedRange().location)
+    }
+
+    /// The line rect for the character at `offset`, in text-container
+    /// coordinates. Lays out only that character's fragment.
+    private func lineRect(forCharacterAt offset: Int) -> CGRect? {
         guard let tlm = textLayoutManager else { return nil }
-        let sel = selectedRange()
-        guard let loc = tlm.location(tlm.documentRange.location, offsetBy: sel.location)
+        guard let loc = tlm.location(tlm.documentRange.location, offsetBy: offset)
         else { return nil }
         tlm.ensureLayout(for: NSTextRange(location: loc))
         guard let fragment = tlm.textLayoutFragment(for: loc) else { return nil }
@@ -389,6 +405,33 @@ public class EditorTextView: NSTextView {
         } ?? fragment.textLineFragments.last
         guard let line else { return frame }
         return line.typographicBounds.offsetBy(dx: frame.minX, dy: frame.minY)
+    }
+
+    /// AppKit's TextKit 2 implementation of scroll-to-range kills the process
+    /// on large documents (observed reproducibly at ~1.5 MB; silent kill, no
+    /// crash report). NSTextView calls it internally after every insertion
+    /// (caret autoscroll), so replace it with the minimal fragment-based
+    /// scroll: lay out just the target's fragment and move the clip view.
+    public override func scrollRangeToVisible(_ range: NSRange) {
+        guard let scrollView = enclosingScrollView else { return }
+        guard let rect = lineRect(forCharacterAt: range.location) else { return }
+
+        let lineRect = rect.offsetBy(dx: textContainerOrigin.x, dy: textContainerOrigin.y)
+        let visible = scrollView.contentView.bounds
+        let margin: CGFloat = 8
+
+        var targetY = visible.origin.y
+        if lineRect.minY < visible.minY {
+            targetY = lineRect.minY - margin
+        } else if lineRect.maxY > visible.maxY {
+            targetY = lineRect.maxY + margin - visible.height
+        } else {
+            return  // already visible
+        }
+        let maxY = max(0, frame.height - visible.height)
+        let clampedY = min(max(0, targetY), maxY)
+        scrollView.contentView.scroll(to: NSPoint(x: visible.origin.x, y: clampedY))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
     }
 
     // MARK: - Link Following

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -421,12 +421,41 @@ public class EditorTextView: NSTextView {
                 self.pendingRecompose = false
                 guard !self.isUpdating else { return }
 
-                let currentSel = self.selectedRange()
-                let rawStart = currentSel.location
-                let rawEnd = currentSel.location + currentSel.length
-                let rawSel = NSRange(location: rawStart, length: rawEnd - rawStart)
-                self.recomposeIncremental(cursorInRaw: rawStart, selectionInRaw: rawSel)
+                // Restyle the new active block now. DEFER the old active block
+                // if it's off screen: deactivating it (rendered ↔ raw — callout
+                // box, checklist marker, …) changes its height, and doing that
+                // synchronously while the user is looking elsewhere shifts the
+                // whole viewport. Marking it unstyled hands it to the async
+                // drain, which TextKit 2 lays out without disturbing the
+                // viewport. Don't re-set the selection (that triggers AppKit's
+                // autoscroll-to-selection on stale layout).
+                let loc = self.selectedRange().location
+                let newIdx = self.blockIndexForRawOffset(loc)
+                var dirty = IndexSet()
+                if let n = newIdx { dirty.insert(n) }
+                var deferred = false
+                if let old = self.activeBlockIndex, old != newIdx, old < self.blocks.count {
+                    if let vis = self.syncStylingBlockRange(), vis.contains(old) {
+                        dirty.insert(old)   // visible — restyle in place
+                    } else {
+                        self.blocks[old].isStyled = false   // off screen — defer
+                        deferred = true
+                    }
+                }
+                // Only the new (visible) active block changes height now, so the
+                // caret anchor's delta is small and reliable. Typewriter mode
+                // centers on the post-restyle layout instead.
+                if self.typewriterModeEnabled {
+                    self.recomposeDirty(dirty, cursorInRaw: loc)
+                    self.scrollCursorToCenter()
+                } else {
+                    self.preservingCaretScreenPosition {
+                        self.recomposeDirty(dirty, cursorInRaw: loc)
+                    }
+                }
+                if deferred { self.scheduleProgressiveStyling() }
             }
+            return
         } else if newActiveIndex == activeBlockIndex {
             // Same block — update active token (re-style to show/hide delimiters)
             applyBlockStyle()
@@ -440,6 +469,30 @@ public class EditorTextView: NSTextView {
     /// vertically centered (typewriter scrolling). When false, scrolling is left
     /// to the normal "keep the cursor visible" behavior. Toggled from View menu.
     public var typewriterModeEnabled: Bool = true
+
+    /// The caret line's top in view (scroll-document) coordinates, or nil.
+    private func caretViewY() -> CGFloat? {
+        caretLineRect().map { $0.minY + textContainerOrigin.y }
+    }
+
+    /// Runs `body` (which restyles the active block, changing its height) while
+    /// keeping the caret line at the same on-screen position. The caret offset
+    /// (`selectedRange().location`) is reliable and the caret is on screen here,
+    /// so `lineRect` resolves correctly. With the off-screen old active block
+    /// deferred (see selectionDidChange), only the visible new active block
+    /// changes height, so the delta is small.
+    private func preservingCaretScreenPosition(_ body: () -> Void) {
+        guard let scrollView = enclosingScrollView, let before = caretViewY() else {
+            body(); return
+        }
+        let screenOffset = before - scrollView.contentView.bounds.origin.y
+        body()
+        guard let after = caretViewY() else { return }
+        let newY = max(0, after - screenOffset)
+        guard abs(newY - scrollView.contentView.bounds.origin.y) > 0.5 else { return }
+        scrollView.contentView.scroll(to: NSPoint(x: scrollView.contentView.bounds.origin.x, y: newY))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+    }
 
     /// Scrolls the view so the cursor's line fragment is vertically centered
     /// in the visible area.

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -107,12 +107,12 @@ public class EditorTextView: NSTextView {
         return ps
     }
 
-    /// Apply a new theme, persist it, and recompose.
+    /// Apply a new theme, persist it, and restyle every block in place.
     public func applyTheme(_ newTheme: EditorTheme) {
         theme = newTheme
         theme.save(to: themeDefaults)
         typingAttributes = baseAttributes
-        recompose(cursorInRaw: currentCursorInRaw())
+        recomposeAllDirty()
     }
 
     var baseAttributes: [NSAttributedString.Key: Any] {
@@ -186,7 +186,7 @@ public class EditorTextView: NSTextView {
             .foregroundColor: foregroundColor,
         ]
         typingAttributes = baseAttributes
-        recompose(cursorInRaw: currentCursorInRaw())
+        recomposeAllDirty()
     }
 
     // MARK: - Edit Flow
@@ -233,38 +233,58 @@ public class EditorTextView: NSTextView {
         // — which fires didChangeText again with no marked text.
         guard !hasMarkedText() else { return }
         syncRawSourceFromDisplay()
-        applyBlockStyle()
         document?.updateChangeCount(.changeDone)
         scrollCursorToCenter()
     }
 
-    /// Syncs rawSource from the text storage and re-parses blocks.
-    /// With word-level rendering, text storage = rawSource, so this is simple.
+    /// Syncs rawSource from the text storage, re-parses blocks, and restyles
+    /// exactly the blocks the edit affected: the parser's changed window, the
+    /// old and new active blocks, and — when the document-global list indent
+    /// unit moved — every list block. One flush, attribute-only; the storage
+    /// string is never replaced on the edit path.
     private func syncRawSourceFromDisplay() {
         guard let ts = textStorage else { return }
 
-        rawSource = ts.string
+        let oldIndentUnit = listIndentUnit
+        rawSource = ts.string   // didSet recomputes listIndentUnit
         let sel = selectedRange()
         let cursorRaw = min(sel.location, (rawSource as NSString).length)
 
-        let previousBlockCount = blocks.count
-        blocks = BlockParser.parse(rawSource, previous: blocks)
-        recalcDisplayRanges()
+        let oldCount = blocks.count
+        let oldActive = activeBlockIndex
+        let (newBlocks, changed) = BlockParser.parseWithDiff(rawSource, previous: blocks)
+        blocks = newBlocks
 
-        // If the number of blocks changed, an edit split or merged blocks (e.g. a
-        // callout/code fence/quote gaining or losing lines). Incremental recompose
-        // only restyles the active block, so a neighbor whose meaning changed —
-        // such as a former callout body line left with a stale background — would
-        // keep its old styling. Do a full recompose to keep the document correct.
-        if blocks.count != previousBlockCount {
-            recompose(cursorInRaw: cursorRaw)
-            return
+        var dirty = IndexSet(integersIn: changed)
+
+        // Map the old active block through the diff so its deactivation
+        // restyle lands on the right index: prefix indices are unchanged,
+        // suffix indices shift by the count delta, and anything inside the
+        // window is already dirty.
+        if let old = oldActive {
+            let suffixCount = newBlocks.count - changed.upperBound
+            if old < changed.lowerBound {
+                dirty.insert(old)
+            } else if old >= oldCount - suffixCount {
+                dirty.insert(old + (newBlocks.count - oldCount))
+            }
         }
 
-        let newBlockIndex = blockIndexForRawOffset(cursorRaw)
-        if newBlockIndex != activeBlockIndex {
-            recomposeIncremental(cursorInRaw: cursorRaw)
+        // The block under the cursor gets cursor-aware delimiter styling
+        // (this also subsumes the old per-keystroke applyBlockStyle pass).
+        if let newActive = blockIndexForRawOffset(cursorRaw) {
+            dirty.insert(newActive)
         }
+
+        // listIndentUnit is document-global: when it changes, the rendered
+        // indentation of every list block changes with it.
+        if listIndentUnit != oldIndentUnit {
+            for (i, block) in blocks.enumerated() where block.kind == .listItem {
+                dirty.insert(i)
+            }
+        }
+
+        recomposeDirty(dirty, cursorInRaw: cursorRaw)
     }
 
     // MARK: - Selection Change Detection

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -61,6 +61,9 @@ public class EditorTextView: NSTextView {
     private var pendingRecompose = false
     /// Coalesces idle-drain scheduling (see EditorTextView+LazyStyling).
     var progressiveStylingScheduled = false
+    /// Coalesces scroll-driven promotion onto the next run-loop turn, off the
+    /// scroll notification (see EditorTextView+LazyStyling).
+    var pendingPromotion = false
     /// Where the idle drain resumes scanning for unstyled blocks (a hint;
     /// it wraps around and self-corrects after edits shift indices).
     var drainCursor = 0

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -165,6 +165,18 @@ public class EditorTextView: NSTextView {
         // Vend decoration-drawing layout fragments (TextKit 2).
         textLayoutManager?.delegate = self
 
+        #if DEBUG
+        // TextKit 1 fallback is silent and permanent: it happens when any
+        // NSLayoutManager API is touched or an unsupported attribute (e.g.
+        // NSTextBlock) enters the storage. Fail loudly instead.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(textKit1FallbackTripwire(_:)),
+            name: NSTextView.willSwitchToNSLayoutManagerNotification,
+            object: self
+        )
+        #endif
+
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(selectionDidChange(_:)),
@@ -176,6 +188,15 @@ public class EditorTextView: NSTextView {
     deinit {
         NotificationCenter.default.removeObserver(self)
     }
+
+    #if DEBUG
+    @objc private func textKit1FallbackTripwire(_ note: Notification) {
+        assertionFailure("""
+        TextKit 1 fallback triggered — an NSLayoutManager API was called or an \
+        unsupported attribute (NSTextBlock/NSTextTable?) entered the storage.
+        """)
+    }
+    #endif
 
     // MARK: - Appearance
 

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -162,6 +162,9 @@ public class EditorTextView: NSTextView {
         blocks = BlockParser.parse(rawSource)
         recompose(cursorInRaw: 0)
 
+        // Vend decoration-drawing layout fragments (TextKit 2).
+        textLayoutManager?.delegate = self
+
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(selectionDidChange(_:)),
@@ -334,14 +337,8 @@ public class EditorTextView: NSTextView {
     /// in the visible area.
     private func scrollCursorToCenter() {
         guard typewriterModeEnabled else { return }
-        guard let lm = layoutManager,
-              let scrollView = enclosingScrollView else { return }
-
-        let sel = selectedRange()
-        let glyphRange = lm.glyphRange(forCharacterRange: NSRange(location: sel.location, length: 0),
-                                        actualCharacterRange: nil)
-        guard glyphRange.location != NSNotFound else { return }
-        let lineRect = lm.lineFragmentRect(forGlyphAt: glyphRange.location, effectiveRange: nil)
+        guard let scrollView = enclosingScrollView,
+              let lineRect = caretLineRect() else { return }
         let cursorY = lineRect.midY + textContainerOrigin.y
 
         let visibleHeight = scrollView.contentView.bounds.height
@@ -351,6 +348,26 @@ public class EditorTextView: NSTextView {
 
         scrollView.contentView.scroll(to: NSPoint(x: 0, y: clampedY))
         scrollView.reflectScrolledClipView(scrollView.contentView)
+    }
+
+    /// The caret line's rect in text-container coordinates (TextKit 2: lays
+    /// out only the caret's fragment, positions above are estimated).
+    private func caretLineRect() -> CGRect? {
+        guard let tlm = textLayoutManager else { return nil }
+        let sel = selectedRange()
+        guard let loc = tlm.location(tlm.documentRange.location, offsetBy: sel.location)
+        else { return nil }
+        tlm.ensureLayout(for: NSTextRange(location: loc))
+        guard let fragment = tlm.textLayoutFragment(for: loc) else { return nil }
+        let frame = fragment.layoutFragmentFrame
+
+        guard let paraStart = fragment.textElement?.elementRange?.location else { return frame }
+        let offsetInPara = tlm.offset(from: paraStart, to: loc)
+        let line = fragment.textLineFragments.first {
+            NSLocationInRange(offsetInPara, $0.characterRange)
+        } ?? fragment.textLineFragments.last
+        guard let line else { return frame }
+        return line.typographicBounds.offsetBy(dx: frame.minX, dy: frame.minY)
     }
 
     // MARK: - Link Following
@@ -367,19 +384,26 @@ public class EditorTextView: NSTextView {
     /// The destination URL of the link under a mouse event, or nil if the click
     /// doesn't land directly on link text.
     private func linkURL(at event: NSEvent) -> URL? {
-        guard let lm = layoutManager, let container = textContainer,
+        guard let tlm = textLayoutManager,
               let storage = textStorage, storage.length > 0 else { return nil }
 
         var point = convert(event.locationInWindow, from: nil)
         point.x -= textContainerOrigin.x
         point.y -= textContainerOrigin.y
 
-        let glyphIndex = lm.glyphIndex(for: point, in: container)
-        // Reject clicks past the end of a line (which still resolve to a glyph).
-        let glyphRect = lm.boundingRect(forGlyphRange: NSRange(location: glyphIndex, length: 1), in: container)
-        guard glyphRect.contains(point) else { return nil }
+        guard let fragment = tlm.textLayoutFragment(for: point) else { return nil }
+        let frame = fragment.layoutFragmentFrame
+        let pointInFragment = CGPoint(x: point.x - frame.minX, y: point.y - frame.minY)
+        // Reject clicks past the end of a line: typographic bounds cover only
+        // the line's used extent.
+        guard let line = fragment.textLineFragments.first(where: {
+            $0.typographicBounds.contains(pointInFragment)
+        }) else { return nil }
 
-        let charIndex = lm.characterIndexForGlyph(at: glyphIndex)
+        let indexInParagraph = line.characterIndex(for: pointInFragment)
+        guard indexInParagraph >= 0,
+              let paraStart = fragment.textElement?.elementRange?.location else { return nil }
+        let charIndex = tlm.offset(from: tlm.documentRange.location, to: paraStart) + indexInParagraph
         guard charIndex < storage.length,
               let dest = storage.attribute(.editorLinkURL, at: charIndex, effectiveRange: nil) as? String
         else { return nil }

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -462,8 +462,12 @@ public class EditorTextView: NSTextView {
     }
 
     /// The line rect for the character at `offset`, in text-container
-    /// coordinates. Lays out only that character's fragment.
-    private func lineRect(forCharacterAt offset: Int) -> CGRect? {
+    /// coordinates. Lays out only the offset's own fragment — forcing layout
+    /// from the document start would lay out (and could OOM on) the whole 1–2
+    /// MB document for a deep caret. For carets in or near the viewport the
+    /// position is exact; for far jumps it may be a TextKit 2 estimate that
+    /// the scroll anchoring + promotion settle once the region is reached.
+    func lineRect(forCharacterAt offset: Int) -> CGRect? {
         guard let tlm = textLayoutManager else { return nil }
         guard let loc = tlm.location(tlm.documentRange.location, offsetBy: offset)
         else { return nil }
@@ -487,17 +491,23 @@ public class EditorTextView: NSTextView {
     /// scroll: lay out just the target's fragment and move the clip view.
     public override func scrollRangeToVisible(_ range: NSRange) {
         guard let scrollView = enclosingScrollView else { return }
-        guard let rect = lineRect(forCharacterAt: range.location) else { return }
-
-        let lineRect = rect.offsetBy(dx: textContainerOrigin.x, dy: textContainerOrigin.y)
+        // Bound the range by its two ends so an extended selection follows the
+        // end being modified rather than always its start.
         let visible = scrollView.contentView.bounds
+        guard let startRect = lineRect(forCharacterAt: range.location) else { return }
+        let endRect = range.length > 0
+            ? (lineRect(forCharacterAt: range.upperBound) ?? startRect) : startRect
+        let top = min(startRect.minY, endRect.minY) + textContainerOrigin.y
+        let bottom = max(startRect.maxY, endRect.maxY) + textContainerOrigin.y
         let margin: CGFloat = 8
 
         var targetY = visible.origin.y
-        if lineRect.minY < visible.minY {
-            targetY = lineRect.minY - margin
-        } else if lineRect.maxY > visible.maxY {
-            targetY = lineRect.maxY + margin - visible.height
+        if top < visible.minY {
+            targetY = top - margin
+        } else if bottom > visible.maxY {
+            // Prefer keeping the bottom edge visible; fall back to the top if
+            // the range is taller than the viewport.
+            targetY = min(bottom + margin - visible.height, top - margin)
         } else {
             return  // already visible
         }

--- a/Sources/MarkdownEditorCore/ListIndentState.swift
+++ b/Sources/MarkdownEditorCore/ListIndentState.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Incremental backing for the document-global list indent unit.
+///
+/// Replicates `EditorTextView.detectListIndentUnit` exactly — any
+/// tab-indented list line forces 4; otherwise the smallest space indent of
+/// any list line; 4 when none — but as a histogram that can be updated per
+/// block on the edit path instead of rescanning the whole document per
+/// keystroke. Block contents tile the document's lines exactly (merged
+/// constructs keep their inner newlines), so adding/removing block contents
+/// is equivalent to rescanning those lines.
+struct ListIndentState {
+    private(set) var tabLines = 0
+    private(set) var histogram: [Int: Int] = [:]
+
+    var unit: Int {
+        if tabLines > 0 { return 4 }
+        return histogram.keys.min() ?? 4
+    }
+
+    mutating func add(_ content: String) { scan(content, sign: 1) }
+    mutating func remove(_ content: String) { scan(content, sign: -1) }
+
+    static func build(from source: String) -> ListIndentState {
+        var state = ListIndentState()
+        state.add(source)
+        return state
+    }
+
+    private mutating func scan(_ content: String, sign: Int) {
+        for line in content.split(separator: "\n", omittingEmptySubsequences: false) {
+            var spaces = 0
+            var sawTab = false
+            for ch in line {
+                if ch == " " { spaces += 1 }
+                else if ch == "\t" { sawTab = true; break }
+                else { break }
+            }
+            let rest = line.drop(while: { $0 == " " || $0 == "\t" })
+            guard EditorTextView.startsWithListMarker(rest) else { continue }
+            if sawTab {
+                tabLines += sign
+            } else if spaces > 0 {
+                let count = (histogram[spaces] ?? 0) + sign
+                histogram[spaces] = count <= 0 ? nil : count
+            }
+        }
+    }
+}

--- a/Sources/md/Document.swift
+++ b/Sources/md/Document.swift
@@ -85,20 +85,10 @@ class Document: NSDocument {
         window.toolbarStyle = .unified
         window.titlebarSeparatorStyle = .line
 
-        // Build the text system chain:
-        //   NSTextStorage → NSLayoutManager → NSTextContainer → NSTextView
-        let textStorage = EditorTextStorage()
-        let layoutManager = NSLayoutManager()
-        textStorage.addLayoutManager(layoutManager)
-
-        let contentSize = NSSize(width: windowWidth, height: CGFloat.greatestFiniteMagnitude)
-        let textContainer = NSTextContainer(size: contentSize)
-        textContainer.widthTracksTextView = true
-        layoutManager.addTextContainer(textContainer)
-
-        editor = EditorTextView(
+        // Build the TextKit 2 text system chain (viewport-based layout).
+        editor = EditorTextView.makeTextKit2(
             frame: NSRect(x: 0, y: 0, width: windowWidth, height: windowHeight),
-            textContainer: textContainer
+            containerSize: NSSize(width: windowWidth, height: CGFloat.greatestFiniteMagnitude)
         )
         editor.minSize = NSSize(width: 0, height: 0)
         editor.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude,

--- a/Tests/MarkdownEditorTests/BlockParserTests.swift
+++ b/Tests/MarkdownEditorTests/BlockParserTests.swift
@@ -400,4 +400,115 @@ struct BlockParserTests {
         #expect(blocks[1].content == "paragraph")
         #expect(blocks[2].content == "> second")
     }
+
+    // MARK: - Changed Window (parseWithDiff)
+
+    @Test("Unchanged re-parse yields an empty window")
+    func diffUnchanged() {
+        let (b1, _) = BlockParser.parseWithDiff("a\nb\nc")
+        let (b2, changed) = BlockParser.parseWithDiff("a\nb\nc", previous: b1)
+        #expect(changed.isEmpty)
+        #expect(b1.map(\.id) == b2.map(\.id))
+    }
+
+    @Test("Editing one block yields a one-block window")
+    func diffSingleEdit() {
+        let (b1, _) = BlockParser.parseWithDiff("a\nb\nc")
+        let (b2, changed) = BlockParser.parseWithDiff("a\nbX\nc", previous: b1)
+        #expect(changed == 1..<2)
+        #expect(b2[0].id == b1[0].id)
+        #expect(b2[2].id == b1[2].id)
+        #expect(b2[1].id != b1[1].id)
+    }
+
+    @Test("Splitting a block yields a two-block window (count change)")
+    func diffSplit() {
+        let (b1, _) = BlockParser.parseWithDiff("hello world\ntail")
+        let (b2, changed) = BlockParser.parseWithDiff("hello\nworld\ntail", previous: b1)
+        #expect(b2.count == 3)
+        #expect(changed == 0..<2)
+        #expect(b2[2].id == b1[1].id)   // suffix keeps its ID
+    }
+
+    @Test("Merging two blocks yields a one-block window")
+    func diffMerge() {
+        let (b1, _) = BlockParser.parseWithDiff("> a\nplain\ntail")
+        // "plain" becomes a quote line and merges into the run.
+        let (b2, changed) = BlockParser.parseWithDiff("> a\n> plain\ntail", previous: b1)
+        #expect(b2.count == 2)
+        #expect(changed == 0..<1)
+        #expect(b2[1].id == b1[2].id)
+    }
+
+    @Test("Identical-content documents: window covers only the edit")
+    func diffIdenticalContent() {
+        let (b1, _) = BlockParser.parseWithDiff("a\na\na\na")
+        let (b2, changed) = BlockParser.parseWithDiff("a\nX\na\na", previous: b1)
+        #expect(changed == 1..<2)
+        // Prefix and suffix matches keep their IDs positionally.
+        #expect(b2[0].id == b1[0].id)
+        #expect(b2[2].id == b1[2].id)
+        #expect(b2[3].id == b1[3].id)
+    }
+
+    @Test("Overlap clamp: duplicating a block doesn't double-match")
+    func diffOverlapClamp() {
+        let (b1, _) = BlockParser.parseWithDiff("a")
+        let (b2, changed) = BlockParser.parseWithDiff("a\na", previous: b1)
+        #expect(b2.count == 2)
+        #expect(changed.count == 1)
+        #expect(Set(b2.map(\.id)).count == 2)
+    }
+
+    // MARK: - Block Kinds
+
+    @Test("Kinds are classified per block")
+    func kinds() {
+        let text = """
+        # Title
+        plain
+        - item
+        3. ordered
+        ---
+        > quote
+
+        > [!note]
+        > body
+        | a | b |
+        | --- | --- |
+        ```
+        code
+        ```
+        $$
+        x
+        $$
+        """
+        let blocks = BlockParser.parse(text)
+        let kinds = blocks.map(\.kind)
+        #expect(kinds == [
+            .heading(level: 1),
+            .paragraph,
+            .listItem,
+            .listItem,
+            .thematicBreak,
+            .quoteRun(isCallout: false),
+            .blank,
+            .quoteRun(isCallout: true),
+            .table,
+            .fence,
+            .mathDisplay,
+        ])
+    }
+
+    @Test("Blank and whitespace-only lines are .blank")
+    func blankKinds() {
+        let blocks = BlockParser.parse("a\n\n   \nb")
+        #expect(blocks.map(\.kind) == [.paragraph, .blank, .blank, .paragraph])
+    }
+
+    @Test("Thematic break beats list classification for '- - -'")
+    func hrBeatsList() {
+        let blocks = BlockParser.parse("- - -")
+        #expect(blocks[0].kind == .thematicBreak)
+    }
 }

--- a/Tests/MarkdownEditorTests/BlockStylingTests.swift
+++ b/Tests/MarkdownEditorTests/BlockStylingTests.swift
@@ -206,7 +206,7 @@ struct BlockStylingNonActiveTests {
         #expect(text == "- apples")
         // Bullet `-` renders as a dot attachment
         let a = attrs(at: 0, in: editor)
-        #expect(a[.attachment] is NSTextAttachment)
+        #expect(a[.fragmentOverlay] is FragmentOverlay)
         // Has indent
         let ps = a[.paragraphStyle] as? NSParagraphStyle
         #expect(ps != nil)
@@ -241,7 +241,7 @@ struct BlockStylingNonActiveTests {
         #expect(isHidden(at: 0, in: editor.textStorage!))
         // "[" (offset 2) has a text attachment (circle icon)
         let a = attrs(at: 2, in: editor)
-        #expect(a[.attachment] is NSTextAttachment)
+        #expect(a[.fragmentOverlay] is FragmentOverlay)
         // " ]" (offsets 3-4) are hidden
         let hiddenA = attrs(at: 3, in: editor)
         let hiddenF = hiddenA[.font] as? NSFont
@@ -260,7 +260,7 @@ struct BlockStylingNonActiveTests {
         #expect(isHidden(at: 0, in: editor.textStorage!))
         // "[" (offset 2) has a text attachment (filled circle icon)
         let a = attrs(at: 2, in: editor)
-        #expect(a[.attachment] is NSTextAttachment)
+        #expect(a[.fragmentOverlay] is FragmentOverlay)
         // "x]" (offsets 3-4) are hidden
         let hiddenA = attrs(at: 3, in: editor)
         let hiddenF = hiddenA[.font] as? NSFont
@@ -281,7 +281,7 @@ struct BlockStylingNonActiveTests {
         let text = displayText(for: 0, in: editor)
         #expect(text == "  - nested")
         // The `-` at offset 2 carries the bullet dot attachment
-        #expect(attrs(at: 2, in: editor)[.attachment] is NSTextAttachment)
+        #expect(attrs(at: 2, in: editor)[.fragmentOverlay] is FragmentOverlay)
     }
 
     @Test("Non-active deeply-indented bullet (4 spaces) renders as a dot")
@@ -293,7 +293,7 @@ struct BlockStylingNonActiveTests {
         let text = displayText(for: 0, in: editor)
         #expect(text == "    - deep")
         // The `-` at offset 4 carries the bullet dot attachment
-        #expect(attrs(at: 4, in: editor)[.attachment] is NSTextAttachment)
+        #expect(attrs(at: 4, in: editor)[.fragmentOverlay] is FragmentOverlay)
     }
 
     // MARK: - Blockquotes
@@ -319,18 +319,15 @@ struct BlockStylingNonActiveTests {
         let editor = makeEditor()
         let styled = editor.styleBlock("> wise words")
 
-        // Paragraph style must be on offset 0 (the >) so NSTextView uses it
-        // for the whole paragraph (it reads the style from the first char).
-        let a0 = styled.attributes(at: 0, effectiveRange: nil)
-        let ps0 = a0[.paragraphStyle] as? NSParagraphStyle
-        #expect(ps0 != nil)
-        #expect(!ps0!.textBlocks.isEmpty)
-
-        // Content should also have the same paragraph style
-        let a2 = styled.attributes(at: 2, effectiveRange: nil)
-        let ps2 = a2[.paragraphStyle] as? NSParagraphStyle
-        #expect(ps2 != nil)
-        #expect(!ps2!.textBlocks.isEmpty)
+        // The decoration must be on offset 0 (the >) — the fragment vendor
+        // reads the paragraph's first character.
+        if let d0 = blockDecoration(at: 0, in: styled), case .leftBar = d0.kind {} else {
+            Issue.record("expected a .leftBar decoration at offset 0")
+        }
+        // Content should carry it too (it spans the whole quote).
+        if let d2 = blockDecoration(at: 2, in: styled), case .leftBar = d2.kind {} else {
+            Issue.record("expected a .leftBar decoration at offset 2")
+        }
     }
 
     @Test("Non-active merged blockquote hides each > delimiter")
@@ -346,16 +343,14 @@ struct BlockStylingNonActiveTests {
         #expect(fgColor(at: 8, in: editor) == NSColor.clear)   // line2 `>`
     }
 
-    @Test("Non-active blockquote line has text block style")
+    @Test("Non-active blockquote line carries the left-bar decoration")
     @MainActor func nonActiveBlockquoteLineParagraphStyle() {
         let editor = makeEditor()
         let styled = editor.styleBlock("> wise words")
 
-        // Paragraph style at offset 0 (first char) carries the text block border
-        let a0 = styled.attributes(at: 0, effectiveRange: nil)
-        let ps0 = a0[.paragraphStyle] as? NSParagraphStyle
-        #expect(ps0 != nil)
-        #expect(!ps0!.textBlocks.isEmpty)
+        if let d0 = blockDecoration(at: 0, in: styled), case .leftBar = d0.kind {} else {
+            Issue.record("expected a .leftBar decoration at offset 0")
+        }
     }
 
     // MARK: - Nested Content
@@ -433,16 +428,16 @@ struct TableNonActiveTests {
         activateBlock(1, in: editor)
 
         let base = editor.displayRanges[0].location
-        // All pipes are hidden (vertical borders drawn by TableRowTextBlock)
+        // All pipes are hidden (vertical borders drawn by the .tableRow decoration)
         let outerF = font(at: base, in: editor)!
         #expect(outerF.pointSize < 1.0)
         let innerF = font(at: base + 4, in: editor)!
         #expect(innerF.pointSize < 1.0)
-        // Header row has a paragraph style with text blocks
-        let ts = editor.textStorage!
-        let ps = ts.attribute(.paragraphStyle, at: base, effectiveRange: nil) as? NSParagraphStyle
-        #expect(ps != nil)
-        #expect(!ps!.textBlocks.isEmpty)
+        // Header row carries the .tableRow decoration
+        if let deco = blockDecoration(at: base, in: editor),
+           case .tableRow = deco.kind {} else {
+            Issue.record("expected a .tableRow decoration on the header row")
+        }
     }
 }
 
@@ -627,13 +622,12 @@ struct ThematicBreakNonActiveTests {
         // Raw text still present
         let text = displayText(for: 0, in: editor)
         #expect(text == "---")
-        // Characters are hidden (visual line rendered via NSTextBlock)
+        // Characters are hidden (the rule is a .horizontalRule decoration)
         #expect(isHidden(at: 0, in: editor.textStorage!))
-        // Paragraph style has an NSTextBlock
-        let a = attrs(at: 0, in: editor)
-        let ps = a[.paragraphStyle] as? NSParagraphStyle
-        #expect(ps != nil)
-        #expect(!ps!.textBlocks.isEmpty)
+        if let deco = blockDecoration(at: 0, in: editor),
+           case .horizontalRule = deco.kind {} else {
+            Issue.record("expected a .horizontalRule decoration")
+        }
     }
 
     @Test("Non-active *** is hidden with horizontal line paragraph style")
@@ -645,10 +639,10 @@ struct ThematicBreakNonActiveTests {
         let text = displayText(for: 0, in: editor)
         #expect(text == "***")
         #expect(isHidden(at: 0, in: editor.textStorage!))
-        let a = attrs(at: 0, in: editor)
-        let ps = a[.paragraphStyle] as? NSParagraphStyle
-        #expect(ps != nil)
-        #expect(!ps!.textBlocks.isEmpty)
+        if let deco = blockDecoration(at: 0, in: editor),
+           case .horizontalRule = deco.kind {} else {
+            Issue.record("expected a .horizontalRule decoration")
+        }
     }
 }
 

--- a/Tests/MarkdownEditorTests/BlockquoteDeletionTests.swift
+++ b/Tests/MarkdownEditorTests/BlockquoteDeletionTests.swift
@@ -29,13 +29,13 @@ struct BlockquoteDeletionTests {
         e.loadContent("> [!note]\n> hi\n> there")
         e.setSelectedRange(NSRange(location: 9, length: 0))   // end of "> [!note]"
         e.recompose(cursorInRaw: 9)
-        e.layoutManager?.ensureLayout(for: e.textContainer!)
+        ensureFullLayout(e)
 
         // Delete the whole "[!note]" marker, one char at a time.
         for _ in 0..<7 {
             let before = e.rawSource
             e.deleteBackward(nil)
-            e.layoutManager?.ensureLayout(for: e.textContainer!)
+            ensureFullLayout(e)
             #expect(e.rawSource != before)   // every press must remove a character
         }
         #expect(e.rawSource == "> \n> hi\n> there")
@@ -47,7 +47,7 @@ struct BlockquoteDeletionTests {
         e.loadContent("> aaa\n> bbb")
         e.setSelectedRange(NSRange(location: 5, length: 0))   // end of "> aaa"
         e.recompose(cursorInRaw: 5)
-        e.layoutManager?.ensureLayout(for: e.textContainer!)
+        ensureFullLayout(e)
         let before = e.rawSource
         e.deleteBackward(nil)
         #expect(e.rawSource != before)

--- a/Tests/MarkdownEditorTests/CalloutRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/CalloutRenderingTests.swift
@@ -5,9 +5,14 @@ import AppKit
 @Suite("Callout — rendering")
 struct CalloutRenderingTests {
 
-    private let leftEdge = NSRectEdge(rawValue: 0)!
-
     // "> [!note]…"  indices: 0'>' 1' ' 2'[' 3'!' 4'n' 5'o' 6't' 7'e' 8']'
+
+    private func boxDecoration(_ deco: BlockDecoration?)
+        -> (background: NSColor, borderColor: NSColor?, edges: CalloutStyle.Edges, width: CGFloat)? {
+        guard let deco, case .box(let bg, let border, let edges, let width) = deco.kind
+        else { return nil }
+        return (bg, border, edges, width)
+    }
 
     @Test("Rendered callout: header replaced by an image, source hidden, tinted bg, no border")
     @MainActor func rendered() {
@@ -15,24 +20,23 @@ struct CalloutRenderingTests {
         let styled = editor.styleBlock("> [!note]\n> body")
 
         // The header image sits on "[".
-        let att = styled.attribute(.attachment, at: 2, effectiveRange: nil) as? NSTextAttachment
+        let att = styled.attribute(.fragmentOverlay, at: 2, effectiveRange: nil) as? FragmentOverlay
         #expect(att != nil)
         #expect(att?.image != nil)
         // The raw "[!note]" header is hidden (near-zero font + clear) — its title
         // is drawn inside the image instead.
         for i in 3...8 { #expect(isHidden(at: i, in: styled)) }
         // A tinted background marks the callout; no border by default.
-        let block = styled.attribute(.paragraphStyle, at: 0, effectiveRange: nil)
-            .flatMap { ($0 as? NSParagraphStyle)?.textBlocks.first }
-        #expect(block?.backgroundColor != nil)
-        #expect(block?.borderColor(for: leftEdge) == nil)
+        let box = boxDecoration(blockDecoration(at: 0, in: styled))
+        #expect(box != nil)
+        #expect(box?.edges.isEmpty == true)
     }
 
     @Test("Unknown type stays a plain block quote")
     @MainActor func unknownPlain() {
         let editor = makeEditor()
         let styled = editor.styleBlock("> [!bogus]\n> body")
-        #expect(styled.attribute(.attachment, at: 2, effectiveRange: nil) == nil)
+        #expect(styled.attribute(.fragmentOverlay, at: 2, effectiveRange: nil) == nil)
         #expect(!isHidden(at: 3, in: styled))
     }
 
@@ -40,24 +44,24 @@ struct CalloutRenderingTests {
     @MainActor func activeRaw() {
         let editor = makeEditor()
         let styled = editor.styleBlock("> [!note]\n> body", cursorPosition: 4)
-        #expect(styled.attribute(.attachment, at: 2, effectiveRange: nil) == nil)
+        #expect(styled.attribute(.fragmentOverlay, at: 2, effectiveRange: nil) == nil)
         #expect(!isHidden(at: 2, in: styled))   // "[" visible (dimmed), editable
     }
 
     @Test("Callout's left inset does not exceed a plain block quote's")
     @MainActor func leftInsetNotLargerThanBlockquote() {
         let editor = makeEditor()
-        let left = leftEdge
-        func leftInset(_ s: String) -> CGFloat {
+        // The text inset now lives on the paragraph style (the decoration is
+        // drawn at the fragment edge behind it).
+        func leftInset(_ s: String) -> CGFloat? {
             let st = editor.styleBlock(s)
-            guard let b = (st.attribute(.paragraphStyle, at: 0, effectiveRange: nil)
-                as? NSParagraphStyle)?.textBlocks.first else { return -1 }
-            return b.width(for: .border, edge: left) + b.width(for: .padding, edge: left)
+            let ps = st.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+            return ps?.headIndent
         }
         let callout = leftInset("> [!note]\n> x")
         let quote = leftInset("> x")
-        #expect(callout > 0 && quote > 0)
-        #expect(callout <= quote + 0.01)
+        #expect((callout ?? -1) > 0 && (quote ?? -1) > 0)
+        #expect((callout ?? .infinity) <= (quote ?? 0) + 0.01)
     }
 
     @Test("The tinted background covers the callout's body lines too")
@@ -66,8 +70,7 @@ struct CalloutRenderingTests {
         let styled = editor.styleBlock("> [!note]\n> body line")
         let bodyIdx = (styled.string as NSString).range(of: "body").location
         #expect(bodyIdx != NSNotFound)
-        let ps = styled.attribute(.paragraphStyle, at: bodyIdx, effectiveRange: nil) as? NSParagraphStyle
-        #expect(ps?.textBlocks.first?.backgroundColor != nil)
+        #expect(boxDecoration(blockDecoration(at: bodyIdx, in: styled)) != nil)
     }
 
     @Test("Custom title text is hidden (drawn in the header image)")
@@ -88,13 +91,9 @@ struct CalloutRenderingTests {
                                  borderEdges: .all, borderWidth: 2)
         ]
         let styled = editor.styleBlock("> [!note]\n> body")
-        let block = styled.attribute(.paragraphStyle, at: 0, effectiveRange: nil)
-            .flatMap { ($0 as? NSParagraphStyle)?.textBlocks.first }
-        #expect(block?.borderColor(for: leftEdge)?.hexString == NSColor(hex: "#112233")?.hexString)
-        // All four edges now have a border.
-        let top = NSRectEdge(rawValue: 1)!, right = NSRectEdge(rawValue: 2)!, bottom = NSRectEdge(rawValue: 3)!
-        #expect(block?.borderColor(for: top) != nil)
-        #expect(block?.borderColor(for: right) != nil)
-        #expect(block?.borderColor(for: bottom) != nil)
+        let box = boxDecoration(blockDecoration(at: 0, in: styled))
+        #expect(box?.borderColor?.hexString == NSColor(hex: "#112233")?.hexString)
+        #expect(box?.edges == .all)
+        #expect(box?.width == 2)
     }
 }

--- a/Tests/MarkdownEditorTests/EditorRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/EditorRenderingTests.swift
@@ -309,17 +309,15 @@ struct EditorStylingTests {
         #expect(color == NSColor.secondaryLabelColor)
     }
 
-    @Test("Blockquote has paragraph style with text block")
+    @Test("Blockquote carries a left-bar decoration")
     @MainActor func blockquoteTextBlock() {
         let editor = makeEditor()
         let styled = editor.styleBlock("> text")
-        var hasTextBlock = false
-        styled.enumerateAttribute(.paragraphStyle, in: NSRange(location: 0, length: styled.length)) { val, _, _ in
-            if let ps = val as? NSParagraphStyle, !ps.textBlocks.isEmpty {
-                hasTextBlock = true
-            }
+        guard let deco = blockDecoration(at: 0, in: styled),
+              case .leftBar = deco.kind else {
+            Issue.record("expected a .leftBar BlockDecoration on the quote")
+            return
         }
-        #expect(hasTextBlock)
     }
 
     @Test("List bullet marker renders as a dot attachment")
@@ -327,7 +325,7 @@ struct EditorStylingTests {
         let editor = makeEditor()
         let styled = editor.styleBlock("- hello")
         // The `-` carries the bullet dot attachment.
-        #expect(styled.attribute(.attachment, at: 0, effectiveRange: nil) is NSTextAttachment)
+        #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) is FragmentOverlay)
         // The trailing space after the bullet is dimmed.
         #expect(isDimmed(at: 1, in: styled))
     }
@@ -340,7 +338,7 @@ struct EditorStylingTests {
         #expect(isHidden(at: 0, in: styled))
         // "[" at 2 has a text attachment
         let a = styled.attributes(at: 2, effectiveRange: nil)
-        #expect(a[.attachment] is NSTextAttachment)
+        #expect(a[.fragmentOverlay] is FragmentOverlay)
         // " ]" at 3-4 are hidden
         #expect(isHidden(at: 3, in: styled))
     }
@@ -353,7 +351,7 @@ struct EditorStylingTests {
         #expect(isHidden(at: 0, in: styled))
         // "[" at 2 has a text attachment
         let a = styled.attributes(at: 2, effectiveRange: nil)
-        #expect(a[.attachment] is NSTextAttachment)
+        #expect(a[.fragmentOverlay] is FragmentOverlay)
         // "x]" at 3-4 are hidden
         #expect(isHidden(at: 3, in: styled))
     }
@@ -367,7 +365,7 @@ struct EditorStylingTests {
         #expect(isHidden(at: 4, in: styled))
         // "[" at position 6 has the circle attachment
         let a = styled.attributes(at: 6, effectiveRange: nil)
-        #expect(a[.attachment] is NSTextAttachment)
+        #expect(a[.fragmentOverlay] is FragmentOverlay)
         // " ]" after the bracket is hidden
         #expect(isHidden(at: 7, in: styled))
     }
@@ -379,7 +377,7 @@ struct EditorStylingTests {
         // Leading spaces have base text color (not part of delimiter)
         #expect(!isDimmed(at: 0, in: styled))
         // The `-` at offset 2 carries the bullet dot attachment
-        #expect(styled.attribute(.attachment, at: 2, effectiveRange: nil) is NSTextAttachment)
+        #expect(styled.attribute(.fragmentOverlay, at: 2, effectiveRange: nil) is FragmentOverlay)
     }
 
     @Test("List items have hanging indent paragraph style")
@@ -501,7 +499,7 @@ struct EditorStylingTests {
         let styled = editor.styleBlock("- hello", cursorPosition: 3)
         // The `-` marker is shown (dimmed), not replaced by an attachment nor
         // hidden with the near-zero clear font.
-        #expect(styled.attribute(.attachment, at: 0, effectiveRange: nil) == nil)
+        #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) == nil)
         let f = styled.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
         #expect((f?.pointSize ?? 0) >= 1.0)
         #expect(isDimmed(at: 0, in: styled))           // marker is dimmed, visible
@@ -608,17 +606,21 @@ struct EditorStylingTests {
         #expect(traits.contains(.boldFontMask))
         // Separator row (offset 10 = start of "| --- | --- |") is hidden
         #expect(isHidden(at: 10, in: styled))
-        // Separator row has a paragraph style with a text block for the border
-        let sepPS = styled.attribute(.paragraphStyle, at: 10, effectiveRange: nil) as? NSParagraphStyle
-        #expect(sepPS != nil)
-        #expect(!sepPS!.textBlocks.isEmpty)
-        // All pipes are hidden (vertical borders drawn by TextBlock)
+        // Separator row carries a separator .tableRow decoration
+        if let deco = blockDecoration(at: 10, in: styled),
+           case .tableRow(_, _, _, let separator) = deco.kind {
+            #expect(separator)
+        } else {
+            Issue.record("expected a .tableRow decoration on the separator row")
+        }
+        // All pipes are hidden (vertical borders drawn by the decoration)
         #expect(isHidden(at: 0, in: styled))
         #expect(isHidden(at: 4, in: styled))
-        // Each row has a text block for vertical border drawing
-        let headerPS = styled.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
-        #expect(headerPS != nil)
-        #expect(!headerPS!.textBlocks.isEmpty)
+        // Each row carries a .tableRow decoration for the borders
+        if let deco = blockDecoration(at: 0, in: styled),
+           case .tableRow = deco.kind {} else {
+            Issue.record("expected a .tableRow decoration on the header row")
+        }
     }
 
     @Test("Table without outer pipes renders with borders and hidden pipes")
@@ -631,10 +633,11 @@ struct EditorStylingTests {
         #expect(NSFontManager.shared.traits(of: hf!).contains(.boldFontMask))
         // Inner pipe at offset 5 is hidden
         #expect(isHidden(at: 5, in: styled))
-        // Header row has a paragraph style with text blocks for borders
-        let ps = styled.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
-        #expect(ps != nil)
-        #expect(!ps!.textBlocks.isEmpty)
+        // Header row carries a .tableRow decoration for the borders
+        if let deco = blockDecoration(at: 0, in: styled),
+           case .tableRow = deco.kind {} else {
+            Issue.record("expected a .tableRow decoration on the header row")
+        }
     }
 
     @Test("Non-active thematic break is hidden with horizontal line style")
@@ -642,13 +645,12 @@ struct EditorStylingTests {
         let editor = makeEditor()
         let styled = editor.styleBlock("---")
         #expect(styled.string == "---")
-        // Characters are hidden (visual line via NSTextBlock)
+        // Characters are hidden (the rule is a .horizontalRule decoration)
         #expect(isHidden(at: 0, in: styled))
-        // Paragraph style has a text block for the border
-        let a = styled.attributes(at: 0, effectiveRange: nil)
-        let ps = a[.paragraphStyle] as? NSParagraphStyle
-        #expect(ps != nil)
-        #expect(!ps!.textBlocks.isEmpty)
+        if let deco = blockDecoration(at: 0, in: styled),
+           case .horizontalRule = deco.kind {} else {
+            Issue.record("expected a .horizontalRule decoration")
+        }
     }
 
     @Test("Active thematic break is dimmed, not hidden")

--- a/Tests/MarkdownEditorTests/IncrementalParseFuzzTests.swift
+++ b/Tests/MarkdownEditorTests/IncrementalParseFuzzTests.swift
@@ -1,0 +1,58 @@
+import Testing
+import AppKit
+@testable import MarkdownEditorCore
+
+/// Seeded random edits through the full editor pipeline. In DEBUG builds
+/// every edit also runs the incremental-vs-full parse assertion inside
+/// syncRawSourceFromDisplay, so this doubles as the incremental parser's
+/// fuzz net; the oracle assertion here checks the styled storage too.
+@Suite("Incremental parse — fuzz")
+struct IncrementalParseFuzzTests {
+
+    @Test("Random edits keep blocks and styling equivalent to a full parse",
+          arguments: [UInt64(1), 7, 1234, 0xBEEF])
+    @MainActor func randomEdits(seed: UInt64) {
+        var rng = SeededGenerator(seed: seed)
+        let editor = makeEditor()
+        editor.loadContent(makeLargeMarkdown(approximateBytes: 6_000, seed: seed))
+
+        // Fragments biased toward structure-changing characters.
+        let fragments = ["\n", "\n\n", "```", "```\n", "$$", "|", ">", "> ",
+                         "# ", "- ", "---\n", "x", "hello **world**",
+                         "| a | b |", "[!note]"]
+
+        for _ in 0..<120 {
+            let ns = editor.rawSource as NSString
+            let len = ns.length
+            switch Int.random(in: 0..<10, using: &rng) {
+            case 0..<5:   // insert a fragment somewhere (edges included)
+                let loc = Int.random(in: 0...len, using: &rng)
+                let frag = fragments.randomElement(using: &rng)!
+                editor.setSelectedRange(NSRange(location: loc, length: 0))
+                editor.insertText(frag, replacementRange: NSRange(location: loc, length: 0))
+            case 5..<8 where len > 0:   // delete a span (possibly multi-block)
+                let loc = Int.random(in: 0..<len, using: &rng)
+                let span = min(Int.random(in: 1...40, using: &rng), len - loc)
+                editor.setSelectedRange(NSRange(location: loc, length: span))
+                editor.insertText("", replacementRange: NSRange(location: loc, length: span))
+            case 8 where len > 0:       // replace a span with a fragment
+                let loc = Int.random(in: 0..<len, using: &rng)
+                let span = min(Int.random(in: 1...20, using: &rng), len - loc)
+                let frag = fragments.randomElement(using: &rng)!
+                editor.setSelectedRange(NSRange(location: loc, length: span))
+                editor.insertText(frag, replacementRange: NSRange(location: loc, length: span))
+            default:                    // undo occasionally
+                editor.performUndo()
+            }
+
+            // Ranges must tile the document after every edit.
+            let total = (editor.rawSource as NSString).length
+            if let last = editor.blocks.last {
+                #expect(last.range.upperBound <= total)
+            }
+        }
+
+        // Converged storage must match the styling oracle.
+        assertMatchesFullRecomposeOracle(editor, "after fuzz (seed \(seed))")
+    }
+}

--- a/Tests/MarkdownEditorTests/IncrementalParseFuzzTests.swift
+++ b/Tests/MarkdownEditorTests/IncrementalParseFuzzTests.swift
@@ -19,7 +19,7 @@ struct IncrementalParseFuzzTests {
         // Fragments biased toward structure-changing characters.
         let fragments = ["\n", "\n\n", "```", "```\n", "$$", "|", ">", "> ",
                          "# ", "- ", "---\n", "x", "hello **world**",
-                         "| a | b |", "[!note]"]
+                         "| a | b |", "[!note]", "  - indented\n", "\t- tabbed\n"]
 
         for _ in 0..<120 {
             let ns = editor.rawSource as NSString
@@ -50,6 +50,10 @@ struct IncrementalParseFuzzTests {
             if let last = editor.blocks.last {
                 #expect(last.range.upperBound <= total)
             }
+            // The incrementally-maintained indent unit must match the
+            // reference whole-document detector.
+            #expect(editor.listIndentUnit ==
+                    EditorTextView.detectListIndentUnit(editor.rawSource))
         }
 
         // Converged storage must match the styling oracle.

--- a/Tests/MarkdownEditorTests/LazyRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/LazyRenderingTests.swift
@@ -1,0 +1,107 @@
+import Testing
+import AppKit
+@testable import MarkdownEditorCore
+
+/// Lazy rendering: in a scroll view, loads style only the viewport window
+/// synchronously; the idle drain and scroll promotion converge the rest.
+/// (Headless editors — no scroll view — style everything synchronously, which
+/// is what every other suite exercises.)
+@Suite("Lazy rendering")
+struct LazyRenderingTests {
+
+    @MainActor private func windowedEditor(height: CGFloat = 300) -> (EditorTextView, NSScrollView) {
+        let editor = makeEditor()
+        let win = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 500, height: height),
+                           styleMask: [.titled], backing: .buffered, defer: false)
+        let scroll = NSScrollView(frame: win.contentLayoutRect)
+        scroll.documentView = editor
+        win.contentView = scroll
+        win.makeFirstResponder(editor)
+        editor.typewriterModeEnabled = false
+        editor.isVerticallyResizable = true
+        editor.minSize = NSSize(width: 0, height: 0)
+        editor.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude,
+                                height: CGFloat.greatestFiniteMagnitude)
+        editor.autoresizingMask = [.width]
+        return (editor, scroll)
+    }
+
+    @MainActor private func bigDocument() -> String {
+        (0..<800).map { "paragraph **number** \($0)" }.joined(separator: "\n\n")
+    }
+
+    @Test("Load styles the viewport window; far blocks stay base-attributed")
+    @MainActor func loadIsViewportFirst() {
+        let (editor, _) = windowedEditor()
+        editor.loadContent(bigDocument())
+
+        #expect(editor.blocks.first?.isStyled == true)
+        let last = editor.blocks.count - 1
+        #expect(editor.blocks[last].isStyled == false)
+
+        // An unstyled block's characters carry exactly the base attributes:
+        // the bold delimiters are not yet hidden.
+        let lastLoc = editor.blocks[last].range.location
+        let f = font(at: lastLoc, in: editor)
+        #expect(f?.fontName == editor.bodyFont.fontName)
+        #expect((f?.pointSize ?? 0) >= 1.0)
+        assertMatchesFullRecomposeOracle(editor, "viewport-first load")
+    }
+
+    @Test("The idle drain converges the whole document to the oracle")
+    @MainActor func drainConverges() {
+        let (editor, _) = windowedEditor()
+        editor.loadContent(bigDocument())
+        drainAllStyling(editor)
+        #expect(editor.blocks.allSatisfy { $0.isStyled })
+        assertMatchesFullRecomposeOracle(editor, "after drain")
+    }
+
+    @Test("Scrolling promotes newly visible blocks synchronously")
+    @MainActor func scrollPromotes() {
+        let (editor, scroll) = windowedEditor()
+        editor.loadContent(bigDocument())
+        ensureFullLayout(editor)
+        editor.sizeToFit()
+        editor.layoutSubtreeIfNeeded()
+
+        let last = editor.blocks.count - 1
+        #expect(editor.blocks[last].isStyled == false)
+
+        // Jump to the bottom of the document.
+        scroll.contentView.scroll(to: NSPoint(x: 0, y: max(0, editor.frame.height - 300)))
+        scroll.reflectScrolledClipView(scroll.contentView)
+
+        #expect(editor.blocks[last].isStyled == true,
+                "scroll promotion must style blocks entering the viewport")
+    }
+
+    @Test("Clicking into an unstyled block styles it as the active block")
+    @MainActor func clickIntoUnstyled() {
+        let (editor, _) = windowedEditor()
+        editor.loadContent(bigDocument())
+
+        let last = editor.blocks.count - 1
+        #expect(editor.blocks[last].isStyled == false)
+        let target = editor.blocks[last].range.location + 2
+        editor.setSelectedRange(NSRange(location: target, length: 0))
+        editor.recomposeIncremental(cursorInRaw: target)
+
+        #expect(editor.blocks[last].isStyled == true)
+        #expect(editor.activeBlockIndex == last)
+        assertMatchesFullRecomposeOracle(editor, "after activating unstyled block")
+    }
+
+    @Test("Undo mid-drain converges cleanly")
+    @MainActor func undoMidDrain() {
+        let (editor, _) = windowedEditor()
+        editor.loadContent(bigDocument())
+        // One edit so there's an undo snapshot, then undo before draining.
+        type("x", into: editor)
+        editor.performUndo()
+        drainAllStyling(editor)
+        #expect(editor.blocks.allSatisfy { $0.isStyled })
+        #expect(editor.rawSource == bigDocument())
+        assertMatchesFullRecomposeOracle(editor, "after undo + drain")
+    }
+}

--- a/Tests/MarkdownEditorTests/LazyRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/LazyRenderingTests.swift
@@ -68,9 +68,12 @@ struct LazyRenderingTests {
         let last = editor.blocks.count - 1
         #expect(editor.blocks[last].isStyled == false)
 
-        // Jump to the bottom of the document.
+        // Jump to the bottom of the document. The scroll notification defers
+        // promotion off the run loop (so it doesn't fight momentum scrolling);
+        // invoke the worker directly to test the styling itself.
         scroll.contentView.scroll(to: NSPoint(x: 0, y: max(0, editor.frame.height - 300)))
         scroll.reflectScrolledClipView(scroll.contentView)
+        editor.promoteVisibleUnstyledBlocks()
 
         #expect(editor.blocks[last].isStyled == true,
                 "scroll promotion must style blocks entering the viewport")

--- a/Tests/MarkdownEditorTests/MathRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/MathRenderingTests.swift
@@ -33,8 +33,8 @@ struct InlineMathRenderingTests {
         let editor = makeEditor()
         let styled = editor.styleBlock("$x^2$")           // no cursor → render
         // Attachment replaces the opening `$`.
-        let attachment = styled.attribute(.attachment, at: 0, effectiveRange: nil)
-        #expect(attachment is NSTextAttachment)
+        let attachment = styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil)
+        #expect(attachment is FragmentOverlay)
         // LaTeX source + closing `$` are hidden.
         #expect(isHidden(at: 1, in: styled))
         #expect(isHidden(at: 4, in: styled))
@@ -44,7 +44,7 @@ struct InlineMathRenderingTests {
     @MainActor func activeShowsRaw() {
         let editor = makeEditor()
         let styled = editor.styleBlock("$x^2$", cursorPosition: 2)
-        #expect(styled.attribute(.attachment, at: 0, effectiveRange: nil) == nil)
+        #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) == nil)
         #expect(!isHidden(at: 1, in: styled))             // source visible
     }
 
@@ -52,7 +52,7 @@ struct InlineMathRenderingTests {
     @MainActor func invalidLatexFallsBack() {
         let editor = makeEditor()
         let styled = editor.styleBlock("$\\frac{$")
-        #expect(styled.attribute(.attachment, at: 0, effectiveRange: nil) == nil)
+        #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) == nil)
         #expect(!isHidden(at: 1, in: styled))             // raw source shown
         let color = styled.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
         #expect(color == NSColor.systemRed)
@@ -102,7 +102,7 @@ struct DisplayMathRenderingTests {
         let editor = makeEditor()
         let styled = editor.styleBlock("$$x+y$$")
         // Attachment replaces the first `$`.
-        #expect(styled.attribute(.attachment, at: 0, effectiveRange: nil) is NSTextAttachment)
+        #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) is FragmentOverlay)
         // The second `$` of the opening delimiter is hidden too.
         #expect(isHidden(at: 1, in: styled))
         #expect(isHidden(at: 2, in: styled))             // content
@@ -120,7 +120,7 @@ struct DisplayMathRenderingTests {
     @MainActor func activeShowsRaw() {
         let editor = makeEditor()
         let styled = editor.styleBlock("$$x+y$$", cursorPosition: 3)
-        #expect(styled.attribute(.attachment, at: 0, effectiveRange: nil) == nil)
+        #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) == nil)
         #expect(!isHidden(at: 2, in: styled))             // source visible
     }
 }
@@ -147,7 +147,7 @@ struct MathFitWidthTests {
 
         let wide = "$$a_{10}x^{10}+a_9x^9+a_8x^8+a_7x^7+a_6x^6+a_5x^5+a_4x^4+a_3x^3+a_2x^2+a_1x+a_0$$"
         let styled = editor.styleBlock(wide)
-        let att = styled.attribute(.attachment, at: 0, effectiveRange: nil) as? NSTextAttachment
+        let att = styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) as? FragmentOverlay
         #expect(att != nil)
         // The natural width exceeds the usable width, so it scales down to
         // exactly the cap (500 − 2·5 line-fragment padding).
@@ -158,7 +158,7 @@ struct MathFitWidthTests {
     @MainActor func normalNotScaled() {
         let editor = makeEditor()
         let styled = editor.styleBlock("$$x+y$$")
-        let att = styled.attribute(.attachment, at: 0, effectiveRange: nil) as? NSTextAttachment
+        let att = styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) as? FragmentOverlay
         #expect(att != nil)
         let w = att?.bounds.width ?? 0
         #expect(w > 0 && w < 200)        // comfortably under the cap

--- a/Tests/MarkdownEditorTests/PendingEditTests.swift
+++ b/Tests/MarkdownEditorTests/PendingEditTests.swift
@@ -1,0 +1,98 @@
+import Testing
+import AppKit
+@testable import MarkdownEditorCore
+
+/// EditorTextStorage accumulates string mutations into one (oldRange, delta)
+/// pending edit — the incremental parser's input. The invariant under test:
+/// applying the pending edit's hull to the OLD string explains every
+/// difference, i.e. old and new strings agree outside it.
+@Suite("Pending edit accumulation")
+struct PendingEditTests {
+
+    @MainActor private func storage(_ s: String) -> EditorTextStorage {
+        let ts = EditorTextStorage()
+        ts.replaceCharacters(in: NSRange(location: 0, length: 0), with: s)
+        _ = ts.consumePendingEdit()
+        return ts
+    }
+
+    /// Checks the hull invariant for a sequence of edits.
+    @MainActor private func verify(_ initial: String, _ edits: [(NSRange, String)],
+                                   sourceLocation: SourceLocation = #_sourceLocation) {
+        let ts = storage(initial)
+        let old = ts.string as NSString
+        for (range, replacement) in edits {
+            ts.replaceCharacters(in: range, with: replacement)
+        }
+        let new = ts.string as NSString
+        guard let p = ts.consumePendingEdit() else {
+            Issue.record("no pending edit recorded", sourceLocation: sourceLocation)
+            return
+        }
+        #expect(new.length - old.length == p.delta,
+                "delta must match total length change", sourceLocation: sourceLocation)
+        // Outside the hull, old and new must agree.
+        let prefixOld = old.substring(to: min(p.oldRange.location, old.length))
+        let prefixNew = new.substring(to: min(p.oldRange.location, new.length))
+        #expect(prefixOld == prefixNew, "prefix must be untouched", sourceLocation: sourceLocation)
+        let suffixOld = old.substring(from: min(p.oldRange.upperBound, old.length))
+        let suffixNew = new.substring(from: min(p.oldRange.upperBound + p.delta, new.length))
+        #expect(suffixOld == suffixNew, "suffix must be untouched", sourceLocation: sourceLocation)
+    }
+
+    @Test("Single insert")
+    @MainActor func singleInsert() {
+        verify("hello world", [(NSRange(location: 5, length: 0), "XYZ")])
+    }
+
+    @Test("Single delete")
+    @MainActor func singleDelete() {
+        verify("hello world", [(NSRange(location: 2, length: 4), "")])
+    }
+
+    @Test("Consecutive typing (insert after insert)")
+    @MainActor func consecutiveTyping() {
+        verify("ab", [(NSRange(location: 1, length: 0), "x"),
+                      (NSRange(location: 2, length: 0), "y"),
+                      (NSRange(location: 3, length: 0), "z")])
+    }
+
+    @Test("Insert then delete spanning it")
+    @MainActor func insertThenDelete() {
+        verify("abcdef", [(NSRange(location: 2, length: 0), "XY"),
+                          (NSRange(location: 1, length: 4), "")])
+    }
+
+    @Test("Disjoint edits coalesce into the hull")
+    @MainActor func disjointEdits() {
+        verify("0123456789", [(NSRange(location: 8, length: 1), "Z"),
+                              (NSRange(location: 1, length: 1), "AA")])
+    }
+
+    @Test("IME-style replace of a marked region")
+    @MainActor func imeReplace() {
+        // Composition: insert provisional text, replace it twice, commit.
+        verify("abc", [(NSRange(location: 1, length: 0), "ni"),
+                       (NSRange(location: 1, length: 2), "你"),
+                       (NSRange(location: 1, length: 1), "你好")])
+    }
+
+    @Test("Backspace run (deletes moving left)")
+    @MainActor func backspaceRun() {
+        verify("abcdef", [(NSRange(location: 5, length: 1), ""),
+                          (NSRange(location: 4, length: 1), ""),
+                          (NSRange(location: 3, length: 1), "")])
+    }
+
+    @Test("Consume clears; programmatic clear works")
+    @MainActor func consumeAndClear() {
+        let ts = storage("abc")
+        ts.replaceCharacters(in: NSRange(location: 0, length: 1), with: "Z")
+        #expect(ts.pendingEdit != nil)
+        _ = ts.consumePendingEdit()
+        #expect(ts.pendingEdit == nil)
+        ts.replaceCharacters(in: NSRange(location: 0, length: 1), with: "Q")
+        ts.clearPendingEdit()
+        #expect(ts.pendingEdit == nil)
+    }
+}

--- a/Tests/MarkdownEditorTests/PerfHarnessTests.swift
+++ b/Tests/MarkdownEditorTests/PerfHarnessTests.swift
@@ -1,0 +1,83 @@
+import Testing
+import AppKit
+@testable import MarkdownEditorCore
+
+/// Large-file latency measurements, gated behind `MD_PERF=1` so the regular
+/// suite stays fast. Numbers are printed for recording in commit messages;
+/// assertions are deliberately generous (sanity bounds, not budgets).
+///
+/// Headless caveat: there is no window, so TextKit layout cost is mostly
+/// absent — these numbers capture the parse + style pipeline, which is the
+/// part this redesign owns.
+@Suite("Perf harness (MD_PERF)",
+       .enabled(if: ProcessInfo.processInfo.environment["MD_PERF"] != nil))
+struct PerfHarnessTests {
+
+    /// Document size; override with MD_PERF_BYTES to bisect or scale.
+    static let documentBytes = ProcessInfo.processInfo.environment["MD_PERF_BYTES"]
+        .flatMap(Int.init) ?? 1_500_000
+
+    @MainActor private func measureMS(_ body: () -> Void) -> Double {
+        let clock = ContinuousClock()
+        let duration = clock.measure(body)
+        return Double(duration.components.seconds) * 1000
+            + Double(duration.components.attoseconds) / 1e15
+    }
+
+    /// Unbuffered progress marker so a hard crash still shows how far we got.
+    private func mark(_ s: String) {
+        FileHandle.standardError.write(Data("[MD_PERF] …\(s)\n".utf8))
+    }
+
+    @Test("Pipeline latency on a ~1.5 MB document")
+    @MainActor func largeFileLatency() {
+        let source = makeLargeMarkdown(approximateBytes: Self.documentBytes, seed: 42)
+        let editor = makeEditor()
+
+        mark("loading")
+        let loadMS = measureMS { editor.loadContent(source) }
+        let blockCount = editor.blocks.count
+        let length = (editor.rawSource as NSString).length
+
+        // Keystroke at the end of the document.
+        mark("keystroke end")
+        editor.setSelectedRange(NSRange(location: length, length: 0))
+        editor.recomposeIncremental(cursorInRaw: length)
+        let endKeystrokeMS = measureMS { type("x", into: editor) }
+
+        // Keystroke mid-document (inside whatever block is there).
+        mark("keystroke mid")
+        let midBlock = editor.blockIndexForRawOffset(length / 2) ?? 0
+        let midLoc = editor.blocks[midBlock].range.location
+        editor.setSelectedRange(NSRange(location: midLoc, length: 0))
+        editor.recomposeIncremental(cursorInRaw: midLoc)
+        let midKeystrokeMS = measureMS { type("x", into: editor) }
+
+        // Enter mid-document (block split → today: full recompose).
+        mark("enter mid")
+        let enterMS = measureMS { pressEnter(in: editor) }
+
+        // 10 KB paste mid-document.
+        mark("paste")
+        let pasteText = makeLargeMarkdown(approximateBytes: 10_000, seed: 99)
+        let pasteMS = measureMS { paste(pasteText, into: editor) }
+
+        // Undo of the paste.
+        mark("undo")
+        let undoMS = measureMS { editor.performUndo() }
+
+        print("""
+        [MD_PERF] document: \(length) chars, \(blockCount) blocks
+        [MD_PERF] loadContent:        \(String(format: "%9.2f", loadMS)) ms
+        [MD_PERF] keystroke (end):    \(String(format: "%9.2f", endKeystrokeMS)) ms
+        [MD_PERF] keystroke (mid):    \(String(format: "%9.2f", midKeystrokeMS)) ms
+        [MD_PERF] enter (mid):        \(String(format: "%9.2f", enterMS)) ms
+        [MD_PERF] paste 10KB (mid):   \(String(format: "%9.2f", pasteMS)) ms
+        [MD_PERF] undo:               \(String(format: "%9.2f", undoMS)) ms
+        """)
+
+        // Sanity bounds only — wildly generous so this never flakes.
+        #expect(loadMS < 120_000)
+        #expect(enterMS < 120_000)
+    }
+}

--- a/Tests/MarkdownEditorTests/PerfHarnessTests.swift
+++ b/Tests/MarkdownEditorTests/PerfHarnessTests.swift
@@ -6,9 +6,10 @@ import AppKit
 /// suite stays fast. Numbers are printed for recording in commit messages;
 /// assertions are deliberately generous (sanity bounds, not budgets).
 ///
-/// Headless caveat: there is no window, so TextKit layout cost is mostly
-/// absent — these numbers capture the parse + style pipeline, which is the
-/// part this redesign owns.
+/// The editor runs windowed (scroll view + window), the same configuration as
+/// the app: loads are viewport-first and the idle drain styles the rest —
+/// headless editors style everything synchronously by design, which is a
+/// tests-only path and not representative.
 @Suite("Perf harness (MD_PERF)",
        .enabled(if: ProcessInfo.processInfo.environment["MD_PERF"] != nil))
 struct PerfHarnessTests {
@@ -29,20 +30,35 @@ struct PerfHarnessTests {
         FileHandle.standardError.write(Data("[MD_PERF] …\(s)\n".utf8))
     }
 
-    @Test("Pipeline latency on a ~1.5 MB document")
+    @Test("Pipeline latency on a large document (windowed, lazy)")
     @MainActor func largeFileLatency() {
         let source = makeLargeMarkdown(approximateBytes: Self.documentBytes, seed: 42)
+
         let editor = makeEditor()
+        let win = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 700, height: 800),
+                           styleMask: [.titled], backing: .buffered, defer: false)
+        let scroll = NSScrollView(frame: win.contentLayoutRect)
+        scroll.documentView = editor
+        win.contentView = scroll
+        win.makeFirstResponder(editor)
+        editor.isVerticallyResizable = true
+        editor.minSize = NSSize(width: 0, height: 0)
+        editor.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude,
+                                height: CGFloat.greatestFiniteMagnitude)
+        editor.autoresizingMask = [.width]
 
         mark("loading")
         let loadMS = measureMS { editor.loadContent(source) }
         let blockCount = editor.blocks.count
+        let styledAtLoad = editor.blocks.filter(\.isStyled).count
         let length = (editor.rawSource as NSString).length
 
         // Keystroke at the end of the document.
-        mark("keystroke end")
+        mark("keystroke end: setSelectedRange")
         editor.setSelectedRange(NSRange(location: length, length: 0))
+        mark("keystroke end: recomposeIncremental")
         editor.recomposeIncremental(cursorInRaw: length)
+        mark("keystroke end: type")
         let endKeystrokeMS = measureMS { type("x", into: editor) }
 
         // Keystroke mid-document (inside whatever block is there).
@@ -53,7 +69,7 @@ struct PerfHarnessTests {
         editor.recomposeIncremental(cursorInRaw: midLoc)
         let midKeystrokeMS = measureMS { type("x", into: editor) }
 
-        // Enter mid-document (block split → today: full recompose).
+        // Enter mid-document (block split).
         mark("enter mid")
         let enterMS = measureMS { pressEnter(in: editor) }
 
@@ -66,14 +82,19 @@ struct PerfHarnessTests {
         mark("undo")
         let undoMS = measureMS { editor.performUndo() }
 
+        // Drain the remaining lazy styling to completion.
+        mark("drain")
+        let drainMS = measureMS { drainAllStyling(editor, maxSlices: 100_000) }
+
         print("""
-        [MD_PERF] document: \(length) chars, \(blockCount) blocks
+        [MD_PERF] document: \(length) chars, \(blockCount) blocks (\(styledAtLoad) styled at load)
         [MD_PERF] loadContent:        \(String(format: "%9.2f", loadMS)) ms
         [MD_PERF] keystroke (end):    \(String(format: "%9.2f", endKeystrokeMS)) ms
         [MD_PERF] keystroke (mid):    \(String(format: "%9.2f", midKeystrokeMS)) ms
         [MD_PERF] enter (mid):        \(String(format: "%9.2f", enterMS)) ms
         [MD_PERF] paste 10KB (mid):   \(String(format: "%9.2f", pasteMS)) ms
         [MD_PERF] undo:               \(String(format: "%9.2f", undoMS)) ms
+        [MD_PERF] full drain:         \(String(format: "%9.2f", drainMS)) ms
         """)
 
         // Sanity bounds only — wildly generous so this never flakes.

--- a/Tests/MarkdownEditorTests/RecomposeEquivalenceTests.swift
+++ b/Tests/MarkdownEditorTests/RecomposeEquivalenceTests.swift
@@ -1,0 +1,164 @@
+import Testing
+import AppKit
+@testable import MarkdownEditorCore
+
+/// After ANY edit or cursor move, the text storage must be attribute-equivalent
+/// to a from-scratch full recompose (the oracle in TestHelpers). These tests
+/// pin that equivalence for the current pipeline so the dirty-set / lazy
+/// rewrites can be verified against the same bar.
+@Suite("Recompose equivalence (oracle)")
+struct RecomposeEquivalenceTests {
+
+    /// A document touching every block kind the renderer styles differently.
+    static let mixedDocument = """
+    # Heading One
+
+    A paragraph with **bold**, *italic*, `code`, and a [link](https://example.com).
+
+    ## Heading Two
+
+    - first item
+    - [ ] open task
+      - nested item
+    1. ordered item
+
+    > [!note]
+    > Callout body with **bold** text.
+
+    > A plain quote
+    > spanning two lines.
+
+    | Col A | Col B |
+    | --- | --- |
+    | a | b |
+
+    ```swift
+    let x = 1
+    ```
+
+    $$
+    e = mc^2
+    $$
+
+    ---
+
+    Closing paragraph with $inline$ math.
+    """
+
+    @MainActor private func loadedEditor() -> EditorTextView {
+        let editor = makeEditor()
+        editor.loadContent(Self.mixedDocument)
+        return editor
+    }
+
+    @Test("Freshly loaded document matches the oracle")
+    @MainActor func afterLoad() {
+        assertMatchesFullRecomposeOracle(loadedEditor())
+    }
+
+    @Test("Incremental activation of every block matches the oracle")
+    @MainActor func activationSweep() {
+        let editor = loadedEditor()
+        for i in editor.blocks.indices {
+            let target = editor.blocks[i].range.location
+            editor.setSelectedRange(NSRange(location: target, length: 0))
+            editor.recomposeIncremental(cursorInRaw: target)
+            assertMatchesFullRecomposeOracle(editor, "after activating block \(i)")
+        }
+    }
+
+    @Test("Typing inside a paragraph matches the oracle after every keystroke")
+    @MainActor func typingInParagraph() {
+        let editor = loadedEditor()
+        let para = (editor.rawSource as NSString).range(of: "A paragraph")
+        editor.setSelectedRange(NSRange(location: para.location, length: 0))
+        editor.recompose(cursorInRaw: para.location)
+        for ch in "Hello **w** " {
+            type(String(ch), into: editor)
+            assertMatchesFullRecomposeOracle(editor, "after typing \(String(reflecting: String(ch)))")
+        }
+    }
+
+    @Test("Enter-splitting a paragraph matches the oracle")
+    @MainActor func enterSplit() {
+        let editor = loadedEditor()
+        let para = (editor.rawSource as NSString).range(of: "with **bold**")
+        editor.setSelectedRange(NSRange(location: para.location, length: 0))
+        editor.recompose(cursorInRaw: para.location)
+        pressEnter(in: editor)
+        assertMatchesFullRecomposeOracle(editor, "after Enter split")
+        pressEnter(in: editor)
+        assertMatchesFullRecomposeOracle(editor, "after second Enter")
+    }
+
+    @Test("Backspace-merging two blocks matches the oracle")
+    @MainActor func backspaceMerge() {
+        let editor = loadedEditor()
+        // Put the cursor at the start of "## Heading Two" and delete the
+        // separating newline, merging it into the preceding (blank) block.
+        let h2 = (editor.rawSource as NSString).range(of: "## Heading Two")
+        editor.setSelectedRange(NSRange(location: h2.location, length: 0))
+        editor.recompose(cursorInRaw: h2.location)
+        pressBackspace(in: editor)
+        assertMatchesFullRecomposeOracle(editor, "after backspace merge")
+        pressBackspace(in: editor)
+        assertMatchesFullRecomposeOracle(editor, "after second backspace")
+    }
+
+    @Test("Multi-block paste matches the oracle")
+    @MainActor func multiBlockPaste() {
+        let editor = loadedEditor()
+        let anchor = (editor.rawSource as NSString).range(of: "Closing paragraph")
+        editor.setSelectedRange(NSRange(location: anchor.location, length: 0))
+        editor.recompose(cursorInRaw: anchor.location)
+        paste("pasted one\n\n## Pasted Heading\n\n> [!tip]\n> pasted callout\n\n", into: editor)
+        assertMatchesFullRecomposeOracle(editor, "after multi-block paste")
+    }
+
+    @Test("Opening and closing a code fence matches the oracle")
+    @MainActor func fenceOpenClose() {
+        let editor = loadedEditor()
+        let anchor = (editor.rawSource as NSString).range(of: "Closing paragraph")
+        editor.setSelectedRange(NSRange(location: anchor.location, length: 0))
+        editor.recompose(cursorInRaw: anchor.location)
+        // Typing ``` opens an unclosed fence that absorbs the rest of the doc.
+        for ch in "```\n" {
+            type(String(ch), into: editor)
+            assertMatchesFullRecomposeOracle(editor, "after typing \(String(reflecting: String(ch))) (open)")
+        }
+        paste("```\n", into: editor)
+        assertMatchesFullRecomposeOracle(editor, "after closing the fence")
+    }
+
+    @Test("Undo and redo match the oracle")
+    @MainActor func undoRedo() {
+        let editor = loadedEditor()
+        let para = (editor.rawSource as NSString).range(of: "A paragraph")
+        editor.setSelectedRange(NSRange(location: para.location, length: 0))
+        editor.recompose(cursorInRaw: para.location)
+        type("edit ", into: editor)
+        editor.performUndo()
+        assertMatchesFullRecomposeOracle(editor, "after undo")
+        editor.performRedo()
+        assertMatchesFullRecomposeOracle(editor, "after redo")
+    }
+
+    @Test("Edit sequence on a generated document matches the oracle")
+    @MainActor func generatedDocumentEdits() {
+        let editor = makeEditor()
+        editor.loadContent(makeLargeMarkdown(approximateBytes: 20_000, seed: 7))
+        assertMatchesFullRecomposeOracle(editor, "after load")
+
+        let ns = editor.rawSource as NSString
+        let mid = editor.blockIndexForRawOffset(ns.length / 2) ?? 0
+        let target = editor.blocks[mid].range.location
+        editor.setSelectedRange(NSRange(location: target, length: 0))
+        editor.recomposeIncremental(cursorInRaw: target)
+        assertMatchesFullRecomposeOracle(editor, "after mid-doc activation")
+
+        type("xyz", into: editor)
+        assertMatchesFullRecomposeOracle(editor, "after mid-doc typing")
+        pressEnter(in: editor)
+        assertMatchesFullRecomposeOracle(editor, "after mid-doc Enter")
+    }
+}

--- a/Tests/MarkdownEditorTests/RecomposeTests.swift
+++ b/Tests/MarkdownEditorTests/RecomposeTests.swift
@@ -46,4 +46,69 @@ struct RecomposeTests {
         let absorbed = (ts.string as NSString).range(of: "absorbed").location
         #expect(calloutBackground(ts, at: absorbed) != nil)
     }
+
+    @Test("Equal-count multi-block replacement restyles the middle block")
+    @MainActor func equalCountMiddleBlockRestyled() {
+        // A selection spanning three blocks replaced by three different blocks
+        // keeps the count unchanged — the case the old count-change heuristic
+        // missed entirely: only the active block got restyled, leaving the
+        // middle replacement block with stale attributes.
+        let editor = makeEditor()
+        editor.loadContent("aaaa\nbbbb\ncccc")
+        // Select from inside "aaaa" to inside "cccc" and replace with text
+        // whose middle line is a heading.
+        let sel = NSRange(location: 2, length: 10)   // "aa\nbbbb\ncc"
+        editor.setSelectedRange(sel)
+        editor.insertText("XX\n# Head\nYY", replacementRange: sel)
+
+        #expect(editor.blocks.count == 3)
+        let headLoc = (editor.rawSource as NSString).range(of: "Head").location
+        let headFont = font(at: headLoc, in: editor)
+        #expect((headFont?.pointSize ?? 0) > editor.bodyFont.pointSize,
+                "middle block must be restyled as a heading")
+        assertMatchesFullRecomposeOracle(editor)
+    }
+
+    @Test("Enter inside a callout restyles both halves")
+    @MainActor func enterSplitInsideCallout() {
+        let editor = makeEditor()
+        editor.loadContent("> [!note]\n> hi there\n\ntail")
+        // Cursor inside "hi there", split the quote run.
+        let cut = (editor.rawSource as NSString).range(of: " there").location
+        editor.setSelectedRange(NSRange(location: cut, length: 0))
+        editor.recompose(cursorInRaw: cut)
+        pressEnter(in: editor)
+
+        // "> [!note]\n> hi" stays a callout; " there" is now a plain paragraph
+        // outside it and must carry no callout background.
+        let ts = editor.textStorage!
+        let thereLoc = (ts.string as NSString).range(of: "there").location
+        #expect(calloutBackground(ts, at: thereLoc) == nil)
+        assertMatchesFullRecomposeOracle(editor)
+    }
+
+    @Test("Heading toggle next to a callout leaves the callout intact")
+    @MainActor func headingToggleNextToCallout() {
+        let editor = makeEditor()
+        editor.loadContent("title\n> [!note]\n> body")
+        editor.setSelectedRange(NSRange(location: 0, length: 0))
+        editor.recompose(cursorInRaw: 0)
+        editor.insertText("# ", replacementRange: NSRange(location: 0, length: 0))
+
+        let ts = editor.textStorage!
+        let bodyLoc = (ts.string as NSString).range(of: "body").location
+        #expect(calloutBackground(ts, at: bodyLoc) != nil)
+        assertMatchesFullRecomposeOracle(editor)
+    }
+
+    @Test("Theme change restyles in place without replacing the storage")
+    @MainActor func themeChangeAttributeOnly() {
+        let editor = makeEditor()
+        editor.loadContent("# Head\n\nbody text")
+        var theme = editor.theme
+        theme.fontSize += 4
+        editor.applyTheme(theme)
+        #expect(editor.textStorage!.string == editor.rawSource)
+        assertMatchesFullRecomposeOracle(editor)
+    }
 }

--- a/Tests/MarkdownEditorTests/RecomposeTests.swift
+++ b/Tests/MarkdownEditorTests/RecomposeTests.swift
@@ -9,8 +9,9 @@ import AppKit
 struct RecomposeTests {
 
     @MainActor private func calloutBackground(_ ts: NSTextStorage, at i: Int) -> NSColor? {
-        let ps = ts.attributes(at: i, effectiveRange: nil)[.paragraphStyle] as? NSParagraphStyle
-        return ps?.textBlocks.first?.backgroundColor
+        guard let deco = ts.attributes(at: i, effectiveRange: nil)[.blockDecoration] as? BlockDecoration,
+              case .box(let background, _, _, _) = deco.kind else { return nil }
+        return background
     }
 
     @Test("Removing a callout marker clears the stale background on its former body")

--- a/Tests/MarkdownEditorTests/RenderingRegressionTests.swift
+++ b/Tests/MarkdownEditorTests/RenderingRegressionTests.swift
@@ -180,4 +180,56 @@ struct RenderingRegressionTests {
         let after = scroll.contentView.bounds.origin.y
         #expect(abs(after - before) < 2.0, "moving to an already-visible line must not scroll")
     }
+
+    // MARK: Cursor move while scrolled away doesn't yank the viewport
+
+    @Test("A cross-block cursor move defers the off-screen old block instead of restyling it")
+    @MainActor func offscreenOldActiveDeferred() {
+        // Varied heights so deactivating a far-off block would change a lot of
+        // height (the source of the old viewport yank).
+        var doc = ""
+        for i in 0..<300 {
+            switch i % 3 {
+            case 0: doc += "> [!note]\n> callout \(i)\n> body line\n\n"
+            case 1: doc += "# Heading number \(i)\n\n"
+            default: doc += "paragraph number \(i) with some words\n\n"
+            }
+        }
+        let (e, scroll) = windowed(doc)
+        e.typewriterModeEnabled = false
+
+        // Activate a block near the top, then scroll far away from it.
+        let topBlock = 4
+        let topLoc = e.blocks[topBlock].range.location
+        e.setSelectedRange(NSRange(location: topLoc, length: 0))
+        e.recomposeIncremental(cursorInRaw: topLoc)
+        #expect(e.activeBlockIndex == topBlock)
+
+        scroll.contentView.scroll(to: NSPoint(x: 0, y: e.frame.height / 2))
+        scroll.reflectScrolledClipView(scroll.contentView)
+        e.promoteVisibleUnstyledBlocks()
+        let before = scroll.contentView.bounds.origin.y
+
+        // Move the caret to a visible block in the middle (the old active block
+        // is now far off screen above). This goes through the same dirty-set
+        // logic the async selection handler uses.
+        let midBlock = e.blockIndexForRawOffset(Int(before) / 20 + 10) ?? topBlock
+        let newLoc = e.blocks[midBlock].range.location
+        e.setSelectedRange(NSRange(location: newLoc, length: 0))
+
+        var dirty = IndexSet([midBlock])
+        // The off-screen old active block must be deferred (marked unstyled),
+        // not added to the synchronous dirty set.
+        let vis = e.syncStylingBlockRange()
+        if let v = vis, v.contains(topBlock) { dirty.insert(topBlock) }
+        else { e.blocks[topBlock].isStyled = false }
+        e.recomposeDirty(dirty, cursorInRaw: newLoc)
+
+        // The far-off old block was deferred, so the synchronous restyle didn't
+        // change its (off-screen) height — the viewport must not have jumped.
+        let after = scroll.contentView.bounds.origin.y
+        #expect(e.blocks[topBlock].isStyled == false,
+                "off-screen old active block should be deferred to the drain")
+        #expect(abs(after - before) < 50, "viewport must not yank on a cross-block cursor move")
+    }
 }

--- a/Tests/MarkdownEditorTests/RenderingRegressionTests.swift
+++ b/Tests/MarkdownEditorTests/RenderingRegressionTests.swift
@@ -64,14 +64,39 @@ struct RenderingRegressionTests {
 
     // MARK: Thematic break — symmetric breathing space
 
-    @Test("Thematic break uses symmetric paragraph spacing")
-    @MainActor func thematicBreakSymmetric() {
-        let editor = makeEditor()
-        let styled = editor.styleBlock("---")
-        let ps = styled.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
-        #expect(ps != nil)
-        #expect(abs((ps?.paragraphSpacingBefore ?? 0) - (ps?.paragraphSpacing ?? 0)) < 0.01,
-                "the rule's breathing space must be symmetric so it sits centered")
+    @Test("Thematic break rule is drawn equidistant from the text above and below")
+    @MainActor func thematicBreakBalanced() {
+        let (e, _) = windowed("Text line above the rule.\n---\nText line below the rule.")
+        guard let tlm = e.textLayoutManager else { Issue.record("no tlm"); return }
+
+        // Collect the three fragments: text, rule, text.
+        var frags: [NSTextLayoutFragment] = []
+        tlm.enumerateTextLayoutFragments(from: tlm.documentRange.location, options: []) {
+            frags.append($0); return frags.count < 3
+        }
+        #expect(frags.count == 3)
+        let (above, rule, below) = (frags[0], frags[1], frags[2])
+
+        // The rule's drawn Y = fragment center + the compensating offset.
+        let ruleY = rule.layoutFragmentFrame.midY + e.thematicBreakCenterOffset
+
+        // Glyph edges of the neighbouring text (container coordinates): the
+        // baseline of the line above, and the cap-top of the line below.
+        func baseline(_ f: NSTextLayoutFragment) -> CGFloat? {
+            guard let line = f.textLineFragments.first else { return nil }
+            return f.layoutFragmentFrame.minY + line.typographicBounds.minY + line.glyphOrigin.y
+        }
+        guard let aboveBaseline = baseline(above),
+              let belowLine = below.textLineFragments.first else {
+            Issue.record("missing line metrics"); return
+        }
+        let belowTop = below.layoutFragmentFrame.minY + belowLine.typographicBounds.minY
+            + belowLine.glyphOrigin.y - e.bodyFont.capHeight
+
+        let gapAbove = ruleY - aboveBaseline
+        let gapBelow = belowTop - ruleY
+        #expect(abs(gapAbove - gapBelow) < 4.0,
+                "rule must sit between the text lines (above=\(gapAbove), below=\(gapBelow))")
     }
 
     // MARK: Scroll targets accurate under lazy layout

--- a/Tests/MarkdownEditorTests/RenderingRegressionTests.swift
+++ b/Tests/MarkdownEditorTests/RenderingRegressionTests.swift
@@ -1,0 +1,158 @@
+import Testing
+import AppKit
+@testable import MarkdownEditorCore
+
+/// Regressions from the TextKit 2 / fragment-overlay migration.
+@Suite("Rendering regressions (TextKit 2)")
+struct RenderingRegressionTests {
+
+    @MainActor private func windowed(_ doc: String, h: CGFloat = 400)
+        -> (EditorTextView, NSScrollView) {
+        let e = makeEditor()
+        let win = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 500, height: h),
+                           styleMask: [.titled], backing: .buffered, defer: false)
+        let scroll = NSScrollView(frame: win.contentLayoutRect)
+        scroll.documentView = e
+        win.contentView = scroll
+        win.makeFirstResponder(e)
+        e.isVerticallyResizable = true
+        e.minSize = NSSize(width: 0, height: 0)
+        e.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude,
+                           height: CGFloat.greatestFiniteMagnitude)
+        e.autoresizingMask = [.width]
+        e.textContainerInset = NSSize(width: 24, height: 18)
+        e.loadContent(doc)
+        ensureFullLayout(e); drainAllStyling(e)
+        e.sizeToFit(); e.layoutSubtreeIfNeeded(); ensureFullLayout(e)
+        return (e, scroll)
+    }
+
+    // MARK: Inline math reserves line height (no overlap with the next line)
+
+    @Test("Inline math line is tall enough for the equation image")
+    @MainActor func inlineMathReservesLineHeight() {
+        let editor = makeEditor()
+        // A heading line that wraps the equation onto the same logical line.
+        let styled = editor.styleBlock("## Heading $\\frac{a}{b}+x^2$")
+        // The overlay's image height.
+        var overlayH: CGFloat = 0
+        styled.enumerateAttribute(.fragmentOverlay,
+                                  in: NSRange(location: 0, length: styled.length)) { v, _, _ in
+            if let o = v as? FragmentOverlay { overlayH = max(overlayH, o.bounds.height) }
+        }
+        #expect(overlayH > 0)
+        // The paragraph style on the math line must reserve at least the image
+        // height (so the tall equation can't overlap the following line).
+        let mathLoc = (styled.string as NSString).range(of: "$").location
+        let ps = styled.attribute(.paragraphStyle, at: mathLoc, effectiveRange: nil) as? NSParagraphStyle
+        #expect((ps?.minimumLineHeight ?? 0) >= overlayH - 0.5,
+                "inline math line must reserve the equation's height")
+    }
+
+    @Test("Display math still reserves its own line height")
+    @MainActor func displayMathReservesHeight() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("$$\n\\frac{a}{b}\n$$")
+        var overlayH: CGFloat = 0
+        styled.enumerateAttribute(.fragmentOverlay,
+                                  in: NSRange(location: 0, length: styled.length)) { v, _, _ in
+            if let o = v as? FragmentOverlay { overlayH = max(overlayH, o.bounds.height) }
+        }
+        let ps = styled.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        #expect((ps?.minimumLineHeight ?? 0) >= overlayH - 0.5)
+    }
+
+    // MARK: Thematic break — symmetric breathing space
+
+    @Test("Thematic break uses symmetric paragraph spacing")
+    @MainActor func thematicBreakSymmetric() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("---")
+        let ps = styled.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        #expect(ps != nil)
+        #expect(abs((ps?.paragraphSpacingBefore ?? 0) - (ps?.paragraphSpacing ?? 0)) < 0.01,
+                "the rule's breathing space must be symmetric so it sits centered")
+    }
+
+    // MARK: Scroll targets accurate under lazy layout
+
+    @Test("The drain styling blocks above the viewport does not shift visible content")
+    @MainActor func drainDoesNotJumpViewport() {
+        // Varied heights so styling a block above the viewport changes its
+        // height meaningfully (heading scale, callout box, display-math).
+        var doc = ""
+        for i in 0..<400 {
+            switch i % 4 {
+            case 0: doc += "# Heading number \(i)\n\n"
+            case 1: doc += "> [!note]\n> callout \(i)\n> body line\n\n"
+            case 2: doc += "$$\n\\frac{a}{b}=\(i)\n$$\n\n"
+            default: doc += "plain paragraph number \(i)\n\n"
+            }
+        }
+        let (e, scroll) = windowed(doc)
+        e.typewriterModeEnabled = false
+
+        // Scroll to the middle (blocks above are styled by promotion; the deep
+        // tail and any gaps remain to be drained).
+        scroll.contentView.scroll(to: NSPoint(x: 0, y: e.frame.height / 2))
+        scroll.reflectScrolledClipView(scroll.contentView)
+        e.promoteVisibleUnstyledBlocks()
+        scroll.reflectScrolledClipView(scroll.contentView)
+
+        // Record the screen Y of a block sitting in the viewport.
+        let visible = scroll.contentView.bounds
+        var anchor: Int? = nil
+        for idx in e.blocks.indices {
+            if let r = e.lineRect(forCharacterAt: e.blocks[idx].range.location) {
+                let y = r.minY + e.textContainerOrigin.y
+                if y > visible.minY + 60 && y < visible.maxY - 60 { anchor = idx; break }
+            }
+        }
+        guard let anchor else { Issue.record("no visible anchor block"); return }
+        func screenY() -> CGFloat {
+            (e.lineRect(forCharacterAt: e.blocks[anchor].range.location)?.minY ?? 0)
+                + e.textContainerOrigin.y - scroll.contentView.bounds.origin.y
+        }
+        let before = screenY()
+
+        // Drain everything (styles blocks above and below the viewport).
+        drainAllStyling(e)
+        scroll.reflectScrolledClipView(scroll.contentView)
+
+        let after = screenY()
+        #expect(abs(after - before) < 8.0,
+                "drain styling must not jump the viewport (Δ=\(after - before))")
+    }
+
+    @Test("Moving the caret to an already-visible line does not scroll")
+    @MainActor func smallMoveNoScroll() {
+        var doc = ""
+        for i in 0..<300 { doc += "line number \(i) with text\n\n" }
+        let (e, scroll) = windowed(doc)
+        e.typewriterModeEnabled = false
+
+        let midY = e.frame.height / 2
+        scroll.contentView.scroll(to: NSPoint(x: 0, y: midY))
+        scroll.reflectScrolledClipView(scroll.contentView)
+        e.promoteVisibleUnstyledBlocks()
+        scroll.reflectScrolledClipView(scroll.contentView)
+
+        // Find a block whose line is comfortably inside the viewport.
+        let visible = scroll.contentView.bounds
+        var visibleBlock: Int? = nil
+        for idx in e.blocks.indices {
+            if let r = e.lineRect(forCharacterAt: e.blocks[idx].range.location) {
+                let y = r.minY + e.textContainerOrigin.y
+                if y > visible.minY + 40 && y < visible.maxY - 40 { visibleBlock = idx; break }
+            }
+        }
+        guard let vb = visibleBlock else { Issue.record("no visible block found"); return }
+
+        let loc = e.blocks[vb].range.location
+        let before = scroll.contentView.bounds.origin.y
+        e.setSelectedRange(NSRange(location: loc, length: 0))
+        e.scrollRangeToVisible(NSRange(location: loc, length: 0))
+        let after = scroll.contentView.bounds.origin.y
+        #expect(abs(after - before) < 2.0, "moving to an already-visible line must not scroll")
+    }
+}

--- a/Tests/MarkdownEditorTests/ScrollStabilityTests.swift
+++ b/Tests/MarkdownEditorTests/ScrollStabilityTests.swift
@@ -1,0 +1,52 @@
+import Testing
+import AppKit
+@testable import MarkdownEditorCore
+
+/// Activating/deactivating a block ABOVE the viewport changes its height
+/// (callout header line + padding vs raw text). TextKit 2 lays out
+/// viewport-relative, so content under the scroll position must not jump.
+@Suite("Scroll stability under height changes")
+struct ScrollStabilityTests {
+
+    @Test("Callout activation above the viewport doesn't shift visible content")
+    @MainActor func activationAboveViewport() {
+        let editor = makeEditor()
+        let win = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 500, height: 300),
+                           styleMask: [.titled], backing: .buffered, defer: false)
+        let scroll = NSScrollView(frame: win.contentLayoutRect)
+        scroll.documentView = editor
+        win.contentView = scroll
+        win.makeFirstResponder(editor)
+        editor.typewriterModeEnabled = false
+        editor.isVerticallyResizable = true
+        editor.minSize = NSSize(width: 0, height: 0)
+        editor.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude,
+                                height: CGFloat.greatestFiniteMagnitude)
+        editor.autoresizingMask = [.width]
+
+        var doc = "> [!note]\n> callout body\n\n"
+        for i in 0..<60 { doc += "paragraph number \(i)\n\n" }
+        editor.loadContent(doc)
+        ensureFullLayout(editor)
+        editor.sizeToFit()
+        editor.layoutSubtreeIfNeeded()
+
+        // Scroll well past the callout.
+        let target = (editor.rawSource as NSString).range(of: "paragraph number 40").location
+        editor.setSelectedRange(NSRange(location: target, length: 0))
+        scroll.contentView.scroll(to: NSPoint(x: 0, y: 800))
+        scroll.reflectScrolledClipView(scroll.contentView)
+        let yBefore = scroll.contentView.bounds.origin.y
+        #expect(yBefore > 0)
+
+        // Activate the callout (height change above the viewport), then deactivate.
+        editor.recomposeIncremental(cursorInRaw: 2)
+        editor.recomposeIncremental(cursorInRaw: target)
+        ensureFullLayout(editor)
+        editor.layoutSubtreeIfNeeded()
+
+        let yAfter = scroll.contentView.bounds.origin.y
+        #expect(abs(yAfter - yBefore) < 2.0,
+                "scroll position jumped by \(yAfter - yBefore)")
+    }
+}

--- a/Tests/MarkdownEditorTests/TestHelpers.swift
+++ b/Tests/MarkdownEditorTests/TestHelpers.swift
@@ -4,21 +4,13 @@ import AppKit
 
 // MARK: - Editor Construction
 
-/// Creates an EditorTextView with a proper text system chain,
-/// mirroring the setup in main.swift.
+/// Creates an EditorTextView with the TextKit 2 text system chain,
+/// mirroring the setup in Document.makeWindowControllers().
 @MainActor
 func makeEditor() -> EditorTextView {
-    let textStorage = EditorTextStorage()
-    let layoutManager = NSLayoutManager()
-    textStorage.addLayoutManager(layoutManager)
-    let textContainer = NSTextContainer(
-        size: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
-    )
-    textContainer.widthTracksTextView = true
-    layoutManager.addTextContainer(textContainer)
-    let editor = EditorTextView(
+    let editor = EditorTextView.makeTextKit2(
         frame: NSRect(x: 0, y: 0, width: 500, height: 300),
-        textContainer: textContainer
+        containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
     )
     // Isolate theme persistence. EditorTextView loads/saves its theme via
     // UserDefaults; without isolation, tests that call `applyTheme` write font
@@ -31,6 +23,14 @@ func makeEditor() -> EditorTextView {
     editor.themeDefaults = defaults
     editor.theme = .load(from: defaults)
     return editor
+}
+
+/// Forces layout of the whole document (TextKit 2). The lazy equivalent of
+/// the old `layoutManager.ensureLayout(for: textContainer)`.
+@MainActor
+func ensureFullLayout(_ editor: EditorTextView) {
+    guard let tlm = editor.textLayoutManager else { return }
+    tlm.ensureLayout(for: tlm.documentRange)
 }
 
 // MARK: - Input Simulation

--- a/Tests/MarkdownEditorTests/TestHelpers.swift
+++ b/Tests/MarkdownEditorTests/TestHelpers.swift
@@ -164,16 +164,18 @@ func isDimmed(at offset: Int, in result: NSAttributedString) -> Bool {
 // fragment overlays are compared component-wise because fresh compositions
 // create fresh instances that never compare equal by pointer-based isEqual.
 
-/// Composes the editor's document from scratch the way full `recompose` does:
+/// Composes the editor's document from scratch the way full styling does:
 /// base attributes everywhere, then per-block styling (cursor-aware for the
-/// active block).
+/// active block). Blocks pending lazy styling (`isStyled == false`) are left
+/// in base attributes — exactly what the storage must hold for them after a
+/// lazy load.
 @MainActor
 func expectedFullComposition(for editor: EditorTextView) -> NSAttributedString {
     let composed = NSMutableAttributedString(string: editor.rawSource,
                                              attributes: editor.baseAttributes)
     let cursorInRaw = editor.selectedRange().location
     for (i, block) in editor.blocks.enumerated() {
-        guard block.range.upperBound <= composed.length else { continue }
+        guard block.range.upperBound <= composed.length, block.isStyled else { continue }
         let cursorInBlock: Int? = (i == editor.activeBlockIndex)
             ? max(0, cursorInRaw - block.range.location) : nil
         let styled = editor.styleBlock(block.content, cursorPosition: cursorInBlock)
@@ -187,6 +189,16 @@ func expectedFullComposition(for editor: EditorTextView) -> NSAttributedString {
         }
     }
     return composed
+}
+
+/// Runs the idle drain to completion synchronously (lazy-rendering tests).
+@MainActor
+func drainAllStyling(_ editor: EditorTextView, maxSlices: Int = 10_000) {
+    var slices = 0
+    while editor.blocks.contains(where: { !$0.isStyled }), slices < maxSlices {
+        editor.drainStylingSlice()
+        slices += 1
+    }
 }
 
 /// Asserts the live text storage is attribute-equivalent to a from-scratch

--- a/Tests/MarkdownEditorTests/TestHelpers.swift
+++ b/Tests/MarkdownEditorTests/TestHelpers.swift
@@ -141,3 +141,257 @@ func isDimmed(at offset: Int, in result: NSAttributedString) -> Bool {
     guard let c = a[.foregroundColor] as? NSColor else { return false }
     return c == NSColor.tertiaryLabelColor
 }
+
+// MARK: - Full-Recompose Oracle
+//
+// The oracle is the reference for what the text storage's attributes should be
+// after ANY sequence of edits/cursor moves: the document composed from scratch
+// exactly the way full `recompose` does it. Incremental paths (dirty-set
+// styling, lazy rendering) must always leave the storage attribute-equivalent
+// to this composition. Comparison is structural: paragraph styles and
+// attachments are compared component-wise because fresh compositions create
+// fresh NSTextBlock / NSTextAttachment instances that never compare equal by
+// pointer-based isEqual.
+
+/// Composes the editor's document from scratch the way full `recompose` does:
+/// base attributes everywhere, then per-block styling (cursor-aware for the
+/// active block).
+@MainActor
+func expectedFullComposition(for editor: EditorTextView) -> NSAttributedString {
+    let composed = NSMutableAttributedString(string: editor.rawSource,
+                                             attributes: editor.baseAttributes)
+    let cursorInRaw = editor.selectedRange().location
+    for (i, block) in editor.blocks.enumerated() {
+        guard block.range.upperBound <= composed.length else { continue }
+        let cursorInBlock: Int? = (i == editor.activeBlockIndex)
+            ? max(0, cursorInRaw - block.range.location) : nil
+        let styled = editor.styleBlock(block.content, cursorPosition: cursorInBlock)
+        styled.enumerateAttributes(
+            in: NSRange(location: 0, length: styled.length), options: []
+        ) { attrs, range, _ in
+            let tsRange = NSRange(location: range.location + block.range.location,
+                                  length: range.length)
+            guard tsRange.upperBound <= composed.length else { return }
+            composed.setAttributes(attrs, range: tsRange)
+        }
+    }
+    return composed
+}
+
+/// Asserts the live text storage is attribute-equivalent to a from-scratch
+/// full recompose. On mismatch, reports the first differing character with a
+/// description of both attribute sets.
+@MainActor
+func assertMatchesFullRecomposeOracle(
+    _ editor: EditorTextView,
+    _ comment: Comment? = nil,
+    sourceLocation: SourceLocation = #_sourceLocation
+) {
+    guard let ts = editor.textStorage else {
+        Issue.record("editor has no text storage", sourceLocation: sourceLocation)
+        return
+    }
+    let expected = expectedFullComposition(for: editor)
+    #expect(ts.string == expected.string,
+            "storage string diverged from rawSource", sourceLocation: sourceLocation)
+
+    let len = min(ts.length, expected.length)
+    var i = 0
+    while i < len {
+        var rA = NSRange(); var rB = NSRange()
+        let whole = NSRange(location: i, length: len - i)
+        let a = expected.attributes(at: i, longestEffectiveRange: &rA, in: whole)
+        let b = ts.attributes(at: i, longestEffectiveRange: &rB, in: whole)
+        if let diff = attributeDifference(expected: a, actual: b) {
+            let ctx = (ts.string as NSString).substring(
+                with: NSRange(location: max(0, i - 10),
+                              length: min(30, len - max(0, i - 10))))
+            Issue.record(
+                """
+                Oracle mismatch at offset \(i) (near \(String(reflecting: ctx))): \(diff)\
+                \(comment.map { " — \($0)" } ?? "")
+                """,
+                sourceLocation: sourceLocation)
+            return
+        }
+        i = max(min(rA.upperBound, rB.upperBound), i + 1)
+    }
+}
+
+/// Returns a human-readable description of the first differing attribute, or
+/// nil when the two attribute dictionaries are equivalent.
+func attributeDifference(
+    expected: [NSAttributedString.Key: Any],
+    actual: [NSAttributedString.Key: Any]
+) -> String? {
+    let keys = Set(expected.keys).union(actual.keys)
+    for key in keys {
+        let a = expected[key]
+        let b = actual[key]
+        switch (a, b) {
+        case (nil, nil):
+            continue
+        case (nil, .some(let v)):
+            return "\(key.rawValue): unexpected \(String(describing: v))"
+        case (.some(let v), nil):
+            return "\(key.rawValue): missing (expected \(String(describing: v)))"
+        case (.some(let va), .some(let vb)):
+            if let fa = va as? NSFont, let fb = vb as? NSFont {
+                if fa.fontName != fb.fontName || abs(fa.pointSize - fb.pointSize) > 0.01 {
+                    return "font: expected \(fa.fontName)@\(fa.pointSize), got \(fb.fontName)@\(fb.pointSize)"
+                }
+            } else if let pa = va as? NSParagraphStyle, let pb = vb as? NSParagraphStyle {
+                if let diff = paragraphStyleDifference(pa, pb) {
+                    return "paragraphStyle: \(diff)"
+                }
+            } else if let aa = va as? NSTextAttachment, let ab = vb as? NSTextAttachment {
+                if String(describing: type(of: aa)) != String(describing: type(of: ab)) {
+                    return "attachment class: \(type(of: aa)) vs \(type(of: ab))"
+                }
+                let ba = aa.bounds, bb = ab.bounds
+                if abs(ba.width - bb.width) > 0.5 || abs(ba.height - bb.height) > 0.5
+                    || abs(ba.origin.y - bb.origin.y) > 0.5 {
+                    return "attachment bounds: \(ba) vs \(bb)"
+                }
+            } else if let oa = va as? NSObject, let ob = vb as? NSObject {
+                if !oa.isEqual(ob) {
+                    return "\(key.rawValue): \(oa) vs \(ob)"
+                }
+            }
+        }
+    }
+    return nil
+}
+
+/// Component-wise paragraph style comparison. NSParagraphStyle.isEqual is
+/// unusable here: embedded NSTextBlocks compare by identity, and every
+/// composition creates fresh instances.
+func paragraphStyleDifference(_ a: NSParagraphStyle, _ b: NSParagraphStyle) -> String? {
+    func ne(_ x: CGFloat, _ y: CGFloat) -> Bool { abs(x - y) > 0.01 }
+    if a.alignment != b.alignment { return "alignment \(a.alignment.rawValue) vs \(b.alignment.rawValue)" }
+    if ne(a.lineSpacing, b.lineSpacing) { return "lineSpacing \(a.lineSpacing) vs \(b.lineSpacing)" }
+    if ne(a.paragraphSpacing, b.paragraphSpacing) { return "paragraphSpacing \(a.paragraphSpacing) vs \(b.paragraphSpacing)" }
+    if ne(a.paragraphSpacingBefore, b.paragraphSpacingBefore) { return "paragraphSpacingBefore \(a.paragraphSpacingBefore) vs \(b.paragraphSpacingBefore)" }
+    if ne(a.headIndent, b.headIndent) { return "headIndent \(a.headIndent) vs \(b.headIndent)" }
+    if ne(a.firstLineHeadIndent, b.firstLineHeadIndent) { return "firstLineHeadIndent \(a.firstLineHeadIndent) vs \(b.firstLineHeadIndent)" }
+    if ne(a.tailIndent, b.tailIndent) { return "tailIndent \(a.tailIndent) vs \(b.tailIndent)" }
+    if ne(a.minimumLineHeight, b.minimumLineHeight) { return "minimumLineHeight \(a.minimumLineHeight) vs \(b.minimumLineHeight)" }
+    if ne(a.maximumLineHeight, b.maximumLineHeight) { return "maximumLineHeight \(a.maximumLineHeight) vs \(b.maximumLineHeight)" }
+    if a.tabStops.count != b.tabStops.count { return "tabStops count \(a.tabStops.count) vs \(b.tabStops.count)" }
+    for (ta, tb) in zip(a.tabStops, b.tabStops) where ne(ta.location, tb.location) {
+        return "tabStop \(ta.location) vs \(tb.location)"
+    }
+    if a.textBlocks.count != b.textBlocks.count {
+        return "textBlocks count \(a.textBlocks.count) vs \(b.textBlocks.count)"
+    }
+    for (ba, bb) in zip(a.textBlocks, b.textBlocks) {
+        if let diff = textBlockDifference(ba, bb) { return diff }
+    }
+    return nil
+}
+
+func textBlockDifference(_ a: NSTextBlock, _ b: NSTextBlock) -> String? {
+    if String(describing: type(of: a)) != String(describing: type(of: b)) {
+        return "textBlock class \(type(of: a)) vs \(type(of: b))"
+    }
+    switch (a.backgroundColor, b.backgroundColor) {
+    case (nil, nil): break
+    case (let ca?, let cb?) where ca.isEqual(cb): break
+    default: return "textBlock backgroundColor \(String(describing: a.backgroundColor)) vs \(String(describing: b.backgroundColor))"
+    }
+    let edges: [NSRectEdge] = [.minX, .minY, .maxX, .maxY]
+    for layer in [NSTextBlock.Layer.padding, .border, .margin] {
+        for edge in edges {
+            let wa = a.width(for: layer, edge: edge)
+            let wb = b.width(for: layer, edge: edge)
+            if abs(wa - wb) > 0.01 {
+                return "textBlock \(layer.rawValue)/\(edge.rawValue) width \(wa) vs \(wb)"
+            }
+        }
+    }
+    return nil
+}
+
+// MARK: - Large Document Generator
+
+/// Deterministic RNG (splitmix64) so generated documents are reproducible
+/// across runs and platforms.
+struct SeededGenerator: RandomNumberGenerator {
+    private var state: UInt64
+    init(seed: UInt64) { state = seed }
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}
+
+/// Generates representative markdown of roughly the requested size: paragraphs
+/// with inline styles, headings, lists (nested, checkboxes), quote runs,
+/// callouts, tables, fenced code, display math, thematic breaks, blank lines.
+func makeLargeMarkdown(approximateBytes: Int, seed: UInt64 = 0xC0FFEE) -> String {
+    var rng = SeededGenerator(seed: seed)
+    let words = ["alpha", "beta", "gamma", "delta", "lorem", "ipsum", "dolor",
+                 "editor", "markdown", "render", "block", "cursor", "style",
+                 "viewport", "layout", "anchor", "fragment", "glyph", "parse"]
+    func sentence(_ n: Int) -> String {
+        var parts: [String] = []
+        for _ in 0..<n {
+            var w = words.randomElement(using: &rng)!
+            switch Int.random(in: 0..<20, using: &rng) {
+            case 0: w = "**\(w)**"
+            case 1: w = "*\(w)*"
+            case 2: w = "`\(w)`"
+            case 3: w = "[\(w)](https://example.com/\(w))"
+            default: break
+            }
+            parts.append(w)
+        }
+        return parts.joined(separator: " ") + "."
+    }
+
+    var chunks: [String] = []
+    var size = 0
+    let calloutTypes = ["note", "tip", "warning", "important", "abstract", "bug"]
+    while size < approximateBytes {
+        let chunk: String
+        switch Int.random(in: 0..<14, using: &rng) {
+        case 0:
+            chunk = "\(String(repeating: "#", count: Int.random(in: 1...4, using: &rng))) \(sentence(4))"
+        case 1:
+            let rows = (0..<Int.random(in: 2...4, using: &rng)).map { _ in
+                "| \(words.randomElement(using: &rng)!) | \(words.randomElement(using: &rng)!) |"
+            }
+            chunk = ([rows[0], "| --- | --- |"] + rows.dropFirst()).joined(separator: "\n")
+        case 2:
+            let lines = (0..<Int.random(in: 2...5, using: &rng)).map { _ in
+                "    let \(words.randomElement(using: &rng)!) = \(Int.random(in: 0..<100, using: &rng))"
+            }
+            chunk = (["```swift"] + lines + ["```"]).joined(separator: "\n")
+        case 3:
+            chunk = "$$\nx_{\(Int.random(in: 0..<9, using: &rng))} = \\frac{a}{b}\n$$"
+        case 4:
+            let body = (0..<Int.random(in: 1...3, using: &rng)).map { _ in "> \(sentence(6))" }
+            chunk = (["> [!\(calloutTypes.randomElement(using: &rng)!)]"] + body).joined(separator: "\n")
+        case 5:
+            chunk = (0..<Int.random(in: 1...3, using: &rng))
+                .map { _ in "> \(sentence(8))" }.joined(separator: "\n")
+        case 6:
+            chunk = (0..<Int.random(in: 2...5, using: &rng)).map { i -> String in
+                let indent = String(repeating: "  ", count: Int.random(in: 0...2, using: &rng))
+                let marker = Bool.random(using: &rng)
+                    ? "- " : (Bool.random(using: &rng) ? "- [ ] " : "\(i + 1). ")
+                return "\(indent)\(marker)\(sentence(5))"
+            }.joined(separator: "\n")
+        case 7:
+            chunk = "---"
+        default:
+            chunk = sentence(Int.random(in: 10...40, using: &rng))
+        }
+        chunks.append(chunk)
+        size += chunk.utf8.count + 2
+    }
+    return chunks.joined(separator: "\n\n")
+}

--- a/Tests/MarkdownEditorTests/TestHelpers.swift
+++ b/Tests/MarkdownEditorTests/TestHelpers.swift
@@ -25,6 +25,18 @@ func makeEditor() -> EditorTextView {
     return editor
 }
 
+/// The BlockDecoration attribute at `offset` in the editor's storage, if any.
+@MainActor
+func blockDecoration(at offset: Int, in editor: EditorTextView) -> BlockDecoration? {
+    attrs(at: offset, in: editor)[.blockDecoration] as? BlockDecoration
+}
+
+/// The BlockDecoration attribute at `offset` in a styled string, if any.
+func blockDecoration(at offset: Int, in result: NSAttributedString) -> BlockDecoration? {
+    guard offset < result.length else { return nil }
+    return result.attribute(.blockDecoration, at: offset, effectiveRange: nil) as? BlockDecoration
+}
+
 /// Forces layout of the whole document (TextKit 2). The lazy equivalent of
 /// the old `layoutManager.ensureLayout(for: textContainer)`.
 @MainActor
@@ -149,9 +161,8 @@ func isDimmed(at offset: Int, in result: NSAttributedString) -> Bool {
 // exactly the way full `recompose` does it. Incremental paths (dirty-set
 // styling, lazy rendering) must always leave the storage attribute-equivalent
 // to this composition. Comparison is structural: paragraph styles and
-// attachments are compared component-wise because fresh compositions create
-// fresh NSTextBlock / NSTextAttachment instances that never compare equal by
-// pointer-based isEqual.
+// fragment overlays are compared component-wise because fresh compositions
+// create fresh instances that never compare equal by pointer-based isEqual.
 
 /// Composes the editor's document from scratch the way full `recompose` does:
 /// base attributes everywhere, then per-block styling (cursor-aware for the
@@ -244,14 +255,13 @@ func attributeDifference(
                 if let diff = paragraphStyleDifference(pa, pb) {
                     return "paragraphStyle: \(diff)"
                 }
-            } else if let aa = va as? NSTextAttachment, let ab = vb as? NSTextAttachment {
-                if String(describing: type(of: aa)) != String(describing: type(of: ab)) {
-                    return "attachment class: \(type(of: aa)) vs \(type(of: ab))"
-                }
-                let ba = aa.bounds, bb = ab.bounds
+            } else if let fa = va as? FragmentOverlay, let fb = vb as? FragmentOverlay {
+                // Overlay images are drawn fresh per composition; bounds carry
+                // the comparable geometry.
+                let ba = fa.bounds, bb = fb.bounds
                 if abs(ba.width - bb.width) > 0.5 || abs(ba.height - bb.height) > 0.5
                     || abs(ba.origin.y - bb.origin.y) > 0.5 {
-                    return "attachment bounds: \(ba) vs \(bb)"
+                    return "overlay bounds: \(ba) vs \(bb)"
                 }
             } else if let oa = va as? NSObject, let ob = vb as? NSObject {
                 if !oa.isEqual(ob) {


### PR DESCRIPTION
## Summary

Redesigns the editor's recompose pipeline so styling/layout stays correct and the editor is responsive on 1–2 MB documents, and migrates the rendering layer to **TextKit 2**. Replaces the three ad-hoc recompose paths (full / incremental / per-keystroke) with one exact, work-bounded engine.

### The pipeline, in phases
- **Dirty-set recompose** — a positional block diff computes exactly which blocks changed; only those (plus the active block) restyle. Removes the `blocks.count != previousBlockCount → full recompose` heuristic, the whole-storage replacement on Enter, and 2–3× redundant per-keystroke restyles.
- **TextKit 2 migration** — viewport-only layout. All NSTextBlock decorations (callout box, quote bar, table borders, thematic-break rule) became fragment-drawn `.blockDecoration`s, and all attachment-on-real-character images (callout header, math, list bullets/checkboxes) became `.fragmentOverlay`s + kern, since TextKit 2 only honors attachments on U+FFFC. A DEBUG tripwire fails loudly on any silent TextKit 1 fallback.
- **Lazy rendering** — loads/theme changes style only the viewport + margin synchronously; an idle drain (time-budgeted slices) and scroll promotion converge the rest. `scrollRangeToVisible` is overridden because AppKit's TextKit 2 implementation crashed at ~1.5 MB.
- **Incremental parsing** — per-keystroke parse is O(edit): `EditorTextStorage` accumulates the edit, `BlockParser.incrementalParse` re-splits a one-block-lookback window with resync, and `listIndentUnit` is an incrementally-maintained histogram.

### Perf (1.5 MB / 23,463 blocks, debug, windowed)
| op | before | after |
|---|---|---|
| open | process killed | ~1.0 s |
| keystroke | crash / 1.6–2.4 s @100 KB | 37–89 ms |
| Enter | crash | ~36 ms |

### TextKit 2 regression fixes (post-migration)
- Inline math in a heading reserved no vertical line height (overlapped the next line) — `reserveLineHeight` fixes it.
- Thematic-break rule sat ~10 pt too high (drawn at fragment center, but text sits at the baseline) — added a `centerOffset`; measured 28/28 pt with screencapture.
- **Viewport jumps on cursor move** (traced via an on-device scroll log from a screen recording): stop re-setting the selection (AppKit autoscroll on stale layout), center after the restyle (typewriter), and — the big one — **defer deactivating the off-screen old active block to the async drain** so a far cursor move doesn't shift the document height above the viewport.

## Known limitation
A **tiny lurch** (≈ up to ~130 px) remains when you click into a block whose rendered and raw forms differ in height (e.g. a checklist item): the clicked block re-renders in place and content below it shifts slightly. The large yanks/jumps are gone. Tracked as a follow-up to investigate.

## Tests
**541 pass** (was 497). New harnesses: a full-recompose attribute-equivalence oracle run pervasively, a seeded incremental-parse fuzz suite cross-checked against the full parser on every edit, windowed scroll/lazy/decoration regression tests, and an `MD_PERF`-gated latency harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)