### PR TITLE
Log block structure (kind + char count) on document load

### DIFF
--- a/Sources/EdmundCore/Diagnostics/Log.swift
+++ b/Sources/EdmundCore/Diagnostics/Log.swift
@@ -90,6 +90,30 @@ public enum Log {
         return result
     }
 
+    /// Logs the structure of a block array at `debug` level: each block's kind
+    /// and character count, with no document text. Example output:
+    ///   Structure (4): heading(2)·18c, paragraph·234c, codeBlock(swift)·456c, callout·120c
+    public static func blockStructure(_ blocks: [Block], category: Category = .compose) {
+        guard shouldLog(.debug) else { return }
+        let parts = blocks.map { b -> String in
+            let c = b.range.length
+            switch b.kind {
+            case .paragraph:              return "paragraph·\(c)c"
+            case .heading(let level):     return "heading(\(level))·\(c)c"
+            case .quoteRun(let isCallout): return "\(isCallout ? "callout" : "quote")·\(c)c"
+            case .fence:                  return "fence·\(c)c"
+            case .mathDisplay:            return "math·\(c)c"
+            case .table:                  return "table·\(c)c"
+            case .listItem:               return "listItem·\(c)c"
+            case .thematicBreak:          return "hr·\(c)c"
+            case .blank:                  return "blank·\(c)c"
+            }
+        }
+        LogStore.shared.write(level: .debug, category: category,
+                              message: "Structure (\(blocks.count)): \(parts.joined(separator: ", "))",
+                              date: Date())
+    }
+
     /// Blocks until queued writes have hit disk. For tests.
     public static func flush() { LogStore.shared.flush() }
 

--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -401,7 +401,7 @@ public class EditorTextView: NSTextView {
             rawSource = LineEnding.normalize(content)
             rebuildListIndentState()
             blocks = BlockParser.parse(rawSource)
-            Log.debug("Parsed \(blocks.count) blocks", category: .compose)
+            Log.blockStructure(blocks)
             undoStack.removeAll()
             redoStack.removeAll()
             recompose(cursorInRaw: 0)

--- a/Tests/EdmundTests/LogTests.swift
+++ b/Tests/EdmundTests/LogTests.swift
@@ -100,4 +100,59 @@ struct LogTests {
         #expect(!fm.fileExists(atPath: old.path))
         #expect(fm.fileExists(atPath: fresh.path))
     }
+
+    @Test("blockStructure: emits one entry per block with kind and char count")
+    @MainActor func blockStructureFormat() {
+        let dir = tempDir()
+        Log.configure(enabled: true, directory: dir, retention: nil)
+
+        // Load a document with a known set of block kinds.
+        let editor = makeEditor()
+        editor.loadContent("## Heading\n\nA paragraph.\n\n> A quote.\n\n```swift\nlet x = 1\n```\n")
+        Log.flush()
+
+        let contents = todaysLog(in: dir) ?? ""
+        // The structure line must appear.
+        #expect(contents.contains("Structure ("))
+        // Heading, paragraph, quote, and fence entries with char counts.
+        #expect(contents.contains("heading(2)·"))
+        #expect(contents.contains("paragraph·"))
+        #expect(contents.contains("quote·"))
+        #expect(contents.contains("fence·"))
+        let structureLine = contents.components(separatedBy: "\n")
+            .first { $0.contains("Structure (") } ?? ""
+        #expect(!structureLine.isEmpty)
+        // Non-blank blocks all have positive char counts.
+        let entries = structureLine.components(separatedBy: ", ")
+        for entry in entries where !entry.contains("blank") {
+            #expect(!entry.hasSuffix("·0c"), "non-blank entry has zero chars: \(entry)")
+        }
+    }
+
+    @Test("blockStructure: emitted at debug level, silent in a hypothetical info-only build")
+    func blockStructureLevel() {
+        let dir = tempDir()
+        Log.configure(enabled: true, directory: dir, retention: nil)
+
+        // Build a minimal block array directly (no editor needed).
+        let blocks = [
+            Block(content: "# H", range: NSRange(location: 0, length: 3), kind: .heading(level: 1)),
+            Block(content: "p",   range: NSRange(location: 4, length: 1), kind: .paragraph),
+        ]
+        Log.blockStructure(blocks, category: .compose)
+        Log.flush()
+
+        let contents = todaysLog(in: dir) ?? ""
+        // In a DEBUG test build the line appears; assert on the structure (not the level tag
+        // so this test doesn't hard-code build configuration).
+        let line = contents.components(separatedBy: "\n").first { $0.contains("Structure (2)") }
+        #if DEBUG
+        #expect(line != nil)
+        // Confirm the two kinds are present.
+        #expect(line?.contains("heading(1)·3c") == true)
+        #expect(line?.contains("paragraph·1c") == true)
+        #else
+        #expect(line == nil)  // info-only: debug lines suppressed
+        #endif
+    }
 }


### PR DESCRIPTION
## What

Replaces the plain `"Parsed N blocks"` debug line with a structural summary that lists every block's kind and character count — enough context to diagnose parse issues in a bug report without exposing any document text.

**Example log line:**
```
[DEBUG] [compose] Structure (4): heading(2)·18c, paragraph·234c, fence·22c, blank·0c
```

## How

- `Log.blockStructure([Block])` in `Log.swift` — formats `BlockKind` + `range.length` for each block, guarded by the existing `shouldLog(.debug)` gate (release builds suppress it automatically).
- `loadContent` in `EditorTextView.swift` — calls `Log.blockStructure(blocks)` in place of the old count-only line.

## Tests (+2 → 642 total)

- **`blockStructureFormat`** — loads a document with heading, paragraph, quote, and fence blocks via `makeEditor()`; asserts the structure line is present and each non-blank block has a positive char count.
- **`blockStructureLevel`** — constructs blocks directly; asserts the line appears in DEBUG builds and would be absent in release (via `#if DEBUG`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)