### PR TITLE
Settings: continuous content-width slider with percentage stepper

### DIFF
--- a/Sources/EdmundCore/TextView/EditorTextView+ContentWidth.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+ContentWidth.swift
@@ -28,6 +28,27 @@ extension EditorTextView {
         return contentBaseInset + (available - column) / 2
     }
 
+    /// The fraction of `viewWidth` the text column actually occupies for a given
+    /// `fraction` — i.e. how much of the screen the content covers. The settings
+    /// slider uses this to show a meaningful percentage (the column at its
+    /// narrowest still covers a sizeable share of the screen, never 0%).
+    public static func contentCoverage(viewWidth: CGFloat, fraction: CGFloat) -> CGFloat {
+        guard viewWidth > 0 else { return 1 }
+        let inset = horizontalInset(viewWidth: viewWidth, fraction: fraction)
+        return (viewWidth - 2 * inset) / viewWidth
+    }
+
+    /// The inverse of `contentCoverage`: the `fraction` that makes the column
+    /// cover `coverage` of `viewWidth`. Lets the settings stepper work in whole
+    /// coverage-percent steps. Clamped to `0...1`.
+    public static func fraction(forCoverage coverage: CGFloat, viewWidth: CGFloat) -> CGFloat {
+        let available = viewWidth - 2 * contentBaseInset
+        guard available > contentMinWidth else { return 1 }
+        let column = coverage * viewWidth
+        let f = (column - contentMinWidth) / (available - contentMinWidth)
+        return min(1, max(0, f))
+    }
+
     /// Recomputes the horizontal text inset from the current width + fraction,
     /// preserving the vertical inset. Cheap (no recompose) — only the inset and
     /// the resulting re-layout change.

--- a/Sources/edmd/Settings/AppSettings.swift
+++ b/Sources/edmd/Settings/AppSettings.swift
@@ -47,6 +47,19 @@ enum AppSettings {
         static let displayOrder: [AppearanceMode] = [.light, .dark, .matchSystem]
     }
 
