### PR TITLE
Render footnotes

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -121,9 +121,9 @@ extension EditorTextView {
         switch kind {
         case .bold, .italic, .boldItalic, .strikethrough, .highlight,
              .code, .link, .image, .lineBreak,
-             .heading, .blockquote:
+             .heading, .blockquote, .footnoteReference:
             return true
-        case .listItem, .table, .codeBlock, .thematicBreak:
+        case .listItem, .table, .codeBlock, .thematicBreak, .footnoteDefinition:
             return false
         case .math(let display):
             // Inline math hides its `$` like other inline tokens; display math
@@ -519,6 +519,26 @@ extension EditorTextView {
                         result.addAttribute(.foregroundColor, value: NSColor.systemRed, range: span.fullRange)
                     }
                 }
+
+            case .footnoteReference:
+                guard span.fullRange.upperBound <= result.length else { continue }
+                // Accent the id; when rendered (cursor outside), raise and shrink
+                // it into a superscript and hide the `[^`/`]` (below). When active,
+                // it stays full size and editable with dimmed delimiters.
+                result.addAttribute(.foregroundColor, value: accentColor, range: span.contentRange)
+                if !cursorInToken {
+                    let small = NSFont(descriptor: bodyFont.fontDescriptor,
+                                       size: bodyFont.pointSize * 0.75) ?? bodyFont
+                    result.addAttribute(.font, value: small, range: span.contentRange)
+                    result.addAttribute(.baselineOffset, value: bodyFont.pointSize * 0.35,
+                                        range: span.contentRange)
+                }
+
+            case .footnoteDefinition:
+                guard span.fullRange.upperBound <= result.length else { continue }
+                // The `[^id]:` marker is dimmed by the delimiter pass below; the
+                // definition text after it stays normal. Nothing to add here.
+                break
 
             case .lineBreak:
                 break  // Delimiter handling done below

--- a/Sources/MarkdownEditorCore/SyntaxHighlighter+CustomParsers.swift
+++ b/Sources/MarkdownEditorCore/SyntaxHighlighter+CustomParsers.swift
@@ -14,6 +14,51 @@ import Markdown
 
 extension SyntaxHighlighter {
 
+    private static let footnoteDefRegex =
+        try! NSRegularExpression(pattern: #"^\[\^([^\]\s]+)\]:"#)
+    private static let footnoteRefRegex =
+        try! NSRegularExpression(pattern: #"\[\^([^\]\s]+)\]"#)
+
+    /// Parses footnotes (not supported by swift-markdown):
+    ///   - `[^id]:` at the start of a block → a `.footnoteDefinition` marker.
+    ///   - `[^id]` elsewhere → a `.footnoteReference`.
+    static func parseFootnotes(_ text: String, into spans: inout [Span]) {
+        let ns = text as NSString
+        let whole = NSRange(location: 0, length: ns.length)
+
+        // Definition marker at the very start of the block: `[^id]:`.
+        if let m = footnoteDefRegex.firstMatch(in: text, range: whole) {
+            let marker = m.range(at: 0)   // includes the trailing ":"
+            spans.append(Span(
+                kind: .footnoteDefinition(id: ns.substring(with: m.range(at: 1))),
+                fullRange: marker,
+                contentRange: m.range(at: 1),
+                delimiterRanges: [marker]))
+        }
+
+        // References `[^id]` anywhere — except the definition marker (followed by
+        // ":") and anything overlapping a code span or the definition above.
+        for m in footnoteRefRegex.matches(in: text, range: whole) {
+            let full = m.range(at: 0)
+            if full.upperBound < ns.length && ns.character(at: full.upperBound) == 0x3A { continue }
+            let overlaps = spans.contains { existing in
+                switch existing.kind {
+                case .code, .codeBlock, .footnoteDefinition: break
+                default: return false
+                }
+                return existing.fullRange.location <= full.location
+                    && existing.fullRange.upperBound >= full.upperBound
+            }
+            guard !overlaps else { continue }
+            spans.append(Span(
+                kind: .footnoteReference(id: ns.substring(with: m.range(at: 1))),
+                fullRange: full,
+                contentRange: m.range(at: 1),                                   // the id
+                delimiterRanges: [NSRange(location: full.location, length: 2),  // "[^"
+                                  NSRange(location: full.upperBound - 1, length: 1)]))  // "]"
+        }
+    }
+
     /// Parses ==highlight== spans using regex (not supported by swift-markdown).
     static func parseHighlight(_ text: String, into spans: inout [Span]) {
         let nsText = text as NSString

--- a/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
+++ b/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
@@ -40,6 +40,10 @@ public enum SyntaxHighlighter {
             case thematicBreak
             case lineBreak
             case math(display: Bool)
+            /// An inline `[^id]` footnote reference.
+            case footnoteReference(id: String)
+            /// A `[^id]:` footnote definition marker at the start of a block.
+            case footnoteDefinition(id: String)
 
             public enum CheckboxState: Equatable, Sendable {
                 case checked, unchecked
@@ -70,6 +74,9 @@ public enum SyntaxHighlighter {
 
         // Deeply indented list items (4+ spaces) that swift-markdown treats as code.
         parseIndentedListItem(text, into: &walker.spans)
+
+        // [^id] footnote references and [^id]: definition markers.
+        parseFootnotes(text, into: &walker.spans)
 
         return walker.spans.sorted { $0.fullRange.location < $1.fullRange.location }
     }

--- a/Tests/MarkdownEditorTests/FootnoteTests.swift
+++ b/Tests/MarkdownEditorTests/FootnoteTests.swift
@@ -1,0 +1,61 @@
+import Testing
+import AppKit
+@testable import MarkdownEditorCore
+
+@Suite("Footnotes")
+struct FootnoteTests {
+
+    private func refIDs(_ text: String) -> [String] {
+        SyntaxHighlighter.parse(text).compactMap {
+            if case .footnoteReference(let id) = $0.kind { return id }; return nil
+        }
+    }
+    private func defIDs(_ text: String) -> [String] {
+        SyntaxHighlighter.parse(text).compactMap {
+            if case .footnoteDefinition(let id) = $0.kind { return id }; return nil
+        }
+    }
+
+    @Test("Inline [^id] parses as a footnote reference")
+    func referenceParses() {
+        #expect(refIDs("a statement[^1] and[^note] here") == ["1", "note"])
+    }
+
+    @Test("[^id]: at block start parses as a definition, not a reference")
+    func definitionParses() {
+        let text = "[^1]: the definition text"
+        #expect(defIDs(text) == ["1"])
+        #expect(refIDs(text).isEmpty)
+    }
+
+    @Test("[^id] inside a code span is not a footnote")
+    func codeSpanNotFootnote() {
+        #expect(refIDs("inline `[^1]` code").isEmpty)
+    }
+
+    @Test("Rendered reference is superscripted (raised, shrunk)")
+    @MainActor func referenceSuperscript() {
+        let editor = makeEditor()
+        let text = "see[^1] here"
+        let styled = editor.styleBlock(text, cursorPosition: nil)
+        let idLoc = (text as NSString).range(of: "1").location
+        let offset = styled.attribute(.baselineOffset, at: idLoc, effectiveRange: nil) as? CGFloat
+        #expect((offset ?? 0) > 0)
+        let f = styled.attribute(.font, at: idLoc, effectiveRange: nil) as? NSFont
+        #expect((f?.pointSize ?? 99) < editor.bodyFont.pointSize)
+    }
+
+    @Test("Definition marker is dimmed; the text stays normal")
+    @MainActor func definitionDimmed() {
+        let editor = makeEditor()
+        let text = "[^1]: body text"
+        let styled = editor.styleBlock(text, cursorPosition: nil)
+        // The "[" of the marker is dimmed.
+        let markerColor = styled.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+        #expect(markerColor == editor.syntaxDimColor)
+        // The body text after the marker keeps the normal foreground.
+        let bodyLoc = (text as NSString).range(of: "body").location
+        let bodyColor = styled.attribute(.foregroundColor, at: bodyLoc, effectiveRange: nil) as? NSColor
+        #expect(bodyColor != editor.syntaxDimColor)
+    }
+}


### PR DESCRIPTION
todo.md "Next": *Footnotes.*

## What
swift-markdown doesn't model footnotes, so a regex pass adds them:
- `[^id]` inline → `.footnoteReference`, rendered as a small **superscript** in the accent color; raw and editable when the cursor is inside.
- `[^id]:` at the start of a block → `.footnoteDefinition`, whose marker is **dimmed** while the definition text stays normal.

References inside code spans (and the definition's own `[^id]`) are excluded.

## Verification
- New tests: inline reference parsing, definition vs reference disambiguation, code-span exclusion, superscript rendering, dimmed-marker rendering.
- Drove the built app: `statement[^1]` / `claim[^note]` render as superscripts; `[^1]: …` shows a dimmed marker with normal text.
- `swift test` green (575 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)