### PR TITLE
Wrap long callout titles; rename content-width setting

### DIFF
--- a/Sources/EdmundCore/Rendering/EditorTextView+CalloutRendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+CalloutRendering.swift
@@ -16,10 +16,16 @@ extension EditorTextView {
     struct CalloutInfo {
         let marker: Callout.Marker
         let style: CalloutStyle
-        /// `[ '[' … end-of-first-line )` — replaced by the icon+title image.
+        /// `[ '[' … end-of-first-line )` — the marker plus any custom title.
         let headerRange: NSRange
         /// Capitalized type name, or the custom title if the header has one.
         let title: String
+        /// When the header carries a custom title, the source range of that
+        /// title text (leading whitespace trimmed). Rendered as real, wrapping
+        /// text so a long title wraps inside the box instead of clipping. `nil`
+        /// for a default callout, whose synthesized type name isn't in the
+        /// source and stays a compact icon+name overlay.
+        let customTitleRange: NSRange?
     }
 
     /// Returns callout info if `span` (a `.blockquote`) begins with a known
@@ -53,7 +59,17 @@ extension EditorTextView {
         let headerRange = NSRange(location: marker.openBracket.location,
                                   length: lineEnd - marker.openBracket.location)
 
-        return CalloutInfo(marker: marker, style: style, headerRange: headerRange, title: title)
+        // A custom title is the real source text after `]` (leading spaces
+        // skipped). Rendered as live wrapping text; absent → default callout.
+        var customTitleRange: NSRange?
+        if !customRaw.trimmingCharacters(in: .whitespaces).isEmpty {
+            var s = titleStart
+            while s < lineEnd, ns.character(at: s) == 0x20 { s += 1 }
+            customTitleRange = NSRange(location: s, length: lineEnd - s)
+        }
+
+        return CalloutInfo(marker: marker, style: style, headerRange: headerRange,
+                           title: title, customTitleRange: customTitleRange)
     }
 
     /// Applies callout styling: the box, the icon + title header image, and the
@@ -99,25 +115,69 @@ extension EditorTextView {
         let headerLineEnd = headerNL.location == NSNotFound
             ? span.fullRange.upperBound : headerNL.location
 
-        // Hide the whole header, draw an icon + title image at the first
-        // character via a fragment overlay.
         let header = info.headerRange
+        let headerLine = NSRange(location: span.fullRange.location,
+                                 length: headerLineEnd - span.fullRange.location)
         if header.length > 0, header.upperBound <= result.length {
-            result.addAttribute(.font, value: hiddenFont, range: header)
-            result.addAttribute(.foregroundColor, value: NSColor.clear, range: header)
-            if let overlay = calloutHeaderOverlay(symbolName: info.style.symbolName,
-                                                  title: info.title, color: c.accent,
-                                                  iconNudge: info.style.iconBaselineNudge) {
-                applyOverlay(overlay, anchor: NSRange(location: header.location, length: 1),
-                             in: result)
-                // Top breathing room: a raised minimum line height on the
-                // header line — still clickable text space, box covers it.
-                let headerLine = NSRange(location: span.fullRange.location,
-                                         length: headerLineEnd - span.fullRange.location)
-                result.addAttribute(
-                    .paragraphStyle,
-                    value: calloutParagraphStyle(minimumLineHeight: overlay.bounds.height + calloutTopPad),
-                    range: headerLine)
+            if let titleRange = info.customTitleRange, titleRange.upperBound <= result.length {
+                // Custom title: hide only the `[!type]` marker (plus the leading
+                // space), keep the title as real bold + tinted text so it WRAPS
+                // inside the box. An icon overlay sits in the indent to its left.
+                let markerHide = NSRange(location: header.location,
+                                         length: titleRange.location - header.location)
+                if markerHide.length > 0 {
+                    result.addAttribute(.font, value: hiddenFont, range: markerHide)
+                    result.addAttribute(.foregroundColor, value: NSColor.clear, range: markerHide)
+                }
+                let titleFont = NSFontManager.shared.convert(bodyFont, toHaveTrait: .boldFontMask)
+                result.addAttribute(.font, value: titleFont, range: titleRange)
+                result.addAttribute(.foregroundColor, value: c.accent, range: titleRange)
+
+                if let (overlay, lead) = calloutIconOverlay(symbolName: info.style.symbolName,
+                                                            color: c.accent,
+                                                            iconNudge: info.style.iconBaselineNudge) {
+                    // Anchor the icon WITHOUT applyOverlay's kern: the icon is
+                    // drawn in the indent margin to the left (bounds.minX), so it
+                    // must not reserve inline advance — kern would push the title
+                    // text right and misalign it from the wrapped lines. The
+                    // anchor char is already hidden by `markerHide` above.
+                    result.addAttribute(.fragmentOverlay, value: overlay,
+                                        range: NSRange(location: header.location, length: 1))
+                    // Title starts past the icon; wrapped title lines align under
+                    // the title (hanging indent at the same lead) — never under
+                    // the icon, like a list item's wrapped lines. The title keeps
+                    // its normal (near-single) line height; the top breathing room
+                    // sits above the first line only, via paragraphSpacingBefore,
+                    // which the box covers.
+                    // The first line carries the width-preserved `> ` marker
+                    // before the (zero-width hidden) `[!type]`, so its title text
+                    // starts `quoteMarkerWidth` past firstLineHeadIndent. Wrapped
+                    // lines have no marker, so headIndent adds that width to align
+                    // them under the title — never under the icon.
+                    let ps = NSMutableParagraphStyle()
+                    ps.lineSpacing = bodyParagraphStyle.lineSpacing
+                    ps.firstLineHeadIndent = lead
+                    ps.headIndent = lead + quoteMarkerWidth
+                    ps.tailIndent = -10
+                    ps.paragraphSpacingBefore = calloutTopPad
+                    result.addAttribute(.paragraphStyle, value: ps, range: headerLine)
+                }
+            } else {
+                // Default title (synthesized type name, not in the source, and
+                // short enough never to wrap): hide the whole header and draw the
+                // icon + name as one compact overlay image.
+                result.addAttribute(.font, value: hiddenFont, range: header)
+                result.addAttribute(.foregroundColor, value: NSColor.clear, range: header)
+                if let overlay = calloutHeaderOverlay(symbolName: info.style.symbolName,
+                                                      title: info.title, color: c.accent,
+                                                      iconNudge: info.style.iconBaselineNudge) {
+                    applyOverlay(overlay, anchor: NSRange(location: header.location, length: 1),
+                                 in: result)
+                    result.addAttribute(
+                        .paragraphStyle,
+                        value: calloutParagraphStyle(minimumLineHeight: overlay.bounds.height + calloutTopPad),
+                        range: headerLine)
+                }
             }
         }
 
@@ -336,6 +396,39 @@ extension EditorTextView {
     }
 
     // MARK: Header image (icon + title)
+
+    /// An icon-only overlay for a custom-title callout, plus the head indent the
+    /// title text should sit at (just past the icon). The overlay is offset to
+    /// the LEFT of its anchor (the hidden marker, laid out at `lead`) so the icon
+    /// lands at the callout's left padding while the real title text wraps
+    /// beneath itself at `lead`. Returns `nil` if the symbol can't resolve.
+    private func calloutIconOverlay(symbolName: String, color: NSColor,
+                                    iconNudge: CGFloat) -> (overlay: FragmentOverlay, lead: CGFloat)? {
+        let pointSize = bodyFont.pointSize
+        let symConfig = NSImage.SymbolConfiguration(pointSize: pointSize, weight: .semibold)
+            .applying(NSImage.SymbolConfiguration(paletteColors: [color]))
+        guard let symbol = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?
+            .withSymbolConfiguration(symConfig) else { return nil }
+
+        let titleFont = NSFontManager.shared.convert(bodyFont, toHaveTrait: .boldFontMask)
+        let gap = pointSize * 0.3
+        let symW = symbol.size.width, symH = symbol.size.height
+        let contentHeight = ceil(max(symH, titleFont.ascender - titleFont.descender))
+
+        let image = NSImage(size: NSSize(width: symW, height: contentHeight), flipped: false) { _ in
+            // Center the icon on the title's cap height (matches the header image).
+            let baseline = abs(titleFont.descender)
+            let capCenter = baseline + titleFont.capHeight / 2
+            symbol.draw(in: NSRect(x: 0, y: capCenter - symH / 2 + iconNudge, width: symW, height: symH))
+            return true
+        }
+
+        let lead = 2 + symW + gap
+        let overlay = FragmentOverlay(image: image,
+                                      bounds: CGRect(x: -(symW + gap), y: -pointSize * 0.15,
+                                                     width: symW, height: contentHeight))
+        return (overlay, lead)
+    }
 
     /// Draws "icon  Title" into one image, tinted to the callout color, and
     /// wraps it in a `FragmentOverlay`. Returns `nil` if the SF Symbol can't

--- a/Sources/edmd/Settings/AppearanceSettingsView.swift
+++ b/Sources/edmd/Settings/AppearanceSettingsView.swift
@@ -26,14 +26,14 @@ struct AppearanceSettingsView: View {
             }
 
             GridRow {
-                Text("Content width:")
+                Text("Max content width:")
                     .gridColumnAlignment(.trailing)
                 HStack(spacing: 8) {
                     Slider(value: $contentWidth, in: 0...1)
                         .frame(width: 200)
                     Text("\(Int((contentWidth * 100).rounded()))%")
                         .monospacedDigit()
-                        .frame(width: 36, alignment: .trailing)
+                        .frame(width: 48, alignment: .trailing)
                 }
                 .onChange(of: contentWidth) { applyContentWidthToOpenDocuments() }
             }

--- a/Tests/EdmundTests/CalloutRenderingTests.swift
+++ b/Tests/EdmundTests/CalloutRenderingTests.swift
@@ -90,14 +90,43 @@ struct CalloutRenderingTests {
         #expect(boxDecoration(blockDecoration(at: bodyIdx, in: styled)) != nil)
     }
 
-    @Test("Custom title text is hidden (drawn in the header image)")
-    @MainActor func customTitleHidden() {
+    @Test("Custom title renders as live bold, tinted text (so it can wrap)")
+    @MainActor func customTitleVisible() {
         let editor = makeEditor()
         let styled = editor.styleBlock("> [!note] My Title\n> body")
-        // "My Title" (after the marker) is part of the hidden header.
-        let r = (styled.string as NSString).range(of: "My Title")
+        let s = styled.string as NSString
+        let r = s.range(of: "My Title")
         #expect(r.location != NSNotFound)
-        #expect(isHidden(at: r.location, in: styled))
+        // No longer baked into a fixed-width image — it's real text that wraps.
+        #expect(!isHidden(at: r.location, in: styled))
+        let f = styled.attribute(.font, at: r.location, effectiveRange: nil) as? NSFont
+        #expect(f?.fontDescriptor.symbolicTraits.contains(.bold) == true)
+        let color = styled.attribute(.foregroundColor, at: r.location, effectiveRange: nil) as? NSColor
+        #expect(color != nil && color != .clear && color != .textColor)
+        // The `[!note]` marker before the title is still hidden.
+        let marker = s.range(of: "[!note]")
+        #expect(isHidden(at: marker.location, in: styled))
+    }
+
+    @Test("A long custom title wraps to multiple lines instead of clipping")
+    @MainActor func longCustomTitleWraps() {
+        let editor = makeEditor()   // ~500pt container
+        let longTitle = "Does the title of callouts wrap around when the window "
+            + "is too small to fit it on a single line of text"
+        editor.loadContent("> [!question] \(longTitle)\n> body\n")
+        ensureFullLayout(editor)
+
+        let off = (editor.rawSource as NSString).range(of: "Does the title").location
+        #expect(off != NSNotFound)
+        guard let tlm = editor.textLayoutManager,
+              let loc = tlm.location(tlm.documentRange.location, offsetBy: off),
+              let frag = tlm.textLayoutFragment(for: loc) else {
+            Issue.record("no header fragment"); return
+        }
+        // Real wrapping text → the header paragraph lays out on 2+ line fragments.
+        // (The old fixed-width title image was a single non-wrapping line.)
+        #expect(frag.textLineFragments.count >= 2,
+                "expected the title to wrap, got \(frag.textLineFragments.count) line(s)")
     }
 
     @Test("Style overrides change the bar color and border edges")


### PR DESCRIPTION
Branch 4 of four — the callout title-wrap fix plus the deferred content-width settings polish.

## Callout title wrapping
A long custom callout title was baked into a fixed-width image and clipped at the window edge. It's now rendered as real bold, tinted text that **wraps inside the box**:
- Only the `[!type]` marker is hidden; the title is live text.
- The icon is an overlay drawn in the indent margin to the title's left, anchored without `applyOverlay`'s kern (kern reserved inline advance and pushed the first line right of the wrapped lines).
- The first line aligns with the icon; wrapped lines hang **under the title, not under the icon** (like a list); near-single line height with top breathing room above the first line.
- Default callouts (synthesized type name, never long) keep the compact icon+name overlay.

Verified in-app: a long `[!question]` title wraps to 3 aligned lines inside the box; default/short callouts unchanged.

## Content-width settings polish
- Renamed **"Content width" → "Max content width"**.
- Widened the percentage label so "100%" no longer truncates (it was nudging the window height).

`swift test` — all 633 pass (incl. callout title tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)