### PR TITLE
Re-layout restyled blocks so new list items align immediately

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+Composition.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Composition.swift
@@ -125,6 +125,20 @@ extension EditorTextView {
         }
         ts.endEditing()
 
+        // A block whose paragraph style we just changed (e.g. a freshly created
+        // list item's indent) can keep a stale first-line layout: on the edit
+        // path `insertText` already laid the line out with the base typing
+        // attributes, and TextKit 2 doesn't re-measure the first-line indent for
+        // an attribute-only change. Force the restyled blocks to re-lay-out so
+        // the new indent shows immediately instead of after the next cursor move.
+        if let tlm = textLayoutManager {
+            for idx in syncSet where idx < blocks.count {
+                if let range = blockTextRange(blocks[idx].range, tlm) {
+                    tlm.invalidateLayout(for: range)
+                }
+            }
+        }
+
         for idx in deferred where idx < blocks.count {
             blocks[idx].isStyled = false
         }
@@ -150,6 +164,13 @@ extension EditorTextView {
         isUpdating = false
 
         if !deferred.isEmpty { scheduleProgressiveStyling() }
+    }
+
+    /// Maps a block's raw NSRange to an `NSTextRange` for layout invalidation.
+    private func blockTextRange(_ nsRange: NSRange, _ tlm: NSTextLayoutManager) -> NSTextRange? {
+        guard let start = tlm.location(tlm.documentRange.location, offsetBy: nsRange.location),
+              let end = tlm.location(start, offsetBy: nsRange.length) else { return nil }
+        return NSTextRange(location: start, end: end)
     }
 
     /// Incremental recompose: only re-styles the old and new active blocks.


### PR DESCRIPTION
todo.md "Now": *List and checklist: Align text in the same line after and not below `-`, `1.`, `- [ ]`, even when newly created from pressing Enter from previous block.*

## Problem
Pressing Return in a list and typing produced a new item whose marker and text were mis-indented (content sat left of the items above/below) until the next cursor move snapped it into place. The paragraph style was already correct in storage — but `insertText` laid the new line out with the base typing attributes first, and TextKit 2 does not re-measure a paragraph's first-line indent for an attribute-only change.

## Fix
After a dirty recompose, invalidate the restyled blocks' layout (`NSTextLayoutManager.invalidateLayout(for:)`) so the corrected first-line indent takes effect immediately. Applies to lists, checklists, quotes, and callouts.

## Verification
- Drove the built app: created new checkbox and bullet items via Return+type; their content now aligns with the surrounding items immediately (previously stale until a click). High-res crop confirms alignment.
- `swift test` green (565 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)