### PR TITLE
Keep the active bullet marker on the dot's column

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -268,15 +268,28 @@ extension EditorTextView {
                 let markerText = String(markerStr.dropFirst(leadingWS.count))
                 let markerWidth = (markerText as NSString).size(withAttributes: [.font: bodyFont]).width
                 let firstLineIndent: CGFloat
-                if cursorInToken || ordered {
-                    // Active item, OR an ordered marker: right-align the marker into
-                    // its slot so the content begins at `contentIndent` — the same
-                    // place as the rendered (inactive) form. This keeps the active
-                    // item aligned with the rest of the list at every depth (and
-                    // clicking into an item doesn't shift its text), while leaving
-                    // the raw "- " / "1." / "- [ ]" marker visible and editable.
+                // For an active bullet we left-shift the raw "-" onto the dot's
+                // column; this kern widens its trailing space so the content
+                // still begins at contentIndent (set after the paragraph style).
+                var activeBulletSpaceKern: CGFloat = 0
+                if ordered || (cursorInToken && checkbox != nil) {
+                    // Ordered marker, or an active checkbox: right-align the marker
+                    // into its slot so the content begins at `contentIndent` — the
+                    // same place as the rendered (inactive) form. This keeps the
+                    // item aligned at every depth (and clicking in doesn't shift
+                    // the text), while leaving the raw "1." / "- [ ]" editable.
                     // Wrapped lines hang at contentIndent via headIndent.
                     firstLineIndent = max(2, contentIndent - markerWidth)
+                } else if cursorInToken {
+                    // Active bullet: sit the raw "-" on the dot's column instead of
+                    // right-aligning it into the slot, so the marker doesn't jump
+                    // sideways when you click into the item. The inactive dot is
+                    // centered in a pointSize-wide box at markerStart, so center the
+                    // dash there too; the kern below keeps the content at
+                    // contentIndent.
+                    let dashWidth = ("-" as NSString).size(withAttributes: [.font: bodyFont]).width
+                    firstLineIndent = max(2, markerStart + (bodyFont.pointSize - dashWidth) / 2)
+                    activeBulletSpaceKern = max(0, contentIndent - (firstLineIndent + markerWidth))
                 } else {
                     // Inactive bullet/checkbox: the marker icon sits at markerStart.
                     firstLineIndent = markerStart
@@ -299,6 +312,13 @@ extension EditorTextView {
                 result.addAttribute(.paragraphStyle,
                                     value: listParagraphStyle(firstLineIndent: firstLineIndent, contentIndent: contentIndent),
                                     range: NSRange(location: 0, length: result.length))
+                // Active bullet: widen the marker's trailing space so the content
+                // lands at contentIndent even though the "-" sits on the dot column.
+                if activeBulletSpaceKern > 0, span.contentRange.location > 0,
+                   span.contentRange.location <= result.length {
+                    result.addAttribute(.kern, value: activeBulletSpaceKern,
+                                        range: NSRange(location: span.contentRange.location - 1, length: 1))
+                }
                 // Strikethrough checked items
                 if !ordered, checkbox == .checked {
                     result.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: span.contentRange)

--- a/Tests/MarkdownEditorTests/ActiveBulletMarkerTests.swift
+++ b/Tests/MarkdownEditorTests/ActiveBulletMarkerTests.swift
@@ -1,0 +1,50 @@
+import Testing
+import AppKit
+@testable import MarkdownEditorCore
+
+// When you click into a bullet item, the raw "-" should stay on the dot's
+// column (where the rendered • sits) rather than jumping a slot to the right.
+// Content must still hang at the same indent so the text doesn't move.
+@Suite("Active bullet marker column")
+@MainActor
+struct ActiveBulletMarkerTests {
+
+    private func ps(_ editor: EditorTextView, _ s: String, cursor: Int?) -> NSParagraphStyle? {
+        let st = editor.styleBlock(s, cursorPosition: cursor)
+        return st.attribute(.paragraphStyle, at: st.length - 1, effectiveRange: nil) as? NSParagraphStyle
+    }
+
+    @Test("Active bullet marker stays on the dot column (not right-aligned into the slot)")
+    func bulletStaysOnDotColumn() {
+        let editor = makeEditor()
+        let active = ps(editor, "- item", cursor: 3)!
+        let inactive = ps(editor, "- item", cursor: nil)!
+        let slot = editor.bodyFont.pointSize +
+            (" " as NSString).size(withAttributes: [.font: editor.bodyFont]).width
+        // The active dash sits on the inactive dot's column (within a fraction of
+        // a slot), not a full slot to the right of it.
+        #expect(abs(active.firstLineHeadIndent - inactive.firstLineHeadIndent) < slot * 0.5)
+        // Content is unchanged so the text doesn't shift when clicking in.
+        #expect(abs(active.headIndent - inactive.headIndent) < 0.5)
+    }
+
+    @Test("Active bullet kerns its trailing space so content keeps the hanging indent")
+    func bulletKernsTrailingSpace() {
+        let editor = makeEditor()
+        let st = editor.styleBlock("- item", cursorPosition: 3)
+        // "- item": the space is index 1; it carries positive kern to push the
+        // content out to the content indent even though the dash sits left.
+        let kern = st.attribute(.kern, at: 1, effectiveRange: nil) as? CGFloat
+        #expect((kern ?? 0) > 0)
+    }
+
+    @Test("Active ordered marker still right-aligns into its slot")
+    func orderedStillRightAligns() {
+        let editor = makeEditor()
+        let active = ps(editor, "1. item", cursor: 4)!
+        // Ordered numbers keep right-alignment (periods line up), so the first
+        // line indent is well right of the bullet column.
+        #expect(active.firstLineHeadIndent < active.headIndent)
+        #expect(active.firstLineHeadIndent > editor.listPadding + 1)
+    }
+}


### PR DESCRIPTION
## Problem
Clicking into a bullet item right-aligned the raw `-` into its slot, so the marker jumped a slot to the right of where the rendered `•` dot sits — the bullet appeared to change places.

## Fix
Sit the active dash on the dot's column instead. The inactive dot is centered in a pointSize-wide box at `markerStart`, so the active dash is centered there too; the marker's trailing space is kerned so the content still begins at the content indent (the text doesn't move when you click in). Ordered numbers and active checkboxes keep their right-aligned slot.

Verified by window-capture: the active dash center lands at the exact same x as the inactive dots (209.5px in the test capture).

## Tests
New `ActiveBulletMarkerTests`: active bullet stays on the dot column, kerns its trailing space, and ordered markers still right-align. Full suite green (588).

🤖 Generated with [Claude Code](https://claude.com/claude-code)