### PR TITLE
Add Obsidian-style [[wikilinks]]

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -5,6 +5,9 @@ extension NSAttributedString.Key {
     /// cmd+click can follow it. Kept separate from the system `.link` attribute
     /// to avoid NSTextView's built-in link styling/cursor behavior.
     static let editorLinkURL = NSAttributedString.Key("EditorLinkURL")
+    /// Stores a wikilink's raw `path#heading` target on its visible text so a
+    /// cmd+click can resolve it to a file or in-document heading.
+    static let editorWikiTarget = NSAttributedString.Key("EditorWikiTarget")
 }
 
 // MARK: - Word-Level Styling
@@ -126,6 +129,10 @@ extension EditorTextView {
         case .listItem, .table, .codeBlock, .thematicBreak, .footnoteDefinition, .comment:
             // Comments are handled explicitly (dimmed in Edit, hidden in Reading).
             return false
+        case .wikilink:
+            // The `[[`, optional `target|`, and `]]` are hidden when rendered,
+            // dimmed when the cursor is inside (like other inline delimiters).
+            return true
         case .math(let display):
             // Inline math hides its `$` like other inline tokens; display math
             // is block-level and handled specially.
@@ -204,6 +211,17 @@ extension EditorTextView {
                 result.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: span.contentRange)
                 if !destination.isEmpty {
                     result.addAttribute(.editorLinkURL, value: destination, range: span.contentRange)
+                }
+
+            case .wikilink(let target):
+                guard span.contentRange.upperBound <= result.length else { continue }
+                // The display text reads as an accent link; the brackets (and a
+                // `target|` alias prefix) are hidden/dimmed by the delimiter pass.
+                result.addAttribute(.foregroundColor, value: accentColor, range: span.contentRange)
+                result.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue,
+                                    range: span.contentRange)
+                if !target.isEmpty {
+                    result.addAttribute(.editorWikiTarget, value: target, range: span.contentRange)
                 }
 
             case .image(let destination):

