### PR TITLE
Dim inline footnote references

### DIFF
--- a/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
@@ -361,10 +361,11 @@ extension EditorTextView {
 
             case .footnoteReference:
                 guard span.fullRange.upperBound <= result.length else { continue }
-                // Accent the id; when rendered (cursor outside), raise and shrink
-                // it into a superscript and hide the `[^`/`]` (below). When active,
-                // it stays full size and editable with dimmed delimiters.
-                result.addAttribute(.foregroundColor, value: accentColor, range: span.contentRange)
+                // Dim the id like other syntax markers (bullets, etc.) rather than
+                // coloring it like a link; when rendered (cursor outside), raise and
+                // shrink it into a superscript and hide the `[^`/`]` (below). When
+                // active, it stays full size and editable with dimmed delimiters.
+                result.addAttribute(.foregroundColor, value: syntaxDimColor, range: span.contentRange)
                 if !cursorInToken {
                     let small = NSFont(descriptor: bodyFont.fontDescriptor,
                                        size: bodyFont.pointSize * 0.75) ?? bodyFont


### PR DESCRIPTION
Inline `[^1]` footnote markers were rendered in the accent color (same as links). Dim them with `syntaxDimColor` (tertiaryLabelColor) like other syntax markers (bullets, etc.) so the reference reads as a quiet superscript rather than a link.

Verified by offscreen render: the `[^1]` shows as a dimmed grey superscript. All 635 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)