### PR TITLE
Set bundle identifier to com.i7t5.md

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleDisplayName</key>
     <string>md</string>
     <key>CFBundleIdentifier</key>
-    <string>com.inatang.md</string>
+    <string>com.i7t5.md</string>
     <key>CFBundleExecutable</key>
     <string>md</string>
     <key>CFBundlePackageType</key>


### PR DESCRIPTION
Aligns the app's `CFBundleIdentifier` with the I7T5 GitHub org (was `com.inatang.md`). This is the canonical id for the editor build installed to `/Applications` and the one computer-use / LaunchServices resolve `md` to.

No code change — `Info.plist` only. Full suite green (562).

🤖 Generated with [Claude Code](https://claude.com/claude-code)