### PR TITLE
Add opt-out diagnostic file logging

### DIFF
--- a/Sources/EdmundCore/Diagnostics/Log.swift
+++ b/Sources/EdmundCore/Diagnostics/Log.swift
@@ -1,0 +1,213 @@
+import Foundation
+
+// MARK: - Diagnostic logging
+//
+// A small always-on (opt-out) file logger that writes human-readable lines to
+// `~/.edmund/logs/edmund-YYYY-MM-DD.log` (one file per day) so problems can be
+// diagnosed after the fact. Logs stay on the user's Mac and may contain document
+// text — that's fine because they never leave the device.
+//
+// Design:
+// - Three semantic levels (`debug`/`info`/`error`). A single compile-time
+//   threshold decides what ships: release writes `info` and up; DEBUG builds also
+//   write `debug`. The user never picks a level — only on/off (see Settings).
+// - Writes happen on a private serial queue, so logging never blocks the caller;
+//   timestamps are captured at the call site, so async writes stay in order.
+// - `measure` times a closure and emits a single duration line — for operations
+//   (load, full recompose) whose cost can't be read off a pair of events.
+
+public enum Log {
+
+    public enum Level: Int, Comparable, Sendable {
+        case debug = 0, info = 1, error = 2
+        public static func < (lhs: Level, rhs: Level) -> Bool { lhs.rawValue < rhs.rawValue }
+        var tag: String {
+            switch self {
+            case .debug: return "DEBUG"
+            case .info:  return "INFO"
+            case .error: return "ERROR"
+            }
+        }
+    }
+
+    /// Subsystem tag on each line — mirrors the architecture's areas so logs can
+    /// be grepped by concern.
+    public enum Category: String, Sendable {
+        case app, document, io, render, compose, selection, lazy, callout
+    }
+
+    /// What gets written in this build. The user opts the whole facility out;
+    /// they do not choose a level.
+    #if DEBUG
+    static let minLevel: Level = .debug
+    #else
+    static let minLevel: Level = .info
+    #endif
+
+    // MARK: Configuration (driven by the app from Settings)
+
+    /// Point the logger at a directory, enable/disable it, and set a retention
+    /// window (`nil` = keep forever). Enabling prunes anything past `retention`.
+    public static func configure(enabled: Bool, directory: URL, retention: TimeInterval?) {
+        LogStore.shared.configure(enabled: enabled, directory: directory, retention: retention)
+    }
+
+    public static func setEnabled(_ enabled: Bool) {
+        LogStore.shared.setEnabled(enabled)
+    }
+
+    // MARK: Emit
+
+    public static func debug(_ message: @autoclosure () -> String, category: Category = .app) {
+        guard shouldLog(.debug) else { return }
+        LogStore.shared.write(level: .debug, category: category, message: message(), date: Date())
+    }
+
+    public static func info(_ message: @autoclosure () -> String, category: Category = .app) {
+        guard shouldLog(.info) else { return }
+        LogStore.shared.write(level: .info, category: category, message: message(), date: Date())
+    }
+
+    public static func error(_ message: @autoclosure () -> String, category: Category = .app) {
+        guard shouldLog(.error) else { return }
+        LogStore.shared.write(level: .error, category: category, message: message(), date: Date())
+    }
+
+    /// Runs `body`, and if logging is active emits one line with how long it took.
+    /// Zero overhead (just runs `body`) when the level is filtered out or logging
+    /// is off.
+    @discardableResult
+    public static func measure<T>(_ label: @autoclosure () -> String,
+                                  category: Category = .app,
+                                  level: Level = .info,
+                                  _ body: () throws -> T) rethrows -> T {
+        guard shouldLog(level) else { return try body() }
+        let start = DispatchTime.now()
+        let result = try body()
+        let ms = Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000
+        LogStore.shared.write(level: level, category: category,
+                              message: "\(label()) — \(String(format: "%.1f", ms)) ms", date: Date())
+        return result
+    }
+
+    /// Blocks until queued writes have hit disk. For tests.
+    public static func flush() { LogStore.shared.flush() }
+
+    private static func shouldLog(_ level: Level) -> Bool {
+        level >= minLevel && LogStore.shared.isEnabled
+    }
+}
+
+// MARK: - Backing store
+
+/// Holds the logger's mutable state. Configuration is guarded by a lock; all file
+/// I/O (and the non-`Sendable` `DateFormatter`s) is confined to one serial queue.
+private final class LogStore: @unchecked Sendable {
+    static let shared = LogStore()
+
+    private let lock = NSLock()
+    private let queue = DispatchQueue(label: "com.i7t5.edmund.log")
+
+    // Lock-guarded configuration.
+    private var _enabled = false
+    private var directory = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".edmund/logs", isDirectory: true)
+
+    // Queue-confined state.
+    private var handle: FileHandle?
+    private var handleDay: String?
+    private let dayFormatter = LogStore.makeFormatter("yyyy-MM-dd")
+    private let timeFormatter = LogStore.makeFormatter("yyyy-MM-dd HH:mm:ss.SSS")
+
+    var isEnabled: Bool { lock.withLock { _enabled } }
+
+    func configure(enabled: Bool, directory: URL, retention: TimeInterval?) {
+        lock.withLock {
+            _enabled = enabled
+            self.directory = directory
+        }
+        queue.async { [weak self] in
+            self?.closeHandle()   // directory may have changed
+            if enabled, let retention { self?.prune(retention: retention) }
+        }
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        lock.withLock { _enabled = enabled }
+    }
+
+    func write(level: Log.Level, category: Log.Category, message: String, date: Date) {
+        let dir = lock.withLock { directory }
+        queue.async { [weak self] in
+            guard let self else { return }
+            let line = "\(self.timeFormatter.string(from: date)) [\(level.tag)] [\(category.rawValue)] \(message)"
+            self.append(line, in: dir, date: date)
+        }
+    }
+
+    func flush() { queue.sync {} }
+
+    // MARK: File I/O (queue only)
+
+    private func append(_ line: String, in dir: URL, date: Date) {
+        let day = dayFormatter.string(from: date)
+        if handleDay != day { closeHandle() }
+        if handle == nil {
+            guard let h = openHandle(dir: dir, day: day) else { return }
+            handle = h
+            handleDay = day
+        }
+        guard let data = (line + "\n").data(using: .utf8) else { return }
+        do {
+            try handle?.write(contentsOf: data)
+        } catch {
+            // The file may have been moved or deleted out from under us; reopen once.
+            closeHandle()
+            if let h = openHandle(dir: dir, day: day) {
+                handle = h
+                handleDay = day
+                try? h.write(contentsOf: data)
+            }
+        }
+    }
+
+    private func openHandle(dir: URL, day: String) -> FileHandle? {
+        let fm = FileManager.default
+        try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("edmund-\(day).log")
+        if !fm.fileExists(atPath: url.path) {
+            fm.createFile(atPath: url.path, contents: nil)
+        }
+        guard let h = try? FileHandle(forWritingTo: url) else { return nil }
+        try? h.seekToEnd()
+        return h
+    }
+
+    private func closeHandle() {
+        try? handle?.close()
+        handle = nil
+        handleDay = nil
+    }
+
+    private func prune(retention: TimeInterval) {
+        let fm = FileManager.default
+        let dir = lock.withLock { directory }
+        guard let urls = try? fm.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: [.contentModificationDateKey]) else { return }
+        let cutoff = Date().addingTimeInterval(-retention)
+        for url in urls where url.lastPathComponent.hasPrefix("edmund-") && url.pathExtension == "log" {
+            let modified = try? url.resourceValues(forKeys: [.contentModificationDateKey])
+                .contentModificationDate
+            if let modified, modified < cutoff {
+                try? fm.removeItem(at: url)
+            }
+        }
+    }
+
+    private static func makeFormatter(_ format: String) -> DateFormatter {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = format
+        return f
+    }
+}