+    /// Content-width slider bounds. The stored value is a fraction of the
+    /// available width (see `EditorTextView+ContentWidth`): the slider runs
+    /// continuously from the Mobile minimum to full width, with a magnetic snap
+    /// only at the default (≈ Obsidian) reading width.
+    enum ContentWidth {
+        /// Slider floor — the "Mobile" width (narrowest readable column).
+        static let minFraction = 0.0
+        /// Out-of-the-box default — ≈ Obsidian's default reading width.
+        static let defaultFraction = 0.25
+        /// How close to the default the marker must get to snap onto it.
+        static let snapTolerance = 0.02
+    }
+
     enum Key {
         static let reopenWindows = "settings.general.reopenWindows"
         static let startupAction = "settings.general.startupAction"
@@ -59,11 +72,12 @@ enum AppSettings {
 
     /// Text-column width as a fraction of the available width (`0...1`). `1`
     /// fills the width; lower narrows toward a mobile-ish minimum, centered.
-    /// Defaults below 1 so full-screen windows get readable margins out of the box.
+    /// Defaults to the Narrower (≈ Obsidian) width so full-screen windows get
+    /// readable margins out of the box.
     static var contentWidthFraction: Double {
         get {
             guard UserDefaults.standard.object(forKey: Key.contentWidthFraction) != nil else {
-                return 0.6
+                return ContentWidth.defaultFraction
             }
             return UserDefaults.standard.double(forKey: Key.contentWidthFraction)
         }

--- a/Sources/edmd/Settings/AppearanceSettingsView.swift
+++ b/Sources/edmd/Settings/AppearanceSettingsView.swift
@@ -9,7 +9,7 @@ import EdmundCore
 struct AppearanceSettingsView: View {
     @ObservedObject var fonts: FontSettings
     @AppStorage(AppSettings.Key.appearanceMode) private var appearanceMode = AppSettings.AppearanceMode.matchSystem
-    @AppStorage(AppSettings.Key.contentWidthFraction) private var contentWidth = 0.6
+    @AppStorage(AppSettings.Key.contentWidthFraction) private var contentWidth = AppSettings.ContentWidth.defaultFraction
 
     var body: some View {
         Grid(alignment: .leadingFirstTextBaseline, verticalSpacing: 12) {
@@ -29,11 +29,25 @@ struct AppearanceSettingsView: View {
                 Text("Max content width:")
                     .gridColumnAlignment(.trailing)
                 HStack(spacing: 8) {
-                    Slider(value: $contentWidth, in: 0...1)
+                    // Continuous from the Mobile minimum to full width, with a
+                    // magnetic snap onto the default (≈ Obsidian) width.
+                    let value = Binding(
+                        get: { contentWidth },
+                        set: { newValue in
+                            let d = AppSettings.ContentWidth.defaultFraction
+                            contentWidth = abs(newValue - d) < AppSettings.ContentWidth.snapTolerance
+                                ? d : newValue
+                        }
+                    )
+                    Slider(value: value, in: AppSettings.ContentWidth.minFraction...1.0)
                         .frame(width: 200)
-                    Text("\(Int((contentWidth * 100).rounded()))%")
-                        .monospacedDigit()
-                        .frame(width: 48, alignment: .trailing)
+                    let percent = contentWidthPercentBinding
+                    TextField("", value: percent, format: .number.precision(.fractionLength(0)))
+                        .multilineTextAlignment(.trailing)
+                        .frame(width: 32)
+                    Stepper("", value: percent, in: contentWidthPercentRange, step: 1)
+                        .labelsHidden()
+                    Text("%")
                 }
                 .onChange(of: contentWidth) { applyContentWidthToOpenDocuments() }
             }
@@ -92,6 +106,33 @@ struct AppearanceSettingsView: View {
             }
         }
         .settingsPanePadding()
+    }
+
+    /// The standard screen the coverage percentage is measured against.
+    private var contentWidthScreen: CGFloat { NSScreen.main?.frame.width ?? 1440 }
+
+    /// The percentage shown/edited is how much of the screen the column covers
+    /// (≈25%…97%), not the raw fraction — so the narrowest setting reads as a
+    /// sensible share of the screen, never 0%. The binding maps that percentage
+    /// back to the stored fraction so the slider and stepper share one value.
+    private var contentWidthPercentBinding: Binding<Double> {
+        Binding(
+            get: {
+                (EditorTextView.contentCoverage(viewWidth: contentWidthScreen,
+                                                fraction: CGFloat(contentWidth)) * 100).rounded()
+            },
+            set: { pct in
+                contentWidth = Double(EditorTextView.fraction(forCoverage: CGFloat(pct / 100),
+                                                              viewWidth: contentWidthScreen))
+            }
+        )
+    }
+
+    /// The coverage-percent range the stepper clamps to (Mobile minimum … full).
+    private var contentWidthPercentRange: ClosedRange<Double> {
+        let lo = (EditorTextView.contentCoverage(viewWidth: contentWidthScreen, fraction: 0) * 100).rounded()
+        let hi = (EditorTextView.contentCoverage(viewWidth: contentWidthScreen, fraction: 1) * 100).rounded()
+        return lo...hi
     }
 
     /// Pushes a content-width change to every open editor live (mirrors the

--- a/Tests/EdmundTests/ContentWidthTests.swift
+++ b/Tests/EdmundTests/ContentWidthTests.swift
@@ -46,6 +46,29 @@ struct ContentWidthTests {
         #expect(wide > narrow)
     }
 
+    @Test("contentCoverage: fraction 1 ≈ whole screen; fraction 0 is the floor share")
+    func coverage() {
+        let w: CGFloat = 1512
+        let full = EditorTextView.contentCoverage(viewWidth: w, fraction: 1)
+        let mobile = EditorTextView.contentCoverage(viewWidth: w, fraction: 0)
+        // Full = the whole width minus the base inset on each side.
+        #expect(abs(full - (w - 2 * base) / w) < 0.001)
+        // Mobile = the fixed minimum column as a share of the screen (never 0).
+        #expect(abs(mobile - minW / w) < 0.001)
+        #expect(mobile > 0.2 && full < 1.0 && full > mobile)
+    }
+
+    @Test("fraction(forCoverage:) inverts contentCoverage")
+    func coverageRoundTrip() {
+        let w: CGFloat = 1512
+        for tenth in 0...10 {
+            let f = CGFloat(tenth) / 10
+            let cov = EditorTextView.contentCoverage(viewWidth: w, fraction: f)
+            let back = EditorTextView.fraction(forCoverage: cov, viewWidth: w)
+            #expect(abs(back - f) < 0.001)
+        }
+    }
+
     @Test("Narrow windows just fill (base inset)")
     func narrowFills() {
         // Available width below the minimum column → no room to center; fill.


### PR DESCRIPTION
Reworks the **Max content width** setting:

- **Continuous slider** from a Mobile minimum to full width, with a magnetic snap onto the default width.
- **Editable percentage + stepper** (mirroring the Line height control), bound to the same value as the slider.
- The percentage now reflects **how much of the screen the column actually covers** (~25%–97%) instead of the raw interpolation fraction, so the narrowest setting no longer reads as a nonsensical 0%.
- New **default** width is the Narrower (≈ Obsidian reading width) value.

Adds `EditorTextView.contentCoverage(viewWidth:fraction:)` and its inverse `fraction(forCoverage:viewWidth:)` for the coverage math, with round-trip tests. Stored value stays a fraction, so the layout + persistence are unchanged.

All 635 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)