### PR TITLE
Add CI: swift test on PRs and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Only the latest run per branch/PR matters; cancel older ones so private-repo
+# macOS minutes (billed at 10x) aren't spent on superseded commits.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: test
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      # Package.swift declares swift-tools-version 6.0, which needs Xcode 16+.
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Swift version
+        run: swift --version
+
+      # Cache the SwiftPM build (deps + compiled objects) keyed on the resolved
+      # dependency graph, so green runs don't recompile SwiftMath etc. each time.
+      - name: Cache .build
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: spm-${{ runner.os }}-
+
+      - name: Test
+        run: swift test


### PR DESCRIPTION
First CI for the repo. Runs `swift test` on every PR and on pushes to `main`.

- **macos-14** runner with `latest-stable` Xcode (swift-tools 6.0 needs Xcode 16+).
- **SwiftPM build cache** keyed on `Package.resolved`, so green runs skip recompiling dependencies.
- **Concurrency cancellation** per ref — superseded commits don't burn private-repo macOS minutes (billed 10×).

The `test` job's status check is the gate branch protection will require before auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)