### PR TITLE
Fix inline math clipping and baseline alignment

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+MathRendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+MathRendering.swift
@@ -43,17 +43,35 @@ extension EditorTextView {
         } else {
             let mode: MTMathUILabelMode = display ? .display : .text
             let math = MTMathImage(latex: latex, fontSize: fontSize, textColor: color, labelMode: mode)
+            // SwiftMath sizes the image to the exact typographic ascent+descent,
+            // which crops a glyph's ink overshoot below the baseline — the bottom
+            // of a lone `x`/`c` sits flush on the image edge and renders clipped.
+            // A small content inset gives the rasterizer room so the full glyph is
+            // drawn; it's folded into the descent below so alignment is unchanged.
+            let insetPad: CGFloat = 2
+            math.contentInsets = MTEdgeInsets(top: insetPad, left: 0, bottom: insetPad, right: 0)
             let (error, image) = math.asImage()
             guard error == nil, let image else { return nil }
 
-            // Typeset once more via a label to read the descent (the distance from
-            // the math baseline to the bottom of the image), used for alignment.
+            // Typeset once more via a label to read ascent/descent, then compute
+            // the baseline's distance from the image bottom the way SwiftMath's
+            // asImage does — including its `height < fontSize/2` clamp, which
+            // re-centers small glyphs (a lone x/c/n). Ignoring the clamp left
+            // those a pixel below the surrounding text baseline.
             let label = MTMathUILabel()
             label.latex = latex
             label.fontSize = fontSize
             label.labelMode = mode
             label.layout()
-            let descent = label.displayList?.descent ?? 0
+            let asc = label.displayList?.ascent ?? 0
+            let desc = label.displayList?.descent ?? 0
+            let clamped = max(asc + desc, fontSize / 2)
+            // `baselineCorrection`: the rasterized image's pixel height rounds,
+            // nudging its internal baseline ~½pt down relative to the text
+            // baseline. Lift the image by that much so the math sits on the text
+            // baseline (verified pixel-for-pixel against surrounding glyphs).
+            let baselineCorrection: CGFloat = 0.5
+            let descent = (asc + desc - clamped) / 2 + desc + insetPad - baselineCorrection
 
             render = MathRender(image: image, descent: descent)
             mathRenderCache.setObject(render, forKey: key)

--- a/Sources/MarkdownEditorCore/EditorTextView+TextKit2.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+TextKit2.swift
@@ -176,19 +176,18 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
         for (offset, overlay) in overlays {
             guard let rect = overlayRect(anchorOffset: offset, overlay: overlay) else { continue }
             let drawRect = rect.offsetBy(dx: point.x, dy: point.y)
-            // Draw the CGImage directly with an explicit vertical flip rather
-            // than NSImage.draw(…respectFlipped:) into an NSGraphicsContext wrapper:
-            // that path dropped the bottom of the image in this flipped TextKit 2
-            // context (clipping math descenders / tall-delimiter bottoms).
-            var proposed = drawRect
-            guard let cgImage = overlay.image.cgImage(forProposedRect: &proposed,
-                                                      context: nil, hints: nil) else { continue }
-            context.saveGState()
-            context.translateBy(x: drawRect.minX, y: drawRect.maxY)
-            context.scaleBy(x: 1, y: -1)
-            context.draw(cgImage, in: CGRect(x: 0, y: 0,
-                                             width: drawRect.width, height: drawRect.height))
-            context.restoreGState()
+            // Draw the (resolution-independent) NSImage into the flipped context,
+            // so it rasterizes at the screen's backing scale — crisp on Retina,
+            // and positioned precisely. (Converting to a CGImage first would bake
+            // it at 1×, then upscale: soft, and quantized a pixel low.) The math
+            // image carries a small transparent inset, so the flipped draw can't
+            // clip a descender at the image edge.
+            let nsContext = NSGraphicsContext(cgContext: context, flipped: true)
+            NSGraphicsContext.saveGraphicsState()
+            NSGraphicsContext.current = nsContext
+            overlay.image.draw(in: drawRect, from: .zero, operation: .sourceOver,
+                               fraction: 1, respectFlipped: true, hints: nil)
+            NSGraphicsContext.restoreGraphicsState()
         }
     }
 


### PR DESCRIPTION
## Problem
Inline math was clipped at the bottom and sat a pixel below the surrounding text baseline (obvious on a lone `$x$`/`$c$` vs the `x` inside `$f(x)$`).

## Root causes (three, compounding)
1. **Overshoot crop** — SwiftMath sizes the image to the exact typographic ascent+descent, cropping a glyph's ink overshoot. A lone `x`/`c` sat flush on the image's bottom edge and lost its bottom. → Add a small `contentInsets` so the rasterizer has room (post-hoc padding can't recover cropped pixels).
2. **Small-glyph baseline** — SwiftMath re-centers glyphs shorter than `fontSize/2` (a lone `x`/`c`/`n`); the descent used for placement ignored that clamp, dropping them low. The previous descender fix had masked this by clipping. → Compute the baseline offset the way `asImage` does.
3. **1× rasterization** — #96 drew the overlay via a 1× CGImage then upscaled: soft, and quantized the position a pixel low. → Draw the resolution-independent `NSImage` directly so it rasterizes at the screen's backing scale; the inset from (1) keeps the flipped draw from clipping a descender. A documented `baselineCorrection` (0.5pt) absorbs the residual rasterization rounding.

This supersedes the CGImage draw from #96.

## Verification
Pixel-for-pixel against surrounding glyphs: lone `x`/`c`/`n` bottoms now match the text baseline; descenders `y`/`p`/`g`, `f(x)` parens, the `∑` operator with limits, and display math all render fully and aligned. Checkboxes, bullets, and callout headers (shared draw path) unaffected. 604 tests pass.

Note: `baselineCorrection` is empirical (pixel-measured at the default size); a follow-up will look for a closed-form value that holds when the user changes font/size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)