### PR TITLE
Syntax-highlight fenced code blocks

### DIFF
--- a/Sources/MarkdownEditorCore/CodeHighlighter.swift
+++ b/Sources/MarkdownEditorCore/CodeHighlighter.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+// MARK: - Code Highlighter
+//
+// A small, language-agnostic tokenizer for fenced code blocks. It is not a full
+// parser — it recognizes the lexical tokens that carry most of the visual
+// signal (comments, strings, numbers, keywords, types, function calls) across
+// the common C-family / script languages. The block's info string picks the
+// comment style (`#` vs `//`), everything else is shared.
+
+enum CodeHighlighter {
+
+    enum TokenType: Equatable {
+        case keyword, type, string, number, comment, function
+    }
+
+    struct Token: Equatable {
+        let range: NSRange
+        let type: TokenType
+    }
+
+    /// Languages whose line comments start with `#` rather than `//`.
+    private static let hashCommentLanguages: Set<String> = [
+        "python", "py", "ruby", "rb", "sh", "bash", "shell", "zsh", "fish",
+        "yaml", "yml", "toml", "ini", "perl", "pl", "r", "makefile", "make",
+        "dockerfile", "docker", "elixir", "ex", "nim", "julia", "jl", "tcl",
+    ]
+
+    /// A union of frequent keywords across popular languages. Over-inclusive is
+    /// fine: a keyword that doesn't apply to the current language simply won't
+    /// appear in its code.
+    private static let keywords: Set<String> = [
+        // declarations / control flow (shared across many languages)
+        "func", "function", "fn", "def", "let", "var", "val", "const", "static",
+        "final", "class", "struct", "enum", "interface", "protocol", "trait",
+        "impl", "extends", "implements", "namespace", "package", "module", "mod",
+        "import", "export", "from", "use", "using", "include", "require",
+        "public", "private", "protected", "internal", "fileprivate", "open",
+        "if", "else", "elif", "for", "while", "do", "switch", "case", "default",
+        "break", "continue", "return", "yield", "goto", "match", "when", "where",
+        "try", "catch", "except", "finally", "throw", "throws", "raise", "rescue",
+        "guard", "defer", "async", "await", "go", "chan", "select", "with", "as",
+        "is", "in", "of", "new", "delete", "typeof", "instanceof", "sizeof",
+        "void", "int", "long", "short", "char", "float", "double", "bool",
+        "boolean", "string", "unsigned", "signed", "auto", "typedef", "template",
+        "virtual", "override", "abstract", "extension", "init", "self", "this",
+        "super", "nil", "null", "none", "undefined", "true", "false", "and",
+        "or", "not", "lambda", "pass", "global", "nonlocal", "mut", "pub", "dyn",
+        "type", "object", "end", "begin", "then", "elsif", "unless", "until",
+    ]
+
+    static func tokenize(_ code: String, language: String?) -> [Token] {
+        let ns = code as NSString
+        let n = ns.length
+        guard n > 0 else { return [] }
+
+        let lang = language?
+            .trimmingCharacters(in: .whitespaces).lowercased() ?? ""
+        let hashComments = hashCommentLanguages.contains(lang)
+
+        func isIdentStart(_ c: unichar) -> Bool {
+            (c >= 65 && c <= 90) || (c >= 97 && c <= 122) || c == 95
+        }
+        func isIdentChar(_ c: unichar) -> Bool { isIdentStart(c) || (c >= 48 && c <= 57) }
+        func isDigit(_ c: unichar) -> Bool { c >= 48 && c <= 57 }
+
+        var tokens: [Token] = []
+        var i = 0
+        while i < n {
+            let c = ns.character(at: i)
+
+            // Line comment: `//` always, `#` for hash-comment languages.
+            if (c == 0x2F && i + 1 < n && ns.character(at: i + 1) == 0x2F)
+                || (c == 0x23 && hashComments) {
+                let start = i
+                while i < n && ns.character(at: i) != 0x0A { i += 1 }
+                tokens.append(Token(range: NSRange(location: start, length: i - start), type: .comment))
+                continue
+            }
+            // Block comment `/* … */`.
+            if c == 0x2F && i + 1 < n && ns.character(at: i + 1) == 0x2A {
+                let start = i; i += 2
+                while i + 1 < n && !(ns.character(at: i) == 0x2A && ns.character(at: i + 1) == 0x2F) { i += 1 }
+                i = min(n, i + 2)
+                tokens.append(Token(range: NSRange(location: start, length: i - start), type: .comment))
+                continue
+            }
+            // String: "…", '…', `…` with backslash escapes; stops at end of line.
+            if c == 0x22 || c == 0x27 || c == 0x60 {
+                let quote = c, start = i; i += 1
+                while i < n {
+                    let d = ns.character(at: i)
+                    if d == 0x5C { i += 2; continue }      // escape
+                    if d == quote { i += 1; break }
+                    if d == 0x0A { break }
+                    i += 1
+                }
+                tokens.append(Token(range: NSRange(location: start, length: min(i, n) - start), type: .string))
+                continue
+            }
+            // Number (incl. trailing hex/exponent/dot chars).
+            if isDigit(c) {
+                let start = i; i += 1
+                while i < n {
+                    let d = ns.character(at: i)
+                    if isIdentChar(d) || d == 0x2E { i += 1 } else { break }
+                }
+                tokens.append(Token(range: NSRange(location: start, length: i - start), type: .number))
+                continue
+            }
+            // Identifier → keyword / type / function call / plain.
+            if isIdentStart(c) {
+                let start = i; i += 1
+                while i < n && isIdentChar(ns.character(at: i)) { i += 1 }
+                let word = ns.substring(with: NSRange(location: start, length: i - start))
+                let range = NSRange(location: start, length: i - start)
+                if keywords.contains(word) {
+                    tokens.append(Token(range: range, type: .keyword))
+                } else if let first = word.unicodeScalars.first, first.properties.isUppercase {
+                    tokens.append(Token(range: range, type: .type))
+                } else {
+                    // Function call: identifier immediately followed by `(`.
+                    var j = i
+                    while j < n && ns.character(at: j) == 0x20 { j += 1 }
+                    if j < n && ns.character(at: j) == 0x28 {
+                        tokens.append(Token(range: range, type: .function))
+                    }
+                }
+                continue
+            }
+            i += 1
+        }
+        return tokens
+    }
+}

