### PR TITLE
Render images inline

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+ImageRendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+ImageRendering.swift
@@ -1,0 +1,69 @@
+import AppKit
+
+// MARK: - Image Rendering
+//
+// `![alt](path)` renders the referenced image inline when the cursor is outside
+// the token, and shows the raw, editable markdown when the cursor is inside it
+// (the `.image` branch of `styleBlock`). The image is drawn by a
+// `FragmentOverlay` anchored on the leading `!` — the same mechanism math and
+// list markers use — with the rest of the markdown hidden and the line height
+// reserved for the picture.
+//
+// Resolution: absolute paths, `~`-paths, and `file:` URLs load directly;
+// relative paths resolve against the document's directory. Remote (http(s))
+// images are skipped for now — loading them synchronously would block the main
+// thread — so they fall back to the alt text.
+
+// Loaded images are cached by resolved absolute path so a recompose doesn't
+// re-read them from disk. NSCache is internally thread-safe.
+nonisolated(unsafe) private let imageCache = NSCache<NSString, NSImage>()
+
+extension EditorTextView {
+
+    /// Loads the image referenced by an `![alt](destination)` link, or nil if it
+    /// can't be resolved/loaded (the caller then shows the raw alt text).
+    func loadImage(destination: String) -> NSImage? {
+        guard let url = resolveImageURL(destination) else { return nil }
+        let key = url.path as NSString
+        if let cached = imageCache.object(forKey: key) { return cached }
+        guard let image = NSImage(contentsOf: url) else { return nil }
+        imageCache.setObject(image, forKey: key)
+        return image
+    }
+
+    /// Resolves a destination string to a local file URL. Returns nil for remote
+    /// URLs (handled as a fallback) or when a relative path can't be anchored.
+    private func resolveImageURL(_ destination: String) -> URL? {
+        let dest = destination.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !dest.isEmpty else { return nil }
+
+        if let url = URL(string: dest), let scheme = url.scheme {
+            return scheme == "file" ? url : nil   // skip http(s)/data for now
+        }
+        if dest.hasPrefix("/") { return URL(fileURLWithPath: dest) }
+        if dest.hasPrefix("~") {
+            return URL(fileURLWithPath: (dest as NSString).expandingTildeInPath)
+        }
+        // Relative to the document's directory.
+        if let docDir = document?.fileURL?.deletingLastPathComponent() {
+            return docDir.appendingPathComponent(dest)
+        }
+        return nil
+    }
+
+    /// A `FragmentOverlay` for the image, scaled down to fit the text width while
+    /// keeping its aspect ratio. `bounds.minY == 0` sits the image bottom on the
+    /// text baseline (the reserved line height makes room above it).
+    func imageOverlay(destination: String) -> FragmentOverlay? {
+        guard let image = loadImage(destination: destination) else { return nil }
+        var size = image.size
+        guard size.width > 0, size.height > 0 else { return nil }
+
+        let maxWidth = availableContentWidth
+        if maxWidth > 0, size.width > maxWidth {
+            size = NSSize(width: maxWidth, height: size.height * (maxWidth / size.width))
+        }
+        return FragmentOverlay(image: image,
+                               bounds: CGRect(x: 0, y: 0, width: size.width, height: size.height))
+    }
+}

--- a/Sources/MarkdownEditorCore/EditorTextView+MathRendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+MathRendering.swift
@@ -79,8 +79,9 @@ extension EditorTextView {
     }
 
     /// The usable text width for one line — the text container minus its line
