### PR TITLE
Stop the viewport lurch when Tab-indenting a list

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+Composition.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Composition.swift
@@ -40,6 +40,34 @@ extension EditorTextView {
                        selectionInRaw: selectionInRaw, settingSelection: true)
     }
 
+    /// Range-bounded recompose: replaces only `oldRange` (pre-edit storage
+    /// coordinates) with `newText` in base attributes, then restyles the given
+    /// dirty blocks. Unlike `recompose`, the storage — and its TextKit 2 layout
+    /// — outside `oldRange` is untouched, so content above the edit keeps its
+    /// laid-out positions and the viewport can't lurch. For edits that rebuild
+    /// `rawSource` but change only a contiguous span (Tab / Shift-Tab indent):
+    /// callers update `rawSource` and re-parse `blocks` first, then pass the old
+    /// span's range and its replacement text.
+    func recomposeReplacing(oldRange: NSRange, with newText: String,
+                            dirty: IndexSet, cursorInRaw: Int,
+                            selectionInRaw: NSRange? = nil) {
+        guard let ts = textStorage else { return }
+
+        isUpdating = true
+        ts.beginEditing()
+        ts.replaceCharacters(in: oldRange,
+                             with: NSAttributedString(string: newText,
+                                                      attributes: baseAttributes))
+        ts.endEditing()
+        // Programmatic replacement; the incremental parser must not see it.
+        (ts as? EditorTextStorage)?.clearPendingEdit()
+        isUpdating = false
+
+        for idx in dirty where idx < blocks.count { blocks[idx].isStyled = false }
+        recomposeDirty(dirty, cursorInRaw: cursorInRaw,
+                       selectionInRaw: selectionInRaw, settingSelection: true)
+    }
+
     /// Dirty-set recompose: restyles exactly the given block indexes in place.
     /// Attribute-only — the storage string is never touched. This is the
     /// single styling path for edits, activation changes, and theme /

--- a/Sources/MarkdownEditorCore/EditorTextView+Indentation.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Indentation.swift
@@ -74,6 +74,12 @@ extension EditorTextView {
         let rawEnd = displayOffsetToRawOffset(sel.location + sel.length)
         let indentLen = (Self.indentUnit as NSString).length
 
+        // The pre-edit storage span covering exactly the affected blocks; only
+        // this is replaced so layout above/below — and the viewport — is kept.
+        let oldRange = NSRange(
+            location: blocks[startBlock].range.location,
+            length: blocks[endBlock].range.upperBound - blocks[startBlock].range.location)
+
         // Record undo
         undoStack.append(UndoSnapshot(rawSource: rawSource, cursorInRaw: rawStart))
         redoStack.removeAll()
@@ -89,6 +95,8 @@ extension EditorTextView {
                 parts.append(block.content)
             }
         }
+        let newText = parts[startBlock...endBlock].joined(separator: blockSeparator)
+        let oldIndentUnit = listIndentUnit
         rawSource = parts.joined(separator: blockSeparator)
         rebuildListIndentState()
 