--- a/Sources/MarkdownEditorCore/EditorTextView+WikiLinks.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+WikiLinks.swift
@@ -1,0 +1,91 @@
+import AppKit
+
+// MARK: - Wikilink Following
+//
+// `[[target]]` links resolve relative to the *opened file's directory* — the
+// app needs only the file, not a whole vault folder. A bare `#heading` scrolls
+// to a heading in the current document; a `path` (optionally `path#heading`)
+// resolves to a sibling `.md` file, falling back to a recursive search under
+// the document's directory. Cross-file heading scrolling is not implemented yet
+// (the file just opens).
+
+extension EditorTextView {
+
+    /// The wikilink target under a mouse event, or nil if the click doesn't land
+    /// on wikilink display text.
+    func wikiTarget(at event: NSEvent) -> String? {
+        guard let storage = textStorage, let i = clickCharIndex(at: event) else { return nil }
+        return storage.attribute(.editorWikiTarget, at: i, effectiveRange: nil) as? String
+    }
+
+    /// Resolves and navigates a wikilink `target` (`path#heading`):
+    ///   - empty path (`#heading`) → scroll to that heading in this document,
+    ///   - a path → open the resolved `.md` file (heading, if any, ignored).
+    func followWikiLink(_ target: String) {
+        let ns = target as NSString
+        let hash = ns.range(of: "#")
+        let path: String
+        let heading: String?
+        if hash.location == NSNotFound {
+            path = target.trimmingCharacters(in: .whitespaces)
+            heading = nil
+        } else {
+            path = ns.substring(to: hash.location).trimmingCharacters(in: .whitespaces)
+            // For subheadings ("H1#H2") target the deepest component.
+            let rest = ns.substring(from: hash.upperBound)
+            heading = rest.split(separator: "#").last.map {
+                $0.trimmingCharacters(in: .whitespaces)
+            } ?? rest.trimmingCharacters(in: .whitespaces)
+        }
+
+        if path.isEmpty {
+            if let heading, !heading.isEmpty { scrollToHeading(heading) } else { NSSound.beep() }
+            return
+        }
+        guard let fileURL = resolveWikiFile(path) else { NSSound.beep(); return }
+        NSDocumentController.shared.openDocument(withContentsOf: fileURL, display: true) { _, _, _ in }
+    }
+
+    /// Scrolls to the first heading block whose text matches `heading`
+    /// (case-insensitive). Beeps if there is no such heading.
+    func scrollToHeading(_ heading: String) {
+        let want = heading.lowercased()
+        for block in blocks {
+            guard case .heading = block.kind,
+                  Self.headingText(block.content).lowercased() == want else { continue }
+            let loc = block.range.location
+            setSelectedRange(NSRange(location: loc, length: 0))
+            scrollRangeToVisible(NSRange(location: loc, length: 0))
+            return
+        }
+        NSSound.beep()
+    }
+
+    /// The text of a heading line, stripped of its leading `#`s and whitespace.
+    static func headingText(_ line: String) -> String {
+        var s = Substring(line)
+        while s.first == "#" { s = s.dropFirst() }
+        return s.trimmingCharacters(in: .whitespaces)
+    }
+
+    /// Resolves a wikilink `path` (without `.md`) to a file URL under the
+    /// document's directory: a direct sibling first, else a recursive search by
+    /// filename. Returns nil if the document has no directory or no match.
+    func resolveWikiFile(_ path: String) -> URL? {
+        guard let docDir = document?.fileURL?.deletingLastPathComponent() else { return nil }
+        let fm = FileManager.default
+        let rel = (path as NSString).pathExtension.isEmpty ? path + ".md" : path
+
+        let direct = docDir.appendingPathComponent(rel)
+        if fm.fileExists(atPath: direct.path) { return direct }
+
+        // Recursive search by the link's filename (Obsidian resolves by name).
+        let wantName = (rel as NSString).lastPathComponent.lowercased()
+        if let walker = fm.enumerator(at: docDir, includingPropertiesForKeys: nil) {
+            for case let url as URL in walker where url.lastPathComponent.lowercased() == wantName {
+                return url
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -618,18 +618,25 @@ public class EditorTextView: NSTextView {
 
     // MARK: - Link Following
 
-    /// Cmd+click on a link's text follows it; any other click edits normally.
+    /// Cmd+click on a link's text follows it: a `[[wikilink]]` resolves to a
+    /// file / heading, a regular link opens its URL. Any other click edits.
     public override func mouseDown(with event: NSEvent) {
-        if event.modifierFlags.contains(.command), let url = linkURL(at: event) {
-            NSWorkspace.shared.open(url)
-            return
+        if event.modifierFlags.contains(.command) {
+            if let target = wikiTarget(at: event) {
+                followWikiLink(target)
+                return
+            }
+            if let url = linkURL(at: event) {
+                NSWorkspace.shared.open(url)
+                return
+            }
         }
         super.mouseDown(with: event)
     }
 
-    /// The destination URL of the link under a mouse event, or nil if the click
-    /// doesn't land directly on link text.
-    private func linkURL(at event: NSEvent) -> URL? {
+    /// The storage character index directly under a mouse event, or nil if the
+    /// click doesn't land on a laid-out glyph (e.g. past the end of a line).
+    func clickCharIndex(at event: NSEvent) -> Int? {
         guard let tlm = textLayoutManager,
               let storage = textStorage, storage.length > 0 else { return nil }
 
@@ -650,7 +657,13 @@ public class EditorTextView: NSTextView {
         guard indexInParagraph >= 0,
               let paraStart = fragment.textElement?.elementRange?.location else { return nil }
         let charIndex = tlm.offset(from: tlm.documentRange.location, to: paraStart) + indexInParagraph
-        guard charIndex < storage.length,
+        return charIndex < storage.length ? charIndex : nil
+    }
+
+    /// The destination URL of the regular link under a mouse event, or nil if
+    /// the click doesn't land directly on link text.
+    private func linkURL(at event: NSEvent) -> URL? {
+        guard let storage = textStorage, let charIndex = clickCharIndex(at: event),
               let dest = storage.attribute(.editorLinkURL, at: charIndex, effectiveRange: nil) as? String
         else { return nil }
         return URL(string: dest)

--- a/Sources/MarkdownEditorCore/SyntaxHighlighter+CustomParsers.swift
+++ b/Sources/MarkdownEditorCore/SyntaxHighlighter+CustomParsers.swift
@@ -87,6 +87,55 @@ extension SyntaxHighlighter {
         }
     }
 
+    private static let wikiLinkRegex =
+        try! NSRegularExpression(pattern: #"\[\[([^\[\]\n]+?)\]\]"#)
+
+    /// Parses Obsidian-style `[[target]]`, `[[target#heading]]`, and
+    /// `[[target|alias]]` internal links. The span's `contentRange` is the
+    /// visible display text (the alias when present, else the target); the
+    /// `[[`, an optional `target|`, and the `]]` are delimiter ranges hidden
+    /// when rendered. Skips `[[` inside code spans / code blocks.
+    static func parseWikiLinks(_ text: String, into spans: inout [Span]) {
+        let ns = text as NSString
+        for m in wikiLinkRegex.matches(in: text, range: NSRange(location: 0, length: ns.length)) {
+            let full = m.range(at: 0)
+            let inner = m.range(at: 1)
+            let innerNS = ns.substring(with: inner) as NSString
+            guard innerNS.length > 0 else { continue }
+            let overlaps = spans.contains { existing in
+                switch existing.kind {
+                case .code, .codeBlock: break
+                default: return false
+                }
+                return existing.fullRange.location <= full.location
+                    && existing.fullRange.upperBound >= full.upperBound
+            }
+            guard !overlaps else { continue }
+
+            // Split target | alias on the first "|".
+            let pipe = innerNS.range(of: "|")
+            let targetRel = pipe.location == NSNotFound
+                ? NSRange(location: 0, length: innerNS.length)
+                : NSRange(location: 0, length: pipe.location)
+            var displayRel = pipe.location == NSNotFound
+                ? targetRel
+                : NSRange(location: pipe.upperBound, length: innerNS.length - pipe.upperBound)
+            if displayRel.length == 0 { displayRel = targetRel }   // "[[Note|]]" → show target
+
+            let target = innerNS.substring(with: targetRel).trimmingCharacters(in: .whitespaces)
+            guard !target.isEmpty || pipe.location != NSNotFound else { continue }
+
+            let content = NSRange(location: inner.location + displayRel.location, length: displayRel.length)
+            let leading = NSRange(location: full.location, length: content.location - full.location)
+            let trailing = NSRange(location: content.upperBound, length: full.upperBound - content.upperBound)
+            spans.append(Span(
+                kind: .wikilink(target: target),
+                fullRange: full,
+                contentRange: content,
+                delimiterRanges: [leading, trailing]))
+        }
+    }
+
     /// Parses ==highlight== spans using regex (not supported by swift-markdown).
     static func parseHighlight(_ text: String, into spans: inout [Span]) {
         let nsText = text as NSString

--- a/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
+++ b/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
@@ -46,6 +46,10 @@ public enum SyntaxHighlighter {
             case footnoteDefinition(id: String)
             /// An Obsidian-style `%%comment%%` (hidden in reading view).
             case comment
+            /// An Obsidian-style `[[target]]` internal link. `target` is the raw
+            /// `path#heading` portion (before any `|alias`); the visible display
+            /// text is the span's contentRange.
+            case wikilink(target: String)
 
             public enum CheckboxState: Equatable, Sendable {
                 case checked, unchecked
@@ -80,16 +84,24 @@ public enum SyntaxHighlighter {
         // [^id] footnote references and [^id]: definition markers.
         parseFootnotes(text, into: &walker.spans)
 
-        // %%comments%%. Comments are opaque: drop any span fully inside one so
-        // its content isn't re-styled as markdown (it's a raw note).
+        // %%comments%% and [[wikilinks]]. Both are opaque: their inner text is
+        // a raw note / link target, not markdown — drop any span fully inside
+        // one so the content isn't re-styled.
         parseComments(text, into: &walker.spans)
-        let commentRanges: [NSRange] = walker.spans.compactMap {
-            if case .comment = $0.kind { return $0.fullRange } else { return nil }
+        parseWikiLinks(text, into: &walker.spans)
+        let opaqueRanges: [NSRange] = walker.spans.compactMap { span in
+            switch span.kind {
+            case .comment, .wikilink: return span.fullRange
+            default: return nil
+            }
         }
-        if !commentRanges.isEmpty {
+        if !opaqueRanges.isEmpty {
             walker.spans.removeAll { span in
-                if case .comment = span.kind { return false }
-                return commentRanges.contains {
+                switch span.kind {
+                case .comment, .wikilink: return false
+                default: break
+                }
+                return opaqueRanges.contains {
                     $0.location <= span.fullRange.location && $0.upperBound >= span.fullRange.upperBound
                 }
             }

--- a/Tests/MarkdownEditorTests/WikiLinkTests.swift
+++ b/Tests/MarkdownEditorTests/WikiLinkTests.swift
@@ -1,0 +1,99 @@
+import Testing
+import AppKit
+@testable import MarkdownEditorCore
+
+@Suite("Wikilinks")
+@MainActor
+struct WikiLinkTests {
+
+    private func wiki(_ spans: [SyntaxHighlighter.Span]) -> SyntaxHighlighter.Span? {
+        spans.first { if case .wikilink = $0.kind { return true }; return false }
+    }
+
+    @Test("Plain [[Note]] parses with the whole name as display + target")
+    func plain() {
+        let spans = SyntaxHighlighter.parse("see [[My Note]] here")
+        let w = wiki(spans)
+        #expect(w != nil)
+        if case .wikilink(let target) = w!.kind { #expect(target == "My Note") }
+        let ns = "see [[My Note]] here" as NSString
+        #expect(ns.substring(with: w!.contentRange) == "My Note")
+    }
+
+    @Test("[[Note|Alias]] shows only the alias; target is the note")
+    func alias() {
+        let src = "[[My Note|click me]]"
+        let w = wiki(SyntaxHighlighter.parse(src))!
+        if case .wikilink(let target) = w.kind { #expect(target == "My Note") }
+        #expect((src as NSString).substring(with: w.contentRange) == "click me")
+    }
+
+    @Test("[[Note#Heading]] keeps the heading in the target")
+    func heading() {
+        let w = wiki(SyntaxHighlighter.parse("[[Note#Section]]"))!
+        if case .wikilink(let target) = w.kind { #expect(target == "Note#Section") }
+    }
+
+    @Test("Rendered wikilink hides the brackets and accents the display text")
+    func rendered() {
+        let editor = makeEditor()
+        let st = editor.styleBlock("go to [[Target|label]] now", cursorPosition: nil)
+        let s = st.string as NSString
+        // Brackets + "Target|" are hidden.
+        #expect(isHidden(at: s.range(of: "[[").location, in: st))
+        #expect(isHidden(at: s.range(of: "Target").location, in: st))
+        #expect(isHidden(at: s.range(of: "]]").location, in: st))
+        // The display "label" is accented and carries the wiki target.
+        let labelLoc = s.range(of: "label").location
+        #expect(!isHidden(at: labelLoc, in: st))
+        let color = st.attribute(.foregroundColor, at: labelLoc, effectiveRange: nil) as? NSColor
+        #expect(color == editor.accentColor)
+        let target = st.attribute(.editorWikiTarget, at: labelLoc, effectiveRange: nil) as? String
+        #expect(target == "Target")
+    }
+
+    @Test("Active wikilink reveals the raw brackets (dimmed, not hidden)")
+    func active() {
+        let editor = makeEditor()
+        let st = editor.styleBlock("[[Note]]", cursorPosition: 3)
+        #expect(!isHidden(at: 0, in: st))   // "[[" shown (dimmed) while editing
+        #expect(st.string == "[[Note]]")
+    }
+
+    @Test("Wikilink content is opaque: inner markdown is not parsed")
+    func opaque() {
+        let spans = SyntaxHighlighter.parse("[[a **b** c]]")
+        #expect(!spans.contains { if case .bold = $0.kind { return true }; return false })
+    }
+
+    @Test("resolveWikiFile finds a sibling .md relative to the opened file")
+    func resolvesSibling() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("wikivault-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let home = dir.appendingPathComponent("Home.md")
+        let target = dir.appendingPathComponent("Target Note.md")
+        try "home".write(to: home, atomically: true, encoding: .utf8)
+        try "target".write(to: target, atomically: true, encoding: .utf8)
+
+        let editor = makeEditor()
+        let doc = NSDocument()
+        doc.fileURL = home
+        editor.document = doc
+
+        // Obsidian links omit the .md extension.
+        #expect(editor.resolveWikiFile("Target Note")?.standardizedFileURL == target.standardizedFileURL)
+        #expect(editor.resolveWikiFile("Missing Note") == nil)
+    }
+
+    @Test("scrollToHeading finds the matching heading block")
+    func headingNavigation() {
+        let editor = makeEditor()
+        editor.loadContent("# Intro\n\nbody\n\n## Details\n\nmore")
+        editor.scrollToHeading("Details")
+        // The caret moved to the start of the "## Details" block.
+        let detailsLoc = (editor.rawSource as NSString).range(of: "## Details").location
+        #expect(editor.selectedRange().location == detailsLoc)
+    }
+}


### PR DESCRIPTION
## What
Adds `[[wikilink]]` support (Obsidian-flavored internal links).

- `[[Note]]`, `[[Note#Heading]]`, `[[Note|Alias]]`, and same-file `[[#Heading]]`.
- Rendered as an **accent link** showing the display text (alias when present, else the target); `[[`, an optional `target|`, and `]]` are hidden when rendered and dimmed when editing.
- **Cmd+click follows** (consistent with regular links): a bare `#heading` scrolls to that heading in the current document; a `path` resolves to a `.md` file and opens it.
- Wikilinks are **opaque** — inner text isn't re-parsed as markdown.

## File resolution without a vault folder
Resolution needs only the **opened file**, not a vault: links resolve against the document's directory (`document.fileURL`), trying a direct sibling first, then a recursive search by filename. The app isn't sandboxed, so the search is unrestricted. (A note outside the opened file's directory tree can't be found — that needs the vault folder, which we don't have.)

## Scope / deferred
- Heading display text is shown raw (e.g. `Note#Heading`) since the storage holds raw markdown; Obsidian's `Note > Heading` rewrite would need an overlay.
- Cross-file heading scrolling (open + scroll) — opens the file for now.
- Heading anchors for regular `[](...)` links — later, as noted.

## Tests
New `WikiLinkTests` (8): parsing of plain/alias/heading forms, rendered hiding + accent + target attribute, active reveal, opacity, real-filesystem sibling resolution, and heading navigation. Full suite green (601). Edit-view rendering verified visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)