### PR TITLE
Nested block styling: callouts, quotes, code, and Return-continuation

### DIFF
--- a/Sources/MarkdownEditorCore/EditorTextView+BlockquoteContinuation.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+BlockquoteContinuation.swift
@@ -9,9 +9,11 @@ import AppKit
 
 extension EditorTextView {
 
-    /// Leading indent + `>` + an optional single space, at the start of a line.
+    /// Leading indent + one or more `>` levels (each with an optional single
+    /// space), at the start of a line. Captures the *full* nesting depth so a
+    /// nested callout/quote line `> > …` continues as `> > `, not `> `.
     private static let blockquotePrefixRegex = try! NSRegularExpression(
-        pattern: #"^[ \t]*>[ \t]?"#
+        pattern: #"^[ \t]*(?:>[ \t]?)+"#
     )
 
     /// Continues a block quote / callout on Return. Returns true if it handled
@@ -35,12 +37,23 @@ extension EditorTextView {
         let hasContent = m.range.length < lineNS.length
 
         if hasContent {
-            // Continue the quote: newline + the same `> ` prefix.
+            // Continue the quote/callout at the same depth: newline + same prefix.
             insertText("\n" + prefix, replacementRange: NSRange(location: location, length: 0))
         } else {
-            // Empty quote line → break out by removing the prefix.
-            insertText("", replacementRange: NSRange(location: lineStart, length: lineEnd - lineStart))
+            // Empty quote line → step out one nesting level (drop the last `>`).
+            // At the top level this empties the line, breaking out of the quote.
+            insertText(Self.reduceQuotePrefix(prefix),
+                       replacementRange: NSRange(location: lineStart, length: lineEnd - lineStart))
         }
         return true
+    }
+
+    /// Drops the deepest `>` level from a quote prefix: `> > ` → `> `,
+    /// `  > ` → `  ` (indent kept), `> ` → `` (broken out).
+    static func reduceQuotePrefix(_ prefix: String) -> String {
+        let ns = prefix as NSString
+        let lastGT = ns.range(of: ">", options: .backwards)
+        guard lastGT.location != NSNotFound else { return "" }
+        return ns.substring(to: lastGT.location)
     }
 }

--- a/Sources/MarkdownEditorCore/EditorTextView+CalloutRendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+CalloutRendering.swift
@@ -56,12 +56,13 @@ extension EditorTextView {
         return CalloutInfo(marker: marker, style: style, headerRange: headerRange, title: title)
     }
 