@@ -99,13 +107,29 @@ extension EditorTextView {
 
         blocks = BlockParser.parse(rawSource, previous: blocks)
 
-        if sel.length > 0 {
-            let newSel = NSRange(location: newRawStart, length: newRawEnd - newRawStart)
-            recompose(cursorInRaw: newRawStart, selectionInRaw: newSel)
-        } else {
-            recompose(cursorInRaw: newRawStart)
+        let selInRaw = sel.length > 0
+            ? NSRange(location: newRawStart, length: newRawEnd - newRawStart) : nil
+        stabilizingViewport {
+            recomposeReplacing(oldRange: oldRange, with: newText,
+                               dirty: indentDirtySet(startBlock, endBlock,
+                                                     unitChanged: listIndentUnit != oldIndentUnit),
+                               cursorInRaw: newRawStart, selectionInRaw: selInRaw)
         }
         document?.updateChangeCount(.changeDone)
+    }
+
+    /// Blocks to restyle for an indent/dedent: the directly-edited span, plus —
+    /// when the document-global list indent unit moved — every list block,
+    /// whose rendered indentation is derived from that unit.
+    private func indentDirtySet(_ startBlock: Int, _ endBlock: Int,
+                                unitChanged: Bool) -> IndexSet {
+        var dirty = IndexSet(integersIn: startBlock...min(endBlock, blocks.count - 1))
+        if unitChanged {
+            for (i, block) in blocks.enumerated() where block.kind == .listItem {
+                dirty.insert(i)
+            }
+        }
+        return dirty
     }
 
     // MARK: - Dedent (Shift-Tab)
@@ -131,6 +155,12 @@ extension EditorTextView {
         let totalRemoved = removed[startBlock...endBlock].reduce(0, +)
         guard totalRemoved > 0 else { return }
 
+        // The pre-edit storage span covering exactly the affected blocks; only
+        // this is replaced so layout above/below — and the viewport — is kept.
+        let oldRange = NSRange(
+            location: blocks[startBlock].range.location,
+            length: blocks[endBlock].range.upperBound - blocks[startBlock].range.location)
+
         // Record undo
         undoStack.append(UndoSnapshot(rawSource: rawSource, cursorInRaw: rawStart))
         redoStack.removeAll()
@@ -146,6 +176,8 @@ extension EditorTextView {
                 parts.append(block.content)
             }
         }
+        let newText = parts[startBlock...endBlock].joined(separator: blockSeparator)
+        let oldIndentUnit = listIndentUnit
         rawSource = parts.joined(separator: blockSeparator)
         rebuildListIndentState()
 
@@ -167,12 +199,13 @@ extension EditorTextView {
 
         blocks = BlockParser.parse(rawSource, previous: blocks)
 
-        if sel.length > 0 {
-            let newSel = NSRange(location: newRawStart,
-                                 length: max(0, newRawEnd - newRawStart))
-            recompose(cursorInRaw: newRawStart, selectionInRaw: newSel)
-        } else {
-            recompose(cursorInRaw: newRawStart)
+        let selInRaw = sel.length > 0
+            ? NSRange(location: newRawStart, length: max(0, newRawEnd - newRawStart)) : nil
+        stabilizingViewport {
+            recomposeReplacing(oldRange: oldRange, with: newText,
+                               dirty: indentDirtySet(startBlock, endBlock,
+                                                     unitChanged: listIndentUnit != oldIndentUnit),
+                               cursorInRaw: newRawStart, selectionInRaw: selInRaw)
         }
         document?.updateChangeCount(.changeDone)
     }

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -505,6 +505,20 @@ public class EditorTextView: NSTextView {
         scrollView.reflectScrolledClipView(scrollView.contentView)
     }
 
+    /// Runs a restyle (`body`) while keeping the viewport visually stable: in
+    /// typewriter mode it re-centers on the caret afterward; otherwise it pins
+    /// the viewport top (`preservingViewportAnchor`) so content above the edit
+    /// doesn't shift. The selection-driven cursor-move path uses the same
+    /// split inline; this wraps it for the indent path's two call sites.
+    func stabilizingViewport(_ body: () -> Void) {
+        if typewriterModeEnabled {
+            body()
+            scrollCursorToCenter()
+        } else {
+            preservingViewportAnchor(body)
+        }
+    }
+
     /// Scrolls the view so the cursor's line fragment is vertically centered
     /// in the visible area.
     private func scrollCursorToCenter() {

--- a/Tests/MarkdownEditorTests/RecomposeEquivalenceTests.swift
+++ b/Tests/MarkdownEditorTests/RecomposeEquivalenceTests.swift
@@ -143,6 +143,45 @@ struct RecomposeEquivalenceTests {
         assertMatchesFullRecomposeOracle(editor, "after redo")
     }
 
+    @Test("Tab / Shift-Tab indent matches the oracle")
+    @MainActor func indentMatchesOracle() {
+        let editor = loadedEditor()
+        // Cursor inside a list item, then indent and dedent it.
+        let item = (editor.rawSource as NSString).range(of: "first item")
+        editor.setSelectedRange(NSRange(location: item.location, length: 0))
+        editor.recompose(cursorInRaw: item.location)
+        editor.insertTab(nil)
+        assertMatchesFullRecomposeOracle(editor, "after Tab indent")
+        editor.insertBacktab(nil)
+        assertMatchesFullRecomposeOracle(editor, "after Shift-Tab dedent")
+    }
+
+    @Test("Multi-line indent across a selection matches the oracle")
+    @MainActor func multiLineIndentMatchesOracle() {
+        let editor = makeEditor()
+        editor.loadContent("- a\n- b\n- c\n")
+        // Select all three list lines and indent them together.
+        editor.setSelectedRange(NSRange(location: 0, length: (editor.rawSource as NSString).length))
+        editor.insertTab(nil)
+        assertMatchesFullRecomposeOracle(editor, "after multi-line indent")
+        #expect(editor.rawSource == "  - a\n  - b\n  - c\n")
+    }
+
+    @Test("Indent that shifts the global list-indent unit restyles every list item")
+    @MainActor func indentUnitChangeMatchesOracle() {
+        let editor = makeEditor()
+        // Only indented list line is at 4 spaces, so the unit is 4.
+        editor.loadContent("- a\n    - deep\n")
+        #expect(editor.listIndentUnit == 4)
+        // Indent the top-level item by 2: the new minimum indent is 2, so the
+        // unit drops to 2 and every list block's rendered indent changes.
+        editor.setSelectedRange(NSRange(location: 0, length: 0))
+        editor.recompose(cursorInRaw: 0)
+        editor.insertTab(nil)
+        #expect(editor.listIndentUnit == 2)
+        assertMatchesFullRecomposeOracle(editor, "after unit-shifting indent")
+    }
+
     @Test("Edit sequence on a generated document matches the oracle")
     @MainActor func generatedDocumentEdits() {
         let editor = makeEditor()

--- a/Tests/MarkdownEditorTests/ScrollStabilityTests.swift
+++ b/Tests/MarkdownEditorTests/ScrollStabilityTests.swift
@@ -49,4 +49,53 @@ struct ScrollStabilityTests {
         #expect(abs(yAfter - yBefore) < 2.0,
                 "scroll position jumped by \(yAfter - yBefore)")
     }
+
+    @Test("Tab-indenting a list in the viewport doesn't lurch the scroll")
+    @MainActor func indentDoesNotLurch() {
+        let editor = makeEditor()
+        let win = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 500, height: 300),
+                           styleMask: [.titled], backing: .buffered, defer: false)
+        let scroll = NSScrollView(frame: win.contentLayoutRect)
+        scroll.documentView = editor
+        win.contentView = scroll
+        win.makeFirstResponder(editor)
+        editor.typewriterModeEnabled = false   // exercise the viewport-top anchor
+        editor.isVerticallyResizable = true
+        editor.minSize = NSSize(width: 0, height: 0)
+        editor.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude,
+                                height: CGFloat.greatestFiniteMagnitude)
+        editor.autoresizingMask = [.width]
+
+        // Plenty of content above a list, so the list sits deep in the document.
+        var doc = ""
+        for i in 0..<40 { doc += "paragraph number \(i)\n\n" }
+        doc += "- list item alpha\n- list item beta\n- list item gamma\n\n"
+        for i in 0..<20 { doc += "tail paragraph \(i)\n\n" }
+        editor.loadContent(doc)
+        ensureFullLayout(editor)
+        editor.sizeToFit()
+        editor.layoutSubtreeIfNeeded()
+
+        // Scroll so the middle list item is centered in the viewport (content
+        // above it, so the scroll origin is well past zero).
+        let target = (editor.rawSource as NSString).range(of: "list item beta").location
+        guard let lineY = editor.lineRect(forCharacterAt: target)?.midY else {
+            Issue.record("no line rect for the list item"); return
+        }
+        scroll.contentView.scroll(to: NSPoint(x: 0, y: max(0, lineY - 150)))
+        scroll.reflectScrolledClipView(scroll.contentView)
+        let yBefore = scroll.contentView.bounds.origin.y
+        #expect(yBefore > 0)
+
+        // Put the caret in the list item and indent it.
+        editor.setSelectedRange(NSRange(location: target, length: 0))
+        editor.insertTab(nil)
+        #expect(editor.rawSource.contains("  - list item beta"))
+
+        ensureFullLayout(editor)
+        editor.layoutSubtreeIfNeeded()
+        let yAfter = scroll.contentView.bounds.origin.y
+        #expect(abs(yAfter - yBefore) < 2.0,
+                "scroll lurched by \(yAfter - yBefore) on Tab indent")
+    }
 }