--- a/Sources/MarkdownEditorCore/EditorTextView+CodeHighlighting.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+CodeHighlighting.swift
@@ -1,0 +1,69 @@
+import AppKit
+
+// MARK: - Code Block Syntax Highlighting
+//
+// Colors a fenced code block's content from `CodeHighlighter` tokens, using the
+// Tomorrow palette in light appearance and One Dark in dark. Only foregrounds
+// are themed — the block keeps the editor's background — so each palette is
+// paired with the appearance whose background it's legible on.
+
+/// Foreground colors for the six highlighted token kinds plus plain code.
+private struct CodePalette {
+    let plain, keyword, type, string, number, comment, function: NSColor
+
+    func color(for type: CodeHighlighter.TokenType) -> NSColor {
+        switch type {
+        case .keyword:  return keyword
+        case .type:     return self.type
+        case .string:   return string
+        case .number:   return number
+        case .comment:  return comment
+        case .function: return function
+        }
+    }
+
+    /// Tomorrow (light).
+    static let tomorrow = CodePalette(
+        plain:    NSColor(hex: "#4d4d4c") ?? .textColor,
+        keyword:  NSColor(hex: "#8959a8") ?? .systemPurple,
+        type:     NSColor(hex: "#c18401") ?? .systemYellow,
+        string:   NSColor(hex: "#718c00") ?? .systemGreen,
+        number:   NSColor(hex: "#f5871f") ?? .systemOrange,
+        comment:  NSColor(hex: "#8e908c") ?? .secondaryLabelColor,
+        function: NSColor(hex: "#4271ae") ?? .systemBlue)
+
+    /// One Dark.
+    static let oneDark = CodePalette(
+        plain:    NSColor(hex: "#abb2bf") ?? .textColor,
+        keyword:  NSColor(hex: "#c678dd") ?? .systemPurple,
+        type:     NSColor(hex: "#e5c07b") ?? .systemYellow,
+        string:   NSColor(hex: "#98c379") ?? .systemGreen,
+        number:   NSColor(hex: "#d19a66") ?? .systemOrange,
+        comment:  NSColor(hex: "#5c6370") ?? .secondaryLabelColor,
+        function: NSColor(hex: "#61afef") ?? .systemBlue)
+}
+
+extension EditorTextView {
+
+    private var prefersDarkCodeTheme: Bool {
+        effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+    }
+
+    /// Applies syntax colors to a code block's content range in place.
+    func highlightCodeBlock(_ result: NSMutableAttributedString,
+                            contentRange: NSRange, language: String?) {
+        guard contentRange.length > 0, contentRange.upperBound <= result.length else { return }
+        let palette = prefersDarkCodeTheme ? CodePalette.oneDark : CodePalette.tomorrow
+
+        // Plain code text first; token colors paint over it.
+        result.addAttribute(.foregroundColor, value: palette.plain, range: contentRange)
+
+        let code = (result.string as NSString).substring(with: contentRange)
+        for token in CodeHighlighter.tokenize(code, language: language) {
+            let abs = NSRange(location: contentRange.location + token.range.location,
+                              length: token.range.length)
+            guard abs.upperBound <= result.length else { continue }
+            result.addAttribute(.foregroundColor, value: palette.color(for: token.type), range: abs)
+        }
+    }
+}

