### PR TITLE
Open a blank Untitled window instead of restoring the last file

### DIFF
--- a/Sources/md/Document.swift
+++ b/Sources/md/Document.swift
@@ -75,6 +75,10 @@ class Document: NSDocument {
         window.titleVisibility = .visible
         window.titlebarAppearsTransparent = false
         window.isMovableByWindowBackground = true
+        // Don't persist/restore document windows: macOS state restoration
+        // otherwise reopens the last-edited file on the next launch, so a fresh
+        // start (or File ▸ New) shows that document instead of a blank Untitled.
+        window.isRestorable = false
         window.center()
         window.minSize = NSSize(width: 320, height: 400)
         window.backgroundColor = NSColor.textBackgroundColor


### PR DESCRIPTION
## Problem

A fresh launch (or File ▸ New) reopened the **last-edited file** (e.g. `todo.md`) instead of showing a blank **Untitled** window.

## Cause

macOS state restoration. With `applicationSupportsSecureRestorableState → true`, AppKit persisted each document window together with its `NSRepresentedURL` and reopened that file on the next launch. No app code reopens recent documents — restoration was the sole cause (the saved state held restorable windows for `math.md` and `todo.md`).

## Fix

Opt document windows out of restoration in `makeWindowControllers`:

```swift
window.isRestorable = false
```

With no restorable window persisted, launch falls through to `applicationShouldOpenUntitledFile → true` and shows a blank Untitled.

## Note

The *existing* saved state was written by the old (restorable) binary, so the first launch of this build restores those windows one last time; after one quit the new build stops persisting them and subsequent launches are clean. Clearing `~/Library/Saved Application State/com.inatang.md.savedState` makes it immediate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)