### PR TITLE
Add Obsidian-style %%comments%%

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -123,7 +123,8 @@ extension EditorTextView {
              .code, .link, .image, .lineBreak,
              .heading, .blockquote, .footnoteReference:
             return true
-        case .listItem, .table, .codeBlock, .thematicBreak, .footnoteDefinition:
+        case .listItem, .table, .codeBlock, .thematicBreak, .footnoteDefinition, .comment:
+            // Comments are handled explicitly (dimmed in Edit, hidden in Reading).
             return false
         case .math(let display):
             // Inline math hides its `$` like other inline tokens; display math
@@ -141,7 +142,8 @@ extension EditorTextView {
     /// - Parameters:
     ///   - markdown: Raw markdown text.
     ///   - cursorPosition: Cursor offset within the markdown (nil = hide all inline delimiters).
-    func styleBlock(_ markdown: String, cursorPosition: Int? = nil) -> NSAttributedString {
+    func styleBlock(_ markdown: String, cursorPosition: Int? = nil,
+                    hideComments: Bool = false) -> NSAttributedString {
         let result = NSMutableAttributedString(string: markdown, attributes: baseAttributes)
         guard !markdown.isEmpty else { return result }
 
@@ -560,6 +562,19 @@ extension EditorTextView {
                 // definition text after it stays normal. Nothing to add here.
                 break
 
+            case .comment:
+                guard span.fullRange.upperBound <= result.length else { continue }
+                // Reading view hides comments entirely; Edit view dims the whole
+                // `%%…%%` (delimiters dimmed again in the delimiter pass). The
+                // content is opaque (no inner markdown), so dimming fullRange is
+                // enough.
+                if hideComments {
+                    result.addAttribute(.font, value: hiddenFont, range: span.fullRange)
+                    result.addAttribute(.foregroundColor, value: NSColor.clear, range: span.fullRange)
+                } else {
+                    result.addAttribute(.foregroundColor, value: syntaxDimColor, range: span.fullRange)
+                }
+
             case .lineBreak:
                 break  // Delimiter handling done below
             }
@@ -607,6 +622,15 @@ extension EditorTextView {
                     if cursorInToken {
                         result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
                     }
+                } else if case .comment = span.kind {
+                    // Comment `%%`: hidden in reading view, dimmed otherwise —
+                    // matching the content styling above.
+                    if hideComments {
+                        result.addAttribute(.font, value: hiddenFont, range: dr)
+                        result.addAttribute(.foregroundColor, value: NSColor.clear, range: dr)
+                    } else {
+                        result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
+                    }
                 } else if cursorInToken || !isDelimiterHideable(span.kind) {
                     // Visible: dim the delimiters
                     result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
@@ -652,7 +676,7 @@ extension EditorTextView {
         let styled: NSAttributedString
         switch viewMode {
         case .edit:    styled = styleBlock(block.content, cursorPosition: cursorInBlock)
-        case .reading: styled = styleBlock(block.content, cursorPosition: nil)
+        case .reading: styled = styleBlock(block.content, cursorPosition: nil, hideComments: true)
         case .source:  styled = sourceStyled(block.content)
         }
         let offset = block.range.location

--- a/Sources/MarkdownEditorCore/SyntaxHighlighter+CustomParsers.swift
+++ b/Sources/MarkdownEditorCore/SyntaxHighlighter+CustomParsers.swift
@@ -59,6 +59,34 @@ extension SyntaxHighlighter {
         }
     }
 
+    private static let commentRegex =
+        try! NSRegularExpression(pattern: "%%([\\s\\S]*?)%%", options: [])
+
+    /// Parses Obsidian-style `%%comment%%` spans (not supported by
+    /// swift-markdown). Matches across newlines within a block; skips `%%`
+    /// inside code spans / code blocks.
+    static func parseComments(_ text: String, into spans: inout [Span]) {
+        let ns = text as NSString
+        for m in commentRegex.matches(in: text, range: NSRange(location: 0, length: ns.length)) {
+            let full = m.range(at: 0)
+            let overlaps = spans.contains { existing in
+                switch existing.kind {
+                case .code, .codeBlock: break
+                default: return false
+                }
+                return existing.fullRange.location <= full.location
+                    && existing.fullRange.upperBound >= full.upperBound
+            }
+            guard !overlaps else { continue }
+            spans.append(Span(
+                kind: .comment,
+                fullRange: full,
+                contentRange: m.range(at: 1),
+                delimiterRanges: [NSRange(location: full.location, length: 2),
+                                  NSRange(location: full.upperBound - 2, length: 2)]))
+        }
+    }
+
     /// Parses ==highlight== spans using regex (not supported by swift-markdown).
     static func parseHighlight(_ text: String, into spans: inout [Span]) {
         let nsText = text as NSString

--- a/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
+++ b/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
@@ -44,6 +44,8 @@ public enum SyntaxHighlighter {
             case footnoteReference(id: String)
             /// A `[^id]:` footnote definition marker at the start of a block.
             case footnoteDefinition(id: String)
+            /// An Obsidian-style `%%comment%%` (hidden in reading view).
+            case comment
 
             public enum CheckboxState: Equatable, Sendable {
                 case checked, unchecked
@@ -77,6 +79,21 @@ public enum SyntaxHighlighter {
 
         // [^id] footnote references and [^id]: definition markers.
         parseFootnotes(text, into: &walker.spans)
+
+        // %%comments%%. Comments are opaque: drop any span fully inside one so
+        // its content isn't re-styled as markdown (it's a raw note).
+        parseComments(text, into: &walker.spans)
+        let commentRanges: [NSRange] = walker.spans.compactMap {
+            if case .comment = $0.kind { return $0.fullRange } else { return nil }
+        }
+        if !commentRanges.isEmpty {
+            walker.spans.removeAll { span in
+                if case .comment = span.kind { return false }
+                return commentRanges.contains {
+                    $0.location <= span.fullRange.location && $0.upperBound >= span.fullRange.upperBound
+                }
+            }
+        }
 
         return walker.spans.sorted { $0.fullRange.location < $1.fullRange.location }
     }

--- a/Tests/MarkdownEditorTests/CommentRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/CommentRenderingTests.swift
@@ -1,0 +1,56 @@
+import Testing
+import AppKit
+@testable import MarkdownEditorCore
+
+@Suite("Comments")
+@MainActor
+struct CommentRenderingTests {
+
+    @Test("%%comment%% is parsed as a comment span")
+    func parsesComment() {
+        let spans = SyntaxHighlighter.parse("a %%hidden note%% b")
+        let comment = spans.first { if case .comment = $0.kind { return true }; return false }
+        #expect(comment != nil)
+        #expect(comment?.fullRange == NSRange(location: 2, length: 15)) // "%%hidden note%%"
+    }
+
+    @Test("Comment content is opaque: inner markdown is not parsed")
+    func opaque() {
+        let spans = SyntaxHighlighter.parse("%%**bold** [x](y)%%")
+        #expect(!spans.contains { if case .bold = $0.kind { return true }; return false })
+        #expect(!spans.contains { if case .link = $0.kind { return true }; return false })
+    }
+
+    @Test("Edit view dims the comment but keeps it visible")
+    func editDims() {
+        let editor = makeEditor()
+        let st = editor.styleBlock("see %%a note%% here", hideComments: false)
+        let loc = (st.string as NSString).range(of: "a note").location
+        #expect(!isHidden(at: loc, in: st))      // content visible
+        #expect(isDimmed(at: loc, in: st))       // but dimmed
+        let pct = (st.string as NSString).range(of: "%%").location
+        #expect(!isHidden(at: pct, in: st))      // delimiters visible (dimmed)
+    }
+
+    @Test("Reading view hides the comment entirely")
+    func readingHides() {
+        let editor = makeEditor()
+        let st = editor.styleBlock("see %%a note%% here", hideComments: true)
+        let loc = (st.string as NSString).range(of: "a note").location
+        let pct = (st.string as NSString).range(of: "%%").location
+        #expect(isHidden(at: loc, in: st))       // content hidden
+        #expect(isHidden(at: pct, in: st))       // delimiters hidden
+        // Surrounding text is untouched.
+        let here = (st.string as NSString).range(of: "here").location
+        #expect(!isHidden(at: here, in: st))
+    }
+
+    @Test("Reading view via viewMode hides comments in the storage")
+    func readingViewMode() {
+        let editor = makeEditor()
+        editor.loadContent("before %%secret%% after")
+        editor.viewMode = .reading
+        let loc = (editor.rawSource as NSString).range(of: "secret").location
+        #expect(isHidden(at: loc, in: editor.textStorage!))
+    }
+}


### PR DESCRIPTION
## What
Adds `%%comment%%` support (Obsidian-style).

- **Edit view**: the whole `%%…%%` is dimmed but visible and editable.
- **Reading view**: comments are hidden entirely.
- **Source view**: shown raw (plain monospace).

## How
- New `.comment` span kind, parsed by `parseComments` (regex, matches across newlines within a block; skips `%%` inside code).
- Comments are **opaque**: any span fully contained in a comment is dropped so the content isn't re-styled as markdown.
- A `hideComments` flag on `styleBlock` (threaded from `restyleBlock` for `.reading`) hides them in reading view via the same near-zero-font + clear-color mechanism used for other hidden delimiters.

## Tests
New `CommentRenderingTests`: parsing, opacity, edit-dims-but-visible, reading-hides, and reading via `viewMode`. Full suite green (593). Edit view verified visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)