### PR TITLE
Fix LaTeX-render crash: embed SwiftMath font bundle in the .app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,11 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .build
-          key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
-          restore-keys: spm-${{ runner.os }}-
+          # v2: the repo was renamed md -> Edmund, which changed the checkout
+          # path and invalidated absolute paths baked into the cached module
+          # cache. Bump this token to discard any pre-rename .build cache.
+          key: spm-v2-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: spm-v2-${{ runner.os }}-
 
       - name: Test
         run: swift test

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ DerivedData/
 # Misc
 .DS_Store
 CLAUDE.md
+misc/

--- a/README.md
+++ b/README.md
@@ -1,22 +1,28 @@
 # Edmund
 
+> [!tip] Guidelines for Build and Contributing coming soon!
+
 Edmund is a native, lightweight macOS markdown editor with Live Preview. 
 
 - **Requirements**: macOS Sonoma 14 or later
 - **Website**: [https://i7t5.com/edmund](https://i7t5.com/edmund)
 
-
 ## Features
 
-- Lightweight and fast
-- Keyboard-first
-- Always offline
-- Native UI/UX
-- Open source and free
+- **Live Preview**: Render as you type. Hides delimiters outside active token / block. Pseudo-WYSIWYG. 
+- **Lightweight and fast**: App size ~5 MB. Lazy rendering via TextKit 2. Minimal dependencies. 
+- **Keyboard-first**: Essential buttons only. Configurable keyboard shortcuts. 
+- **Powerful and compatible**: 
+  - Follows [cmark-gfm](https://github.com/github/cmark-gfm) standards through Apple's official [swift-markdown](https://github.com/swiftlang/swift-markdown). 
+  - Supports ==highlights==, [[WikiLinks]], footnotes `[^1]`, code blocks with syntax highlighting, as well as Obsidian-flavored comments and callouts through custom parser. 
+  - Renders both inline and display math in LaTex using [SwiftMath](https://github.com/mgriebling/SwiftMath). 
+- **Native UI/UX**: Respects Apple design guidelines. AppKit + SwiftUI. 
+- **Secure and private**: Always offline. Network connection required for software updates only. 
+- **Open and free**: MIT License. Free of charge. 
 
 ## Roadmap
 
-See [here](LINK TBD). 
+See [ROADMAP.md](ROADMAP.md). 
 
 ## Dependencies
 
@@ -28,17 +34,17 @@ See [here](LINK TBD).
 - Obsidian, Notion, etc. 
 - Typora
 - [MarkText](https://marktext.me)
+- [Nodes](https://nodes-web.com)
 - [Scratch](https://github.com/erictli/scratch)
 - [editxr](https://github.com/pixdeo/editxr)
-- [Nodes](https://nodes-web.com)
 
 ## Motivation and credits
 
-I wanted to create the [CotEditor](https://coteditor.com) for Markdown editors. See this blog post for more design philosophy and behind-the-scenes. 
+I wanted to create an open source alternative to Typora that would be the [CotEditor](https://coteditor.com) of Markdown editors. See this [blog post](link TBD) for more design philosophy and behind-the-scenes. 
 
 The following have greatly influenced my architecture and/or design choices. I owe them many thanks:  
 
-- [Swift Markdown Engine](https://github.com/nodes-app/swift-markdown-engine) for the rendering mechanism and the TextKit 2 integration
+- [Swift Markdown Engine](https://github.com/nodes-app/swift-markdown-engine) / [Nodes](https://nodes-web.com) for the parser/token architecture and the TextKit 2 integration
 - [Typora](https://typora.io) for menu bar item organization
 - [Tomorrow Light](https://github.com/chriskempson/tomorrow-theme) and [One Dark](https://github.com/atom/atom/tree/master/packages/one-dark-syntax) for code syntax highlighting
 

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -24,6 +24,17 @@ cp ".build/release/${EXECUTABLE}" "${BUNDLE}/Contents/MacOS/${EXECUTABLE}"
 cp Info.plist "${BUNDLE}/Contents/"
 cp Resources/AppIcon.icns "${BUNDLE}/Contents/Resources/AppIcon.icns"
 
+# SwiftPM dependencies that ship resources (SwiftMath's math fonts) emit a
+# per-target bundle next to the binary. SwiftMath's generated Bundle.module
+# accessor looks for it at Bundle.main.bundleURL — i.e. the .app root — and only
+# otherwise at a hardcoded absolute .build path that doesn't exist once the app is
+# installed. Copy the bundle into the .app root so it's self-contained; without
+# this the app crashes the moment it renders any LaTeX.
+echo "Copying SwiftPM resource bundles..."
+for bundle in .build/release/*.bundle; do
+    [ -e "$bundle" ] && cp -R "$bundle" "${BUNDLE}/"
+done
+
 # Compile the asset catalog so the app's AccentColor (our brown) is available.
 # macOS uses it only when the user's system accent is "Multicolor"; a specific
 # system accent still wins, which is the behavior we want.


### PR DESCRIPTION
## The crash

Opening any document containing LaTeX crashed the app with `EXC_BREAKPOINT` (SIGTRAP). Both crash reports bottom out at the same place:

```
EditorTextView.mathOverlay
  → MTMathImage.init → MTFontManager.font(withName:size:)
    → MTFont.fontBundle.getter → NSBundle.module → _assertionFailure
```

SwiftMath loads its math fonts via `Bundle.module`. The generated accessor checks two locations only: the `.app` root (`Bundle.main.bundleURL`) and a **hardcoded absolute path into the dev `.build` directory**. `build-app.sh` never copied the bundle into the `.app`, so the installed app relied entirely on that dev path — which doesn't exist on a clean machine, and pointed at the pre-rename `md_edit/…` folder in stale builds. First LaTeX render → `fatalError`.

## The fix

`build-app.sh` now copies every `.build/release/*.bundle` into the `.app` root, where the accessor looks first. The app is self-contained and no longer depends on the dev `.build` folder.

Verified by hiding the dev `.build` bundle and confirming the app still opens a math document without crashing — it uses the embedded copy.

## Also included

A second commit with docs/housekeeping: expanded README feature list + credits, roadmap link, and `misc/` added to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)