### PR DESCRIPTION
## Problem

Pressing **Tab** / **Shift-Tab** to indent a list jerked the viewport — the visible content jumped on every indent.

## Cause

`indentListBlocks` / `dedentListBlocks` called the full string-replacing `recompose`, which replaces the **entire** text storage. That invalidates all TextKit 2 layout and then autoscrolls to the selection on *estimated* layout, yanking the viewport. (Same lurch class as the cursor-move fix in #72, but on a different path.)

## Fix

Indenting can't change block structure here — a list line stays a `.listItem`; this parser has no indented-code rule — so the edit is purely local and horizontal. Replace only the affected span and keep the viewport stable:

- **`recomposeReplacing(oldRange:with:dirty:…)`** replaces just the edited block span, so layout above and below (and the scroll position) is untouched.
- **`stabilizingViewport { }`** re-centers the caret in typewriter mode, otherwise pins the viewport top — the same anchor the cursor-move path uses.
- indent/dedent escalate the dirty set to every list item only when the document-global indent unit shifts.

## Tests (+4)

- `Tab / Shift-Tab indent matches the oracle`, `Multi-line indent across a selection…`, `Indent that shifts the global list-indent unit restyles every list item` — attribute-equivalence to a full recompose.
- `Tab-indenting a list in the viewport doesn't lurch the scroll` — indents a list deep in a document and asserts the scroll origin moves **< 2 px**.

Full suite: **546 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)