### PR TITLE
Propagate the system accent through the editor

### DIFF
--- a/Sources/EdmundCore/Rendering/EditorTextView+ListRendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+ListRendering.swift
@@ -49,9 +49,9 @@ extension EditorTextView {
     private func checkboxOverlay(checked: Bool) -> FragmentOverlay {
         let fontSize = bodyFont.pointSize
         let symbolName = checked ? "checkmark.circle.fill" : "circle"
-        // Checked: white checkmark knocked out of a yellow circle (two palette
-        // layers — checkmark first, circle second). Unchecked: dim outline.
-        let palette: [NSColor] = checked ? [.white, .systemYellow] : [.tertiaryLabelColor]
+        // Checked: white checkmark knocked out of an accent-tinted circle (two
+        // palette layers — checkmark first, circle second). Unchecked: dim outline.
+        let palette: [NSColor] = checked ? [.white, accentColor] : [.tertiaryLabelColor]
         let config = NSImage.SymbolConfiguration(pointSize: fontSize, weight: .regular)
             .applying(NSImage.SymbolConfiguration(paletteColors: palette))
 

--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -148,7 +148,12 @@ public class EditorTextView: NSTextView {
 
     // MARK: - Derived Visual Properties
 
-    var accentColor: NSColor { theme.accentColor }
+    /// The app accent: the macOS system accent (`controlAccentColor`), which
+    /// resolves to the app's AccentColor asset — our brown — when the bundle
+    /// ships the compiled asset catalog, and to the user's System Settings accent
+    /// otherwise. Drives links, the checked-checkbox icon, the insertion point,
+    /// and the selection tint so the editor matches the native AppKit controls.
+    var accentColor: NSColor { .controlAccentColor }
 
     /// Foreground color for all body text. Uses the system text color so it
     /// flips automatically between near-black (light) and near-white (dark).
@@ -221,7 +226,7 @@ public class EditorTextView: NSTextView {
 
         textAntialias = theme.antialias
         backgroundColor = editorBackgroundColor
-        insertionPointColor = foregroundColor
+        insertionPointColor = accentColor
         selectedTextAttributes = [
             .backgroundColor: accentColor.withAlphaComponent(0.3),
             .foregroundColor: foregroundColor,
@@ -281,7 +286,7 @@ public class EditorTextView: NSTextView {
     public override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
         backgroundColor = editorBackgroundColor
-        insertionPointColor = foregroundColor
+        insertionPointColor = accentColor
         selectedTextAttributes = [
             .backgroundColor: accentColor.withAlphaComponent(0.3),
             .foregroundColor: foregroundColor,

--- a/Tests/EdmundTests/EditorFeatureTests.swift
+++ b/Tests/EdmundTests/EditorFeatureTests.swift
@@ -308,10 +308,10 @@ struct AppearanceIntegrationTests {
         #expect(editor.backgroundColor == NSColor.textBackgroundColor)
     }
 
-    @Test("Insertion point uses textColor")
+    @Test("Insertion point uses the accent color")
     @MainActor func insertionPoint() {
         let editor = makeEditor()
-        #expect(editor.insertionPointColor == NSColor.textColor)
+        #expect(editor.insertionPointColor == editor.accentColor)
     }
 
     @Test("Body text uses textColor")


### PR DESCRIPTION
Repoints the editor's accent from the hardcoded blue to `NSColor.controlAccentColor` — the macOS system accent, which resolves to the app's brown `AccentColor` asset when the bundle ships the compiled asset catalog, and to the user's System Settings accent otherwise.

Flows through the single `accentColor` chokepoint to:
- `[](…)` markdown links and `[[…]]` wikilinks
- the **checked-checkbox icon** (was `systemYellow`)
- the **insertion point / cursor** (was `textColor`)
- the **selection tint**

This keeps the editor consistent with the native AppKit controls (tabs, pickers), which already follow the accent asset. The `==highlight==` mark keeps its own yellow. Updated the `insertionPoint` test to expect the accent.

All 633 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)