### PR TITLE
Balance callout vertical padding

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+CalloutRendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+CalloutRendering.swift
@@ -152,14 +152,17 @@ extension EditorTextView {
 
     // MARK: Padding constants (shared by the box and the header image)
 
-    /// Top breathing room — baked into the header image so it's part of the
-    /// header *line* (clickable text space), not dead block padding.
+    /// Top breathing room — raised on the header line's minimum line height
+    /// (clickable text space), not dead block padding.
     private var calloutTopPad: CGFloat { bodyFont.pointSize * 0.8 }
     /// Bottom breathing room. Delivered by growing the last line's layout
     /// fragment frame (a box `bottomPad`), so it is genuine clickable text
     /// space below the last line — not trailing paragraph spacing, which
     /// TextKit 2 leaves out of the fragment and which clicks would miss.
-    var calloutBottomPad: CGFloat { bodyFont.pointSize * 0.8 }
+    /// Tuned so the *rendered* bottom gap matches the rendered top gap: the
+    /// header overlay sits low in its line, so the top renders ~0.4·pointSize
+    /// larger than `calloutTopPad`, and this makes the bottom match it.
+    var calloutBottomPad: CGFloat { bodyFont.pointSize * 1.14 }
 
     // MARK: Paragraph style (text insets; the box itself is a BlockDecoration)
 


### PR DESCRIPTION
## Problem
A callout's top and bottom padding looked unbalanced — measured **19pt** above the header vs **13.5pt** below the last line.

## Cause
Top and bottom use different mechanisms (header `minimumLineHeight` vs the last line's grown fragment frame). The header overlay sits low in its line box, so the rendered top gap runs ~0.4·pointSize larger than its constant, while the bottom renders close to its constant.

## Fix
Keep the original (roomy) top and raise `calloutBottomPad` (0.8 → 1.14·pointSize) so the *rendered* bottom matches the top. Both now render at ~19pt, verified by pixel-measuring the rendered window. Padding remains clickable text space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)