### PR TITLE
Wrap long custom callout titles (drop the type icon)

### DIFF
--- a/Sources/EdmundCore/Rendering/EditorTextView+CalloutRendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+CalloutRendering.swift
@@ -120,9 +120,17 @@ extension EditorTextView {
                                  length: headerLineEnd - span.fullRange.location)
         if header.length > 0, header.upperBound <= result.length {
             if let titleRange = info.customTitleRange, titleRange.upperBound <= result.length {
-                // Custom title: hide only the `[!type]` marker (plus the leading
-                // space), keep the title as real bold + tinted text so it WRAPS
-                // inside the box. An icon overlay sits in the indent to its left.
+                // Custom title: hide the `[!type]` marker and render the title as
+                // real bold + tinted text so a long title WRAPS inside the box.
+                //
+                // NOTE: custom-title callouts deliberately have NO type icon.
+                // The icon is an image, and drawing an image on this (potentially
+                // multi-line, wrapping) header line wedges TextKit 2's layout to a
+                // single line — clipping the title. Every way of drawing it was
+                // tried and hit the same wall; see
+                // docs/callout-title-wrap-investigation.md. Default callouts (the
+                // `else` below) keep their icon: their synthesized type name is
+                // short and never wraps, so it stays a single-line image overlay.
                 let markerHide = NSRange(location: header.location,
                                          length: titleRange.location - header.location)
                 if markerHide.length > 0 {
@@ -133,35 +141,19 @@ extension EditorTextView {
                 result.addAttribute(.font, value: titleFont, range: titleRange)
                 result.addAttribute(.foregroundColor, value: c.accent, range: titleRange)
 
-                if let (overlay, lead) = calloutIconOverlay(symbolName: info.style.symbolName,
-                                                            color: c.accent,
-                                                            iconNudge: info.style.iconBaselineNudge) {
-                    // Anchor the icon WITHOUT applyOverlay's kern: the icon is
-                    // drawn in the indent margin to the left (bounds.minX), so it
-                    // must not reserve inline advance — kern would push the title
-                    // text right and misalign it from the wrapped lines. The
-                    // anchor char is already hidden by `markerHide` above.
-                    result.addAttribute(.fragmentOverlay, value: overlay,
-                                        range: NSRange(location: header.location, length: 1))
-                    // Title starts past the icon; wrapped title lines align under
-                    // the title (hanging indent at the same lead) — never under
-                    // the icon, like a list item's wrapped lines. The title keeps
-                    // its normal (near-single) line height; the top breathing room
-                    // sits above the first line only, via paragraphSpacingBefore,
-                    // which the box covers.
-                    // The first line carries the width-preserved `> ` marker
-                    // before the (zero-width hidden) `[!type]`, so its title text
-                    // starts `quoteMarkerWidth` past firstLineHeadIndent. Wrapped
-                    // lines have no marker, so headIndent adds that width to align
-                    // them under the title — never under the icon.
-                    let ps = NSMutableParagraphStyle()
-                    ps.lineSpacing = bodyParagraphStyle.lineSpacing
-                    ps.firstLineHeadIndent = lead
-                    ps.headIndent = lead + quoteMarkerWidth
-                    ps.tailIndent = -10
-                    ps.paragraphSpacingBefore = calloutTopPad
-                    result.addAttribute(.paragraphStyle, value: ps, range: headerLine)
-                }
+                // The title sits at the callout's left padding. The first line
+                // carries the width-preserved `> ` marker before the (hidden)
+                // `[!type]`, so its text starts `quoteMarkerWidth` past the inset;
+                // headIndent adds that width so wrapped lines align under the
+                // title. Top breathing room is above the first line only (the box
+                // covers it).
+                let ps = NSMutableParagraphStyle()
+                ps.lineSpacing = bodyParagraphStyle.lineSpacing
+                ps.firstLineHeadIndent = 2
+                ps.headIndent = 2 + quoteMarkerWidth
+                ps.tailIndent = -10
+                ps.paragraphSpacingBefore = calloutTopPad
+                result.addAttribute(.paragraphStyle, value: ps, range: headerLine)
             } else {
                 // Default title (synthesized type name, not in the source, and
                 // short enough never to wrap): hide the whole header and draw the
@@ -396,39 +388,6 @@ extension EditorTextView {
     }
 
     // MARK: Header image (icon + title)
-
-    /// An icon-only overlay for a custom-title callout, plus the head indent the
-    /// title text should sit at (just past the icon). The overlay is offset to
-    /// the LEFT of its anchor (the hidden marker, laid out at `lead`) so the icon
-    /// lands at the callout's left padding while the real title text wraps
-    /// beneath itself at `lead`. Returns `nil` if the symbol can't resolve.
-    private func calloutIconOverlay(symbolName: String, color: NSColor,
-                                    iconNudge: CGFloat) -> (overlay: FragmentOverlay, lead: CGFloat)? {
-        let pointSize = bodyFont.pointSize
-        let symConfig = NSImage.SymbolConfiguration(pointSize: pointSize, weight: .semibold)
-            .applying(NSImage.SymbolConfiguration(paletteColors: [color]))
-        guard let symbol = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?
-            .withSymbolConfiguration(symConfig) else { return nil }
-
-        let titleFont = NSFontManager.shared.convert(bodyFont, toHaveTrait: .boldFontMask)
-        let gap = pointSize * 0.3
-        let symW = symbol.size.width, symH = symbol.size.height
-        let contentHeight = ceil(max(symH, titleFont.ascender - titleFont.descender))
-
-        let image = NSImage(size: NSSize(width: symW, height: contentHeight), flipped: false) { _ in
-            // Center the icon on the title's cap height (matches the header image).
-            let baseline = abs(titleFont.descender)
-            let capCenter = baseline + titleFont.capHeight / 2
-            symbol.draw(in: NSRect(x: 0, y: capCenter - symH / 2 + iconNudge, width: symW, height: symH))
-            return true
-        }
-
-        let lead = 2 + symW + gap
-        let overlay = FragmentOverlay(image: image,
-                                      bounds: CGRect(x: -(symW + gap), y: -pointSize * 0.15,
-                                                     width: symW, height: contentHeight))
-        return (overlay, lead)
-    }
 
     /// Draws "icon  Title" into one image, tinted to the callout color, and
     /// wraps it in a `FragmentOverlay`. Returns `nil` if the SF Symbol can't

--- a/docs/callout-title-wrap-investigation.md
+++ b/docs/callout-title-wrap-investigation.md
@@ -1,0 +1,83 @@
+# Callout title wrapping — investigation notes
+
+Context for anyone revisiting how custom callout titles are rendered. This
+captures a long investigation so it doesn't have to be repeated.
+
+## Goal
+
+A callout's header is `> [!type] Optional custom title`. We wanted a **custom**
+title to (1) render as **real, literal text** (bold + tinted), (2) **wrap**
+inside the box when the window is narrow, and (3) show the type **icon** to its
+left.
+
+Default callouts (no custom title) show a synthesized type name ("Note", "Tip")
+that isn't in the source, so it must stay an image/overlay.
+
+## The hard constraint
+
+The text storage must always equal `rawSource` (the whole edit pipeline depends
+on it). So we can't inject characters, and — per the TextKit 2 notes in
+`EditorTextView+TextKit2.swift` — we can't use `NSTextAttachment` for the icon
+(TextKit 2 only honors attachments on U+FFFC, which `rawSource` never contains).
+The icon therefore has to be drawn as an **image** at the hidden marker's
+position, like `.fragmentOverlay` does for math / bullets / the default header.
+
+## The blocker (root cause)
+
+**Drawing any image on a multi-line layout fragment wedges that fragment's
+layout to a single line**, clipping the wrapped title. A TextKit 2 reentrancy
+quirk: putting an image on screen for that line re-triggers a layout pass that
+collapses the wrapping text to one line.
+
+Isolated exhaustively — the title clips when, and only when, the icon image
+reaches the screen, by **every** mechanism tried:
+
+| Approach | Result |
+| --- | --- |
+| Icon as `.fragmentOverlay`, drawn by the layout fragment | CLIP |
+| Icon kept out of `overlays` (separate field), drawn in fragment | CLIP |
+| Icon drawn frame-relative (no `textLineFragments` read) | CLIP |
+| Icon drawn before vs after `super.draw` | CLIP either way |
+| Raw `CGContext.draw(cgImage)` instead of `NSImage.draw` | CLIP |
+| Icon drawn in the editor's own `draw(_:)` after `super.draw` | CLIP |
+| Pre-rasterized to a bitmap, then drawn | CLIP |
+| Separate transparent overlay subview drawing the image | CLIP |
+| Same overlay, layer-backed (`wantsLayer`) | CLIP |
+| CALayer sublayers with `contents = cgImage` | CLIP |
+
+Controls confirming it's specifically *image drawing on a multi-line line*:
+no icon at all → WRAP; icon present but the image-draw skipped → WRAP; overlay
+computes positions but fills a plain rect instead of the image → WRAP. (Reading
+layout is fine; drawing a *shape* is fine; drawing an *image* is not.) The
+existing overlays — math, bullets, default callout header — never hit this
+because they only ever sit on **single-line** fragments.
+
+So literal-text title + wrapping + an on-line icon image are mutually exclusive
+in this TextKit 2 setup.
+
+## Deployment target / newer TextKit 2
+
+Considered bumping `platforms` from `.macOS(.v14)` to v15+ in case a newer
+TextKit 2 fixes the reentrancy. Not pursued: no evidence Apple fixed this
+specific, obscure interaction, and it would drop macOS 14 (Sonoma) support —
+including the dev machine this was found on — so it wouldn't help without an OS
+upgrade. If revisiting: reproduce on the newest macOS first (a long custom-title
+callout in a narrow window — does it still clip on initial display?).
+
+## What shipped
+
+**Drop the icon for custom-title callouts.** A custom title is real, literal,
+bold + tinted text that wraps inside the box (wrapped lines hang under the
+title); it has **no** type icon. Default callouts keep their icon+name image
+(short, single-line, never wraps). This is the only option that works reliably.
+See `styleCalloutContent` in `EditorTextView+CalloutRendering.swift`.
+
+## The image alternative (preserved, not shipped)
+
+Rendering the whole header (icon + wrapped title) as a single width-aware image
+on a single-line fragment *does* sidestep the wedge, and the image itself
+renders correctly. But it has two unsolved TextKit 2 problems: the header
+fragment lays out ~2× the `minimumLineHeight` (title sits too low, big empty
+band above), and a width-timing race can show a one-line image until a deferred
+re-render. That WIP is preserved on branch **`fix/callout-title-image`** for a
+possible future revisit.


### PR DESCRIPTION
A long custom callout title was baked into a fixed-width image and clipped at the box edge. It now renders as **real, bold, tinted text that wraps** inside the box (wrapped lines hang under the title).

Custom-title callouts intentionally have **no type icon**: the icon is an image, and drawing an image on the wrapping/multi-line header line wedges TextKit 2's layout back to one line — every drawing path tried hit the same wall. Default callouts (synthesized type name, short, never wraps) keep their icon+name image overlay.

Full investigation + the preserved image-based alternative (branch `fix/callout-title-image`): `docs/callout-title-wrap-investigation.md`.

## Verification
- All 633 tests pass.
- Visually verified: a long `[!question]` custom title wraps to 3 aligned lines (no icon); `[!note]` default keeps its icon; short custom title renders without an icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)