--- a/Sources/EdmundCore/TextView/EditorTextView+Composition.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+Composition.swift
@@ -24,20 +24,22 @@ extension EditorTextView {
     func recompose(cursorInRaw: Int, selectionInRaw: NSRange? = nil) {
         guard let ts = textStorage else { return }
 
-        isUpdating = true
-        let fullRange = NSRange(location: 0, length: ts.length)
-        ts.beginEditing()
-        ts.replaceCharacters(in: fullRange,
-                             with: NSAttributedString(string: rawSource,
-                                                      attributes: baseAttributes))
-        ts.endEditing()
-        // Whole-document replacement; blocks are re-parsed by our callers.
-        (ts as? EditorTextStorage)?.clearPendingEdit()
-        isUpdating = false
+        Log.measure("Full recompose (\(blocks.count) blocks)", category: .compose, level: .debug) {
+            isUpdating = true
+            let fullRange = NSRange(location: 0, length: ts.length)
+            ts.beginEditing()
+            ts.replaceCharacters(in: fullRange,
+                                 with: NSAttributedString(string: rawSource,
+                                                          attributes: baseAttributes))
+            ts.endEditing()
+            // Whole-document replacement; blocks are re-parsed by our callers.
+            (ts as? EditorTextStorage)?.clearPendingEdit()
+            isUpdating = false
 
-        for i in blocks.indices { blocks[i].isStyled = false }
-        recomposeDirty(IndexSet(blocks.indices), cursorInRaw: cursorInRaw,
-                       selectionInRaw: selectionInRaw, settingSelection: true)
+            for i in blocks.indices { blocks[i].isStyled = false }
+            recomposeDirty(IndexSet(blocks.indices), cursorInRaw: cursorInRaw,
+                           selectionInRaw: selectionInRaw, settingSelection: true)
+        }
     }
 
     /// Range-bounded recompose: replaces only `oldRange` (pre-edit storage

--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -392,17 +392,20 @@ public class EditorTextView: NSTextView {
 
     /// Replace the editor's content. Used by NSDocument on file open.
     public func loadContent(_ content: String) {
-        // Remember the file's line ending, then normalize the buffer to LF so
-        // block parsing and rendering never see a stray `\r`. A file that mixes
-        // styles is normalized to LF on save too (rather than its dominant style),
-        // so its endings become consistent.
-        originalLineEnding = LineEnding.isInconsistent(in: content) ? .lf : LineEnding.detect(in: content)
-        rawSource = LineEnding.normalize(content)
-        rebuildListIndentState()
-        blocks = BlockParser.parse(rawSource)
-        undoStack.removeAll()
-        redoStack.removeAll()
-        recompose(cursorInRaw: 0)
+        Log.measure("Loaded document (\(content.count) chars)", category: .document) {
+            // Remember the file's line ending, then normalize the buffer to LF so
+            // block parsing and rendering never see a stray `\r`. A file that mixes
+            // styles is normalized to LF on save too (rather than its dominant style),
+            // so its endings become consistent.
+            originalLineEnding = LineEnding.isInconsistent(in: content) ? .lf : LineEnding.detect(in: content)
+            rawSource = LineEnding.normalize(content)
+            rebuildListIndentState()
+            blocks = BlockParser.parse(rawSource)
+            Log.debug("Parsed \(blocks.count) blocks", category: .compose)
+            undoStack.removeAll()
+            redoStack.removeAll()
+            recompose(cursorInRaw: 0)
+        }
     }
 }
 

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -190,9 +190,11 @@ class Document: NSDocument, HeadingNavigable {
 
     override nonisolated func read(from data: Data, ofType typeName: String) throws {
         guard let contents = String(data: data, encoding: .utf8) else {
+            Log.error("Read failed: \(data.count) bytes not valid UTF-8", category: .io)
             throw NSError(domain: NSOSStatusErrorDomain, code: -1,
                           userInfo: [NSLocalizedDescriptionKey: "Could not read file as UTF-8"])
         }
+        Log.info("Read \(data.count) bytes from disk", category: .io)
         pendingContent = contents
     }
 
@@ -348,9 +350,11 @@ class Document: NSDocument, HeadingNavigable {
             ? normalized
             : normalized.replacingOccurrences(of: "\n", with: ending.string)
         guard let data = text.data(using: .utf8) else {
+            Log.error("Save failed: could not encode \(text.count) chars as UTF-8", category: .io)
             throw NSError(domain: NSOSStatusErrorDomain, code: -1,
                           userInfo: [NSLocalizedDescriptionKey: "Could not encode text as UTF-8"])
         }
+        Log.info("Saving \(data.count) bytes (\(ending.displayName))", category: .io)
         return data
     }
 }

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -24,6 +24,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        AppSettings.applyLogging()
+        Log.info("Edmund launched", category: .app)
         AppSettings.applyAppearance()
         setupMenuBar()
 
@@ -33,6 +35,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         let args = CommandLine.arguments
         if args.count > 1 {
             let url = URL(fileURLWithPath: args[1])
+            Log.info("Opening file from launch argument: \(url.path)", category: .document)
             NSDocumentController.shared.openDocument(withContentsOf: url, display: true) { _, _, _ in }
         }
     }

