### PR TITLE
Fix freshly-created list marker rendered a slot too deep

### DIFF
--- a/Sources/MarkdownEditorCore/SyntaxHighlighter+Walker.swift
+++ b/Sources/MarkdownEditorCore/SyntaxHighlighter+Walker.swift
@@ -480,7 +480,17 @@ extension SyntaxHighlighter {
                 return
             }
             let full = nsRange(for: range)
-            let delims = delimiterRanges(parent: full, children: listItem.children)
+            var delims = delimiterRanges(parent: full, children: listItem.children)
+            // An empty list item (just "- " / "1. " / "- [ ] " with no content,
+            // e.g. a marker freshly created by pressing Return) has no child
+            // nodes, so `delimiterRanges` finds no marker and the whole item is
+            // treated as content. That collapses the marker's width to zero and
+            // pushes the freshly-typed marker a full slot too deep. Synthesize
+            // the marker delimiter from the leading text so the content begins
+            // after it, matching a non-empty item.
+            if delims.isEmpty, let markerLen = Self.leadingListMarkerLength(in: source, range: full) {
+                delims = [NSRange(location: full.location, length: markerLen)]
+            }
             let content = contentRange(full: full, delims: delims)
 
             // swift-markdown flags an item as a task list item via `checkbox`,
@@ -507,6 +517,22 @@ extension SyntaxHighlighter {
                 delimiterRanges: delims
             ))
             descendInto(listItem)
+        }
+
+        /// Matches a list item's leading marker (optional indentation +
+        /// `-`/`*`/`+` or `N.`, plus an optional `[ ]`/`[x]` checkbox), used to
+        /// recover the marker range for an empty item that has no child nodes.
+        private static let listMarkerRegex = try! NSRegularExpression(
+            pattern: #"^[ \t]*(?:[-*+][ \t]+(?:\[[ xX]\][ \t]*)?|\d+\.[ \t]+)"#)
+
+        /// Length (UTF-16) of the leading list marker within `range` of `source`,
+        /// or nil if the text there doesn't begin with a marker.
+        private static func leadingListMarkerLength(in source: String, range: NSRange) -> Int? {
+            let line = (source as NSString).substring(with: range)
+            let m = listMarkerRegex.firstMatch(
+                in: line, range: NSRange(location: 0, length: (line as NSString).length))
+            guard let m, m.range.location == 0, m.range.length > 0 else { return nil }
+            return m.range.length
         }
 
         /// Reads a task-list checkbox state from the item's leading marker text

--- a/Tests/MarkdownEditorTests/NewListItemAlignmentTests.swift
+++ b/Tests/MarkdownEditorTests/NewListItemAlignmentTests.swift
@@ -1,0 +1,56 @@
+import Testing
+import AppKit
+@testable import MarkdownEditorCore
+
+// Regression: a list marker freshly created by pressing Return (an *empty*
+// list item) must keep the same hanging indent as a non-empty item. An empty
+// item has no child nodes, so the marker used to be treated as content — its
+// width collapsed to zero and `firstLineHeadIndent` jumped to `headIndent`,
+// rendering the new marker a full slot too deep until the next edit.
+@Suite("New list item alignment")
+@MainActor
+struct NewListItemAlignmentTests {
+
+    private func ps(_ editor: EditorTextView, blockIdx: Int) -> NSParagraphStyle? {
+        let r = editor.blocks[blockIdx].range
+        return editor.textStorage?.attribute(.paragraphStyle, at: r.location,
+                                             effectiveRange: nil) as? NSParagraphStyle
+    }
+
+    /// Presses Return at the end of block 0 to spawn a new empty item (block 1).
+    private func spawnNewItem(_ content: String) -> EditorTextView {
+        let editor = makeEditor()
+        editor.loadContent(content)
+        let endOfFirst = (content as NSString).range(of: "\n").location
+        editor.setSelectedRange(NSRange(location: endOfFirst, length: 0))
+        editor.insertNewline(nil)
+        return editor
+    }
+
+    @Test("Empty bullet keeps a hanging indent (marker not collapsed into content)")
+    func bullet() {
+        let editor = spawnNewItem("- alpha\n- beta")
+        let new = ps(editor, blockIdx: 1)
+        #expect(new != nil)
+        // Marker width is preserved: the first line hangs left of the content.
+        #expect(new!.firstLineHeadIndent < new!.headIndent)
+    }
+
+    @Test("Empty ordered item aligns with its siblings")
+    func ordered() {
+        let editor = spawnNewItem("1. alpha\n2. beta")
+        let sibling = ps(editor, blockIdx: 0)
+        let new = ps(editor, blockIdx: 1)
+        #expect(new != nil && sibling != nil)
+        #expect(abs(new!.firstLineHeadIndent - sibling!.firstLineHeadIndent) < 0.5)
+        #expect(abs(new!.headIndent - sibling!.headIndent) < 0.5)
+    }
+
+    @Test("Empty checkbox keeps a hanging indent")
+    func checkbox() {
+        let editor = spawnNewItem("- [ ] alpha\n- [ ] beta")
+        let new = ps(editor, blockIdx: 1)
+        #expect(new != nil)
+        #expect(new!.firstLineHeadIndent < new!.headIndent)
+    }
+}


### PR DESCRIPTION
## Problem
A list marker created by pressing Return (an *empty* list item — `- `, `1. `, `- [ ] `) rendered a full slot too deep until the next edit snapped it back. Reported across all three list types via screen recordings.

## Cause
An empty list item has no child nodes, so the swift-markdown AST walker found no marker delimiter and treated the whole item as content. The marker's width collapsed to zero, so the active item's `firstLineHeadIndent` jumped to the content indent.

## Fix
Synthesize the marker delimiter from the leading text for empty items (in `SyntaxHighlighter+Walker.swift`), so the content range begins after the marker — exactly like a non-empty item.

## Tests
New `NewListItemAlignmentTests` suite asserts an empty bullet/ordered/checkbox keeps its hanging indent (marker not collapsed). Full suite green (585).

🤖 Generated with [Claude Code](https://claude.com/claude-code)