### PR TITLE
Pin viewport top on cursor-move restyle (fix residual scroll lurch)

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -449,7 +449,7 @@ public class EditorTextView: NSTextView {
                     self.recomposeDirty(dirty, cursorInRaw: loc)
                     self.scrollCursorToCenter()
                 } else {
-                    self.preservingCaretScreenPosition {
+                    self.preservingViewportAnchor {
                         self.recomposeDirty(dirty, cursorInRaw: loc)
                     }
                 }
@@ -470,27 +470,38 @@ public class EditorTextView: NSTextView {
     /// to the normal "keep the cursor visible" behavior. Toggled from View menu.
     public var typewriterModeEnabled: Bool = true
 
-    /// The caret line's top in view (scroll-document) coordinates, or nil.
-    private func caretViewY() -> CGFloat? {
-        caretLineRect().map { $0.minY + textContainerOrigin.y }
-    }
-
     /// Runs `body` (which restyles the active block, changing its height) while
-    /// keeping the caret line at the same on-screen position. The caret offset
-    /// (`selectedRange().location`) is reliable and the caret is on screen here,
-    /// so `lineRect` resolves correctly. With the off-screen old active block
-    /// deferred (see selectionDidChange), only the visible new active block
-    /// changes height, so the delta is small.
-    private func preservingCaretScreenPosition(_ body: () -> Void) {
-        guard let scrollView = enclosingScrollView, let before = caretViewY() else {
+    /// pinning the line at the TOP of the viewport to the same screen position
+    /// — so the part of the document the user is looking at doesn't move, even
+    /// when the height change (or a lazy-layout height estimate) is above the
+    /// caret. Anchoring the viewport top rather than the caret is what removes
+    /// the residual lurch: a caret anchor holds the caret but lets the content
+    /// above it slide.
+    ///
+    /// Reliability: `layoutViewport()` first guarantees the on-screen fragments
+    /// are laid out, so the top fragment's character offset is correct; both
+    /// samples then go through `lineRect` (which forces layout) for a
+    /// consistent measurement. A mis-measure degrades to no scroll — never a
+    /// yank or a jump to the document start.
+    func preservingViewportAnchor(_ body: () -> Void) {
+        guard let scrollView = enclosingScrollView, let tlm = textLayoutManager else {
             body(); return
         }
-        let screenOffset = before - scrollView.contentView.bounds.origin.y
+        tlm.textViewportLayoutController.layoutViewport()
+        let visible = scrollView.contentView.bounds
+        let topPoint = CGPoint(x: 0, y: visible.minY - textContainerOrigin.y)
+        guard let frag = tlm.textLayoutFragment(for: topPoint) else { body(); return }
+        let anchorOffset = tlm.offset(from: tlm.documentRange.location,
+                                      to: frag.rangeInElement.location)
+        let beforeY = lineRect(forCharacterAt: anchorOffset)?.minY
+
         body()
-        guard let after = caretViewY() else { return }
-        let newY = max(0, after - screenOffset)
-        guard abs(newY - scrollView.contentView.bounds.origin.y) > 0.5 else { return }
-        scrollView.contentView.scroll(to: NSPoint(x: scrollView.contentView.bounds.origin.x, y: newY))
+
+        guard let beforeY, let afterY = lineRect(forCharacterAt: anchorOffset)?.minY else { return }
+        let delta = afterY - beforeY
+        guard abs(delta) > 0.5 else { return }
+        let newY = max(0, visible.origin.y + delta)
+        scrollView.contentView.scroll(to: NSPoint(x: visible.origin.x, y: newY))
         scrollView.reflectScrolledClipView(scrollView.contentView)
     }
 

--- a/Tests/MarkdownEditorTests/RenderingRegressionTests.swift
+++ b/Tests/MarkdownEditorTests/RenderingRegressionTests.swift
@@ -232,4 +232,46 @@ struct RenderingRegressionTests {
                 "off-screen old active block should be deferred to the drain")
         #expect(abs(after - before) < 50, "viewport must not yank on a cross-block cursor move")
     }
+
+    @Test("Activating a height-changing block keeps the viewport top pinned")
+    @MainActor func viewportTopStableOnActivation() {
+        // A document with a callout (rendered ↔ active height differs) sitting
+        // below the top of the viewport.
+        var doc = ""
+        for i in 0..<30 { doc += "filler paragraph number \(i)\n\n" }
+        doc += "> [!note]\n> callout body one\n> callout body two\n\n"
+        for i in 0..<40 { doc += "trailing paragraph \(i)\n\n" }
+        let (e, scroll) = windowed(doc)
+        e.typewriterModeEnabled = false
+
+        // Scroll so the callout is in view but NOT at the very top.
+        let calloutIdx = e.blocks.firstIndex { if case .quoteRun = $0.kind { return true }; return false }!
+        let cy = e.lineRect(forCharacterAt: e.blocks[calloutIdx].range.location)?.minY ?? 0
+        scroll.contentView.scroll(to: NSPoint(x: 0, y: max(0, cy - 120)))
+        scroll.reflectScrolledClipView(scroll.contentView)
+        e.promoteVisibleUnstyledBlocks(); scroll.reflectScrolledClipView(scroll.contentView)
+
+        // Screen position of the line at the top of the viewport.
+        func topLineScreenY() -> CGFloat {
+            let visible = scroll.contentView.bounds
+            guard let tlm = e.textLayoutManager else { return 0 }
+            let p = CGPoint(x: 0, y: visible.minY - e.textContainerOrigin.y)
+            guard let frag = tlm.textLayoutFragment(for: p) else { return 0 }
+            let off = tlm.offset(from: tlm.documentRange.location, to: frag.rangeInElement.location)
+            return (e.lineRect(forCharacterAt: off)?.minY ?? 0) + e.textContainerOrigin.y - visible.origin.y
+        }
+        let before = topLineScreenY()
+
+        // Activate the callout (height changes), via the viewport anchor path.
+        let loc = e.blocks[calloutIdx].range.location + 2
+        e.setSelectedRange(NSRange(location: loc, length: 0))
+        e.preservingViewportAnchor {
+            e.recomposeDirty(IndexSet([calloutIdx]), cursorInRaw: loc)
+        }
+        scroll.reflectScrolledClipView(scroll.contentView)
+        let after = topLineScreenY()
+        #expect(abs(after - before) < 6.0,
+                "viewport top must stay pinned when a visible block changes height (Δ=\(after - before))")
+    }
+
 }


### PR DESCRIPTION
## Summary

Follow-up to #71. Removes the residual "tiny lurch" when moving the cursor into a block whose rendered and raw forms differ in height (callouts, display math, tables).

## Investigation

Measured the actual rendered↔active height delta per block kind: single-line blocks (checklist, bullet, paragraph, heading) = **0**, table = 4 pt, callout = 13 pt, display math = 16 pt. Clicking between two checklist items causes **zero** scroll. So no single block's real height change explains the larger (~130 px) lurches — those were the caret anchor faithfully compensating **lazy-layout height *estimate* shifts** of undrained blocks above the caret. Holding the caret fixed lets the content above it slide.

## Fix

Switched the non-typewriter cursor-move anchor from the **caret** to the **viewport top**, so the part of the document the user is looking at stays pinned regardless of where the height change (or estimate shift) is.

Earlier viewport-anchor attempts mis-resolved the top fragment's character offset because the viewport wasn't laid out yet. Calling `textViewportLayoutController.layoutViewport()` first makes the offset reliable — verified for both fully-drained and lazy documents — and both before/after samples go through `lineRect` (which forces layout), so a mis-measure degrades to *no scroll* rather than a yank or a jump to the document start.

## Tests

New windowed regression test pins the viewport top across a callout activation. **542 pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)