--- a/Sources/edmd/Settings/AppSettings.swift
+++ b/Sources/edmd/Settings/AppSettings.swift
@@ -3,6 +3,7 @@
 // same keys via @AppStorage.
 
 import AppKit
+import EdmundCore
 
 enum AppSettings {
     enum StartupAction: String, CaseIterable, Identifiable {
@@ -60,6 +61,34 @@ enum AppSettings {
         static let snapTolerance = 0.02
     }
 
+    /// How long diagnostic logs are kept before being pruned on launch.
+    enum LogRetention: String, CaseIterable, Identifiable {
+        case oneDay, twoDays, oneWeek, twoWeeks, thirtyDays, never
+        var id: Self { self }
+        var label: String {
+            switch self {
+            case .oneDay: return "1 day"
+            case .twoDays: return "2 days"
+            case .oneWeek: return "1 week"
+            case .twoWeeks: return "2 weeks"
+            case .thirtyDays: return "30 days"
+            case .never: return "Never"
+            }
+        }
+        /// The retention window in seconds; `nil` means keep forever.
+        var timeInterval: TimeInterval? {
+            let day: TimeInterval = 24 * 60 * 60
+            switch self {
+            case .oneDay: return day
+            case .twoDays: return 2 * day
+            case .oneWeek: return 7 * day
+            case .twoWeeks: return 14 * day
+            case .thirtyDays: return 30 * day
+            case .never: return nil
+            }
+        }
+    }
+
     enum Key {
         static let reopenWindows = "settings.general.reopenWindows"
         static let startupAction = "settings.general.startupAction"
@@ -68,6 +97,8 @@ enum AppSettings {
         static let appearanceMode = "settings.appearance.mode"
         static let contentWidthFraction = "settings.appearance.contentWidthFraction"
         static let suppressInconsistentLineEndingWarning = "settings.general.suppressInconsistentLineEndingWarning"
+        static let diagnosticLogging = "settings.general.diagnosticLogging"
+        static let logRetention = "settings.general.logRetention"
     }
 
     /// Text-column width as a fraction of the available width (`0...1`). `1`
@@ -135,6 +166,42 @@ enum AppSettings {
     static var suppressInconsistentLineEndingWarning: Bool {
         get { UserDefaults.standard.bool(forKey: Key.suppressInconsistentLineEndingWarning) }
         set { UserDefaults.standard.set(newValue, forKey: Key.suppressInconsistentLineEndingWarning) }
+    }
+
+    /// Whether diagnostic logging is on. Defaults to on; the user can opt out.
+    static var diagnosticLogging: Bool {
+        get {
+            guard UserDefaults.standard.object(forKey: Key.diagnosticLogging) != nil else {
+                return true
+            }
+            return UserDefaults.standard.bool(forKey: Key.diagnosticLogging)
+        }
+        set { UserDefaults.standard.set(newValue, forKey: Key.diagnosticLogging) }
+    }
+
+    static var logRetention: LogRetention {
+        get {
+            guard let raw = UserDefaults.standard.string(forKey: Key.logRetention),
+                  let value = LogRetention(rawValue: raw) else {
+                return .twoWeeks
+            }
+            return value
+        }
+        set { UserDefaults.standard.set(newValue.rawValue, forKey: Key.logRetention) }
+    }
+
+    /// Where diagnostic logs live: `~/.edmund/logs`.
+    static var logDirectory: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".edmund/logs", isDirectory: true)
+    }
+
+    /// Pushes the current logging settings into the `Log` facility. Called at
+    /// launch and whenever the toggle or retention changes.
+    static func applyLogging() {
+        Log.configure(enabled: diagnosticLogging,
+                      directory: logDirectory,
+                      retention: logRetention.timeInterval)
     }
 
     @MainActor static func applyAppearance() {

--- a/Sources/edmd/Settings/GeneralSettingsView.swift
+++ b/Sources/edmd/Settings/GeneralSettingsView.swift
@@ -11,6 +11,8 @@ struct GeneralSettingsView: View {
     @AppStorage(AppSettings.Key.startupAction) private var startupAction = AppSettings.StartupAction.createNewDocument
     @AppStorage(AppSettings.Key.autoSaveWithVersions) private var autoSave = true
     @AppStorage(AppSettings.Key.conflictResolution) private var conflict = AppSettings.ConflictResolution.ask
+    @AppStorage(AppSettings.Key.diagnosticLogging) private var diagnosticLogging = true
+    @AppStorage(AppSettings.Key.logRetention) private var logRetention = AppSettings.LogRetention.twoWeeks
     @State private var showingWarnings = false
 
     var body: some View {
@@ -63,6 +65,32 @@ struct GeneralSettingsView: View {
                 Text("Dialog warnings:")
                     .gridColumnAlignment(.trailing)
                 Button("Manage Warnings…") { showingWarnings = true }
+            }
+
+            GridRow {
+                Text("Diagnostics:")
+                    .gridColumnAlignment(.trailing)
+                VStack(alignment: .leading, spacing: 6) {
+                    Toggle("Save diagnostic logs", isOn: $diagnosticLogging)
+                        .onChange(of: diagnosticLogging) { AppSettings.applyLogging() }
+                    HStack(spacing: 6) {
+                        Text("Clear logs after:")
+                        Picker("", selection: $logRetention) {
+                            ForEach(AppSettings.LogRetention.allCases) { Text($0.label).tag($0) }
+                        }
+                        .labelsHidden()
+                        .fixedSize()
+                        .onChange(of: logRetention) { AppSettings.applyLogging() }
+                    }
+                    .disabled(!diagnosticLogging)
+                    .padding(.leading, 20)
+                    Text("Logs are kept on this Mac at ~/.edmund/logs to help diagnose problems, and never leave your device. Older logs are deleted automatically.")
+                        .foregroundStyle(.secondary)
+                        .controlSize(.small)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(width: 380, alignment: .leading)
+                        .padding(.leading, 20)
+                }
             }
         }
         .settingsPanePadding()

--- a/Tests/EdmundTests/LogTests.swift
+++ b/Tests/EdmundTests/LogTests.swift
@@ -1,0 +1,103 @@
+import Testing
+import Foundation
+@testable import EdmundCore
+
+/// The diagnostic logger: writes lines to a daily file, honors the on/off switch,
+/// emits durations via `measure`, and prunes files past the retention window.
+/// Serialized — these share the process-wide `Log` singleton and a temp directory.
+@Suite("Diagnostic logging", .serialized)
+struct LogTests {
+
+    /// A fresh temp directory for one test's logs.
+    private func tempDir() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("edmund-logtest-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func todaysLog(in dir: URL) -> String? {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd"
+        let url = dir.appendingPathComponent("edmund-\(f.string(from: Date())).log")
+        return try? String(contentsOf: url, encoding: .utf8)
+    }
+
+    @Test("Enabled: writes a line per level with tag and category")
+    func writesLines() {
+        let dir = tempDir()
+        Log.configure(enabled: true, directory: dir, retention: nil)
+        Log.info("hello world", category: .document)
+        Log.error("boom", category: .io)
+        Log.flush()
+
+        let contents = todaysLog(in: dir) ?? ""
+        #expect(contents.contains("[INFO] [document] hello world"))
+        #expect(contents.contains("[ERROR] [io] boom"))
+    }
+
+    @Test("Disabled: writes nothing")
+    func disabledWritesNothing() {
+        let dir = tempDir()
+        Log.configure(enabled: false, directory: dir, retention: nil)
+        Log.info("should not appear", category: .app)
+        Log.error("nor this", category: .app)
+        Log.flush()
+
+        #expect(todaysLog(in: dir) == nil)
+    }
+
+    @Test("measure: returns the body's value and logs a duration line")
+    func measureLogsDuration() {
+        let dir = tempDir()
+        Log.configure(enabled: true, directory: dir, retention: nil)
+        let result = Log.measure("did work", category: .compose) { 6 * 7 }
+        Log.flush()
+
+        #expect(result == 42)
+        let contents = todaysLog(in: dir) ?? ""
+        #expect(contents.contains("did work — "))
+        #expect(contents.contains(" ms"))
+    }
+
+    @Test("Loading a document logs its duration and the full recompose")
+    @MainActor func loadContentInstrumented() {
+        let dir = tempDir()
+        Log.configure(enabled: true, directory: dir, retention: nil)
+
+        let editor = makeEditor()
+        editor.loadContent("# Title\n\nSome body text.\n")
+        Log.flush()
+
+        let contents = todaysLog(in: dir) ?? ""
+        // The load duration (info) and, in this DEBUG test build, the recompose
+        // sub-duration (debug) both land.
+        #expect(contents.contains("[document] Loaded document ("))
+        #expect(contents.contains("[compose] Full recompose ("))
+        #expect(contents.contains(" ms"))
+    }
+
+    @Test("Retention prunes files older than the window, keeps newer ones")
+    func retentionPrunes() throws {
+        let dir = tempDir()
+        let fm = FileManager.default
+
+        // An "old" log file, back-dated well past the window.
+        let old = dir.appendingPathComponent("edmund-2000-01-01.log")
+        fm.createFile(atPath: old.path, contents: Data("stale\n".utf8))
+        let longAgo = Date(timeIntervalSince1970: 946_684_800) // 2000-01-01
+        try fm.setAttributes([.modificationDate: longAgo], ofItemAtPath: old.path)
+
+        // A current file we expect to survive.
+        let fresh = dir.appendingPathComponent("edmund-keep.log")
+        fm.createFile(atPath: fresh.path, contents: Data("fresh\n".utf8))
+
+        // Configure with a one-day retention; the prune runs on configure.
+        Log.configure(enabled: true, directory: dir, retention: 24 * 60 * 60)
+        Log.flush()
+
+        #expect(!fm.fileExists(atPath: old.path))
+        #expect(fm.fileExists(atPath: fresh.path))
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -157,6 +157,14 @@ recomputed on resize).
   `Document.editor` (see the font/line-height/content-width `applyTo…` helpers).
 - Theme/appearance/fonts flow into `EditorTheme` → the editor's derived
   `bodyFont`, colors, paragraph styles.
+- **Diagnostic logging** (`EdmundCore/Diagnostics/Log.swift`): an always-on
+  (opt-out) file logger. `Log.{debug,info,error}(_:category:)` and
+  `Log.measure(_:) { … }` (single-line durations) write to
+  `~/.edmund/logs/edmund-YYYY-MM-DD.log` on a private serial queue. One
+  compile-time level threshold ships (DEBUG = `debug`+; release = `info`+) — the
+  user only toggles it on/off and picks a retention window (Settings ▸ General ▸
+  Diagnostics). `AppSettings.applyLogging()` pushes the toggle/retention into
+  `Log.configure` at launch and on change; retention is pruned there.
 
 ---
 


### PR DESCRIPTION
## What

Edmund had **no logging at all**. This adds an always-on (opt-out) file logger so problems can be diagnosed after the fact — both now (e.g. the parked callout live-restyle issue) and in future.

## How it works

- **`EdmundCore/Diagnostics/Log.swift`** — `Log.{debug,info,error}(_:category:)` and **`Log.measure(_:) { … }`** (emits a single duration line) write to `~/.edmund/logs/edmund-YYYY-MM-DD.log` on a private serial queue. Timestamps are captured at the call site so async writes stay ordered. State is lock-guarded; the backing store is `@unchecked Sendable` (Swift 6 clean).
- **One compile-time level threshold** ships — DEBUG builds write `debug`+, release writes `info`+. The user never picks a verbosity; their only control is on/off.
- **Settings ▸ General ▸ Diagnostics**: `Save diagnostic logs` toggle (default **on**) + `Clear logs after` retention popup (1 day…30 days/Never, default **2 weeks**). `AppSettings.applyLogging()` pushes the toggle/retention into `Log.configure` at launch and on change; retention is pruned there.
- **Instrumented**: app launch, file open/read/save (`io`/`document`), and the two durational paths — `loadContent` (info, with char count) and full `recompose` (debug).

Logs stay on the user's Mac and may contain document text — fine, since they never leave the device.

## Verification

- `swift build` clean; **`swift test` → 640 pass** (635 baseline + 5 new logging tests: per-level write, disabled = silent, `measure` returns value + logs duration, load path emits load+recompose durations, retention prunes old / keeps new).
- Ran the built app: `~/.edmund/logs` populated with the expected `app`/`document` lines.
- Screencaptured the Settings ▸ General pane — the Diagnostics section renders consistently with the existing Grid (toggle, "2 weeks" popup, explanatory note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)