-    /// Applies callout styling. `active` shows the raw marker (dimmed, editable);
-    /// otherwise the header is replaced by an icon + title image.
+    /// Applies callout styling: the box, the icon + title header image, and the
+    /// recursively-rendered body. Only called for an *inactive* callout — when
+    /// the cursor is inside, the caller renders the raw `>` source instead so the
+    /// markers stay editable.
     func styleCalloutContent(_ result: NSMutableAttributedString,
                              span: SyntaxHighlighter.Span,
-                             info: CalloutInfo,
-                             active: Bool) {
+                             info: CalloutInfo) {
         guard span.fullRange.upperBound <= result.length else { return }
         let c = resolvedCalloutColors(info.style)
 
@@ -93,41 +94,190 @@ extension EditorTextView {
         result.addAttribute(.blockDecoration, value: box(bottomPad: calloutBottomPad),
                             range: lastLine)
 
-        let m = info.marker
-        if active {
-            // Editing: dim the raw "[!type]" marker; the custom title (if any)
-            // stays as normal, editable text.
-            let markerFull = NSRange(location: m.openBracket.location,
-                                     length: m.closeBracket.upperBound - m.openBracket.location)
-            if markerFull.upperBound <= result.length {
-                result.addAttribute(.foregroundColor, value: syntaxDimColor, range: markerFull)
+        // End of the header (first) line, before any body lines.
+        let headerNL = ns.range(of: "\n", options: [], range: span.fullRange)
+        let headerLineEnd = headerNL.location == NSNotFound
+            ? span.fullRange.upperBound : headerNL.location
+
+        // Hide the whole header, draw an icon + title image at the first
+        // character via a fragment overlay.
+        let header = info.headerRange
+        if header.length > 0, header.upperBound <= result.length {
+            result.addAttribute(.font, value: hiddenFont, range: header)
+            result.addAttribute(.foregroundColor, value: NSColor.clear, range: header)
+            if let overlay = calloutHeaderOverlay(symbolName: info.style.symbolName,
+                                                  title: info.title, color: c.accent,
+                                                  iconNudge: info.style.iconBaselineNudge) {
+                applyOverlay(overlay, anchor: NSRange(location: header.location, length: 1),
+                             in: result)
+                // Top breathing room: a raised minimum line height on the
+                // header line — still clickable text space, box covers it.
+                let headerLine = NSRange(location: span.fullRange.location,
+                                         length: headerLineEnd - span.fullRange.location)
+                result.addAttribute(
+                    .paragraphStyle,
+                    value: calloutParagraphStyle(minimumLineHeight: overlay.bounds.height + calloutTopPad),
+                    range: headerLine)
             }
-            return
         }
 
-        // Rendered: hide the whole header, draw an icon + title image at the
-        // first character via a fragment overlay.
-        let header = info.headerRange
-        guard header.length > 0, header.upperBound <= result.length else { return }
-        result.addAttribute(.font, value: hiddenFont, range: header)
-        result.addAttribute(.foregroundColor, value: NSColor.clear, range: header)
-        if let overlay = calloutHeaderOverlay(symbolName: info.style.symbolName,
-                                              title: info.title, color: c.accent,
-                                              iconNudge: info.style.iconBaselineNudge) {
-            applyOverlay(overlay, anchor: NSRange(location: header.location, length: 1),
-                         in: result)
-            // Top breathing room: a raised minimum line height on the header
-            // line — still clickable text space, the box covers it.
-            let ns = result.string as NSString
-            let nl = ns.range(of: "\n", options: [], range: span.fullRange)
-            let headerLineEnd = nl.location == NSNotFound ? span.fullRange.upperBound : nl.location
-            let headerLine = NSRange(location: span.fullRange.location,
-                                     length: headerLineEnd - span.fullRange.location)
-            result.addAttribute(
-                .paragraphStyle,
-                value: calloutParagraphStyle(minimumLineHeight: overlay.bounds.height + calloutTopPad),
-                range: headerLine)
+        // Render the body (the lines after the header) recursively: strip one
+        // `>` level, re-style the inner markdown, and splice it back so nested
+        // code/quotes/callouts/lists/etc. render inside the box.
+        renderCalloutBody(result, span: span, headerLineEnd: headerLineEnd)
+    }
+
+    /// Renders a callout's body — every line after the header — by stripping one
+    /// level of `>` prefix, running the full `styleBlock` over the stripped
+    /// inner markdown (which recurses into deeper callouts), and splicing the
+    /// resulting attributes back onto the real characters with the prefixes
+    /// hidden. Nested boxes/bars stack with the outer callout's box.
+    private func renderCalloutBody(_ result: NSMutableAttributedString,
+                                   span: SyntaxHighlighter.Span,
+                                   headerLineEnd: Int) {
+        let end = span.fullRange.upperBound
+        // Body starts after the header line's trailing newline.
+        guard headerLineEnd < end else { return }
+        let bodyStart = headerLineEnd + 1   // skip the `\n`
+        guard bodyStart < end else { return }
+
+        let ns = result.string as NSString
+        let space: unichar = 0x20, gt: unichar = 0x3E, newline: unichar = 0x0A
+
+        // Build the stripped inner markdown (UTF-16 units) with a parallel map
+        // back to real offsets, hide each line's `>` prefix, and remember each
+        // line's real and stripped ranges so we can splice paragraph styles and
+        // decorations per line.
+        var units: [unichar] = []
+        var realIndex: [Int] = []           // stripped UTF-16 offset → real offset
+        var lineMap: [(real: NSRange, stripped: NSRange)] = []
+        var cursor = bodyStart
+        while cursor < end {
+            let lineNL = ns.range(of: "\n", options: [],
+                                  range: NSRange(location: cursor, length: end - cursor))
+            let lineEnd = lineNL.location == NSNotFound ? end : lineNL.location
+
+            // Leading `>` prefix: optional spaces, `>`, optional single space.
+            var p = cursor
+            while p < lineEnd, ns.character(at: p) == space { p += 1 }
+            if p < lineEnd, ns.character(at: p) == gt {
+                p += 1
+                if p < lineEnd, ns.character(at: p) == space { p += 1 }
+            }
+            let prefixLen = p - cursor
+            if prefixLen > 0 {
+                let pr = NSRange(location: cursor, length: prefixLen)
+                result.addAttribute(.font, value: hiddenFont, range: pr)
+                result.addAttribute(.foregroundColor, value: NSColor.clear, range: pr)
+            }
+
+            let sStart = units.count
+            for i in p..<lineEnd { units.append(ns.character(at: i)); realIndex.append(i) }
+            lineMap.append((real: NSRange(location: cursor, length: lineEnd - cursor),
+                            stripped: NSRange(location: sStart, length: units.count - sStart)))
+
+            if lineEnd < end {
+                units.append(newline); realIndex.append(lineEnd)   // keep the `\n`
+                cursor = lineEnd + 1
+            } else {
+                cursor = end
+            }
         }
+        guard !units.isEmpty else { return }
+
+        let stripped = String(utf16CodeUnits: units, count: units.count)
+
+        // Segment the stripped body with BlockParser and style each block on
+        // its own — mirroring the top-level pipeline. This enforces strict
+        // `>`-prefix membership: a line without the deeper prefix is its own
+        // block, so swift-markdown's lazy continuation can't pull a `> ` line
+        // into an adjacent `> > ` callout/quote. The body is only rendered for an
+        // inactive callout (the cursor is elsewhere), so inner blocks render
+        // fully — no cursor reveal needed.
+        let sub = NSMutableAttributedString(string: stripped, attributes: baseAttributes)
+        for b in BlockParser.parse(stripped) {
+            guard b.range.upperBound <= sub.length else { continue }
+            let styled = styleBlock(b.content, cursorPosition: nil)
+            styled.enumerateAttributes(in: NSRange(location: 0, length: styled.length),
+                                       options: []) { attrs, r, _ in
+                sub.setAttributes(attrs,
+                                  range: NSRange(location: r.location + b.range.location, length: r.length))
+            }
+        }
+
+        spliceStyledBody(sub, realIndex: realIndex, lineMap: lineMap, into: result)
+    }
+
+    /// Splices an inner-rendered body (`sub`, in stripped space) back onto the
+    /// real characters. Character attributes are mapped per run (skipping the
+    /// hidden prefixes); paragraph styles and block decorations are applied per
+    /// line, inset/stacked so inner content stays inside the outer box.
+    private func spliceStyledBody(_ sub: NSAttributedString,
+                                  realIndex: [Int],
+                                  lineMap: [(real: NSRange, stripped: NSRange)],
+                                  into result: NSMutableAttributedString) {
+        let step = 2 + quoteMarkerWidth   // one nesting level of horizontal inset
+        let subLen = sub.length
+
+        // Character attributes (everything except paragraph style / decoration),
+        // mapped from stripped offsets to real offsets in coalesced runs.
+        sub.enumerateAttributes(in: NSRange(location: 0, length: subLen), options: []) { attrs, sr, _ in
+            var ca = attrs
+            ca[.paragraphStyle] = nil
+            ca[.blockDecoration] = nil
+            guard !ca.isEmpty else { return }
+            var k = sr.location
+            while k < sr.upperBound {
+                let runStart = realIndex[k]
+                var last = runStart
+                var j = k + 1
+                while j < sr.upperBound, realIndex[j] == last + 1 { last = realIndex[j]; j += 1 }
+                result.addAttributes(ca, range: NSRange(location: runStart, length: last - runStart + 1))
+                k = j
+            }
+        }
+
+        // Paragraph styles and decorations, per body line.
+        for lm in lineMap {
+            let ss = lm.stripped.location
+            guard ss < subLen else { continue }
+
+            // Paragraph style: inset by one level so inner content stays inside
+            // the box; preserve any inner style (list indent, centered math, …).
+            let innerPS = (sub.attribute(.paragraphStyle, at: ss, effectiveRange: nil)
+                as? NSParagraphStyle) ?? bodyParagraphStyle
+            let ps = innerPS.mutableCopy() as! NSMutableParagraphStyle
+            ps.firstLineHeadIndent += step
+            ps.headIndent += step
+            if ps.tailIndent == 0 { ps.tailIndent = -10 }
+            result.addAttribute(.paragraphStyle, value: ps, range: lm.real)
+
+            // Decoration: stack any inner box/bar (inset bumped) under the
+            // outer callout box already present on this line.
+            let innerDeco = sub.attribute(.blockDecoration, at: ss, effectiveRange: nil)
+            let bumped = bumpedDecorations(innerDeco, by: step)
+            if !bumped.isEmpty {
+                var stack: [BlockDecoration] = []
+                if let outer = result.attribute(.blockDecoration, at: lm.real.location,
+                                                effectiveRange: nil) as? BlockDecoration {
+                    stack.append(outer)
+                }
+                stack.append(contentsOf: bumped)
+                result.addAttribute(.blockDecoration, value: BlockDecorationList(stack), range: lm.real)
+            }
+        }
+    }
+
+    /// Returns inner decorations with every `.box` inset increased by `step`
+    /// (so a nested box sits within its parent); other kinds are unchanged.
+    private func bumpedDecorations(_ value: Any?, by step: CGFloat) -> [BlockDecoration] {
+        func bump(_ d: BlockDecoration) -> BlockDecoration {
+            if case .box = d.kind { return BlockDecoration(d.kind, inset: d.inset + step) }
+            return d
+        }
+        if let list = value as? BlockDecorationList { return list.decorations.map(bump) }
+        if let single = value as? BlockDecoration { return [bump(single)] }
+        return []
     }
 
     // MARK: Colors (appearance-aware)

--- a/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+Rendering.swift
@@ -255,9 +255,13 @@ extension EditorTextView {
                 // A block quote whose first line is `[!type]` is a callout
                 // (GitHub-flavored) — render it with an icon, colored label, and
                 // colored bar instead of the plain quote styling.
-                if let callout = calloutInfo(forBlockquote: span, markdown: markdown) {
-                    styleCalloutContent(result, span: span, info: callout, active: cursorInToken)
+                if let callout = calloutInfo(forBlockquote: span, markdown: markdown), !cursorInToken {
+                    styleCalloutContent(result, span: span, info: callout)
                 } else {
+                    // Plain block quote — also the editing form of a callout: when
+                    // the cursor is inside a callout we fall through here so its raw
+                    // `>` / `[!type]` source shows (dimmed) and the markers can be
+                    // edited, instead of the box/header/nested chrome.
                     // Attributes must cover fullRange so the first character of each
                     // paragraph (the `> ` delimiter) carries the style/decoration —
                     // the fragment vendor reads the paragraph's first character.

--- a/Sources/MarkdownEditorCore/EditorTextView+TextKit2.swift
+++ b/Sources/MarkdownEditorCore/EditorTextView+TextKit2.swift
@@ -63,14 +63,21 @@ public final class BlockDecoration: NSObject, @unchecked Sendable {
     }
 
     public let kind: Kind
+    /// Horizontal inset (points) from the text column's left and right edges at
+    /// which a `.box` is drawn. Non-zero for boxes nested inside another box
+    /// (e.g. a callout inside a callout), so the inner box sits within the outer
+    /// one. Ignored by `.leftBar` (which draws relative to the indented text
+    /// origin and so already follows nesting) and the other kinds.
+    public let inset: CGFloat
 
-    public init(_ kind: Kind) {
+    public init(_ kind: Kind, inset: CGFloat = 0) {
         self.kind = kind
+        self.inset = inset
     }
 
     public override func isEqual(_ object: Any?) -> Bool {
         guard let other = object as? BlockDecoration else { return false }
-        return kind == other.kind
+        return kind == other.kind && inset == other.inset
     }
 
     public override var hash: Int {
@@ -81,6 +88,25 @@ public final class BlockDecoration: NSObject, @unchecked Sendable {
         case .horizontalRule: return 4
         }
     }
+}
+
+/// An ordered stack of decorations drawn behind one paragraph, outermost
+/// first. Used when nesting puts more than one box/bar on the same line — e.g.
+/// a callout's outer box plus an inner nested callout's box. A single
+/// decoration still uses a bare `BlockDecoration`; the fragment reads either.
+public final class BlockDecorationList: NSObject, @unchecked Sendable {
+    public let decorations: [BlockDecoration]
+
+    public init(_ decorations: [BlockDecoration]) {
+        self.decorations = decorations
+    }
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? BlockDecorationList else { return false }
+        return decorations == other.decorations
+    }
+
+    public override var hash: Int { decorations.count }
 }
 
 /// An image drawn at a character's laid-out position, with attachment-style
@@ -108,14 +134,15 @@ public final class FragmentOverlay: NSObject, @unchecked Sendable {
 /// text and any `FragmentOverlay` images at their characters' positions.
 final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
 
-    let decoration: BlockDecoration?
+    /// Decorations drawn behind the paragraph, outermost first.
+    let decorations: [BlockDecoration]
     /// Paragraph-relative anchor offsets and their overlays.
     let overlays: [(offset: Int, overlay: FragmentOverlay)]
 
     init(textElement: NSTextElement, range: NSTextRange?,
-         decoration: BlockDecoration?,
+         decorations: [BlockDecoration],
          overlays: [(offset: Int, overlay: FragmentOverlay)]) {
-        self.decoration = decoration
+        self.decorations = decorations
         self.overlays = overlays
         super.init(textElement: textElement, range: range)
     }
@@ -140,9 +167,15 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
     /// the last line, the next block tiles clear of it, and the box (drawn over
     /// the full frame height) covers it. Mirrors how the header's raised
     /// minimumLineHeight makes the top padding clickable text space.
+    ///
+    /// Padding is *summed* across stacked boxes: when a nested callout is the
+    /// last line of its parent, the line needs the nested box's bottom padding
+    /// *and* the parent's below it (see `draw`), so both fit.
     private var boxBottomPad: CGFloat {
-        if case .box(_, _, _, _, let bottomPad)? = decoration?.kind { return bottomPad }
-        return 0
+        decorations.reduce(0) { acc, deco in
+            if case .box(_, _, _, _, let bottomPad) = deco.kind { return acc + bottomPad }
+            return acc
+        }
     }
 
     override var layoutFragmentFrame: CGRect {
@@ -154,7 +187,7 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
     override var renderingSurfaceBounds: CGRect {
         var bounds = super.renderingSurfaceBounds
         let frame = layoutFragmentFrame
-        if decoration != nil {
+        if !decorations.isEmpty {
             bounds = bounds.union(CGRect(x: containerLeft - 4, y: 0,
                                          width: containerWidth + 8, height: frame.height))
         }
@@ -168,8 +201,17 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
 
     override func draw(at point: CGPoint, in context: CGContext) {
         context.saveGState()
-        if let decoration {
-            drawDecoration(decoration, at: point, in: context)
+        // Decorations are stacked outermost-first. Each box stops short of the
+        // fragment bottom by the padding of the boxes drawn before it, so an
+        // outer box's bottom padding stays visible *below* an inner nested box
+        // (e.g. the parent callout's padding under a nested callout) instead of
+        // being covered by it.
+        var precedingBottomPad: CGFloat = 0
+        for decoration in decorations {
+            drawDecoration(decoration, at: point, in: context, bottomInset: precedingBottomPad)
+            if case .box(_, _, _, _, let bottomPad) = decoration.kind {
+                precedingBottomPad += bottomPad
+            }
         }
         context.restoreGState()
         super.draw(at: point, in: context)
@@ -208,7 +250,8 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
                       height: overlay.bounds.height)
     }
 
-    private func drawDecoration(_ decoration: BlockDecoration, at point: CGPoint, in context: CGContext) {
+    private func drawDecoration(_ decoration: BlockDecoration, at point: CGPoint,
+                                in context: CGContext, bottomInset: CGFloat = 0) {
         let frame = layoutFragmentFrame
         // Fragment-local rect spanning the full text column for this fragment.
         let columnRect = CGRect(x: point.x + containerLeft, y: point.y,
@@ -217,7 +260,14 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
         switch decoration.kind {
         case .box(let background, let borderColor, let edges, let borderWidth, _):
             // The fragment frame already includes any box bottomPad (see
-            // layoutFragmentFrame), so columnRect covers the padded area.
+            // layoutFragmentFrame), so columnRect covers the padded area. A
+            // nested box insets symmetrically so it sits within its parent box,
+            // and stops `bottomInset` short of the frame bottom so the enclosing
+            // box's padding shows below it.
+            var columnRect = decoration.inset > 0
+                ? columnRect.insetBy(dx: decoration.inset, dy: 0)
+                : columnRect
+            columnRect.size.height -= bottomInset
             context.setFillColor(background.cgColor)
             context.fill(columnRect)
             if let borderColor, !edges.isEmpty {
@@ -288,8 +338,15 @@ extension EditorTextView: NSTextLayoutManagerDelegate {
                                         range: textElement.elementRange)
         }
         let str = paragraph.attributedString
-        let decoration = str.attribute(.blockDecoration, at: 0,
-                                       effectiveRange: nil) as? BlockDecoration
+        let decoValue = str.attribute(.blockDecoration, at: 0, effectiveRange: nil)
+        let decorations: [BlockDecoration]
+        if let list = decoValue as? BlockDecorationList {
+            decorations = list.decorations
+        } else if let single = decoValue as? BlockDecoration {
+            decorations = [single]
+        } else {
+            decorations = []
+        }
         var overlays: [(offset: Int, overlay: FragmentOverlay)] = []
         str.enumerateAttribute(.fragmentOverlay,
                                in: NSRange(location: 0, length: str.length),
@@ -298,13 +355,13 @@ extension EditorTextView: NSTextLayoutManagerDelegate {
                 overlays.append((range.location, overlay))
             }
         }
-        guard decoration != nil || !overlays.isEmpty else {
+        guard !decorations.isEmpty || !overlays.isEmpty else {
             return NSTextLayoutFragment(textElement: textElement,
                                         range: textElement.elementRange)
         }
         return DecoratedTextLayoutFragment(textElement: textElement,
                                            range: textElement.elementRange,
-                                           decoration: decoration,
+                                           decorations: decorations,
                                            overlays: overlays)
     }
 }

--- a/Sources/MarkdownEditorCore/SyntaxHighlighter+Walker.swift
+++ b/Sources/MarkdownEditorCore/SyntaxHighlighter+Walker.swift
@@ -21,6 +21,12 @@ extension SyntaxHighlighter {
         private var insideEmphasis = false
         private var insideStrong = false
         private var insideOrderedList = false
+        /// >0 while walking inside a *plain* block quote. Nested block-level
+        /// constructs (code blocks, headings, lists, tables, rules, nested
+        /// quotes) are left literal there — only inline emphasis renders.
+        /// Callouts are not walked at all (their bodies are rendered
+        /// recursively by the styling layer), so this never counts them.
+        private var plainQuoteDepth = 0
 
         init(source: String) {
             self.source = source
@@ -129,6 +135,7 @@ extension SyntaxHighlighter {
         // MARK: - Visitors
 
         mutating func visitHeading(_ heading: Heading) {
+            if plainQuoteDepth > 0 { return }   // literal inside a plain quote
             guard let range = heading.range else { return }
             let full = nsRange(for: range)
             let delimLen = heading.level + 1
@@ -272,6 +279,7 @@ extension SyntaxHighlighter {
         // MARK: - Code Blocks
 
         mutating func visitCodeBlock(_ codeBlock: CodeBlock) {
+            if plainQuoteDepth > 0 { return }   // literal inside a plain quote
             guard let range = codeBlock.range else { return }
             let full = nsRange(for: range)
             guard full.length > 0 else { return }
@@ -382,6 +390,10 @@ extension SyntaxHighlighter {
         // MARK: - Block Quotes
 
         mutating func visitBlockQuote(_ blockQuote: BlockQuote) {
+            // A block quote nested inside a plain block quote is fully literal:
+            // emit no span and don't descend (matches showing `> [!note]` raw
+            // inside an outer quote).
+            if plainQuoteDepth > 0 { return }
             guard let range = blockQuote.range else {
                 descendInto(blockQuote)
                 return
@@ -419,12 +431,36 @@ extension SyntaxHighlighter {
                 contentRange: content,
                 delimiterRanges: delims
             ))
+
+            // A callout's body is rendered recursively by the styling layer
+            // (which strips the `>` prefixes and re-parses), so don't descend —
+            // doing so would emit nested spans over `>`-prefixed source ranges.
+            // A plain quote descends, but with a depth guard so only its inline
+            // content renders (nested blocks stay literal).
+            if Self.quoteOpensCallout(firstLineOf: full, in: nsSource) { return }
+            plainQuoteDepth += 1
             descendInto(blockQuote)
+            plainQuoteDepth -= 1
+        }
+
+        /// Whether the first line of a block quote (its source `range`) opens a
+        /// callout — `> [!type]` (known or unknown type). Mirrors
+        /// `BlockParser.quoteRunOpensCallout` over an NSRange.
+        private static func quoteOpensCallout(firstLineOf range: NSRange, in source: NSString) -> Bool {
+            let bound = NSRange(location: range.location, length: range.length)
+            let nl = source.range(of: "\n", options: [], range: bound)
+            let lineEnd = nl.location == NSNotFound ? range.upperBound : nl.location
+            let line = source.substring(with: NSRange(location: range.location,
+                                                      length: lineEnd - range.location))
+            let trimmed = line.drop(while: { $0 == " " })
+            guard trimmed.first == ">" else { return false }
+            return Callout.parseMarker(String(trimmed.dropFirst())) != nil
         }
 
         // MARK: - Tables
 
         mutating func visitTable(_ table: Table) {
+            if plainQuoteDepth > 0 { return }   // literal inside a plain quote
             guard let range = table.range else {
                 descendInto(table)
                 return
@@ -469,12 +505,14 @@ extension SyntaxHighlighter {
         // MARK: - Lists
 
         mutating func visitOrderedList(_ orderedList: OrderedList) {
+            if plainQuoteDepth > 0 { return }   // literal inside a plain quote
             insideOrderedList = true
             descendInto(orderedList)
             insideOrderedList = false
         }
 
         mutating func visitListItem(_ listItem: ListItem) {
+            if plainQuoteDepth > 0 { return }   // literal inside a plain quote
             guard let range = listItem.range else {
                 descendInto(listItem)
                 return
@@ -553,6 +591,7 @@ extension SyntaxHighlighter {
         // MARK: - Thematic Break
 
         mutating func visitThematicBreak(_ thematicBreak: ThematicBreak) {
+            if plainQuoteDepth > 0 { return }   // literal inside a plain quote
             guard let range = thematicBreak.range else { return }
             let full = nsRange(for: range)
 

--- a/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
+++ b/Sources/MarkdownEditorCore/SyntaxHighlighter.swift
@@ -107,7 +107,38 @@ public enum SyntaxHighlighter {
             }
         }
 
+        // A callout's body is rendered recursively by the styling layer (it
+        // strips the `>` prefixes and re-parses the inner markdown), so drop any
+        // other span the custom parsers placed inside a callout — keeping it
+        // would double-style the body. Plain block quotes are unaffected: their
+        // inline spans are intentionally kept.
+        let calloutRanges: [NSRange] = walker.spans.compactMap { span in
+            guard case .blockquote = span.kind,
+                  isCalloutFirstLine(of: span.fullRange, in: text) else { return nil }
+            return span.fullRange
+        }
+        if !calloutRanges.isEmpty {
+            walker.spans.removeAll { span in
+                if case .blockquote = span.kind { return false }
+                return calloutRanges.contains {
+                    $0.location <= span.fullRange.location && $0.upperBound >= span.fullRange.upperBound
+                }
+            }
+        }
+
         return walker.spans.sorted { $0.fullRange.location < $1.fullRange.location }
+    }
+
+    /// Whether the first line of `range` in `text` opens a callout (`> [!type]`).
+    private static func isCalloutFirstLine(of range: NSRange, in text: String) -> Bool {
+        let ns = text as NSString
+        let nl = ns.range(of: "\n", options: [], range: range)
+        let lineEnd = nl.location == NSNotFound ? range.upperBound : nl.location
+        let line = ns.substring(with: NSRange(location: range.location,
+                                              length: lineEnd - range.location))
+        let trimmed = line.drop(while: { $0 == " " })
+        guard trimmed.first == ">" else { return false }
+        return Callout.parseMarker(String(trimmed.dropFirst())) != nil
     }
 
 }

--- a/Tests/MarkdownEditorTests/BlockquoteContinuationTests.swift
+++ b/Tests/MarkdownEditorTests/BlockquoteContinuationTests.swift
@@ -58,4 +58,39 @@ struct BlockquoteContinuationTests {
         editor.insertNewline(nil)
         #expect(editor.rawSource == "  > note\n  > ")
     }
+
+    @Test("A nested callout line continues at its depth ('> > ')")
+    @MainActor func continueNestedCallout() {
+        let editor = makeEditor()
+        editor.loadContent("> [!note] Note\n> > tip body")
+        editor.setSelectedRange(NSRange(location: (editor.rawSource as NSString).length, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "> [!note] Note\n> > tip body\n> > ")
+    }
+
+    @Test("A nested plain quote line continues at its depth ('> > ')")
+    @MainActor func continueNestedQuote() {
+        let editor = makeEditor()
+        editor.loadContent("> outer\n> > inner")
+        editor.setSelectedRange(NSRange(location: (editor.rawSource as NSString).length, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "> outer\n> > inner\n> > ")
+    }
+
+    @Test("Enter on an empty nested line steps out one level")
+    @MainActor func stepOutOneLevel() {
+        let editor = makeEditor()
+        editor.loadContent("> [!note]\n> > body\n> > ")
+        editor.setSelectedRange(NSRange(location: (editor.rawSource as NSString).length, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "> [!note]\n> > body\n> ")
+    }
+
+    @Test("reduceQuotePrefix drops the deepest level")
+    @MainActor func reduceQuotePrefix() {
+        #expect(EditorTextView.reduceQuotePrefix("> > ") == "> ")
+        #expect(EditorTextView.reduceQuotePrefix("> ") == "")
+        #expect(EditorTextView.reduceQuotePrefix("  > > ") == "  > ")
+        #expect(EditorTextView.reduceQuotePrefix("  > ") == "  ")
+    }
 }

--- a/Tests/MarkdownEditorTests/EditorRenderingTests.swift
+++ b/Tests/MarkdownEditorTests/EditorRenderingTests.swift
@@ -862,8 +862,8 @@ struct QuoteCalloutHangingIndentTests {
         #expect(abs(hang - editor.quoteMarkerWidth) < 0.5)
     }
 
-    @Test("Callout body lines hang after the marker")
-    @MainActor func calloutHangingIndent() {
+    @Test("Callout body lines are inset one marker width, first and wrapped aligned")
+    @MainActor func calloutBodyIndent() {
         let editor = makeEditor()
         let styled = editor.styleBlock("> [!note]\n> body text")
         // Inspect the body line's paragraph style (after the header newline).
@@ -871,7 +871,12 @@ struct QuoteCalloutHangingIndentTests {
         let bodyLoc = ns.range(of: "\n").location + 1
         let ps = styled.attribute(.paragraphStyle, at: bodyLoc, effectiveRange: nil) as? NSParagraphStyle
         #expect(ps != nil)
-        let hang = (ps?.headIndent ?? 0) - (ps?.firstLineHeadIndent ?? 0)
-        #expect(abs(hang - editor.quoteMarkerWidth) < 0.5)
+        // The callout body is rendered recursively with the `>` prefix hidden
+        // (zero width), so the inset is uniform: content begins one marker width
+        // (plus the 2pt bar inset) into the box, and wrapped lines align with
+        // the first line rather than hanging.
+        let step = 2 + editor.quoteMarkerWidth
+        #expect(abs((ps?.firstLineHeadIndent ?? 0) - step) < 0.5)
+        #expect(abs((ps?.headIndent ?? 0) - (ps?.firstLineHeadIndent ?? 0)) < 0.5)
     }
 }

--- a/Tests/MarkdownEditorTests/NestedBlockStylingTests.swift
+++ b/Tests/MarkdownEditorTests/NestedBlockStylingTests.swift
@@ -1,0 +1,242 @@
+import Testing
+import AppKit
+@testable import MarkdownEditorCore
+
+// Nested block styling: containers decide whether their nested *blocks* render.
+//   - Code block  → literal (covered elsewhere; CodeBlock never descends).
+//   - Plain quote → nested blocks literal; inline still renders.
+//   - Callout     → everything renders (recursive sub-render).
+
+private func isMonospaced(_ f: NSFont?) -> Bool {
+    f?.fontDescriptor.symbolicTraits.contains(.monoSpace) ?? false
+}
+
+private func isBold(_ f: NSFont?) -> Bool {
+    guard let f else { return false }
+    return NSFontManager.shared.traits(of: f).contains(.boldFontMask)
+}
+
+private func decorationList(at offset: Int, in s: NSAttributedString) -> BlockDecorationList? {
+    guard offset < s.length else { return nil }
+    return s.attribute(.blockDecoration, at: offset, effectiveRange: nil) as? BlockDecorationList
+}
+
+@Suite("Nested — plain block quote keeps nested blocks literal")
+@MainActor
+struct PlainQuoteNestedTests {
+
+    @Test("Inline emphasis inside a quote still renders")
+    func inlineStillRenders() {
+        let s = makeEditor().styleBlock("> **important** text")
+        let loc = (s.string as NSString).range(of: "important").location
+        #expect(isBold(s.attribute(.font, at: loc, effectiveRange: nil) as? NSFont))
+    }
+
+    @Test("A fenced code block inside a quote stays literal (not monospaced)")
+    func nestedCodeLiteral() {
+        let s = makeEditor().styleBlock("> intro\n> ```swift\n> let x = 1\n> ```")
+        let loc = (s.string as NSString).range(of: "let x").location
+        #expect(!isMonospaced(s.attribute(.font, at: loc, effectiveRange: nil) as? NSFont))
+    }
+
+    @Test("A list item inside a quote stays literal (no bullet overlay, marker visible)")
+    func nestedListLiteral() {
+        let s = makeEditor().styleBlock("> intro\n> - item")
+        let ns = s.string as NSString
+        // No list bullet/overlay is emitted anywhere in the block.
+        var hasOverlay = false
+        s.enumerateAttribute(.fragmentOverlay, in: NSRange(location: 0, length: s.length),
+                             options: []) { v, _, stop in if v != nil { hasOverlay = true; stop.pointee = true } }
+        #expect(!hasOverlay)
+        // The raw "-" marker is still visible text, not a hidden marker.
+        let dash = ns.range(of: "- item").location
+        #expect(!isHidden(at: dash, in: s))
+    }
+
+    @Test("A heading inside a quote stays literal (not enlarged/bold)")
+    func nestedHeadingLiteral() {
+        let s = makeEditor().styleBlock("> intro\n> # Heading")
+        let loc = (s.string as NSString).range(of: "Heading").location
+        let f = s.attribute(.font, at: loc, effectiveRange: nil) as? NSFont
+        #expect(!isBold(f))
+    }
+}
+
+@Suite("Nested — callout renders inner blocks")
+@MainActor
+struct CalloutNestedTests {
+
+    @Test("A code block inside a callout renders (closing fence detected, monospaced)")
+    func codeInCallout() {
+        let s = makeEditor().styleBlock(
+            "> [!note] Note\n> Body\n> ```python\n> def f():\n>     pass\n> ```")
+        let ns = s.string as NSString
+        #expect(isMonospaced(s.attribute(.font, at: ns.range(of: "def f").location,
+                                         effectiveRange: nil) as? NSFont))
+        // The closing fence must be recognized: `pass` is inside the code, also mono.
+        #expect(isMonospaced(s.attribute(.font, at: ns.range(of: "pass").location,
+                                         effectiveRange: nil) as? NSFont))
+    }
+
+    @Test("A plain block quote inside a callout draws a left bar inside the box")
+    func quoteInCallout() {
+        let s = makeEditor().styleBlock("> [!note] Note\n> > quoted line\n> > more")
+        let loc = (s.string as NSString).range(of: "quoted line").location
+        let list = decorationList(at: loc, in: s)
+        #expect(list != nil)
+        // Outer callout box plus the inner quote's left bar.
+        #expect(list?.decorations.contains { if case .box = $0.kind { return true }; return false } == true)
+        #expect(list?.decorations.contains { if case .leftBar = $0.kind { return true }; return false } == true)
+    }
+
+    @Test("A callout inside a callout stacks two boxes, the inner one inset")
+    func calloutInCallout() {
+        let editor = makeEditor()
+        let s = editor.styleBlock("> [!note] Outer\n> > [!tip] Inner\n> > tip body")
+        let loc = (s.string as NSString).range(of: "tip body").location
+        let list = decorationList(at: loc, in: s)
+        #expect(list != nil)
+        let boxes = list?.decorations.filter { if case .box = $0.kind { return true }; return false } ?? []
+        #expect(boxes.count == 2)
+        // Outermost box at inset 0, inner box inset by one marker step.
+        #expect(boxes.first?.inset == 0)
+        #expect((boxes.last?.inset ?? 0) > 0)
+    }
+
+    @Test("A nested callout at the parent's last line keeps both boxes' bottom padding")
+    func nestedBottomPadding() {
+        // The last line carries the inner Tip box *and* the outer Note box, each
+        // with its own bottomPad, so the drawing can show the Tip's padding and
+        // then the Note's padding below it (summed frame growth).
+        let s = makeEditor().styleBlock("> [!note] Note\n> Hello\n> > [!tip] Tip\n> > nested")
+        let loc = (s.string as NSString).range(of: "nested").location
+        let list = s.attribute(.blockDecoration, at: loc, effectiveRange: nil) as? BlockDecorationList
+        #expect(list != nil)
+        let pads = (list?.decorations ?? []).compactMap { d -> CGFloat? in
+            if case .box(_, _, _, _, let bp) = d.kind { return bp }
+            return nil
+        }
+        #expect(pads.count == 2)
+        #expect(pads.allSatisfy { $0 > 0 })
+    }
+
+    @Test("A checklist inside a callout renders its checkbox as an overlay")
+    func checklistInCallout() {
+        let s = makeEditor().styleBlock("> [!note] Note\n> - [ ] task")
+        var hasOverlay = false
+        s.enumerateAttribute(.fragmentOverlay, in: NSRange(location: 0, length: s.length),
+                             options: []) { v, _, stop in if v != nil { hasOverlay = true; stop.pointee = true } }
+        #expect(hasOverlay)
+    }
+
+    @Test("A table inside a callout renders table-row chrome")
+    func tableInCallout() {
+        let s = makeEditor().styleBlock(
+            "> [!note] Note\n> | a | b |\n> | --- | --- |\n> | 1 | 2 |")
+        let loc = (s.string as NSString).range(of: "1").location
+        let list = decorationList(at: loc, in: s)
+        #expect(list?.decorations.contains {
+            if case .tableRow = $0.kind { return true }; return false
+        } == true)
+    }
+
+    @Test("Display math inside a callout renders an overlay image")
+    func mathInCallout() {
+        let s = makeEditor().styleBlock("> [!note] Note\n> $$x^2$$")
+        var hasOverlay = false
+        s.enumerateAttribute(.fragmentOverlay, in: NSRange(location: 0, length: s.length),
+                             options: []) { v, _, stop in if v != nil { hasOverlay = true; stop.pointee = true } }
+        #expect(hasOverlay)
+    }
+
+    @Test("An active callout shows raw '>' source for editing (no box, no overlay)")
+    func activeCalloutShowsRawSource() {
+        let editor = makeEditor()
+        // cursorPosition inside the callout → editing form: raw `>` visible
+        // (dimmed), no box decoration, no header overlay.
+        let s = editor.styleBlock("> [!note] Note\n> body\n> > [!tip] Tip\n> > tip body",
+                                  cursorPosition: 3)
+        // No callout box anywhere.
+        var hasBox = false
+        s.enumerateAttribute(.blockDecoration, in: NSRange(location: 0, length: s.length),
+                             options: []) { v, _, stop in
+            let kinds = (v as? BlockDecorationList)?.decorations ?? [v as? BlockDecoration].compactMap { $0 }
+            if kinds.contains(where: { if case .box = $0.kind { return true }; return false }) {
+                hasBox = true; stop.pointee = true
+            }
+        }
+        #expect(!hasBox)
+        // No header overlay (icon/title image).
+        var hasOverlay = false
+        s.enumerateAttribute(.fragmentOverlay, in: NSRange(location: 0, length: s.length),
+                             options: []) { v, _, stop in if v != nil { hasOverlay = true; stop.pointee = true } }
+        #expect(!hasOverlay)
+        // The leading `>` of the active callout is visible (dimmed), not hidden.
+        #expect(!isHidden(at: 0, in: s))
+        // The `[!note]` marker text is present and visible (editable).
+        let bracket = (s.string as NSString).range(of: "[!note]").location
+        #expect(!isHidden(at: bracket, in: s))
+    }
+
+    @Test("A heading inside a callout renders (bold/enlarged)")
+    func headingRendersInCallout() {
+        let editor = makeEditor()
+        let s = editor.styleBlock("> [!note] Note\n> # Inside\n> body")
+        let f = s.attribute(.font, at: (s.string as NSString).range(of: "Inside").location,
+                            effectiveRange: nil) as? NSFont
+        #expect(isBold(f))
+        #expect((f?.pointSize ?? 0) > editor.bodyFont.pointSize)
+    }
+
+    @Test("Strict membership: a single-'>' line is not part of a '> >' nested callout")
+    func nestedMembershipStrict() {
+        // `> note body` carries one `>`, so it belongs to the Note, not the Tip
+        // (which needs `> >`). It must render with only the Note box.
+        let s = makeEditor().styleBlock("> [!note] Note\n> > [!tip] Tip\n> note body")
+        let loc = (s.string as NSString).range(of: "note body").location
+        let deco = s.attribute(.blockDecoration, at: loc, effectiveRange: nil)
+        // A single decoration (the Note box) — not a stack that includes the Tip box.
+        if let list = deco as? BlockDecorationList {
+            #expect(list.decorations.count == 1)
+        } else {
+            #expect(deco is BlockDecoration)
+        }
+    }
+
+    @Test("A heading inside a callout is NOT a document heading")
+    func headingInCalloutNotDocumentHeading() {
+        let editor = makeEditor()
+        editor.loadContent("intro\n\n> [!note] Note\n> # Inside\n> body\n\n## After")
+        editor.setSelectedRange(NSRange(location: 2, length: 0))
+        editor.scrollToHeading("Inside")        // not a real heading block
+        #expect(editor.selectedRange().location == 2)   // caret unmoved
+        // A genuine top-level heading is still found.
+        editor.scrollToHeading("After")
+        let after = (editor.rawSource as NSString).range(of: "## After").location
+        #expect(editor.selectedRange().location == after)
+    }
+}
+
+@Suite("Nested — decoration model")
+struct DecorationModelTests {
+
+    private func box(inset: CGFloat) -> BlockDecoration {
+        BlockDecoration(.box(background: .clear, borderColor: nil,
+                             borderEdges: [], borderWidth: 0, bottomPad: 0), inset: inset)
+    }
+
+    @Test("Box inset participates in equality")
+    func boxInsetEquality() {
+        #expect(box(inset: 0) == box(inset: 0))
+        #expect(box(inset: 0) != box(inset: 5))
+    }
+
+    @Test("BlockDecorationList compares its decorations by value")
+    func listEquality() {
+        let a = BlockDecorationList([box(inset: 0), box(inset: 5)])
+        let b = BlockDecorationList([box(inset: 0), box(inset: 5)])
+        let c = BlockDecorationList([box(inset: 0)])
+        #expect(a == b)
+        #expect(a != c)
+    }
+}

--- a/Tests/MarkdownEditorTests/RecomposeTests.swift
+++ b/Tests/MarkdownEditorTests/RecomposeTests.swift
@@ -17,7 +17,10 @@ struct RecomposeTests {
     @Test("Removing a callout marker clears the stale background on its former body")
     @MainActor func unmergeCalloutClearsBody() {
         let editor = makeEditor()
-        editor.loadContent("> [!note]\n> body line")
+        // A trailing block to park the cursor on, so the callout is *inactive*
+        // and renders its box (an active callout shows raw source, no box).
+        editor.loadContent("> [!note]\n> body line\n\ntrailer")
+        activateBlock(editor.blocks.count - 1, in: editor)
         // Sanity: the body line starts out with the callout background.
         let ts = editor.textStorage!
         #expect(calloutBackground(ts, at: (editor.rawSource as NSString).range(of: "body").location) != nil)
@@ -28,6 +31,7 @@ struct RecomposeTests {
         editor.setSelectedRange(NSRange(location: mk.location, length: 0))
         editor.insertText("", replacementRange: mk)
 
+        activateBlock(editor.blocks.count - 1, in: editor)
         let bodyLoc = (editor.textStorage!.string as NSString).range(of: "body").location
         #expect(calloutBackground(editor.textStorage!, at: bodyLoc) == nil)
     }
@@ -35,14 +39,16 @@ struct RecomposeTests {
     @Test("Adding a callout marker styles the lines it absorbs")
     @MainActor func mergeCalloutStylesAbsorbed() {
         let editor = makeEditor()
-        // Two plain quote lines (separate blocks, no callout background).
-        editor.loadContent(">\n> absorbed")
+        // Two plain quote lines (separate blocks, no callout background), plus a
+        // trailing block to park the cursor on so the callout renders inactive.
+        editor.loadContent(">\n> absorbed\n\ntrailer")
         // Type the marker into the first line, making it a callout opener that
         // merges the second line in.
         let firstLineEnd = 1  // after ">"
         editor.setSelectedRange(NSRange(location: firstLineEnd, length: 0))
         editor.insertText(" [!note]", replacementRange: NSRange(location: firstLineEnd, length: 0))
 
+        activateBlock(editor.blocks.count - 1, in: editor)
         let ts = editor.textStorage!
         let absorbed = (ts.string as NSString).range(of: "absorbed").location
         #expect(calloutBackground(ts, at: absorbed) != nil)


### PR DESCRIPTION
Renders block constructs differently based on their container, matching Obsidian, and makes callouts editable/continuable.

## Behavior
- **Code block** → contents literal (unchanged).
- **Plain block quote** → nested *blocks* (code, lists, headings, nested quotes/callouts) stay literal text; inline emphasis still renders.
- **Callout** → everything renders inside the box: code blocks, nested quotes (bar inside box), **nested callouts (inset, stacked boxes)**, headings, lists/checkboxes, tables, display math, images.
- **Heading in a callout** renders but is never a document heading (ready for a future outline).
- **Strict `>`-prefix membership**: a single-`>` line is not pulled into a `> >` nested callout/quote.
- **Editing a callout**: when the cursor is inside, it shows raw `>` source (dimmed, editable) instead of the rendered chrome — Obsidian-style.
- **Return-continuation**: Return inside a nested callout/quote repeats the full `>`-chain (`> > `); Return on an empty line steps out one level.

## Implementation
1. **Decoration model** — `BlockDecorationList` (stacked decorations, drawn outermost-first), a box `inset` for nesting, and summed bottom padding so a parent callout keeps its padding *below* a nested callout.
2. **Rendering** — walker `plainQuoteDepth` guard (plain quotes inline-only); callout bodies rendered recursively via `BlockParser` segmentation + attribute splice with `>` prefixes hidden.
3. **Continuation** — full-depth `>`-chain prefix on Return, step-out on empty.

## Tests
625 pass. New: `NestedBlockStylingTests` (every nested case + decoration model + active-editing + nested bottom-padding), plus nested Return-continuation and strict-membership tests; updated two recompose tests to probe the callout box from an inactive state.

## Verification
Verified light + dark via offscreen render: rendered callouts (nested boxes, code, quote bar), the raw-source editing state, strict membership, and the nested-callout bottom-padding fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)