### PR TITLE
Fix undo/redo viewport jump + center off-screen edits; invalidate layout after lazy drain

### DIFF
--- a/Sources/EdmundCore/TextView/EditorTextView+Composition.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+Composition.swift
@@ -167,7 +167,7 @@ extension EditorTextView {
     }
 
     /// Maps a block's raw NSRange to an `NSTextRange` for layout invalidation.
-    private func blockTextRange(_ nsRange: NSRange, _ tlm: NSTextLayoutManager) -> NSTextRange? {
+    func blockTextRange(_ nsRange: NSRange, _ tlm: NSTextLayoutManager) -> NSTextRange? {
         guard let start = tlm.location(tlm.documentRange.location, offsetBy: nsRange.location),
               let end = tlm.location(start, offsetBy: nsRange.length) else { return nil }
         return NSTextRange(location: start, end: end)

--- a/Sources/EdmundCore/TextView/EditorTextView+LazyStyling.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+LazyStyling.swift
@@ -43,6 +43,14 @@ extension EditorTextView {
         let nsString = ts.string as NSString
         let cursor = selectedRange().location
         var remaining = false
+        // Blocks restyled this slice need their TextKit 2 layout invalidated
+        // afterward: restyling is attribute-only, and TextKit 2 doesn't
+        // re-measure a fragment's geometry (height, first-line indent) for an
+        // attribute-only change — so a deferred block whose styled height differs
+        // from its base/estimated height would otherwise keep a stale fragment,
+        // leaving an empty band on screen. `recomposeDirty` invalidates its
+        // synchronously-styled blocks for the same reason.
+        var restyled = IndexSet()
         // Explicit pool: styling churns through transient images/attributed
         // strings, and a caller may run many slices without a run-loop turn.
         autoreleasepool {
@@ -61,6 +69,7 @@ extension EditorTextView {
                         ? max(0, cursor - blocks[idx].range.location) : nil
                     restyleBlock(idx, cursorInBlock: cursorInBlock)
                     blocks[idx].isStyled = true
+                    restyled.insert(idx)
                     let sep = blocks[idx].range.upperBound
                     if sep < nsString.length && nsString.character(at: sep) == 0x0A {
                         ts.setAttributes(baseAttributes, range: NSRange(location: sep, length: 1))
@@ -76,6 +85,14 @@ extension EditorTextView {
             }
             drainCursor = idx
             ts.endEditing()
+        }
+
+        if let tlm = textLayoutManager {
+            for idx in restyled where idx < blocks.count {
+                if let range = blockTextRange(blocks[idx].range, tlm) {
+                    tlm.invalidateLayout(for: range)
+                }
+            }
         }
         isUpdating = false
 

--- a/Sources/EdmundCore/TextView/EditorTextView+TypewriterScroll.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+TypewriterScroll.swift
@@ -56,11 +56,26 @@ extension EditorTextView {
     }
 
     /// Scrolls the view so the cursor's line fragment is vertically centered
-    /// in the visible area.
+    /// in the visible area — but only in typewriter mode.
     func scrollCursorToCenter() {
         guard typewriterModeEnabled else { return }
-        guard let scrollView = enclosingScrollView,
-              let lineRect = caretLineRect() else { return }
+        centerViewportOnCaret()
+    }
+
+    /// Scrolls the view so the caret's line fragment is vertically centered in
+    /// the visible area, regardless of typewriter mode. Used by typewriter
+    /// centering and by undo/redo when the restored edit is off-screen.
+    ///
+    /// The caret's geometry must be laid out for real first — a TextKit 2
+    /// estimate for an off-screen caret would center on the wrong place (or not
+    /// move at all). When the caret is too far from the viewport to lay out
+    /// cheaply, fall back to a plain reveal rather than risk a huge layout.
+    func centerViewportOnCaret() {
+        guard let scrollView = enclosingScrollView else { return }
+        guard ensureCaretRegionLaidOut() else {
+            scrollRangeToVisible(selectedRange()); return
+        }
+        guard let lineRect = caretLineRect() else { return }
         let cursorY = lineRect.midY + textContainerOrigin.y
 
         let visibleHeight = scrollView.contentView.bounds.height
@@ -70,6 +85,49 @@ extension EditorTextView {
 
         scrollView.contentView.scroll(to: NSPoint(x: 0, y: clampedY))
         scrollView.reflectScrolledClipView(scrollView.contentView)
+    }
+
+    /// Lays out the span between the current viewport and the caret so the
+    /// caret's line geometry is real rather than a TextKit 2 estimate. Returns
+    /// false when that span is too large to lay out cheaply (the caller should
+    /// fall back to a plain reveal) — this is the guard that keeps a deep caret
+    /// in a 1–2 MB document from triggering the process-killing full-document
+    /// layout that motivated the rest of this file.
+    @discardableResult
+    func ensureCaretRegionLaidOut() -> Bool {
+        guard let tlm = textLayoutManager else { return false }
+        let caretOffset = selectedRange().location
+        tlm.textViewportLayoutController.layoutViewport()
+
+        let lo: Int, hi: Int
+        if let vp = tlm.textViewportLayoutController.viewportRange {
+            let vpStart = tlm.offset(from: tlm.documentRange.location, to: vp.location)
+            let vpEnd = tlm.offset(from: tlm.documentRange.location, to: vp.endLocation)
+            lo = min(vpStart, caretOffset); hi = max(vpEnd, caretOffset)
+        } else {
+            // No viewport yet (first layout): lay out from the document start.
+            lo = 0; hi = caretOffset
+        }
+
+        let cap = 60_000   // ~a few screenfuls; bounds the layout cost
+        guard hi - lo <= cap,
+              let a = tlm.location(tlm.documentRange.location, offsetBy: max(0, lo)),
+              let b = tlm.location(tlm.documentRange.location, offsetBy: hi),
+              let range = NSTextRange(location: a, end: b) else { return false }
+        tlm.ensureLayout(for: range)
+        return true
+    }
+
+    /// Whether the caret's line fragment lies within the viewport defined by
+    /// `origin` (a clip-view bounds origin), in view coordinates.
+    func caretIsVisible(forViewportOrigin origin: CGPoint) -> Bool {
+        guard let scrollView = enclosingScrollView,
+              let lineRect = caretLineRect() else { return false }
+        let visible = CGRect(origin: origin, size: scrollView.contentView.bounds.size)
+        let caretInView = CGRect(x: visible.minX,
+                                 y: lineRect.minY + textContainerOrigin.y,
+                                 width: 1, height: lineRect.height)
+        return visible.intersects(caretInView)
     }
 
     /// The caret line's rect in text-container coordinates (TextKit 2: lays

--- a/Sources/EdmundCore/TextView/EditorTextView+Undo.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+Undo.swift
@@ -58,7 +58,34 @@ extension EditorTextView {
         rawSource = snapshot.rawSource
         rebuildListIndentState()
         blocks = BlockParser.parse(rawSource, previous: blocks)
-        recompose(cursorInRaw: snapshot.cursorInRaw)
+
+        // Drive the viewport deliberately so undo/redo doesn't lurch.
+        if typewriterModeEnabled {
+            // Typewriter: the caret is always centered, so re-center on it.
+            recompose(cursorInRaw: snapshot.cursorInRaw)
+            centerViewportOnCaret()
+        } else if let scrollView = enclosingScrollView {
+            // Remember exactly where the viewport was, recompose, then: if the
+            // restored caret (the change being undone) is already on screen,
+            // hold the viewport perfectly still — no measured-delta nudge, so no
+            // residual jump. Only when the edit is off-screen do we scroll, and
+            // then we put the caret at the exact vertical center.
+            let savedOrigin = scrollView.contentView.bounds.origin
+            recompose(cursorInRaw: snapshot.cursorInRaw)
+            // Lay out the caret's real geometry before deciding visible-vs-center,
+            // otherwise an off-screen caret's estimated position can look "visible"
+            // and the viewport wrongly holds instead of centering.
+            ensureCaretRegionLaidOut()
+            if caretIsVisible(forViewportOrigin: savedOrigin) {
+                scrollView.contentView.scroll(to: savedOrigin)
+                scrollView.reflectScrolledClipView(scrollView.contentView)
+            } else {
+                centerViewportOnCaret()
+            }
+        } else {
+            recompose(cursorInRaw: snapshot.cursorInRaw)
+        }
+
         isUndoRedoing = false
         lastEditType = .other
         lastEditBlockIndex = nil


### PR DESCRIPTION
First of four branches addressing reported editor bugs.

## Undo/redo viewport jump
`restoreSnapshot` recomposed without managing the viewport, so the re-render's height change lurched the content on every undo/redo. Now:
- **Edit on screen** → viewport held exactly still (saved scroll origin restored; no measured-delta nudge, so no residual jump).
- **Edit off screen** → caret scrolled to the exact vertical center.

Centering (`centerViewportOnCaret`) first lays out the bounded viewport↔caret span (`ensureCaretRegionLaidOut`) so it measures the caret's real geometry instead of a TextKit 2 estimate — the estimate was why an off-screen undo failed to move. The span is capped so a deep caret in a large document falls back to a plain reveal rather than a process-killing full-document layout.

## Invalidate layout after the lazy drain
`drainStylingSlice` restyled deferred blocks but never invalidated their TextKit 2 layout, while `recomposeDirty` does (an attribute-only restyle doesn't re-measure fragment geometry). A deferred block whose styled height differed from its estimate could keep a stale fragment — an empty band on screen (the "delete jump"). Now mirrors `recomposeDirty` and invalidates each drained block's layout.

## Verification
- `swift build` green; `swift test` — all 625 pass.
- Undo/redo viewport behavior confirmed in the running app (on-screen hold-still + off-screen center-on-caret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)