### PR TITLE
Fix clipped bottoms on inline math and other overlays

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+TextKit2.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+TextKit2.swift
@@ -176,12 +176,19 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
         for (offset, overlay) in overlays {
             guard let rect = overlayRect(anchorOffset: offset, overlay: overlay) else { continue }
             let drawRect = rect.offsetBy(dx: point.x, dy: point.y)
-            let nsContext = NSGraphicsContext(cgContext: context, flipped: true)
-            NSGraphicsContext.saveGraphicsState()
-            NSGraphicsContext.current = nsContext
-            overlay.image.draw(in: drawRect, from: .zero, operation: .sourceOver,
-                               fraction: 1, respectFlipped: true, hints: nil)
-            NSGraphicsContext.restoreGraphicsState()
+            // Draw the CGImage directly with an explicit vertical flip rather
+            // than NSImage.draw(…respectFlipped:) into an NSGraphicsContext wrapper:
+            // that path dropped the bottom of the image in this flipped TextKit 2
+            // context (clipping math descenders / tall-delimiter bottoms).
+            var proposed = drawRect
+            guard let cgImage = overlay.image.cgImage(forProposedRect: &proposed,
+                                                      context: nil, hints: nil) else { continue }
+            context.saveGState()
+            context.translateBy(x: drawRect.minX, y: drawRect.maxY)
+            context.scaleBy(x: 1, y: -1)
+            context.draw(cgImage, in: CGRect(x: 0, y: 0,
+                                             width: drawRect.width, height: drawRect.height))
+            context.restoreGState()
         }
     }
 


### PR DESCRIPTION
## Problem
Inline math had its bottom cropped — descenders (`y`, `p`, `g`) and tall-delimiter bottoms (the parens in `f(x)`, integral signs) were clipped at the text baseline. Even `c`/`x` lost a sliver.

## Cause
Fragment overlays were drawn with `NSImage.draw(…respectFlipped:)` into an `NSGraphicsContext` wrapping the flipped TextKit 2 draw context. In the live on-screen context that path dropped the below-baseline portion of the image. (The generated image and an offscreen render both contained the full glyph — the loss only happened in the live drawing context.)

## Fix
Draw the overlay's `CGImage` directly with an explicit vertical flip (`translate`/`scale` + `context.draw`), which paints the whole image. This path is shared by inline/display math, images, callout headers, list bullets, and checkboxes.

## Verification
Visual, via window capture: math descenders and `f(x)` parens now render fully; checkboxes, bullet, callout header, inline `a²+b²`, and the display-math integral all unchanged. Full suite green (604).

Note: this is a draw-path bug that only reproduces in the live TextKit 2 drawing context — an offscreen `cacheDisplay` render does *not* clip, so it isn't headless-unit-testable. Verified visually instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)