### PR TITLE
Add an edit / read / source view-mode toggle

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -604,6 +604,19 @@ extension EditorTextView {
         return result
     }
 
+    /// Plain monospaced styling for source mode: the raw markdown with no
+    /// markup interpretation (no hidden delimiters, overlays, or decorations).
+    func sourceStyled(_ markdown: String) -> NSAttributedString {
+        let mono = NSFont.monospacedSystemFont(ofSize: bodyFont.pointSize, weight: .regular)
+        let ps = NSMutableParagraphStyle()
+        ps.lineSpacing = theme.lineSpacing
+        return NSAttributedString(string: markdown, attributes: [
+            .font: mono,
+            .foregroundColor: foregroundColor,
+            .paragraphStyle: ps,
+        ])
+    }
+
     // MARK: - In-Place Block Restyling
 
     /// Re-styles a single block in the text storage in place (no string mutation).
@@ -616,7 +629,12 @@ extension EditorTextView {
         let block = blocks[blockIndex]
         guard block.range.upperBound <= ts.length else { return }
 
-        let styled = styleBlock(block.content, cursorPosition: cursorInBlock)
+        let styled: NSAttributedString
+        switch viewMode {
+        case .edit:    styled = styleBlock(block.content, cursorPosition: cursorInBlock)
+        case .reading: styled = styleBlock(block.content, cursorPosition: nil)
+        case .source:  styled = sourceStyled(block.content)
+        }
         let offset = block.range.location
 
         styled.enumerateAttributes(in: NSRange(location: 0, length: styled.length), options: []) { attrs, range, _ in

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -96,6 +96,24 @@ public class EditorTextView: NSTextView {
 
     public var theme: EditorTheme = .load()
 
+    /// How the document is presented:
+    ///   - `edit`    — live preview; the block under the caret reveals its raw
+    ///                 markdown (the default editing experience).
+    ///   - `reading` — everything rendered, no raw ever revealed; read-only.
+    ///   - `source`  — plain monospaced raw markdown, no styling.
+    public enum ViewMode: Sendable { case edit, reading, source }
+
+    public var viewMode: ViewMode = .edit {
+        didSet {
+            guard oldValue != viewMode else { return }
+            isEditable = (viewMode != .reading)
+            // Re-style every block under the new mode (viewport-first for big docs).
+            guard !blocks.isEmpty else { return }
+            recomposeDirty(IndexSet(integersIn: 0..<blocks.count),
+                           cursorInRaw: selectedRange().location)
+        }
+    }
+
     /// User overrides for callout styles, keyed by lowercased type. Lets a
     /// settings layer customize a built-in type's color / icon / border /
     /// background (or add new types). Empty by default (GitHub styles).

--- a/Sources/md/Document.swift
+++ b/Sources/md/Document.swift
@@ -11,6 +11,8 @@ class Document: NSDocument {
 
     var editor: EditorTextView!
     private var statusBar: StatusBarView!
+    private var viewModeButton: NSButton?
+    private static let viewModeItemID = NSToolbarItem.Identifier("viewMode")
 
     /// Content loaded from disk before the editor window exists.
     /// `nonisolated(unsafe)` because `read(from:ofType:)` may be called
@@ -83,12 +85,6 @@ class Document: NSDocument {
         window.minSize = NSSize(width: 320, height: 400)
         window.backgroundColor = NSColor.textBackgroundColor
 
-        // Empty toolbar gives the titlebar extra height (roomy traffic lights).
-        let toolbar = NSToolbar(identifier: "MainToolbar")
-        window.toolbar = toolbar
-        window.toolbarStyle = .unified
-        window.titlebarSeparatorStyle = .line
-
         // Build the TextKit 2 text system chain (viewport-based layout).
         editor = EditorTextView.makeTextKit2(
             frame: NSRect(x: 0, y: 0, width: windowWidth, height: windowHeight),
@@ -103,6 +99,16 @@ class Document: NSDocument {
         editor.textContainerInset = NSSize(width: 24, height: 18)
         editor.typewriterModeEnabled = AppDelegate.typewriterModeEnabled()
         editor.document = self
+
+        // Toolbar holds the right-aligned view-mode toggle (and gives the
+        // titlebar extra height for roomy traffic lights). Set it only after
+        // `editor` exists — assigning the toolbar synchronously vends its items.
+        let toolbar = NSToolbar(identifier: "MainToolbar")
+        toolbar.delegate = self
+        toolbar.displayMode = .iconOnly
+        window.toolbar = toolbar
+        window.toolbarStyle = .unified
+        window.titlebarSeparatorStyle = .line
 
         let statusBarHeight: CGFloat = 22
         let contentBounds = window.contentView!.bounds
@@ -232,6 +238,69 @@ class Document: NSDocument {
         }
     }
 
+    // MARK: - View Mode (edit / reading / source)
+
+    private func icon(for mode: EditorTextView.ViewMode) -> NSImage? {
+        let name: String
+        switch mode {
+        case .edit:    name = "pencil"
+        case .reading: name = "book"
+        case .source:  name = "chevron.left.forwardslash.chevron.right"
+        }
+        return NSImage(systemSymbolName: name, accessibilityDescription: label(for: mode))
+    }
+
+    private func label(for mode: EditorTextView.ViewMode) -> String {
+        switch mode {
+        case .edit:    return "Edit"
+        case .reading: return "Read"
+        case .source:  return "Source"
+        }
+    }
+
+    /// Shows the active mode's icon on the button (with the menu chevrons), and
+    /// keeps the tooltip in sync.
+    private func refreshViewModeButton() {
+        guard let editor else { return }
+        viewModeButton?.image = viewModeButtonImage(for: editor.viewMode)
+        viewModeButton?.toolTip = "View mode: \(label(for: editor.viewMode))"
+    }
+
+    private func setViewMode(_ mode: EditorTextView.ViewMode) {
+        editor.viewMode = mode
+        refreshViewModeButton()
+    }
+
+    @objc private func selectEditMode(_ sender: Any?)    { setViewMode(.edit) }
+    @objc private func selectReadingMode(_ sender: Any?) { setViewMode(.reading) }
+    @objc private func selectSourceMode(_ sender: Any?)  { setViewMode(.source) }
+
+    /// Drops the mode menu down from the chevron button.
+    @objc private func showViewModeMenu(_ sender: NSButton) {
+        let menu = viewModeMenu()
+        menu.popUp(positioning: nil,
+                   at: NSPoint(x: 0, y: sender.bounds.height + 4), in: sender)
+    }
+
+    /// A checklist menu: each mode with its icon, the current one checked.
+    private func viewModeMenu() -> NSMenu {
+        let menu = NSMenu()
+        menu.autoenablesItems = false   // actions always fire on selection
+        let entries: [(EditorTextView.ViewMode, Selector)] = [
+            (.edit,    #selector(selectEditMode(_:))),
+            (.reading, #selector(selectReadingMode(_:))),
+            (.source,  #selector(selectSourceMode(_:))),
+        ]
+        for (mode, action) in entries {
+            let item = NSMenuItem(title: label(for: mode), action: action, keyEquivalent: "")
+            item.target = self
+            item.image = icon(for: mode)
+            item.state = (editor?.viewMode == mode) ? .on : .off
+            menu.addItem(item)
+        }
+        return menu
+    }
+
     // MARK: - Writing
 
     override func data(ofType typeName: String) throws -> Data {
@@ -247,5 +316,61 @@ class Document: NSDocument {
                           userInfo: [NSLocalizedDescriptionKey: "Could not encode text as UTF-8"])
         }
         return data
+    }
+}
+
+// MARK: - Toolbar (view-mode toggle)
+
+extension Document: NSToolbarDelegate {
+    func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        [.flexibleSpace, Self.viewModeItemID]
+    }
+
+    func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        [.flexibleSpace, Self.viewModeItemID]
+    }
+
+    func toolbar(_ toolbar: NSToolbar,
+                 itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
+                 willBeInsertedIntoToolbar flag: Bool) -> NSToolbarItem? {
+        guard itemIdentifier == Self.viewModeItemID else { return nil }
+        let item = NSToolbarItem(itemIdentifier: itemIdentifier)
+        item.label = "View Mode"
+        item.visibilityPriority = .high
+
+        // A single button — "<active-mode icon> ⌄⌃" — that drops the menu.
+        let button = NSButton(image: viewModeButtonImage(for: editor.viewMode),
+                              target: self, action: #selector(showViewModeMenu(_:)))
+        button.bezelStyle = .texturedRounded
+        button.imagePosition = .imageOnly
+        viewModeButton = button
+        item.view = button
+        refreshViewModeButton()
+        return item
+    }
+
+    /// Composes the toolbar button face: the active mode's icon at full toolbar
+    /// size with a small `chevron.up.chevron.down` to its right (menu affordance).
+    private func viewModeButtonImage(for mode: EditorTextView.ViewMode) -> NSImage {
+        // Proportions match Finder's view-mode control: a prominent mode icon
+        // with a smaller `chevron.up.chevron.down` tucked close to its right.
+        let modeIcon = (icon(for: mode)?.withSymbolConfiguration(
+            .init(pointSize: 16, weight: .regular))) ?? NSImage()
+        let chevrons = (NSImage(systemSymbolName: "chevron.up.chevron.down",
+                                accessibilityDescription: nil)?
+            .withSymbolConfiguration(.init(pointSize: 10, weight: .medium))) ?? NSImage()
+        let gap: CGFloat = 2
+        let size = NSSize(width: modeIcon.size.width + gap + chevrons.size.width,
+                          height: max(modeIcon.size.height, chevrons.size.height))
+        let image = NSImage(size: size)
+        image.lockFocus()
+        modeIcon.draw(at: NSPoint(x: 0, y: (size.height - modeIcon.size.height) / 2),
+                      from: .zero, operation: .sourceOver, fraction: 1)
+        chevrons.draw(at: NSPoint(x: modeIcon.size.width + gap,
+                                  y: (size.height - chevrons.size.height) / 2),
+                      from: .zero, operation: .sourceOver, fraction: 1)
+        image.unlockFocus()
+        image.isTemplate = true   // tint with the toolbar's light/dark color
+        return image
     }
 }

--- a/Tests/MarkdownEditorTests/ViewModeTests.swift
+++ b/Tests/MarkdownEditorTests/ViewModeTests.swift
@@ -1,0 +1,52 @@
+import Testing
+import AppKit
+@testable import MarkdownEditorCore
+
+@Suite("View modes")
+@MainActor
+struct ViewModeTests {
+
+    private func font(_ editor: EditorTextView, at loc: Int) -> NSFont? {
+        editor.textStorage?.attribute(.font, at: loc, effectiveRange: nil) as? NSFont
+    }
+
+    @Test("Source mode shows plain monospace raw markdown")
+    func sourceMode() {
+        let editor = makeEditor()
+        editor.loadContent("# Heading\n\nThis is **bold**.")
+        editor.viewMode = .source
+
+        // The `#` heading marker keeps body size + monospace (not a big heading).
+        let f0 = font(editor, at: 0)
+        #expect(f0?.isFixedPitch == true)
+        #expect((f0?.pointSize ?? 99) <= editor.bodyFont.pointSize)
+        // The `**` bold markers aren't hidden — everything is shown raw.
+        let boldLoc = (editor.rawSource as NSString).range(of: "**bold**").location
+        #expect(!isHidden(at: boldLoc, in: editor.textStorage!))
+        #expect(font(editor, at: boldLoc)?.isFixedPitch == true)
+    }
+
+    @Test("Reading mode never reveals raw markers, even with a caret in the block")
+    func readingMode() {
+        let editor = makeEditor()
+        editor.loadContent("**bold**")
+        editor.viewMode = .reading
+        // Put the caret inside the token; reading mode must keep `**` hidden.
+        editor.setSelectedRange(NSRange(location: 3, length: 0))
+        editor.recomposeDirty(IndexSet(integersIn: 0..<editor.blocks.count), cursorInRaw: 3)
+        #expect(isHidden(at: 0, in: editor.textStorage!))
+        #expect(editor.isEditable == false)
+    }
+
+    @Test("Edit mode reveals the active block's raw markers")
+    func editModeReveals() {
+        let editor = makeEditor()
+        editor.loadContent("**bold**")
+        editor.viewMode = .edit
+        editor.setSelectedRange(NSRange(location: 3, length: 0))
+        editor.recomposeDirty(IndexSet(integersIn: 0..<editor.blocks.count), cursorInRaw: 3)
+        // Active token shows dimmed (visible) `**`, not hidden.
+        #expect(!isHidden(at: 0, in: editor.textStorage!))
+        #expect(editor.isEditable == true)
+    }
+}


### PR DESCRIPTION
todo.md "Next": *Title bar / toolbar: Rightmost button: Toggle between edit, reading, and source… Right click on the button for a menu to choose viewing mode.*

## What
A right-aligned toolbar button shows the **active mode's icon** with a small `chevron.up.chevron.down` (menu affordance) and drops a checklist menu:
- **Edit** (pencil) — live preview; the caret's block reveals its raw markdown.
- **Read** (book) — everything rendered, raw never revealed, read-only.
- **Source** (`</>`) — plain monospaced raw markdown, no styling.

The button icon and the menu's checkmark track the current mode.

## Implementation
- `EditorTextView.ViewMode` + `viewMode` property; its `didSet` toggles `isEditable` and re-styles every block (viewport-first for large docs).
- `restyleBlock` honors the mode: active-block reveal only in Edit; `cursorPosition: nil` (full render) in Read; a plain monospace `sourceStyled` in Source.
- Toolbar item built in `Document` (delegate-vended; set after the editor exists so item creation doesn't touch a nil editor).

## Verification
- New tests: source = monospace raw (markers not hidden), read = no reveal even with a caret in the block + read-only, edit = active block reveals + editable.
- Drove the built app through all three modes via the menu (Source confirmed switching to plain raw).
- `swift test` green (582 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)