-    /// fragment padding on both sides. Used to cap over-wide equations.
-    private var availableContentWidth: CGFloat {
+    /// fragment padding on both sides. Used to cap over-wide equations (and
+    /// over-wide images).
+    var availableContentWidth: CGFloat {
         guard let container = textContainer else { return 0 }
         return container.containerSize.width - 2 * container.lineFragmentPadding
     }

--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -204,11 +204,31 @@ extension EditorTextView {
                     result.addAttribute(.editorLinkURL, value: destination, range: span.contentRange)
                 }
 
-            case .image:
-                guard span.contentRange.upperBound <= result.length else { continue }
-                result.addAttribute(.foregroundColor, value: accentColor, range: span.contentRange)
-                let italic = NSFontManager.shared.convert(bodyFont, toHaveTrait: .italicFontMask)
-                result.addAttribute(.font, value: italic, range: span.contentRange)
+            case .image(let destination):
+                guard span.fullRange.upperBound <= result.length else { continue }
+                if !cursorInToken, let overlay = imageOverlay(destination: destination) {
+                    // Rendered: draw the image at the leading `!` and hide the
+                    // rest of the `![alt](path)` markdown, reserving the line
+                    // height so the picture has room.
+                    let hideStart = span.fullRange.location + 1
+                    let hideLen = span.fullRange.upperBound - hideStart
+                    if hideLen > 0 {
+                        let hideRange = NSRange(location: hideStart, length: hideLen)
+                        result.addAttribute(.font, value: hiddenFont, range: hideRange)
+                        result.addAttribute(.foregroundColor, value: NSColor.clear, range: hideRange)
+                    }
+                    applyOverlay(overlay,
+                                 anchor: NSRange(location: span.fullRange.location, length: 1),
+                                 in: result)
+                    reserveLineHeight(overlay.bounds.height,
+                                      forOverlayAt: span.fullRange.location, in: result)
+                } else {
+                    // Active, or the image couldn't be loaded: show the alt text
+                    // accented (link-like); delimiters are dimmed/hidden below.
+                    result.addAttribute(.foregroundColor, value: accentColor, range: span.contentRange)
+                    let italic = NSFontManager.shared.convert(bodyFont, toHaveTrait: .italicFontMask)
+                    result.addAttribute(.font, value: italic, range: span.contentRange)
+                }
 
             case .blockquote:
                 guard span.fullRange.upperBound <= result.length else { continue }

--- a/Tests/MarkdownEditorTests/ImageRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/ImageRenderingTests.swift
@@ -1,0 +1,59 @@
+import Testing
+import AppKit
+@testable import MarkdownEditorCore
+
+@Suite("Image rendering")
+@MainActor
+struct ImageRenderingTests {
+
+    /// Writes a tiny solid PNG to a temp file and returns its absolute path
+    /// (absolute so resolution doesn't need a document directory).
+    private func tempPNGPath() -> String {
+        let size = NSSize(width: 24, height: 16)
+        let img = NSImage(size: size)
+        img.lockFocus()
+        NSColor.systemBlue.setFill()
+        NSRect(origin: .zero, size: size).fill()
+        img.unlockFocus()
+        let rep = NSBitmapImageRep(data: img.tiffRepresentation!)!
+        let data = rep.representation(using: .png, properties: [:])!
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("md-img-test-\(UUID().uuidString).png")
+        try! data.write(to: url)
+        return url.path
+    }
+
+    @Test("Image syntax parses to an image span carrying the destination")
+    func parsesImage() {
+        let dests = SyntaxHighlighter.parse("![alt](pic.png)").compactMap { s -> String? in
+            if case .image(let d) = s.kind { return d }; return nil
+        }
+        #expect(dests == ["pic.png"])
+    }
+
+    @Test("Rendered image draws an overlay and hides the raw markdown")
+    func rendersOverlay() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("![alt](\(tempPNGPath()))", cursorPosition: nil)
+        // Overlay anchored on the leading `!`.
+        let overlay = styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) as? FragmentOverlay
+        #expect(overlay != nil)
+        // The rest of the markdown is hidden (near-zero font).
+        let f = styled.attribute(.font, at: 5, effectiveRange: nil) as? NSFont
+        #expect((f?.pointSize ?? 99) < 1.0)
+    }
+
+    @Test("Active image shows the raw markdown (no overlay)")
+    func activeShowsRaw() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("![alt](\(tempPNGPath()))", cursorPosition: 3)
+        #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) == nil)
+    }
+
+    @Test("Unloadable image falls back to alt text (no overlay)")
+    func fallbackNoOverlay() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("![alt](/no/such/file.png)", cursorPosition: nil)
+        #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) == nil)
+    }
+}


### PR DESCRIPTION
todo.md "Next": *Images.*

## What
`![alt](path)` renders the referenced image inline (cursor outside the token) and shows the raw, editable `![alt](path)` when the cursor is inside it — reusing the `FragmentOverlay` mechanism that math and list markers use.

## Details
- Image anchored on the leading `!`; the rest of the markdown is hidden; the line height is reserved for the picture.
- Resolution: absolute paths, `~`-paths, and `file:` URLs load directly; relative paths resolve against the document's directory.
- Over-wide images scale down to the text width (aspect preserved); loaded images are cached by resolved path.
- Remote (http) images are skipped for now (synchronous load would block the UI) and fall back to the alt text — as do paths that fail to load.

## Verification
- New tests: image span carries the destination; rendered image draws an overlay and hides the markdown; active image shows raw; unloadable path falls back (no overlay).
- Drove the built app: a local PNG renders inline between paragraphs; clicking into it reveals the editable `![alt](path)`.
- `swift test` green (570 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)