### PR TITLE
Give callouts real bottom padding (clickable text space)

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+CalloutRendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+CalloutRendering.swift
@@ -67,26 +67,31 @@ extension EditorTextView {
 
         // The box is drawn by DecoratedTextLayoutFragment behind every
         // paragraph of the callout; the fragments tile into one continuous box.
-        result.addAttribute(
-            .blockDecoration,
-            value: BlockDecoration(.box(background: c.background,
-                                        borderColor: c.border,
-                                        borderEdges: info.style.borderEdges,
-                                        borderWidth: info.style.borderWidth)),
-            range: span.fullRange)
+        func box(bottomPad: CGFloat) -> BlockDecoration {
+            BlockDecoration(.box(background: c.background,
+                                 borderColor: c.border,
+                                 borderEdges: info.style.borderEdges,
+                                 borderWidth: info.style.borderWidth,
+                                 bottomPad: bottomPad))
+        }
+        result.addAttribute(.blockDecoration, value: box(bottomPad: 0),
+                            range: span.fullRange)
         result.addAttribute(.paragraphStyle, value: calloutParagraphStyle(),
                             range: span.fullRange)
-        // Bottom breathing room: paragraph spacing on the last line. The box
-        // covers it (it's inside the last fragment's frame), and clicks there
-        // resolve to the callout's last line — no dead zone.
+        // Bottom breathing room: the last line's box carries a bottomPad, which
+        // grows that fragment's frame (see layoutFragmentFrame). The extra space
+        // is genuine clickable text space below the last line — clicks there
+        // land on the callout, the next block tiles clear, and the box covers
+        // it — no dead zone, no trailing paragraph spacing.
         let ns = result.string as NSString
         var lastLineStart = span.fullRange.location
         let nl = ns.range(of: "\n", options: .backwards,
                           range: span.fullRange)
         if nl.location != NSNotFound { lastLineStart = nl.upperBound }
-        result.addAttribute(.paragraphStyle, value: calloutParagraphStyle(isLastLine: true),
-                            range: NSRange(location: lastLineStart,
-                                           length: span.fullRange.upperBound - lastLineStart))
+        let lastLine = NSRange(location: lastLineStart,
+                               length: span.fullRange.upperBound - lastLineStart)
+        result.addAttribute(.blockDecoration, value: box(bottomPad: calloutBottomPad),
+                            range: lastLine)
 
         let m = info.marker
         if active {
@@ -118,11 +123,9 @@ extension EditorTextView {
             let headerLineEnd = nl.location == NSNotFound ? span.fullRange.upperBound : nl.location
             let headerLine = NSRange(location: span.fullRange.location,
                                      length: headerLineEnd - span.fullRange.location)
-            let headerIsLastLine = nl.location == NSNotFound
             result.addAttribute(
                 .paragraphStyle,
-                value: calloutParagraphStyle(isLastLine: headerIsLastLine,
-                                             minimumLineHeight: overlay.bounds.height + calloutTopPad),
+                value: calloutParagraphStyle(minimumLineHeight: overlay.bounds.height + calloutTopPad),
                 range: headerLine)
         }
     }
@@ -152,8 +155,11 @@ extension EditorTextView {
     /// Top breathing room — baked into the header image so it's part of the
     /// header *line* (clickable text space), not dead block padding.
     private var calloutTopPad: CGFloat { bodyFont.pointSize * 0.8 }
-    /// Bottom breathing room (kept as block padding; slightly less, to balance).
-    private var calloutBottomPad: CGFloat { bodyFont.pointSize * 0.65 }
+    /// Bottom breathing room. Delivered by growing the last line's layout
+    /// fragment frame (a box `bottomPad`), so it is genuine clickable text
+    /// space below the last line — not trailing paragraph spacing, which
+    /// TextKit 2 leaves out of the fragment and which clicks would miss.
+    var calloutBottomPad: CGFloat { bodyFont.pointSize * 0.8 }
 
     // MARK: Paragraph style (text insets; the box itself is a BlockDecoration)
 
@@ -161,11 +167,10 @@ extension EditorTextView {
     /// kept small so the callout's text lines up with a plain block quote's —
     /// the quote's 2pt bar inset matches this 2pt — and the top breathing room
     /// lives in the header image (clickable text space). The bottom breathing
-    /// room is the last line's paragraph spacing: it's inside the last
-    /// fragment's frame, so the drawn box covers it and clicks there land on
-    /// the callout's last line.
-    private func calloutParagraphStyle(isLastLine: Bool = false,
-                                       minimumLineHeight: CGFloat = 0) -> NSParagraphStyle {
+    /// room is the last line's box `bottomPad` (which grows that fragment's
+    /// frame), so the drawn box covers it and clicks there land on the
+    /// callout's last line — no trailing paragraph spacing needed.
+    private func calloutParagraphStyle(minimumLineHeight: CGFloat = 0) -> NSParagraphStyle {
         let ps = NSMutableParagraphStyle()
         ps.lineSpacing = bodyParagraphStyle.lineSpacing
         ps.firstLineHeadIndent = 2
@@ -173,7 +178,6 @@ extension EditorTextView {
         // matching list items and plain blockquotes.
         ps.headIndent = 2 + quoteMarkerWidth
         ps.tailIndent = -10
-        ps.paragraphSpacing = isLastLine ? calloutBottomPad : 0
         ps.minimumLineHeight = minimumLineHeight
         return ps
     }

--- a/Sources/MarkdownEditorCore/EditorTextView+TextKit2.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+TextKit2.swift
@@ -39,8 +39,13 @@ public final class BlockDecoration: NSObject, @unchecked Sendable {
 
     public enum Kind: Equatable {
         /// Filled box across the text column (callouts), with optional borders.
+        /// `bottomPad` extends the fill/border below the fragment's text frame —
+        /// TextKit 2 does not include trailing `paragraphSpacing` in the
+        /// fragment height, so a callout's last line carries the bottom padding
+        /// here (and a matching paragraphSpacing pushes the next block clear).
         case box(background: NSColor, borderColor: NSColor?,
-                 borderEdges: CalloutStyle.Edges, borderWidth: CGFloat)
+                 borderEdges: CalloutStyle.Edges, borderWidth: CGFloat,
+                 bottomPad: CGFloat)
         /// Vertical bar just left of the paragraph's text (plain block quotes).
         case leftBar(color: NSColor, width: CGFloat)
         /// Table-row chrome: vertical column borders at text-relative x
@@ -127,6 +132,25 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
         textLayoutManager?.textContainer?.size.width ?? layoutFragmentFrame.width
     }
 
+    /// A box decoration's `bottomPad` grows the fragment's own frame (not just
+    /// its drawing): TextKit 2 leaves trailing `paragraphSpacing` out of the
+    /// fragment, so padding added that way is dead space — clicks there miss the
+    /// text. Making the fragment frame taller means the line fragments stay
+    /// anchored at the top, the extra height is genuine clickable space below
+    /// the last line, the next block tiles clear of it, and the box (drawn over
+    /// the full frame height) covers it. Mirrors how the header's raised
+    /// minimumLineHeight makes the top padding clickable text space.
+    private var boxBottomPad: CGFloat {
+        if case .box(_, _, _, _, let bottomPad)? = decoration?.kind { return bottomPad }
+        return 0
+    }
+
+    override var layoutFragmentFrame: CGRect {
+        var frame = super.layoutFragmentFrame
+        frame.size.height += boxBottomPad
+        return frame
+    }
+
     override var renderingSurfaceBounds: CGRect {
         var bounds = super.renderingSurfaceBounds
         let frame = layoutFragmentFrame
@@ -185,7 +209,9 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
                                 width: containerWidth, height: frame.height)
 
         switch decoration.kind {
-        case .box(let background, let borderColor, let edges, let borderWidth):
+        case .box(let background, let borderColor, let edges, let borderWidth, _):
+            // The fragment frame already includes any box bottomPad (see
+            // layoutFragmentFrame), so columnRect covers the padded area.
             context.setFillColor(background.cgColor)
             context.fill(columnRect)
             if let borderColor, !edges.isEmpty {

--- a/Tests/MarkdownEditorTests/CalloutRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/CalloutRenderingTests.swift
@@ -9,7 +9,7 @@ struct CalloutRenderingTests {
 
     private func boxDecoration(_ deco: BlockDecoration?)
         -> (background: NSColor, borderColor: NSColor?, edges: CalloutStyle.Edges, width: CGFloat)? {
-        guard let deco, case .box(let bg, let border, let edges, let width) = deco.kind
+        guard let deco, case .box(let bg, let border, let edges, let width, _) = deco.kind
         else { return nil }
         return (bg, border, edges, width)
     }
@@ -30,6 +30,23 @@ struct CalloutRenderingTests {
         let box = boxDecoration(blockDecoration(at: 0, in: styled))
         #expect(box != nil)
         #expect(box?.edges.isEmpty == true)
+    }
+
+    @Test("Last line carries the box bottom padding; earlier lines don't")
+    @MainActor func lastLineBottomPad() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("> [!note]\n> first\n> last")
+        func bottomPad(at i: Int) -> CGFloat? {
+            guard case .box(_, _, _, _, let bp)? = blockDecoration(at: i, in: styled)?.kind
+            else { return nil }
+            return bp
+        }
+        let ns = styled.string as NSString
+        let lastStart = ns.range(of: "\n", options: .backwards).upperBound
+        // TextKit 2 omits trailing paragraphSpacing from the fragment frame, so
+        // the bottom breathing room is drawn by extending the last line's box.
+        #expect((bottomPad(at: 0) ?? -1) == 0)             // header line
+        #expect((bottomPad(at: lastStart) ?? 0) > 0)        // last line
     }
 
     @Test("Unknown type stays a plain block quote")

--- a/Tests/MarkdownEditorTests/RecomposeTests.swift
+++ b/Tests/MarkdownEditorTests/RecomposeTests.swift
@@ -10,7 +10,7 @@ struct RecomposeTests {
 
     @MainActor private func calloutBackground(_ ts: NSTextStorage, at i: Int) -> NSColor? {
         guard let deco = ts.attributes(at: i, effectiveRange: nil)[.blockDecoration] as? BlockDecoration,
-              case .box(let background, _, _, _) = deco.kind else { return nil }
+              case .box(let background, _, _, _, _) = deco.kind else { return nil }
         return background
     }
 


### PR DESCRIPTION
todo.md "Now": *Callout: Add bottom padding to make vertical padding look balanced.*

## Problem
The callout's bottom breathing room was trailing `paragraphSpacing`. TextKit 2 leaves that out of the layout fragment, so it was **dead space** — clicking it missed the callout (cursor didn't land in the last line) and the drawn box stopped at the text.

## Fix
Deliver the bottom padding by growing the last line's layout **fragment frame** (a box `bottomPad`, applied in `layoutFragmentFrame`). The line fragments stay anchored at the top, so the extra height is genuine clickable space below the last line: clicks land on the callout, the next block tiles clear, and the box covers it — the same mechanism that makes the header's top padding real text space. Bottom pad now matches the top (`0.8 × fontSize`).

## Verification
- New test asserts the last line's box carries a `bottomPad` while earlier lines don't.
- Drove the built app: clicking in the bottom-padding zone activates the callout and places the caret at the end of its last line (no dead zone).
- `swift test` green (565 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)