--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -175,10 +175,10 @@ extension EditorTextView {
                 result.addAttribute(.foregroundColor, value: codeColor, range: span.contentRange)
                 result.addAttribute(.backgroundColor, value: inlineCodeBackground, range: span.contentRange)
 
-            case .codeBlock:
+            case .codeBlock(let language):
                 guard span.contentRange.upperBound <= result.length else { continue }
                 result.addAttribute(.font, value: codeBlockFont, range: span.contentRange)
-                result.addAttribute(.foregroundColor, value: codeColor, range: span.contentRange)
+                highlightCodeBlock(result, contentRange: span.contentRange, language: language)
 
             case .strikethrough:
                 guard span.contentRange.upperBound <= result.length else { continue }

--- a/Tests/MarkdownEditorTests/CodeHighlighterTests.swift
+++ b/Tests/MarkdownEditorTests/CodeHighlighterTests.swift
@@ -1,0 +1,42 @@
+import Testing
+import Foundation
+@testable import MarkdownEditorCore
+
+@Suite("CodeHighlighter")
+struct CodeHighlighterTests {
+
+    private func tokens(_ code: String, _ lang: String?) -> [(text: String, type: CodeHighlighter.TokenType)] {
+        let ns = code as NSString
+        return CodeHighlighter.tokenize(code, language: lang).map {
+            (ns.substring(with: $0.range), $0.type)
+        }
+    }
+
+    @Test("Recognizes keywords, functions, numbers, strings, comments")
+    func swiftTokens() {
+        let t = tokens("// hi\nfunc greet() { let n = 42; return \"x\" }", "swift")
+        #expect(t.contains { $0.text == "// hi" && $0.type == .comment })
+        #expect(t.contains { $0.text == "func" && $0.type == .keyword })
+        #expect(t.contains { $0.text == "greet" && $0.type == .function })
+        #expect(t.contains { $0.text == "let" && $0.type == .keyword })
+        #expect(t.contains { $0.text == "42" && $0.type == .number })
+        #expect(t.contains { $0.text == "\"x\"" && $0.type == .string })
+    }
+
+    @Test("# starts a comment in hash-comment languages only")
+    func hashComment() {
+        #expect(tokens("# note", "python").contains { $0.type == .comment })
+        #expect(!tokens("# note", "swift").contains { $0.type == .comment })
+    }
+
+    @Test("Capitalized identifier is typed as a type")
+    func typeToken() {
+        #expect(tokens("let x: String = y", "swift").contains { $0.text == "String" && $0.type == .type })
+    }
+
+    @Test("Block comments span across lines")
+    func blockComment() {
+        let t = tokens("a /* multi\nline */ b", "c")
+        #expect(t.contains { $0.text == "/* multi\nline */" && $0.type == .comment })
+    }
+}

--- a/Tests/MarkdownEditorTests/EditorRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/EditorRenderingTests.swift
@@ -661,20 +661,24 @@ struct EditorStylingTests {
         #expect(!isHidden(at: 0, in: styled))
     }
 
-    @Test("Code block fences are dimmed, content has monospace+code color")
+    @Test("Code block fences are dimmed; content is monospace and syntax-highlighted")
     @MainActor func codeBlockStyling() {
         let editor = makeEditor()
-        let styled = editor.styleBlock("```\nhello\n```")
-        #expect(styled.string == "```\nhello\n```")
-        // Fences dimmed
+        let styled = editor.styleBlock("```swift\nlet hello = 1\n```")
+        #expect(styled.string == "```swift\nlet hello = 1\n```")
+        // Fences dimmed.
         #expect(isDimmed(at: 0, in: styled))
-        // Content "hello" at offset 4 has code color and monospace
-        let f = styled.attribute(.font, at: 4, effectiveRange: nil) as? NSFont
-        #expect(f != nil)
-        #expect(f!.isFixedPitch)
-        let color = styled.attribute(.foregroundColor, at: 4, effectiveRange: nil) as? NSColor
-        #expect(color != nil)
-        #expect(color!.redComponent > 0.5 && color!.greenComponent < 0.2)
+        let ns = styled.string as NSString
+        let kwLoc = ns.range(of: "let").location
+        let plainLoc = ns.range(of: "hello").location
+        // Content is monospace.
+        let f = styled.attribute(.font, at: plainLoc, effectiveRange: nil) as? NSFont
+        #expect(f?.isFixedPitch == true)
+        // The keyword is colored distinctly from a plain identifier.
+        let kw = styled.attribute(.foregroundColor, at: kwLoc, effectiveRange: nil) as? NSColor
+        let plain = styled.attribute(.foregroundColor, at: plainLoc, effectiveRange: nil) as? NSColor
+        #expect(kw != nil && plain != nil)
+        #expect(kw != plain)
     }
 
     // MARK: - Active Token (cursor inside)


### PR DESCRIPTION
todo.md "Next": *Code block: Syntax highlighting — Tomorrow for light mode, One Dark for dark mode.*

## What
A small, language-agnostic tokenizer (`CodeHighlighter`) colors a fenced code block's content: comments, strings, numbers, keywords, types, and function calls. Colors come from the **Tomorrow** palette in light appearance and **One Dark** in dark — each paired with the appearance whose background it's legible on (only foregrounds are themed; the block keeps the editor background).

The block's info string (` ```python `) selects the line-comment style (`#` vs `//`); everything else is shared across languages.

## Verification
- New tokenizer tests: keyword/function/number/string/comment recognition, `#`-comment language gating, capitalized-identifier types, multi-line block comments. Existing code-block rendering test updated to assert highlighting (keyword colored distinctly from a plain identifier).
- Drove the built app with Swift and Python blocks in both light (Tomorrow) and dark (One Dark) — verified live.
- `swift test` green (579 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)