### PR TITLE
Bump CI actions off Node 20 (checkout/cache @v5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: test
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Package.swift declares swift-tools-version 6.0, which needs Xcode 16+.
       - uses: maxim-lobanov/setup-xcode@v1
@@ -29,7 +29,7 @@ jobs:
       # Cache the SwiftPM build (deps + compiled objects) keyed on the resolved
       # dependency graph, so green runs don't recompile SwiftMath etc. each time.
       - name: Cache .build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .build
           key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}


### PR DESCRIPTION
`actions/checkout@v4` and `actions/cache@v4` run on Node 20, which GitHub forces to Node 24 on **June 16, 2026** (currently a non-blocking deprecation warning on every run). Bumps both to `@v5`, whose `action.yml` declares `using: node24`, clearing the warning ahead of the deadline.

No behavior change — same checkout + SwiftPM cache, newer runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)