### PR TITLE
Hang quote/callout wrapped lines after the marker

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+CalloutRendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+CalloutRendering.swift
@@ -169,7 +169,9 @@ extension EditorTextView {
         let ps = NSMutableParagraphStyle()
         ps.lineSpacing = bodyParagraphStyle.lineSpacing
         ps.firstLineHeadIndent = 2
-        ps.headIndent = 2
+        // Hanging indent so wrapped body lines align after the `> ` marker,
+        // matching list items and plain blockquotes.
+        ps.headIndent = 2 + quoteMarkerWidth
         ps.tailIndent = -10
         ps.paragraphSpacing = isLastLine ? calloutBottomPad : 0
         ps.minimumLineHeight = minimumLineHeight

--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -92,14 +92,24 @@ extension EditorTextView {
     /// against rendered output (see RenderingRegressionTests / screencapture).
     var thematicBreakCenterOffset: CGFloat { bodyFont.pointSize * 0.3 }
 
+    /// Width of the `> ` quote marker in body text. Used as the hanging indent
+    /// for blockquotes and callouts so wrapped/continuation lines align after
+    /// the marker (like list items) rather than under the `>`. The marker is
+    /// rendered width-preserved (clear when inactive, dimmed when active) on
+    /// each line's first visual line, so subsequent lines hang by this width.
+    var quoteMarkerWidth: CGFloat {
+        ("> " as NSString).size(withAttributes: [.font: bodyFont]).width
+    }
+
     /// Paragraph style for blockquotes: a 2pt text inset matching the width of
-    /// the left bar that the `.leftBar` BlockDecoration draws.
+    /// the left bar that the `.leftBar` BlockDecoration draws, plus a hanging
+    /// indent so wrapped lines align after the `> ` marker.
     private func blockquoteParagraphStyle() -> NSParagraphStyle {
         let ps = NSMutableParagraphStyle()
         ps.lineSpacing = bodyParagraphStyle.lineSpacing
         ps.paragraphSpacing = bodyParagraphStyle.paragraphSpacing
         ps.firstLineHeadIndent = 2
-        ps.headIndent = 2
+        ps.headIndent = 2 + quoteMarkerWidth
         return ps
     }
 

--- a/Tests/MarkdownEditorTests/EditorRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/EditorRenderingTests.swift
@@ -838,3 +838,36 @@ struct EditorRecomposeTests {
         #expect(f!.pointSize > 1.0)  // Not hidden
     }
 }
+
+// MARK: - Quote / Callout Hanging Indent
+
+/// Wrapped/continuation lines of a blockquote or callout must hang after the
+/// `> ` marker (like list items), not under the `>`. That is encoded as a
+/// paragraph-style hanging indent: headIndent − firstLineHeadIndent ≈ the
+/// width of the `> ` marker.
+@Suite("Quote/Callout hanging indent")
+struct QuoteCalloutHangingIndentTests {
+
+    @Test("Blockquote wrapped lines hang after the marker")
+    @MainActor func blockquoteHangingIndent() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("> quoted text")
+        let ps = styled.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        #expect(ps != nil)
+        let hang = (ps?.headIndent ?? 0) - (ps?.firstLineHeadIndent ?? 0)
+        #expect(abs(hang - editor.quoteMarkerWidth) < 0.5)
+    }
+
+    @Test("Callout body lines hang after the marker")
+    @MainActor func calloutHangingIndent() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("> [!note]\n> body text")
+        // Inspect the body line's paragraph style (after the header newline).
+        let ns = styled.string as NSString
+        let bodyLoc = ns.range(of: "\n").location + 1
+        let ps = styled.attribute(.paragraphStyle, at: bodyLoc, effectiveRange: nil) as? NSParagraphStyle
+        #expect(ps != nil)
+        let hang = (ps?.headIndent ?? 0) - (ps?.firstLineHeadIndent ?? 0)
+        #expect(abs(hang - editor.quoteMarkerWidth) < 0.5)
+    }
+}


### PR DESCRIPTION
todo.md "Now": *Quote and Callout: Align text in the same line after and not below `>`, same as `-` and `- [ ]`.*

## Problem
Blockquotes and callouts used a flat 2pt `headIndent`, so wrapped/continuation lines hung under the `>` rather than aligning with the text after `> ` — unlike list items.

## Fix
Add a hanging indent equal to the `> ` marker width to `blockquoteParagraphStyle()` and `calloutParagraphStyle()`, so continuation lines align with the first line's text.

## Verification
- New tests assert `headIndent − firstLineHeadIndent ≈ width("> ")` for both blockquote and callout body lines.
- `swift test` green (564 tests).
- Built + opened a wrapping quote and callout; confirmed continuation lines align after the marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)