### PR TITLE
Follow #heading anchors and cross-file headings in links

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+WikiLinks.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+WikiLinks.swift
@@ -1,15 +1,26 @@
 import AppKit
 
-// MARK: - Wikilink Following
+// MARK: - Internal Link Following
 //
-// `[[target]]` links resolve relative to the *opened file's directory* — the
-// app needs only the file, not a whole vault folder. A bare `#heading` scrolls
-// to a heading in the current document; a `path` (optionally `path#heading`)
-// resolves to a sibling `.md` file, falling back to a recursive search under
-// the document's directory. Cross-file heading scrolling is not implemented yet
-// (the file just opens).
+// `[[wikilinks]]` and regular `[](dest)` links share one navigation core:
+//   - `#heading`            → scroll to a heading in the current document,
+//   - `path` / `path#head`  → resolve a file under the opened file's directory
+//                             (a direct child, else a recursive search), open
+//                             it, and scroll to the heading if one was named,
+//   - external URL (scheme) → open in the default app (regular links only).
+//
+// Resolution needs only the opened file (its directory), not a vault folder.
+
+/// Implemented by the owning document so a freshly opened document can be
+/// scrolled to a heading after a cross-file link is followed.
+@MainActor
+public protocol HeadingNavigable: AnyObject {
+    func navigateToHeading(_ heading: String)
+}
 
 extension EditorTextView {
+
+    // MARK: Hit testing
 
     /// The wikilink target under a mouse event, or nil if the click doesn't land
     /// on wikilink display text.
@@ -18,37 +29,60 @@ extension EditorTextView {
         return storage.attribute(.editorWikiTarget, at: i, effectiveRange: nil) as? String
     }
 
-    /// Resolves and navigates a wikilink `target` (`path#heading`):
-    ///   - empty path (`#heading`) → scroll to that heading in this document,
-    ///   - a path → open the resolved `.md` file (heading, if any, ignored).
-    func followWikiLink(_ target: String) {
-        let ns = target as NSString
-        let hash = ns.range(of: "#")
-        let path: String
-        let heading: String?
-        if hash.location == NSNotFound {
-            path = target.trimmingCharacters(in: .whitespaces)
-            heading = nil
-        } else {
-            path = ns.substring(to: hash.location).trimmingCharacters(in: .whitespaces)
-            // For subheadings ("H1#H2") target the deepest component.
-            let rest = ns.substring(from: hash.upperBound)
-            heading = rest.split(separator: "#").last.map {
-                $0.trimmingCharacters(in: .whitespaces)
-            } ?? rest.trimmingCharacters(in: .whitespaces)
-        }
+    // MARK: Following
 
+    /// Follows a `[[wikilink]]` target (`path#heading`, no scheme, `.md` implied).
+    func followWikiLink(_ target: String) {
+        let (path, heading) = Self.splitHeading(target)
         if path.isEmpty {
-            if let heading, !heading.isEmpty { scrollToHeading(heading) } else { NSSound.beep() }
+            if let heading { scrollToHeading(heading) } else { NSSound.beep() }
             return
         }
-        guard let fileURL = resolveWikiFile(path) else { NSSound.beep(); return }
-        NSDocumentController.shared.openDocument(withContentsOf: fileURL, display: true) { _, _, _ in }
+        openLinkedFile(path: path, heading: heading)
     }
+
+    /// Follows a regular markdown link destination: an external URL opens in the
+    /// default app; `#heading` scrolls in-document; a local `path#heading`
+    /// resolves a file and opens it (scrolling to the heading if named).
+    func followLinkDestination(_ destination: String) {
+        let dest = destination.trimmingCharacters(in: .whitespaces)
+        if let url = URL(string: dest), let scheme = url.scheme, scheme != "file" {
+            NSWorkspace.shared.open(url)
+            return
+        }
+        // A markdown link destination is URL-encoded (e.g. `%20` for a space),
+        // so decode both the path and the heading anchor.
+        let (rawPath, rawHeading) = Self.splitHeading(dest)
+        let path = rawPath.removingPercentEncoding ?? rawPath
+        let heading = rawHeading.map { $0.removingPercentEncoding ?? $0 }
+        if path.isEmpty {
+            if let heading { scrollToHeading(heading) } else { NSSound.beep() }
+            return
+        }
+        openLinkedFile(path: path, heading: heading)
+    }
+
+    /// Resolves `path` to a file and opens it, scrolling the opened document to
+    /// `heading` when one is named (cross-file, via `HeadingNavigable`).
+    private func openLinkedFile(path: String, heading: String?) {
+        guard let fileURL = resolveLinkedFile(path) else { NSSound.beep(); return }
+        NSDocumentController.shared.openDocument(withContentsOf: fileURL, display: true) { _, _, _ in
+            guard let heading else { return }
+            // Re-find the document by URL on the main actor (the NSDocument
+            // isn't Sendable, so we don't capture it across the boundary). By
+            // now its content has loaded (showWindows → loadContent).
+            Task { @MainActor in
+                let doc = NSDocumentController.shared.document(for: fileURL)
+                (doc as? HeadingNavigable)?.navigateToHeading(heading)
+            }
+        }
+    }
+
+    // MARK: Heading navigation
 
     /// Scrolls to the first heading block whose text matches `heading`
     /// (case-insensitive). Beeps if there is no such heading.
-    func scrollToHeading(_ heading: String) {
+    public func scrollToHeading(_ heading: String) {
         let want = heading.lowercased()
         for block in blocks {
             guard case .heading = block.kind,
@@ -68,10 +102,34 @@ extension EditorTextView {
         return s.trimmingCharacters(in: .whitespaces)
     }
 
-    /// Resolves a wikilink `path` (without `.md`) to a file URL under the
-    /// document's directory: a direct sibling first, else a recursive search by
-    /// filename. Returns nil if the document has no directory or no match.
-    func resolveWikiFile(_ path: String) -> URL? {
+    /// Splits `path#heading` (or `#heading`, or `path`) into a path and the
+    /// deepest heading component (so `Note#H1#H2` targets `H2`). A nil heading
+    /// means none was named.
+    static func splitHeading(_ s: String) -> (path: String, heading: String?) {
+        let ns = s as NSString
+        let hash = ns.range(of: "#")
+        guard hash.location != NSNotFound else {
+            return (s.trimmingCharacters(in: .whitespaces), nil)
+        }
+        let path = ns.substring(to: hash.location).trimmingCharacters(in: .whitespaces)
+        let rest = ns.substring(from: hash.upperBound)
+        let heading = rest.split(separator: "#").last
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .flatMap { $0.isEmpty ? nil : $0 }
+        return (path, heading)
+    }
+
+    // MARK: File resolution
+
+    /// Resolves a link `path` to a file URL. Absolute / `~` / `file:` paths load
+    /// directly; otherwise it resolves under the opened file's directory — a
+    /// direct child first, else a recursive search by filename — appending `.md`
+    /// when the path has no extension (Obsidian-style wikilinks omit it).
+    func resolveLinkedFile(_ path: String) -> URL? {
+        if let url = URL(string: path), url.scheme == "file" { return url }
+        if path.hasPrefix("/") { return URL(fileURLWithPath: path) }
+        if path.hasPrefix("~") { return URL(fileURLWithPath: (path as NSString).expandingTildeInPath) }
+
         guard let docDir = document?.fileURL?.deletingLastPathComponent() else { return nil }
         let fm = FileManager.default
         let rel = (path as NSString).pathExtension.isEmpty ? path + ".md" : path

--- a/Sources/MarkdownEditorCore/EditorTextView.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView.swift
@@ -626,8 +626,8 @@ public class EditorTextView: NSTextView {
                 followWikiLink(target)
                 return
             }
-            if let url = linkURL(at: event) {
-                NSWorkspace.shared.open(url)
+            if let dest = linkDestination(at: event) {
+                followLinkDestination(dest)
                 return
             }
         }
@@ -660,13 +660,12 @@ public class EditorTextView: NSTextView {
         return charIndex < storage.length ? charIndex : nil
     }
 
-    /// The destination URL of the regular link under a mouse event, or nil if
-    /// the click doesn't land directly on link text.
-    private func linkURL(at event: NSEvent) -> URL? {
-        guard let storage = textStorage, let charIndex = clickCharIndex(at: event),
-              let dest = storage.attribute(.editorLinkURL, at: charIndex, effectiveRange: nil) as? String
-        else { return nil }
-        return URL(string: dest)
+    /// The raw destination string of the regular link under a mouse event, or
+    /// nil if the click doesn't land directly on link text. The destination is
+    /// resolved by `followLinkDestination` (external URL, `#heading`, or file).
+    private func linkDestination(at event: NSEvent) -> String? {
+        guard let storage = textStorage, let charIndex = clickCharIndex(at: event) else { return nil }
+        return storage.attribute(.editorLinkURL, at: charIndex, effectiveRange: nil) as? String
     }
 
     // MARK: - Helpers

--- a/Sources/md/Document.swift
+++ b/Sources/md/Document.swift
@@ -7,7 +7,7 @@ import MarkdownEditorCore
 /// recent documents, and more — all for free.
 ///
 /// The actual editing is delegated entirely to `EditorTextView`.
-class Document: NSDocument {
+class Document: NSDocument, HeadingNavigable {
 
     var editor: EditorTextView!
     private var statusBar: StatusBarView!
@@ -196,6 +196,12 @@ class Document: NSDocument {
             pendingContent = nil
         }
         updateStatusBar()
+    }
+
+    /// Cross-file link following: scroll this document's editor to a heading
+    /// once it's on screen (the content has already loaded in showWindows).
+    func navigateToHeading(_ heading: String) {
+        editor?.scrollToHeading(heading)
     }
 
     // MARK: - Rename & Move (manual — NSDocument's built-in versions

--- a/Tests/MarkdownEditorTests/WikiLinkTests.swift
+++ b/Tests/MarkdownEditorTests/WikiLinkTests.swift
@@ -82,9 +82,38 @@ struct WikiLinkTests {
         doc.fileURL = home
         editor.document = doc
 
-        // Obsidian links omit the .md extension.
-        #expect(editor.resolveWikiFile("Target Note")?.standardizedFileURL == target.standardizedFileURL)
-        #expect(editor.resolveWikiFile("Missing Note") == nil)
+        // Obsidian wikilinks omit the .md extension; regular links include it.
+        #expect(editor.resolveLinkedFile("Target Note")?.standardizedFileURL == target.standardizedFileURL)
+        #expect(editor.resolveLinkedFile("Target Note.md")?.standardizedFileURL == target.standardizedFileURL)
+        #expect(editor.resolveLinkedFile("Missing Note") == nil)
+    }
+
+    @Test("splitHeading separates path and the deepest heading component")
+    func splitsHeading() {
+        #expect(EditorTextView.splitHeading("Note#Section").path == "Note")
+        #expect(EditorTextView.splitHeading("Note#Section").heading == "Section")
+        #expect(EditorTextView.splitHeading("Note#H1#H2").heading == "H2")   // deepest
+        #expect(EditorTextView.splitHeading("#OnlyHeading").path == "")
+        #expect(EditorTextView.splitHeading("#OnlyHeading").heading == "OnlyHeading")
+        #expect(EditorTextView.splitHeading("JustAPath").heading == nil)
+    }
+
+    @Test("Regular [](#heading) link scrolls to the heading in this document")
+    func regularAnchorScrolls() {
+        let editor = makeEditor()
+        editor.loadContent("# Top\n\n[jump](#Details)\n\n## Details\n\nbody")
+        editor.followLinkDestination("#Details")
+        let detailsLoc = (editor.rawSource as NSString).range(of: "## Details").location
+        #expect(editor.selectedRange().location == detailsLoc)
+    }
+
+    @Test("Regular link anchor percent-decodes the path")
+    func percentDecodedHeading() {
+        let editor = makeEditor()
+        editor.loadContent("# Top\n\n## My Section\n\nbody")
+        editor.followLinkDestination("#My%20Section")
+        let loc = (editor.rawSource as NSString).range(of: "## My Section").location
+        #expect(editor.selectedRange().location == loc)
     }
 
     @Test("scrollToHeading finds the matching heading block")


### PR DESCRIPTION
## What
Completes link navigation:
- **`#heading` anchors for regular `[](…)` links** — `[text](#heading)` scrolls in-document; `[text](Note.md#heading)` opens the file and scrolls.
- **Cross-file heading scroll for wikilinks** — `[[Note#Heading]]` now opens the file *and* scrolls to the heading (previously it just opened the file).

## How
- One navigation core shared by wikilinks and regular links: external URL → open; `#heading` → scroll in-doc; local `path#heading` → resolve + open + scroll.
- Regular-link destinations are followed as raw strings (percent-decoded) instead of `URL(string:)`, so anchors and local paths resolve.
- Cross-file scrolling is delegated to the opened document via a new `HeadingNavigable` protocol — the core re-finds the document by URL on the main actor (avoids capturing the non-Sendable `NSDocument`) and calls `navigateToHeading`, which `Document` implements by scrolling its editor.
- `resolveLinkedFile` now also handles absolute / `~` / `file:` paths and explicit extensions (regular links include `.md`; wikilinks omit it).

## Tests
`WikiLinkTests` extended (11 total): `splitHeading` parsing incl. deepest subheading, regular `[](#heading)` scroll, percent-decoded anchor, and sibling resolution with/without `.md`. Full suite green (604). App launch + link rendering verified visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)