### PR TITLE
Add Format menu, keyboard shortcuts, and view-mode cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,24 +5,39 @@
 Edmund is a native, lightweight macOS markdown editor with Live Preview. 
 
 - **Requirements**: macOS Sonoma 14 or later
-- **Website**: [https://i7t5.com/edmund](https://i7t5.com/edmund)
+- **Website**: <https://i7t5.com/edmund>
 
 ## Features
 
-- **Live Preview**: Render as you type. Hides delimiters outside active token / block. Pseudo-WYSIWYG. 
+- **Live Preview**: WYSIWYG. Render as you type. Hides delimiters outside active token / block. 
 - **Lightweight and fast**: App size ~5 MB. Lazy rendering via TextKit 2. Minimal dependencies. 
 - **Keyboard-first**: Essential buttons only. Configurable keyboard shortcuts. 
 - **Powerful and compatible**: 
-  - Follows [cmark-gfm](https://github.com/github/cmark-gfm) standards through Apple's official [swift-markdown](https://github.com/swiftlang/swift-markdown). 
-  - Supports ==highlights==, [[WikiLinks]], footnotes `[^1]`, code blocks with syntax highlighting, as well as Obsidian-flavored comments and callouts through custom parser. 
+  - Follows [cmark-gfm](https://github.com/github/cmark-gfm) through Apple's own [swift-markdown](https://github.com/swiftlang/swift-markdown). 
+  - Opt-in support for non-GFM syntax such as ==highlights==, [[WikiLinks]], footnotes `[^1]`, code blocks with syntax highlighting, as well as Obsidian-flavored comments and callouts through. 
   - Renders both inline and display math in LaTex using [SwiftMath](https://github.com/mgriebling/SwiftMath). 
 - **Native UI/UX**: Respects Apple design guidelines. AppKit + SwiftUI. 
 - **Secure and private**: Always offline. Network connection required for software updates only. 
-- **Open and free**: MIT License. Free of charge. 
+- **Open and free**: Apache License 2.0. Free of charge. 
 
 ## Roadmap
 
-See [ROADMAP.md](ROADMAP.md). 
+See [ROADMAP](ROADMAP.md). 
+
+Current priorities: 
+
+- Full [GFM spec](https://github.github.com/gfm/#fenced-code-blocks) support. Including but not limited to: 
+  - Table alignment
+  - ATX headings
+- Render icons in custom-titled callouts / alerts
+- Comprehensive math support through [RaTeX](https://github.com/erweixin/RaTeX) integration (extension)
+- Native export to PDF with style
+- Automatic updates via Sparkle
+- Themes
+- Onboarding
+  - Log preference
+  - Advanced Math
+  - Pandoc path for more export options
 
 ## Dependencies
 
@@ -31,14 +46,22 @@ See [ROADMAP.md](ROADMAP.md).
 
 ## Alternatives
 
-- Obsidian, Notion, etc. 
-- Typora
-- [MarkText](https://marktext.me)
-- [Nodes](https://nodes-web.com)
-- [Scratch](https://github.com/erictli/scratch)
-- [editxr](https://github.com/pixdeo/editxr)
+If Edmund's not your thing, some of the following might be: 
 
-## Motivation and credits
+- Closed source
+  - Obsidian, cyberWriter, Notion
+  - Typora, Lettera (currently in [beta](https://lettera.md))
+- Open source
+  - WYSIWYG: [MarkText](https://marktext.me), [Nodes](https://nodes-web.com), [Scratch](https://github.com/erictli/scratch)
+  - Split-screen: [MacDown](https://macdown.uranusjr.com), [MiaoYan](https://miaoyan.app)
+  - [MarkEdit](https://github.com/MarkEdit-app/MarkEdit) - TextEdit for Markdown
+    - I *love* this. If only I wasn't so dependent on rendered math...
+  - [editxr](https://github.com/pixdeo/editxr) - TUI
+  - More feature-rich: [Zettlr](https://www.zettlr.com), [Joplin](https://joplinapp.org), [Tangent](https://www.tangentnotes.com)
+
+The list is by no means exhaustive, and neither was it meant to be. I just wanted to give credit to the makers of these apps, esp. the aesthetic open sourced ones. If you want a comprehensive list, [this](https://github.com/mundimark/awesome-markdown-editors) might be more helpful. 
+
+## Motivation, philosophy, credits
 
 I wanted to create an open source alternative to Typora that would be the [CotEditor](https://coteditor.com) of Markdown editors. See this [blog post](link TBD) for more design philosophy and behind-the-scenes. 
 
@@ -50,4 +73,4 @@ The following have greatly influenced my architecture and/or design choices. I o
 
 ## License
 
- TBD
+[Apache License 2.0](LICENSE)

--- a/Sources/EdmundCore/Editing/EditorTextView+FormattingCommands.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+FormattingCommands.swift
@@ -1,0 +1,293 @@
+import AppKit
+
+// MARK: - Format-menu actions
+//
+// Public @objc action methods targeted by the Format menu (nil-target items
+// route through the responder chain to the focused editor — the same wiring as
+// undo/redo). Each delegates to a primitive/helper in +FormattingCore.
+//
+// Toggling: most commands are invertible — applying twice restores the original
+// — except Checklist, Footnote, and Table, which the spec marks otherwise.
+
+extension EditorTextView {
+
+    // MARK: Inline font styles
+
+    @objc public func formatBold(_ sender: Any?)          { toggleInlineWrap(open: "**", close: "**") }
+    @objc public func formatItalic(_ sender: Any?)        { toggleInlineWrap(open: "*", close: "*") }
+    @objc public func formatUnderline(_ sender: Any?)     { toggleInlineWrap(open: "<u>", close: "</u>") }
+    @objc public func formatStrikethrough(_ sender: Any?) { toggleInlineWrap(open: "~~", close: "~~") }
+    @objc public func formatHighlight(_ sender: Any?)     { toggleInlineWrap(open: "==", close: "==") }
+    @objc public func formatCode(_ sender: Any?)          { toggleInlineWrap(open: "`", close: "`") }
+    @objc public func formatInlineMath(_ sender: Any?)    { toggleInlineWrap(open: "$", close: "$") }
+    @objc public func formatKeyboard(_ sender: Any?)      { toggleInlineWrap(open: "<kbd>", close: "</kbd>") }
+    @objc public func formatComment(_ sender: Any?)       { toggleInlineWrap(open: "%%", close: "%%") }
+
+    // MARK: Inline links
+
+    @objc public func formatWikilink(_ sender: Any?)      { toggleInlineWrap(open: "[[", close: "]]") }
+    @objc public func formatLink(_ sender: Any?)          { insertLink() }
+    @objc public func formatImage(_ sender: Any?)         { insertImage() }
+    @objc public func formatFootnote(_ sender: Any?)      { insertFootnote() }
+
+    // MARK: Blocks
+
+    @objc public func formatBulletedList(_ sender: Any?)  { toggleLinePrefix("- ") }
+    @objc public func formatNumberedList(_ sender: Any?)  { toggleNumberedList() }
+    @objc public func formatChecklist(_ sender: Any?)     { toggleChecklist() }
+    @objc public func formatBlockQuote(_ sender: Any?)    { toggleLinePrefix("> ") }
+    @objc public func formatCodeBlock(_ sender: Any?)     { insertCodeBlock() }
+    @objc public func formatMathBlock(_ sender: Any?)     { toggleInlineWrap(open: "$$", close: "$$") }
+    @objc public func formatTable(_ sender: Any?)         { insertTable() }
+
+    /// Heading level read from the menu item's `tag` (1–6).
+    @objc public func formatHeading(_ sender: Any?) {
+        applyHeadingLevel((sender as? NSMenuItem)?.tag ?? 1)
+    }
+
+    /// Callout type read from the menu item's `representedObject` (already cased:
+    /// uppercase for GitHub alerts, lowercase for Obsidian callouts).
+    @objc public func formatCallout(_ sender: Any?) {
+        guard let type = (sender as? NSMenuItem)?.representedObject as? String else { return }
+        applyCalloutType(type)
+    }
+
+    // MARK: - Menu validation
+    //
+    // Formatting actions are disabled in Reading mode (the editor is read-only).
+
+    public override func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        if let action = menuItem.action, Self.formattingActions.contains(action) {
+            return viewMode != .reading
+        }
+        return super.validateMenuItem(menuItem)
+    }
+
+    static let formattingActions: Set<Selector> = [
+        #selector(formatBold(_:)), #selector(formatItalic(_:)), #selector(formatUnderline(_:)),
+        #selector(formatStrikethrough(_:)), #selector(formatHighlight(_:)), #selector(formatCode(_:)),
+        #selector(formatInlineMath(_:)), #selector(formatKeyboard(_:)), #selector(formatComment(_:)),
+        #selector(formatWikilink(_:)), #selector(formatLink(_:)), #selector(formatImage(_:)),
+        #selector(formatFootnote(_:)), #selector(formatBulletedList(_:)), #selector(formatNumberedList(_:)),
+        #selector(formatChecklist(_:)), #selector(formatBlockQuote(_:)), #selector(formatCodeBlock(_:)),
+        #selector(formatMathBlock(_:)), #selector(formatTable(_:)), #selector(formatHeading(_:)),
+        #selector(formatCallout(_:)),
+    ]
+
+    // MARK: - Heading
+
+    func applyHeadingLevel(_ level: Int) {
+        transformSelectedLines { lines in
+            let nonEmpty = lines.filter { !$0.isEmpty }
+            let allAtLevel = !nonEmpty.isEmpty && nonEmpty.allSatisfy { self.leadingHashCount($0) == level }
+            return lines.map { line in
+                guard !line.isEmpty else { return line }
+                let stripped = self.stripLeadingHashes(line)
+                // Re-applying the same level clears the heading.
+                return allAtLevel ? stripped : String(repeating: "#", count: level) + " " + stripped
+            }
+        }
+    }
+
+    // MARK: - Lists / quote
+
+    /// Prepend `prefix` to every line, or strip it when every non-empty line
+    /// already has it (toggle). Used for `- ` bullets and `> ` block quotes.
+    func toggleLinePrefix(_ prefix: String) {
+        transformSelectedLines { lines in
+            let nonEmpty = lines.filter { !$0.isEmpty }
+            let stripAll = !nonEmpty.isEmpty && nonEmpty.allSatisfy { $0.hasPrefix(prefix) }
+            if stripAll {
+                return lines.map { $0.hasPrefix(prefix) ? String($0.dropFirst(prefix.count)) : $0 }
+            }
+            if lines == [""] { return [prefix] }     // caret on a blank line → start one
+            return lines.map { $0.isEmpty ? $0 : prefix + $0 }
+        }
+    }
+
+    func toggleNumberedList() {
+        let ns = rawSource as NSString
+        let ctx = selectedLineContext()
+
+        // Continue numbering from the line before the selection, if it is a list.
+        var start = 1
+        if ctx.range.location > 0 {
+            let prev = ns.lineRange(for: NSRange(location: ctx.range.location - 1, length: 0))
+            var prevLine = ns.substring(with: prev)
+            if prevLine.hasSuffix("\n") { prevLine.removeLast() }
+            if let n = leadingListNumber(prevLine) { start = n + 1 }
+        }
+
+        transformSelectedLines { lines in
+            let nonEmpty = lines.filter { !$0.isEmpty }
+            let allNumbered = !nonEmpty.isEmpty && nonEmpty.allSatisfy { self.leadingListNumber($0) != nil }
+            if allNumbered {
+                return lines.map { self.stripLeadingNumber($0) }
+            }
+            if lines == [""] { return ["\(start). "] }
+            var n = start
+            return lines.map { line -> String in
+                guard !line.isEmpty else { return line }
+                defer { n += 1 }
+                return "\(n). " + line
+            }
+        }
+    }
+
+    /// Checklist (NOT invertible): non-checklist lines gain `- [ ] `; existing
+    /// checklist lines toggle their mark `[ ]` ↔ `[x]`.
+    func toggleChecklist() {
+        transformSelectedLines { lines in
+            lines.map { line in
+                let ns = line as NSString
+                // "- [ ] " or "- [x] " — mark is at offset 3, closing "] " at 4–5.
+                if ns.length >= 6,
+                   ns.substring(to: 3) == "- [",
+                   ns.substring(with: NSRange(location: 4, length: 2)) == "] " {
+                    let mark = ns.character(at: 3)
+                    let newMark = (mark == 0x20) ? "x" : " "   // ' ' ↔ 'x'
+                    return "- [" + newMark + "] " + ns.substring(from: 6)
+                }
+                return "- [ ] " + line
+            }
+        }
+    }
+
+    // MARK: - Inline link / image / footnote
+
+    private func insertLink() {
+        let ns = rawSource as NSString
+        let sel = selectedRange()
+        if sel.length > 0 {
+            let text = ns.substring(with: sel)
+            if let inner = unwrapLink(text) {     // toggle off
+                applyFormattingEdit(rawRange: sel, replacement: inner,
+                                    select: NSRange(location: sel.location, length: (inner as NSString).length))
+                return
+            }
+            let replacement = "[" + text + "]()"
+            let caret = sel.location + 1 + (text as NSString).length + 2   // inside ()
+            applyFormattingEdit(rawRange: sel, replacement: replacement,
+                                select: NSRange(location: caret, length: 0))
+        } else {
+            applyFormattingEdit(rawRange: NSRange(location: sel.location, length: 0),
+                                replacement: "[]()",
+                                select: NSRange(location: sel.location + 3, length: 0))  // inside ()
+        }
+    }
+
+    private func insertImage() {
+        let ns = rawSource as NSString
+        let sel = selectedRange()
+        if sel.length > 0 {
+            let text = ns.substring(with: sel)
+            if let inner = unwrapImage(text) {    // toggle off
+                applyFormattingEdit(rawRange: sel, replacement: inner,
+                                    select: NSRange(location: sel.location, length: (inner as NSString).length))
+                return
+            }
+            let replacement = "![" + text + "]()"
+            let caret = sel.location + 2 + (text as NSString).length + 2  // inside ()
+            applyFormattingEdit(rawRange: sel, replacement: replacement,
+                                select: NSRange(location: caret, length: 0))
+        } else {
+            applyFormattingEdit(rawRange: NSRange(location: sel.location, length: 0),
+                                replacement: "![]()",
+                                select: NSRange(location: sel.location + 4, length: 0))  // inside ()
+        }
+    }
+
+    /// Footnote (NOT invertible): insert `[^n]` after the selection/caret and a
+    /// `[^n]: ` definition at the bottom of the file; the caret lands at the
+    /// definition so the note can be typed.
+    private func insertFootnote() {
+        let ns = rawSource as NSString
+        let sel = selectedRange()
+        let n = nextFootnoteNumber()
+        let markerPos = sel.length > 0 ? sel.upperBound : sel.location
+
+        var newRaw = ns.replacingCharacters(in: NSRange(location: markerPos, length: 0),
+                                            with: "[^\(n)]")
+        let body = newRaw as NSString
+        let needsNewline = body.length > 0 && body.character(at: body.length - 1) != 0x0A
+        newRaw += (needsNewline ? "\n" : "") + "[^\(n)]: "
+        let caret = (newRaw as NSString).length
+        applyWholeDocumentEdit(newRawSource: newRaw, select: NSRange(location: caret, length: 0))
+    }
+
+    // MARK: - Code block / table
+
+    private func insertCodeBlock() {
+        let ctx = selectedLineContext()
+        // Toggle off when the selected lines are already a full fence.
+        if ctx.lines.count >= 2, ctx.lines.first!.hasPrefix("```"), ctx.lines.last! == "```" {
+            let inner = ctx.lines.dropFirst().dropLast().joined(separator: "\n")
+            var replacement = inner
+            if ctx.trailingNewline { replacement += "\n" }
+            applyFormattingEdit(rawRange: ctx.range, replacement: replacement,
+                                select: NSRange(location: ctx.range.location, length: 0))
+            return
+        }
+        let content = ctx.lines.joined(separator: "\n")
+        var replacement = "```\n" + content + "\n```"
+        if ctx.trailingNewline { replacement += "\n" }
+        // Caret on the opening-fence info line, right after "```".
+        applyFormattingEdit(rawRange: ctx.range, replacement: replacement,
+                            select: NSRange(location: ctx.range.location + 3, length: 0))
+    }
+
+    /// Insert a 2×2 placeholder table on its own line after the caret's line.
+    /// Ignores the selection; not a toggle.
+    private func insertTable() {
+        let ns = rawSource as NSString
+        let sel = selectedRange()
+        let line = ns.lineRange(for: NSRange(location: min(sel.location, ns.length), length: 0))
+        let lineEndsWithNewline = line.upperBound > line.location && ns.character(at: line.upperBound - 1) == 0x0A
+        let lineIsBlank = ns.substring(with: line).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+
+        let table = "| Header 1 | Header 2 |\n| --- | --- |\n| Cell 1 | Cell 2 |\n"
+        let insertPos: Int
+        let replacement: String
+        let lead: Int
+        if lineIsBlank {
+            insertPos = line.location
+            replacement = table
+            lead = 0
+        } else if lineEndsWithNewline {
+            insertPos = line.upperBound
+            replacement = table
+            lead = 0
+        } else {
+            insertPos = ns.length
+            replacement = "\n" + table
+            lead = 1
+        }
+        // Caret at the first header cell ("Header 1"), i.e. past the leading
+        // newline (if any) and "| ".
+        let caret = insertPos + lead + 2
+        applyFormattingEdit(rawRange: NSRange(location: insertPos, length: 0),
+                            replacement: replacement,
+                            select: NSRange(location: caret, length: 0))
+    }
+
+    // MARK: - Callout / alert
+
+    /// Wrap the selected lines in a callout (`> [!TYPE]` header + `> ` body), or
+    /// strip it when the lines are already that callout. `type` is pre-cased.
+    func applyCalloutType(_ type: String) {
+        transformSelectedLines { lines in
+            let header = "> [!\(type)]"
+            if let first = lines.first,
+               first.trimmingCharacters(in: .whitespaces).lowercased() == "> [!\(type.lowercased())]" {
+                // Strip: drop the header, unprefix the body.
+                return lines.dropFirst().map {
+                    if $0.hasPrefix("> ") { return String($0.dropFirst(2)) }
+                    if $0.hasPrefix(">")  { return String($0.dropFirst(1)) }
+                    return $0
+                }
+            }
+            let body = lines.map { $0.isEmpty ? ">" : "> " + $0 }
+            return [header] + body
+        }
+    }
+}

--- a/Sources/EdmundCore/Editing/EditorTextView+FormattingCommands.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+FormattingCommands.swift
@@ -25,7 +25,7 @@ extension EditorTextView {
 
     // MARK: Inline links
 
-    @objc public func formatWikilink(_ sender: Any?)      { toggleInlineWrap(open: "[[", close: "]]") }
+    @objc public func formatWikilink(_ sender: Any?)      { toggleInlineWrap(open: "[[", close: "]]", expandToWord: true) }
     @objc public func formatLink(_ sender: Any?)          { insertLink() }
     @objc public func formatImage(_ sender: Any?)         { insertImage() }
     @objc public func formatFootnote(_ sender: Any?)      { insertFootnote() }
@@ -37,7 +37,7 @@ extension EditorTextView {
     @objc public func formatChecklist(_ sender: Any?)     { toggleChecklist() }
     @objc public func formatBlockQuote(_ sender: Any?)    { toggleLinePrefix("> ") }
     @objc public func formatCodeBlock(_ sender: Any?)     { insertCodeBlock() }
-    @objc public func formatMathBlock(_ sender: Any?)     { toggleInlineWrap(open: "$$", close: "$$") }
+    @objc public func formatMathBlock(_ sender: Any?)     { insertMathBlock() }
     @objc public func formatTable(_ sender: Any?)         { insertTable() }
 
     /// Heading level read from the menu item's `tag` (1–6).
@@ -91,17 +91,29 @@ extension EditorTextView {
 
     // MARK: - Lists / quote
 
-    /// Prepend `prefix` to every line, or strip it when every non-empty line
-    /// already has it (toggle). Used for `- ` bullets and `> ` block quotes.
+    /// Prepend `prefix` to every line, or strip it when every non-empty line is
+    /// already that exact type (toggle). For list prefixes (`"- "` etc.) existing
+    /// other list markers are stripped before the new prefix is applied, so lists
+    /// seamlessly replace each other (bullet→numbered, checklist→bullet, etc.).
     func toggleLinePrefix(_ prefix: String) {
+        let isList = (prefix == "- " || prefix == "* " || prefix == "+ ")
         transformSelectedLines { lines in
             let nonEmpty = lines.filter { !$0.isEmpty }
-            let stripAll = !nonEmpty.isEmpty && nonEmpty.allSatisfy { $0.hasPrefix(prefix) }
+            // Toggle off only when every non-empty line is exactly this list type.
+            let stripAll: Bool
+            if isList {
+                stripAll = !nonEmpty.isEmpty && nonEmpty.allSatisfy { self.isBulletLine($0) && $0.hasPrefix(prefix) }
+            } else {
+                stripAll = !nonEmpty.isEmpty && nonEmpty.allSatisfy { $0.hasPrefix(prefix) }
+            }
             if stripAll {
                 return lines.map { $0.hasPrefix(prefix) ? String($0.dropFirst(prefix.count)) : $0 }
             }
-            if lines == [""] { return [prefix] }     // caret on a blank line → start one
-            return lines.map { $0.isEmpty ? $0 : prefix + $0 }
+            if lines == [""] { return [prefix] }
+            return lines.map { line -> String in
+                guard !line.isEmpty else { return line }
+                return isList ? prefix + self.stripListPrefix(line) : prefix + line
+            }
         }
     }
 
@@ -122,33 +134,30 @@ extension EditorTextView {
             let nonEmpty = lines.filter { !$0.isEmpty }
             let allNumbered = !nonEmpty.isEmpty && nonEmpty.allSatisfy { self.leadingListNumber($0) != nil }
             if allNumbered {
-                return lines.map { self.stripLeadingNumber($0) }
+                return lines.map { self.stripListPrefix($0) }
             }
             if lines == [""] { return ["\(start). "] }
             var n = start
             return lines.map { line -> String in
                 guard !line.isEmpty else { return line }
                 defer { n += 1 }
-                return "\(n). " + line
+                return "\(n). " + self.stripListPrefix(line)
             }
         }
     }
 
-    /// Checklist (NOT invertible): non-checklist lines gain `- [ ] `; existing
-    /// checklist lines toggle their mark `[ ]` ↔ `[x]`.
+    /// Checklist (NOT invertible): non-checklist lines gain `- [ ] ` (stripping
+    /// any existing list marker first); existing checklist lines toggle `[ ]`↔`[x]`.
     func toggleChecklist() {
         transformSelectedLines { lines in
             lines.map { line in
-                let ns = line as NSString
-                // "- [ ] " or "- [x] " — mark is at offset 3, closing "] " at 4–5.
-                if ns.length >= 6,
-                   ns.substring(to: 3) == "- [",
-                   ns.substring(with: NSRange(location: 4, length: 2)) == "] " {
+                if self.isChecklistLine(line) {
+                    let ns = line as NSString
                     let mark = ns.character(at: 3)
-                    let newMark = (mark == 0x20) ? "x" : " "   // ' ' ↔ 'x'
+                    let newMark = (mark == 0x20) ? "x" : " "
                     return "- [" + newMark + "] " + ns.substring(from: 6)
                 }
-                return "- [ ] " + line
+                return "- [ ] " + self.stripListPrefix(line)
             }
         }
     }
@@ -158,53 +167,95 @@ extension EditorTextView {
     private func insertLink() {
         let ns = rawSource as NSString
         let sel = selectedRange()
+
         if sel.length > 0 {
             let text = ns.substring(with: sel)
-            if let inner = unwrapLink(text) {     // toggle off
+            if let inner = unwrapLink(text) {
                 applyFormattingEdit(rawRange: sel, replacement: inner,
                                     select: NSRange(location: sel.location, length: (inner as NSString).length))
                 return
             }
             let replacement = "[" + text + "]()"
-            let caret = sel.location + 1 + (text as NSString).length + 2   // inside ()
+            let caret = sel.location + 1 + (text as NSString).length + 2
             applyFormattingEdit(rawRange: sel, replacement: replacement,
                                 select: NSRange(location: caret, length: 0))
-        } else {
-            applyFormattingEdit(rawRange: NSRange(location: sel.location, length: 0),
-                                replacement: "[]()",
-                                select: NSRange(location: sel.location + 3, length: 0))  // inside ()
+            return
         }
+
+        // Caret: check if inside an existing link → unwrap it.
+        if let linkRange = linkRangeAroundCaret() {
+            let linkText = ns.substring(with: linkRange)
+            if let inner = unwrapLink(linkText) {
+                applyFormattingEdit(rawRange: linkRange, replacement: inner,
+                                    select: NSRange(location: linkRange.location, length: (inner as NSString).length))
+                return
+            }
+        }
+
+        // Expand to current word.
+        if let word = currentWordRange() {
+            let wordText = ns.substring(with: word)
+            let replacement = "[" + wordText + "]()"
+            let caret = word.location + 1 + (wordText as NSString).length + 2
+            applyFormattingEdit(rawRange: word, replacement: replacement,
+                                select: NSRange(location: caret, length: 0))
+            return
+        }
+
+        // No word: insert empty link, caret inside ().
+        applyFormattingEdit(rawRange: NSRange(location: sel.location, length: 0),
+                            replacement: "[]()",
+                            select: NSRange(location: sel.location + 3, length: 0))
     }
 
     private func insertImage() {
         let ns = rawSource as NSString
         let sel = selectedRange()
+
         if sel.length > 0 {
             let text = ns.substring(with: sel)
-            if let inner = unwrapImage(text) {    // toggle off
+            if let inner = unwrapImage(text) {
                 applyFormattingEdit(rawRange: sel, replacement: inner,
                                     select: NSRange(location: sel.location, length: (inner as NSString).length))
                 return
             }
             let replacement = "![" + text + "]()"
-            let caret = sel.location + 2 + (text as NSString).length + 2  // inside ()
+            let caret = sel.location + 2 + (text as NSString).length + 2
             applyFormattingEdit(rawRange: sel, replacement: replacement,
                                 select: NSRange(location: caret, length: 0))
-        } else {
-            applyFormattingEdit(rawRange: NSRange(location: sel.location, length: 0),
-                                replacement: "![]()",
-                                select: NSRange(location: sel.location + 4, length: 0))  // inside ()
+            return
         }
+
+        // Expand to current word.
+        if let word = currentWordRange() {
+            let wordText = ns.substring(with: word)
+            let replacement = "![" + wordText + "]()"
+            let caret = word.location + 2 + (wordText as NSString).length + 2
+            applyFormattingEdit(rawRange: word, replacement: replacement,
+                                select: NSRange(location: caret, length: 0))
+            return
+        }
+
+        applyFormattingEdit(rawRange: NSRange(location: sel.location, length: 0),
+                            replacement: "![]()",
+                            select: NSRange(location: sel.location + 4, length: 0))
     }
 
-    /// Footnote (NOT invertible): insert `[^n]` after the selection/caret and a
-    /// `[^n]: ` definition at the bottom of the file; the caret lands at the
-    /// definition so the note can be typed.
+    /// Footnote (NOT invertible): inserts `[^n]` after the selection/caret (or the
+    /// end of the current word when no selection) and appends `[^n]: ` at EOF.
     private func insertFootnote() {
         let ns = rawSource as NSString
         let sel = selectedRange()
         let n = nextFootnoteNumber()
-        let markerPos = sel.length > 0 ? sel.upperBound : sel.location
+
+        let markerPos: Int
+        if sel.length > 0 {
+            markerPos = sel.upperBound
+        } else if let word = currentWordRange() {
+            markerPos = word.upperBound
+        } else {
+            markerPos = sel.location
+        }
 
         var newRaw = ns.replacingCharacters(in: NSRange(location: markerPos, length: 0),
                                             with: "[^\(n)]")
@@ -215,11 +266,10 @@ extension EditorTextView {
         applyWholeDocumentEdit(newRawSource: newRaw, select: NSRange(location: caret, length: 0))
     }
 
-    // MARK: - Code block / table
+    // MARK: - Code block / math block / table
 
     private func insertCodeBlock() {
         let ctx = selectedLineContext()
-        // Toggle off when the selected lines are already a full fence.
         if ctx.lines.count >= 2, ctx.lines.first!.hasPrefix("```"), ctx.lines.last! == "```" {
             let inner = ctx.lines.dropFirst().dropLast().joined(separator: "\n")
             var replacement = inner
@@ -231,12 +281,31 @@ extension EditorTextView {
         let content = ctx.lines.joined(separator: "\n")
         var replacement = "```\n" + content + "\n```"
         if ctx.trailingNewline { replacement += "\n" }
-        // Caret on the opening-fence info line, right after "```".
         applyFormattingEdit(rawRange: ctx.range, replacement: replacement,
                             select: NSRange(location: ctx.range.location + 3, length: 0))
     }
 
-    /// Insert a 2×2 placeholder table on its own line after the caret's line.
+    /// Display math block: `$$\n{content}\n$$`. Toggle-off when the selected
+    /// lines are already fenced with `$$`.
+    private func insertMathBlock() {
+        let ctx = selectedLineContext()
+        if ctx.lines.count >= 2, ctx.lines.first! == "$$", ctx.lines.last! == "$$" {
+            let inner = ctx.lines.dropFirst().dropLast().joined(separator: "\n")
+            var replacement = inner
+            if ctx.trailingNewline { replacement += "\n" }
+            applyFormattingEdit(rawRange: ctx.range, replacement: replacement,
+                                select: NSRange(location: ctx.range.location, length: 0))
+            return
+        }
+        let content = ctx.lines.joined(separator: "\n")
+        var replacement = "$$\n" + content + "\n$$"
+        if ctx.trailingNewline { replacement += "\n" }
+        // Caret on the first content line (after the opening "$$\n").
+        applyFormattingEdit(rawRange: ctx.range, replacement: replacement,
+                            select: NSRange(location: ctx.range.location + 3, length: 0))
+    }
+
+    /// Insert a 3×2 placeholder table with padded dividers (matching header width).
     /// Ignores the selection; not a toggle.
     private func insertTable() {
         let ns = rawSource as NSString
@@ -245,7 +314,14 @@ extension EditorTextView {
         let lineEndsWithNewline = line.upperBound > line.location && ns.character(at: line.upperBound - 1) == 0x0A
         let lineIsBlank = ns.substring(with: line).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 
-        let table = "| Header 1 | Header 2 |\n| --- | --- |\n| Cell 1 | Cell 2 |\n"
+        // 3 columns, dividers padded to match "Header N" length (8 chars).
+        let table = """
+            | Header 1 | Header 2 | Header 3 |
+            | -------- | -------- | -------- |
+            | Cell 1 | Cell 2 | Cell 3 |
+            | Cell 4 | Cell 5 | Cell 6 |
+
+            """  // trailing newline via the heredoc newline before closing """
         let insertPos: Int
         let replacement: String
         let lead: Int
@@ -262,9 +338,7 @@ extension EditorTextView {
             replacement = "\n" + table
             lead = 1
         }
-        // Caret at the first header cell ("Header 1"), i.e. past the leading
-        // newline (if any) and "| ".
-        let caret = insertPos + lead + 2
+        let caret = insertPos + lead + 2   // past leading newline (if any) + "| "
         applyFormattingEdit(rawRange: NSRange(location: insertPos, length: 0),
                             replacement: replacement,
                             select: NSRange(location: caret, length: 0))

--- a/Sources/EdmundCore/Editing/EditorTextView+FormattingCommands.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+FormattingCommands.swift
@@ -6,12 +6,49 @@ import AppKit
 // route through the responder chain to the focused editor — the same wiring as
 // undo/redo). Each delegates to a primitive/helper in +FormattingCore.
 //
-// Toggling: most commands are invertible — applying twice restores the original
-// — except Checklist, Footnote, and Table, which the spec marks otherwise.
+// ## Invertibility
+//
+// Most format commands are toggles: applying twice returns to the original text
+// and cursor position. Exceptions:
+//   • Checklist (⌘L)  — NOT invertible. Re-applying cycles [ ] ↔ [x] instead of
+//                        removing the checklist marker.
+//   • Footnote        — NOT invertible. Inserts a new [^n] each time.
+//   • Table           — NOT a toggle. Always inserts a fresh placeholder table.
+//
+// ## Caret repositioning
+//
+// After wrap-on (no selection or wrap-off leaves content selected):
+//   • Symmetric inline styles (Bold, Italic, …): caret placed on the first char
+//     of the wrapped content — so the next keystroke edits inside the delimiters.
+//   • Link/Image (no selection): caret lands inside the `()` so the URL can be
+//     typed immediately.
+//   • Link/Wikilink/Image (selection or word expansion): caret inside `()` or
+//     after content.
+//   • Footnote: caret at the end-of-file definition line, ready to type the note.
+//   • Math Block / Code Block: caret on the opening-fence line (language / math
+//     content).
+//   • Table: caret on the first header cell.
+//
+// ## List replacement
+//
+// Applying any list format (Bulleted / Numbered / Checklist) to a line that
+// already carries a different list marker strips the old marker first (via
+// stripListPrefix), so lists replace rather than nest:
+//   `- [ ] task` → ⌥⌘B  →  `- task`   (not `- - [ ] task`)
+//   `1. item`    → ⌘L   →  `- [ ] item`
+//
+// ## Whitespace stripping
+//
+// Inline wraps (Bold, Italic, Code, etc.) exclude leading/trailing spaces from
+// the delimiters: selecting " word " and pressing Cmd+B gives " **word** ", not
+// "** word **". Toggle-off detection also operates on the trimmed range, so
+// selecting " **word** " and pressing Cmd+B correctly unwraps.
 
 extension EditorTextView {
 
-    // MARK: Inline font styles
+    // MARK: - Inline font styles
+    // All toggle (applying twice restores original). Empty-caret fallback inserts
+    // symmetric empty delimiters with the caret centred: `**|**`, `*|*`, etc.
 
     @objc public func formatBold(_ sender: Any?)          { toggleInlineWrap(open: "**", close: "**") }
     @objc public func formatItalic(_ sender: Any?)        { toggleInlineWrap(open: "*", close: "*") }
@@ -23,14 +60,17 @@ extension EditorTextView {
     @objc public func formatKeyboard(_ sender: Any?)      { toggleInlineWrap(open: "<kbd>", close: "</kbd>") }
     @objc public func formatComment(_ sender: Any?)       { toggleInlineWrap(open: "%%", close: "%%") }
 
-    // MARK: Inline links
+    // MARK: - Inline links
+    // Link / Image: caret in `()` so URL can be typed next.
+    // Wikilink:     expands to the current word at caret (expandToWord: true).
+    // Footnote:     NOT invertible — inserts [^n] marker and EOF definition.
 
     @objc public func formatWikilink(_ sender: Any?)      { toggleInlineWrap(open: "[[", close: "]]", expandToWord: true) }
     @objc public func formatLink(_ sender: Any?)          { insertLink() }
     @objc public func formatImage(_ sender: Any?)         { insertImage() }
     @objc public func formatFootnote(_ sender: Any?)      { insertFootnote() }
 
-    // MARK: Blocks
+    // MARK: - Block-level commands
 
     @objc public func formatBulletedList(_ sender: Any?)  { toggleLinePrefix("- ") }
     @objc public func formatNumberedList(_ sender: Any?)  { toggleNumberedList() }
@@ -41,11 +81,13 @@ extension EditorTextView {
     @objc public func formatTable(_ sender: Any?)         { insertTable() }
 
     /// Heading level read from the menu item's `tag` (1–6).
+    /// Heading H1–H6: strips any existing `#…` prefix and applies the new level.
+    /// Re-applying the same level clears the heading. Applies per selected line.
     @objc public func formatHeading(_ sender: Any?) {
         applyHeadingLevel((sender as? NSMenuItem)?.tag ?? 1)
     }
 
-    /// Callout type read from the menu item's `representedObject` (already cased:
+    /// Callout type read from the menu item's `representedObject` (pre-cased:
     /// uppercase for GitHub alerts, lowercase for Obsidian callouts).
     @objc public func formatCallout(_ sender: Any?) {
         guard let type = (sender as? NSMenuItem)?.representedObject as? String else { return }
@@ -53,7 +95,6 @@ extension EditorTextView {
     }
 
     // MARK: - Menu validation
-    //
     // Formatting actions are disabled in Reading mode (the editor is read-only).
 
     public override func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
@@ -77,13 +118,15 @@ extension EditorTextView {
     // MARK: - Heading
 
     func applyHeadingLevel(_ level: Int) {
+        // All selected lines get the same heading level applied or cleared.
+        // "Same level" is determined by majority: if every non-empty line already
+        // has exactly `level` hashes, they are all cleared (toggle-off).
         transformSelectedLines { lines in
             let nonEmpty = lines.filter { !$0.isEmpty }
             let allAtLevel = !nonEmpty.isEmpty && nonEmpty.allSatisfy { self.leadingHashCount($0) == level }
             return lines.map { line in
                 guard !line.isEmpty else { return line }
                 let stripped = self.stripLeadingHashes(line)
-                // Re-applying the same level clears the heading.
                 return allAtLevel ? stripped : String(repeating: "#", count: level) + " " + stripped
             }
         }
@@ -92,16 +135,23 @@ extension EditorTextView {
     // MARK: - Lists / quote
 
     /// Prepend `prefix` to every line, or strip it when every non-empty line is
-    /// already that exact type (toggle). For list prefixes (`"- "` etc.) existing
-    /// other list markers are stripped before the new prefix is applied, so lists
-    /// seamlessly replace each other (bullet→numbered, checklist→bullet, etc.).
+    /// already that exact type (toggle-off).
+    ///
+    /// List replacement: for bullet prefixes (`"- "` etc.), any existing list
+    /// marker (checklist, numbered, other bullet) is stripped before the new one
+    /// is applied, so list types replace each other rather than stacking. Block
+    /// quotes (`"> "`) are not list markers; they stack normally.
+    ///
+    /// Toggle-off check: only fires when every non-empty line is EXACTLY this
+    /// bullet type — not checklists (which also start with `"- "` but are a
+    /// different type) or numbered lists.
     func toggleLinePrefix(_ prefix: String) {
         let isList = (prefix == "- " || prefix == "* " || prefix == "+ ")
         transformSelectedLines { lines in
             let nonEmpty = lines.filter { !$0.isEmpty }
-            // Toggle off only when every non-empty line is exactly this list type.
             let stripAll: Bool
             if isList {
+                // Toggle-off only for exact bullets, not checklists or numbered.
                 stripAll = !nonEmpty.isEmpty && nonEmpty.allSatisfy { self.isBulletLine($0) && $0.hasPrefix(prefix) }
             } else {
                 stripAll = !nonEmpty.isEmpty && nonEmpty.allSatisfy { $0.hasPrefix(prefix) }
@@ -112,16 +162,20 @@ extension EditorTextView {
             if lines == [""] { return [prefix] }
             return lines.map { line -> String in
                 guard !line.isEmpty else { return line }
+                // Strip existing list marker before adding new one (replacement, not nesting).
                 return isList ? prefix + self.stripListPrefix(line) : prefix + line
             }
         }
     }
 
+    /// Numbered list: prepend `1.`, `2.`, … per line (toggle-off strips the
+    /// prefix). If the line immediately before the selection ends with `N. `,
+    /// numbering continues from N+1 rather than restarting at 1.
+    /// Replacement: strips any existing list marker before numbering.
     func toggleNumberedList() {
         let ns = rawSource as NSString
         let ctx = selectedLineContext()
 
-        // Continue numbering from the line before the selection, if it is a list.
         var start = 1
         if ctx.range.location > 0 {
             let prev = ns.lineRange(for: NSRange(location: ctx.range.location - 1, length: 0))
@@ -146,24 +200,33 @@ extension EditorTextView {
         }
     }
 
-    /// Checklist (NOT invertible): non-checklist lines gain `- [ ] ` (stripping
-    /// any existing list marker first); existing checklist lines toggle `[ ]`↔`[x]`.
+    /// Checklist (NOT invertible):
+    ///   • Checklist line: toggles the mark `[ ]` ↔ `[x]`.
+    ///   • Any other line (plain, bullet, numbered): strips the existing list
+    ///     marker and prepends `- [ ] ` (replacement, not nesting).
     func toggleChecklist() {
         transformSelectedLines { lines in
             lines.map { line in
                 if self.isChecklistLine(line) {
                     let ns = line as NSString
                     let mark = ns.character(at: 3)
-                    let newMark = (mark == 0x20) ? "x" : " "
+                    let newMark = (mark == 0x20) ? "x" : " "   // ' ' ↔ 'x'
                     return "- [" + newMark + "] " + ns.substring(from: 6)
                 }
+                // Strip existing list marker before adding checklist prefix.
                 return "- [ ] " + self.stripListPrefix(line)
             }
         }
     }
 
-    // MARK: - Inline link / image / footnote
+    // MARK: - Link / Image / Footnote
 
+    /// Link (⌘K): toggle.
+    /// • With selection: wraps as `[selection]()`, caret in `()`. If the selection
+    ///   is already `[text](dest)`, unwraps to the text.
+    /// • No selection: if caret is inside an existing `[text](url)`, unwraps it.
+    ///   Otherwise expands to the current word, producing `[word]()`, caret in `()`.
+    ///   Fallback (no word): inserts `[]()`, caret in `()`.
     private func insertLink() {
         let ns = rawSource as NSString
         let sel = selectedRange()
@@ -176,13 +239,13 @@ extension EditorTextView {
                 return
             }
             let replacement = "[" + text + "]()"
-            let caret = sel.location + 1 + (text as NSString).length + 2
+            let caret = sel.location + 1 + (text as NSString).length + 2  // inside ()
             applyFormattingEdit(rawRange: sel, replacement: replacement,
                                 select: NSRange(location: caret, length: 0))
             return
         }
 
-        // Caret: check if inside an existing link → unwrap it.
+        // Caret: check if inside an existing link → unwrap.
         if let linkRange = linkRangeAroundCaret() {
             let linkText = ns.substring(with: linkRange)
             if let inner = unwrapLink(linkText) {
@@ -196,7 +259,7 @@ extension EditorTextView {
         if let word = currentWordRange() {
             let wordText = ns.substring(with: word)
             let replacement = "[" + wordText + "]()"
-            let caret = word.location + 1 + (wordText as NSString).length + 2
+            let caret = word.location + 1 + (wordText as NSString).length + 2  // inside ()
             applyFormattingEdit(rawRange: word, replacement: replacement,
                                 select: NSRange(location: caret, length: 0))
             return
@@ -208,6 +271,8 @@ extension EditorTextView {
                             select: NSRange(location: sel.location + 3, length: 0))
     }
 
+    /// Image: same shape as Link, prefixed with `!`.
+    /// Caret ends up inside the `()` so the URL/path can be typed.
     private func insertImage() {
         let ns = rawSource as NSString
         let sel = selectedRange()
@@ -220,17 +285,16 @@ extension EditorTextView {
                 return
             }
             let replacement = "![" + text + "]()"
-            let caret = sel.location + 2 + (text as NSString).length + 2
+            let caret = sel.location + 2 + (text as NSString).length + 2  // inside ()
             applyFormattingEdit(rawRange: sel, replacement: replacement,
                                 select: NSRange(location: caret, length: 0))
             return
         }
 
-        // Expand to current word.
         if let word = currentWordRange() {
             let wordText = ns.substring(with: word)
             let replacement = "![" + wordText + "]()"
-            let caret = word.location + 2 + (wordText as NSString).length + 2
+            let caret = word.location + 2 + (wordText as NSString).length + 2  // inside ()
             applyFormattingEdit(rawRange: word, replacement: replacement,
                                 select: NSRange(location: caret, length: 0))
             return
@@ -241,13 +305,16 @@ extension EditorTextView {
                             select: NSRange(location: sel.location + 4, length: 0))
     }
 
-    /// Footnote (NOT invertible): inserts `[^n]` after the selection/caret (or the
-    /// end of the current word when no selection) and appends `[^n]: ` at EOF.
+    /// Footnote (NOT invertible): inserts `[^n]` after the selection / end of
+    /// current word / caret, then appends `[^n]: ` at the end of the document.
+    /// Caret lands at the EOF definition so the note body can be typed immediately.
+    /// `n` is the next unused number (max existing [^k] + 1, starting at 1).
     private func insertFootnote() {
         let ns = rawSource as NSString
         let sel = selectedRange()
         let n = nextFootnoteNumber()
 
+        // Insertion point: after selection, or after the current word, or at caret.
         let markerPos: Int
         if sel.length > 0 {
             markerPos = sel.upperBound
@@ -266,11 +333,14 @@ extension EditorTextView {
         applyWholeDocumentEdit(newRawSource: newRaw, select: NSRange(location: caret, length: 0))
     }
 
-    // MARK: - Code block / math block / table
+    // MARK: - Block insert
 
+    /// Code block: wraps selected lines in ` ``` `…` ``` ` fences (toggle-off removes
+    /// them). Caret lands on the opening-fence line so a language tag can be typed.
     private func insertCodeBlock() {
         let ctx = selectedLineContext()
         if ctx.lines.count >= 2, ctx.lines.first!.hasPrefix("```"), ctx.lines.last! == "```" {
+            // Toggle off: unwrap the fenced content.
             let inner = ctx.lines.dropFirst().dropLast().joined(separator: "\n")
             var replacement = inner
             if ctx.trailingNewline { replacement += "\n" }
@@ -281,12 +351,14 @@ extension EditorTextView {
         let content = ctx.lines.joined(separator: "\n")
         var replacement = "```\n" + content + "\n```"
         if ctx.trailingNewline { replacement += "\n" }
+        // Caret after the opening "```" so a language tag can be typed.
         applyFormattingEdit(rawRange: ctx.range, replacement: replacement,
                             select: NSRange(location: ctx.range.location + 3, length: 0))
     }
 
-    /// Display math block: `$$\n{content}\n$$`. Toggle-off when the selected
-    /// lines are already fenced with `$$`.
+    /// Math block: wraps selected lines in `$$`…`$$` fences (toggle-off removes
+    /// them). Each `$$` occupies its own line (block math format).
+    /// Caret lands on the first content line between the fences.
     private func insertMathBlock() {
         let ctx = selectedLineContext()
         if ctx.lines.count >= 2, ctx.lines.first! == "$$", ctx.lines.last! == "$$" {
@@ -305,8 +377,9 @@ extension EditorTextView {
                             select: NSRange(location: ctx.range.location + 3, length: 0))
     }
 
-    /// Insert a 3×2 placeholder table with padded dividers (matching header width).
-    /// Ignores the selection; not a toggle.
+    /// Table: inserts a 3×2 placeholder table (3 columns, 2 data rows) after the
+    /// current line. Not a toggle. Dividers are padded to match header widths (8 chars).
+    /// Caret lands on the first header cell.
     private func insertTable() {
         let ns = rawSource as NSString
         let sel = selectedRange()
@@ -314,14 +387,14 @@ extension EditorTextView {
         let lineEndsWithNewline = line.upperBound > line.location && ns.character(at: line.upperBound - 1) == 0x0A
         let lineIsBlank = ns.substring(with: line).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 
-        // 3 columns, dividers padded to match "Header N" length (8 chars).
+        // 3 columns; dividers padded to "Header N" length (8 dashes).
         let table = """
             | Header 1 | Header 2 | Header 3 |
             | -------- | -------- | -------- |
             | Cell 1 | Cell 2 | Cell 3 |
             | Cell 4 | Cell 5 | Cell 6 |
 
-            """  // trailing newline via the heredoc newline before closing """
+            """
         let insertPos: Int
         let replacement: String
         let lead: Int
@@ -347,13 +420,13 @@ extension EditorTextView {
     // MARK: - Callout / alert
 
     /// Wrap the selected lines in a callout (`> [!TYPE]` header + `> ` body), or
-    /// strip it when the lines are already that callout. `type` is pre-cased.
+    /// strip it when the lines are already that callout. `type` is pre-cased
+    /// (uppercase for GitHub, lowercase for Obsidian).
     func applyCalloutType(_ type: String) {
         transformSelectedLines { lines in
             let header = "> [!\(type)]"
             if let first = lines.first,
                first.trimmingCharacters(in: .whitespaces).lowercased() == "> [!\(type.lowercased())]" {
-                // Strip: drop the header, unprefix the body.
                 return lines.dropFirst().map {
                     if $0.hasPrefix("> ") { return String($0.dropFirst(2)) }
                     if $0.hasPrefix(">")  { return String($0.dropFirst(1)) }

--- a/Sources/EdmundCore/Editing/EditorTextView+FormattingCommands.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+FormattingCommands.swift
@@ -47,18 +47,27 @@ import AppKit
 extension EditorTextView {
 
     // MARK: - Inline font styles
-    // All toggle (applying twice restores original). Empty-caret fallback inserts
-    // symmetric empty delimiters with the caret centred: `**|**`, `*|*`, etc.
+    // All toggle (applying twice restores original).
+    //
+    // Caret-with-no-selection behaviour: a caret INSIDE a word acts on the whole
+    // word (`anyth|ing` + Cmd+B → `**anything**`); pressing again unwraps it. When
+    // the caret is not in a word (blank line, between punctuation), empty delimiters
+    // are inserted with the caret centred (`**|**`).
+    //
+    // Bold and Italic additionally use markdown's `*`-nesting semantics at a caret,
+    // so the two compose: `**w**` + Cmd+I → `***w***`, and `***w***` + Cmd+B →
+    // `*w*`. See toggleStarEmphasis. The other styles use the generic word wrap
+    // (expandToWord), since they don't nest with each other.
 
-    @objc public func formatBold(_ sender: Any?)          { toggleInlineWrap(open: "**", close: "**") }
-    @objc public func formatItalic(_ sender: Any?)        { toggleInlineWrap(open: "*", close: "*") }
-    @objc public func formatUnderline(_ sender: Any?)     { toggleInlineWrap(open: "<u>", close: "</u>") }
-    @objc public func formatStrikethrough(_ sender: Any?) { toggleInlineWrap(open: "~~", close: "~~") }
-    @objc public func formatHighlight(_ sender: Any?)     { toggleInlineWrap(open: "==", close: "==") }
-    @objc public func formatCode(_ sender: Any?)          { toggleInlineWrap(open: "`", close: "`") }
-    @objc public func formatInlineMath(_ sender: Any?)    { toggleInlineWrap(open: "$", close: "$") }
-    @objc public func formatKeyboard(_ sender: Any?)      { toggleInlineWrap(open: "<kbd>", close: "</kbd>") }
-    @objc public func formatComment(_ sender: Any?)       { toggleInlineWrap(open: "%%", close: "%%") }
+    @objc public func formatBold(_ sender: Any?)          { toggleStarEmphasis(stars: 2) }
+    @objc public func formatItalic(_ sender: Any?)        { toggleStarEmphasis(stars: 1) }
+    @objc public func formatUnderline(_ sender: Any?)     { toggleInlineWrap(open: "<u>", close: "</u>", expandToWord: true) }
+    @objc public func formatStrikethrough(_ sender: Any?) { toggleInlineWrap(open: "~~", close: "~~", expandToWord: true) }
+    @objc public func formatHighlight(_ sender: Any?)     { toggleInlineWrap(open: "==", close: "==", expandToWord: true) }
+    @objc public func formatCode(_ sender: Any?)          { toggleInlineWrap(open: "`", close: "`", expandToWord: true) }
+    @objc public func formatInlineMath(_ sender: Any?)    { toggleInlineWrap(open: "$", close: "$", expandToWord: true) }
+    @objc public func formatKeyboard(_ sender: Any?)      { toggleInlineWrap(open: "<kbd>", close: "</kbd>", expandToWord: true) }
+    @objc public func formatComment(_ sender: Any?)       { toggleInlineWrap(open: "%%", close: "%%", expandToWord: true) }
 
     // MARK: - Inline links
     // Link / Image: caret in `()` so URL can be typed next.

--- a/Sources/EdmundCore/Editing/EditorTextView+FormattingCore.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+FormattingCore.swift
@@ -1,0 +1,286 @@
+import AppKit
+
+// MARK: - Formatting primitives & helpers
+//
+// The Format-menu commands (EditorTextView+FormattingCommands) all funnel
+// through the two edit primitives here. They follow the same template as the
+// Tab-indent path (EditorTextView+Indentation): push a single undo snapshot,
+// rebuild `rawSource`, re-parse blocks, and restyle only the affected span via
+// `recomposeReplacing` — preserving the hard invariant that the text storage
+// always equals `rawSource` (rendering is attribute-only).
+
+extension EditorTextView {
+
+    // MARK: - Edit primitives
+
+    /// Replace one contiguous `rawRange` (in current rawSource coordinates) with
+    /// `replacement` as a single undoable step, restyle the affected block span
+    /// in place, and set `select` (a caret when `length == 0`).
+    func applyFormattingEdit(rawRange: NSRange, replacement: String, select: NSRange) {
+        guard !blocks.isEmpty else { return }
+        let ns = rawSource as NSString
+        let loc = min(max(0, rawRange.location), ns.length)
+        let clamped = NSRange(location: loc, length: min(rawRange.length, ns.length - loc))
+
+        guard let startBlock = blockIndexForRawOffset(clamped.location),
+              let endBlock = blockIndexForRawOffset(clamped.upperBound) else { return }
+
+        // Pre-edit storage span covering exactly the affected blocks, so layout
+        // (and the viewport) above/below the edit stays put.
+        let oldSpan = NSRange(
+            location: blocks[startBlock].range.location,
+            length: blocks[endBlock].range.upperBound - blocks[startBlock].range.location)
+
+        undoStack.append(UndoSnapshot(rawSource: rawSource, cursorInRaw: selectedRange().location))
+        redoStack.removeAll()
+        lastEditType = .other
+        lastEditBlockIndex = nil
+
+        rawSource = ns.replacingCharacters(in: clamped, with: replacement)
+        rebuildListIndentState()
+        blocks = BlockParser.parse(rawSource, previous: blocks)
+
+        // The replaced region grew/shrank by `delta`; the new block-aligned span
+        // is the old span plus that delta. Its text is the storage replacement.
+        let delta = (replacement as NSString).length - clamped.length
+        let newSpan = NSRange(location: oldSpan.location, length: max(0, oldSpan.length + delta))
+        let newRaw = rawSource as NSString
+        let safeSpan = NSRange(location: min(newSpan.location, newRaw.length),
+                               length: min(newSpan.length, newRaw.length - min(newSpan.location, newRaw.length)))
+        let newText = newRaw.substring(with: safeSpan)
+
+        let lastPos = safeSpan.length > 0 ? safeSpan.upperBound - 1 : safeSpan.location
+        let newStart = blockIndexForRawOffset(safeSpan.location) ?? 0
+        let newEnd = blockIndexForRawOffset(lastPos) ?? newStart
+        let dirty = IndexSet(integersIn: newStart...min(newEnd, blocks.count - 1))
+
+        let sel = NSRange(location: min(select.location, newRaw.length),
+                          length: min(select.length, newRaw.length - min(select.location, newRaw.length)))
+        stabilizingViewport {
+            recomposeReplacing(oldRange: oldSpan, with: newText, dirty: dirty,
+                               cursorInRaw: sel.location,
+                               selectionInRaw: sel.length > 0 ? sel : nil)
+        }
+        document?.updateChangeCount(.changeDone)
+    }
+
+    /// Replace the whole document as one undoable step (for non-contiguous edits
+    /// like footnotes: an inline marker plus an end-of-file definition).
+    func applyWholeDocumentEdit(newRawSource: String, select: NSRange) {
+        undoStack.append(UndoSnapshot(rawSource: rawSource, cursorInRaw: selectedRange().location))
+        redoStack.removeAll()
+        lastEditType = .other
+        lastEditBlockIndex = nil
+
+        rawSource = newRawSource
+        rebuildListIndentState()
+        blocks = BlockParser.parse(rawSource, previous: blocks)
+
+        let len = (rawSource as NSString).length
+        let loc = min(select.location, len)
+        let sel = NSRange(location: loc, length: min(select.length, len - loc))
+        recompose(cursorInRaw: sel.location, selectionInRaw: sel.length > 0 ? sel : nil)
+        document?.updateChangeCount(.changeDone)
+    }
+
+    // MARK: - Line-range helpers
+
+    /// The full lines covered by the current selection (or caret), their
+    /// contents split on `\n`, and whether the range ends in a trailing newline.
+    func selectedLineContext() -> (range: NSRange, lines: [String], trailingNewline: Bool) {
+        let ns = rawSource as NSString
+        let sel = selectedRange()
+        let startLine = ns.lineRange(for: NSRange(location: min(sel.location, ns.length), length: 0))
+        let lastChar = sel.length > 0 ? max(sel.location, sel.upperBound - 1) : sel.location
+        let endLine = ns.lineRange(for: NSRange(location: min(lastChar, ns.length), length: 0))
+        let range = NSRange(location: startLine.location,
+                            length: endLine.upperBound - startLine.location)
+        let text = ns.substring(with: range)
+        let trailing = text.hasSuffix("\n")
+        var lines = text.components(separatedBy: "\n")
+        if trailing { lines.removeLast() }
+        return (range, lines, trailing)
+    }
+
+    /// Apply a per-line `transform` over the selected line range. With a
+    /// selection the transformed lines stay selected; with a bare caret the
+    /// caret tracks its line (shifted by that line's length change).
+    func transformSelectedLines(_ transform: ([String]) -> [String]) {
+        let sel = selectedRange()
+        let ctx = selectedLineContext()
+        let newLines = transform(ctx.lines)
+        var replacement = newLines.joined(separator: "\n")
+        if ctx.trailingNewline { replacement += "\n" }
+
+        let select: NSRange
+        if sel.length > 0 {
+            let len = (replacement as NSString).length - (ctx.trailingNewline ? 1 : 0)
+            select = NSRange(location: ctx.range.location, length: max(0, len))
+        } else {
+            let oldFirst = (ctx.lines.first.map { ($0 as NSString).length }) ?? 0
+            let newFirst = (newLines.first.map { ($0 as NSString).length }) ?? 0
+            let caretInLine = sel.location - ctx.range.location
+            let newCaretInLine = min(max(0, caretInLine + (newFirst - oldFirst)), newFirst)
+            select = NSRange(location: ctx.range.location + newCaretInLine, length: 0)
+        }
+        applyFormattingEdit(rawRange: ctx.range, replacement: replacement, select: select)
+    }
+
+    // MARK: - Inline wrap (toggle)
+
+    /// Wrap the selection (or caret) in `open`…`close`, or unwrap when already
+    /// wrapped. Span-aware per the spec:
+    ///   - With a selection: toggle off only when the delimiters sit immediately
+    ///     around the selection (or the selection itself is the wrapped text).
+    ///   - With a caret: remove empty delimiters straddling the caret, else
+    ///     unwrap the current word if it is wrapped, else insert empty
+    ///     delimiters with the caret centered.
+    func toggleInlineWrap(open: String, close: String) {
+        let ns = rawSource as NSString
+        let sel = selectedRange()
+        let openLen = (open as NSString).length
+        let closeLen = (close as NSString).length
+
+        if sel.length > 0 {
+            // Delimiters immediately surround the selection.
+            let before = sel.location - openLen
+            if before >= 0, sel.upperBound + closeLen <= ns.length,
+               ns.substring(with: NSRange(location: before, length: openLen)) == open,
+               ns.substring(with: NSRange(location: sel.upperBound, length: closeLen)) == close {
+                let inner = ns.substring(with: sel)
+                let full = NSRange(location: before, length: openLen + sel.length + closeLen)
+                applyFormattingEdit(rawRange: full, replacement: inner,
+                                    select: NSRange(location: before, length: sel.length))
+                return
+            }
+            // The selection itself is the wrapped text.
+            let selText = ns.substring(with: sel)
+            if (selText as NSString).length >= openLen + closeLen,
+               selText.hasPrefix(open), selText.hasSuffix(close) {
+                let innerLen = (selText as NSString).length - openLen - closeLen
+                let inner = (selText as NSString).substring(with: NSRange(location: openLen, length: innerLen))
+                applyFormattingEdit(rawRange: sel, replacement: inner,
+                                    select: NSRange(location: sel.location, length: innerLen))
+                return
+            }
+            // Wrap on.
+            applyFormattingEdit(rawRange: sel, replacement: open + selText + close,
+                                select: NSRange(location: sel.location + openLen, length: sel.length))
+            return
+        }
+
+        let caret = sel.location
+        // Empty delimiters straddling the caret → remove.
+        if caret - openLen >= 0, caret + closeLen <= ns.length,
+           ns.substring(with: NSRange(location: caret - openLen, length: openLen)) == open,
+           ns.substring(with: NSRange(location: caret, length: closeLen)) == close {
+            applyFormattingEdit(rawRange: NSRange(location: caret - openLen, length: openLen + closeLen),
+                                replacement: "",
+                                select: NSRange(location: caret - openLen, length: 0))
+            return
+        }
+        // Current word already wrapped → unwrap.
+        if let word = currentWordRange() {
+            let before = word.location - openLen
+            if before >= 0, word.upperBound + closeLen <= ns.length,
+               ns.substring(with: NSRange(location: before, length: openLen)) == open,
+               ns.substring(with: NSRange(location: word.upperBound, length: closeLen)) == close {
+                let inner = ns.substring(with: word)
+                let full = NSRange(location: before, length: openLen + word.length + closeLen)
+                applyFormattingEdit(rawRange: full, replacement: inner,
+                                    select: NSRange(location: caret - openLen, length: 0))
+                return
+            }
+        }
+        // Insert empty delimiters, caret centered.
+        applyFormattingEdit(rawRange: NSRange(location: caret, length: 0),
+                            replacement: open + close,
+                            select: NSRange(location: caret + openLen, length: 0))
+    }
+
+    /// The maximal run of alphanumerics around the caret, or nil when the caret
+    /// is not adjacent to a word character.
+    func currentWordRange() -> NSRange? {
+        let ns = rawSource as NSString
+        let caret = selectedRange().location
+        func isWord(_ at: Int) -> Bool {
+            guard let scalar = ns.substring(with: NSRange(location: at, length: 1)).unicodeScalars.first
+            else { return false }
+            return CharacterSet.alphanumerics.contains(scalar)
+        }
+        var start = caret
+        while start > 0, isWord(start - 1) { start -= 1 }
+        var end = caret
+        while end < ns.length, isWord(end) { end += 1 }
+        return end > start ? NSRange(location: start, length: end - start) : nil
+    }
+
+    // MARK: - Markdown line helpers
+
+    /// Number of leading `#` (1–6) when the line is an ATX heading (`#`s then a
+    /// space); 0 otherwise.
+    func leadingHashCount(_ line: String) -> Int {
+        let ns = line as NSString
+        var i = 0
+        while i < ns.length, i < 6, ns.character(at: i) == 0x23 { i += 1 }  // '#'
+        if i > 0, i < ns.length, ns.character(at: i) == 0x20 { return i }
+        return 0
+    }
+
+    func stripLeadingHashes(_ line: String) -> String {
+        let n = leadingHashCount(line)
+        guard n > 0 else { return line }
+        let ns = line as NSString
+        var j = n
+        while j < ns.length, ns.character(at: j) == 0x20 { j += 1 }
+        return ns.substring(from: j)
+    }
+
+    /// The leading list number when the line is `N. `; nil otherwise.
+    func leadingListNumber(_ line: String) -> Int? {
+        let ns = line as NSString
+        var i = 0
+        while i < ns.length, ns.character(at: i) >= 0x30, ns.character(at: i) <= 0x39 { i += 1 }
+        guard i > 0, i + 1 < ns.length,
+              ns.character(at: i) == 0x2E, ns.character(at: i + 1) == 0x20 else { return nil }
+        return Int(ns.substring(to: i))
+    }
+
+    func stripLeadingNumber(_ line: String) -> String {
+        guard leadingListNumber(line) != nil else { return line }
+        let ns = line as NSString
+        var i = 0
+        while ns.character(at: i) != 0x2E { i += 1 }
+        return ns.substring(from: i + 2)  // skip ". "
+    }
+
+    /// The next unused footnote number (max existing `[^n]` + 1, starting at 1).
+    func nextFootnoteNumber() -> Int {
+        guard let re = try? NSRegularExpression(pattern: #"\[\^(\d+)\]"#) else { return 1 }
+        let ns = rawSource as NSString
+        var maxN = 0
+        re.enumerateMatches(in: rawSource, range: NSRange(location: 0, length: ns.length)) { m, _, _ in
+            guard let m, m.numberOfRanges > 1, let n = Int(ns.substring(with: m.range(at: 1))) else { return }
+            maxN = max(maxN, n)
+        }
+        return maxN + 1
+    }
+
+    /// Returns the link text when `s` is exactly `[text](dest)`, else nil.
+    func unwrapLink(_ s: String) -> String? {
+        captureFirst(s, pattern: #"^\[([^\]]*)\]\([^)]*\)$"#)
+    }
+
+    /// Returns the alt text when `s` is exactly `![alt](dest)`, else nil.
+    func unwrapImage(_ s: String) -> String? {
+        captureFirst(s, pattern: #"^!\[([^\]]*)\]\([^)]*\)$"#)
+    }
+
+    private func captureFirst(_ s: String, pattern: String) -> String? {
+        guard let re = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let ns = s as NSString
+        guard let m = re.firstMatch(in: s, range: NSRange(location: 0, length: ns.length)),
+              m.numberOfRanges > 1 else { return nil }
+        return ns.substring(with: m.range(at: 1))
+    }
+}

--- a/Sources/EdmundCore/Editing/EditorTextView+FormattingCore.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+FormattingCore.swift
@@ -129,43 +129,61 @@ extension EditorTextView {
     // MARK: - Inline wrap (toggle)
 
     /// Wrap the selection (or caret) in `open`…`close`, or unwrap when already
-    /// wrapped. Span-aware per the spec:
-    ///   - With a selection: toggle off only when the delimiters sit immediately
-    ///     around the selection (or the selection itself is the wrapped text).
-    ///   - With a caret: remove empty delimiters straddling the caret, else
-    ///     unwrap the current word if it is wrapped, else insert empty
-    ///     delimiters with the caret centered.
-    func toggleInlineWrap(open: String, close: String) {
+    /// wrapped. Span-aware:
+    ///   - With a selection: strips leading/trailing spaces before wrapping, so
+    ///     `" word "` → `" **word** "`. Toggle-off checks the trimmed range.
+    ///   - With a caret: removes empty delimiters straddling the caret; else
+    ///     unwraps the current word when it is already wrapped; else inserts
+    ///     empty delimiters (or, when `expandToWord` is true, wraps the current
+    ///     word instead of inserting empty delimiters).
+    func toggleInlineWrap(open: String, close: String, expandToWord: Bool = false) {
         let ns = rawSource as NSString
         let sel = selectedRange()
         let openLen = (open as NSString).length
         let closeLen = (close as NSString).length
 
         if sel.length > 0 {
-            // Delimiters immediately surround the selection.
-            let before = sel.location - openLen
-            if before >= 0, sel.upperBound + closeLen <= ns.length,
-               ns.substring(with: NSRange(location: before, length: openLen)) == open,
-               ns.substring(with: NSRange(location: sel.upperBound, length: closeLen)) == close {
-                let inner = ns.substring(with: sel)
-                let full = NSRange(location: before, length: openLen + sel.length + closeLen)
-                applyFormattingEdit(rawRange: full, replacement: inner,
-                                    select: NSRange(location: before, length: sel.length))
-                return
-            }
-            // The selection itself is the wrapped text.
             let selText = ns.substring(with: sel)
-            if (selText as NSString).length >= openLen + closeLen,
-               selText.hasPrefix(open), selText.hasSuffix(close) {
-                let innerLen = (selText as NSString).length - openLen - closeLen
-                let inner = (selText as NSString).substring(with: NSRange(location: openLen, length: innerLen))
-                applyFormattingEdit(rawRange: sel, replacement: inner,
-                                    select: NSRange(location: sel.location, length: innerLen))
+
+            // Compute effective leading/trailing whitespace to strip.
+            let leading = selText.prefix(while: { $0 == " " || $0 == "\t" }).count
+            let trailing = selText.reversed().prefix(while: { $0 == " " || $0 == "\t" }).count
+            let hasContent = leading + trailing < sel.length
+            let effLead = hasContent ? leading : 0
+            let effTrail = hasContent ? trailing : 0
+            let trimmedSel = NSRange(location: sel.location + effLead,
+                                     length: sel.length - effLead - effTrail)
+            let trimmedText = ns.substring(with: trimmedSel)
+
+            // Check 1: delimiters sit immediately around the trimmed selection.
+            let before = trimmedSel.location - openLen
+            if before >= 0, trimmedSel.upperBound + closeLen <= ns.length,
+               ns.substring(with: NSRange(location: before, length: openLen)) == open,
+               ns.substring(with: NSRange(location: trimmedSel.upperBound, length: closeLen)) == close {
+                let full = NSRange(location: before, length: openLen + trimmedSel.length + closeLen)
+                applyFormattingEdit(rawRange: full, replacement: trimmedText,
+                                    select: NSRange(location: before, length: trimmedSel.length))
                 return
             }
-            // Wrap on.
-            applyFormattingEdit(rawRange: sel, replacement: open + selText + close,
-                                select: NSRange(location: sel.location + openLen, length: sel.length))
+
+            // Check 2: the trimmed selection itself is the wrapped text.
+            let trimmedLen = (trimmedText as NSString).length
+            if trimmedLen >= openLen + closeLen,
+               trimmedText.hasPrefix(open), trimmedText.hasSuffix(close) {
+                let innerLen = trimmedLen - openLen - closeLen
+                let inner = (trimmedText as NSString).substring(with: NSRange(location: openLen, length: innerLen))
+                applyFormattingEdit(rawRange: trimmedSel, replacement: inner,
+                                    select: NSRange(location: trimmedSel.location, length: innerLen))
+                return
+            }
+
+            // Wrap on — apply only to the non-whitespace content.
+            let leadStr = String(selText.prefix(effLead))
+            let trailStr = String(selText.suffix(effTrail))
+            let replacement = leadStr + open + trimmedText + close + trailStr
+            applyFormattingEdit(rawRange: sel, replacement: replacement,
+                                select: NSRange(location: sel.location + effLead + openLen,
+                                                length: trimmedSel.length))
             return
         }
 
@@ -189,6 +207,15 @@ extension EditorTextView {
                 let full = NSRange(location: before, length: openLen + word.length + closeLen)
                 applyFormattingEdit(rawRange: full, replacement: inner,
                                     select: NSRange(location: caret - openLen, length: 0))
+                return
+            }
+            // Expand to word when requested.
+            if expandToWord {
+                let wordText = ns.substring(with: word)
+                let replacement = open + wordText + close
+                applyFormattingEdit(rawRange: word, replacement: replacement,
+                                    select: NSRange(location: word.location + openLen
+                                                        + (wordText as NSString).length, length: 0))
                 return
             }
         }
@@ -264,6 +291,89 @@ extension EditorTextView {
             maxN = max(maxN, n)
         }
         return maxN + 1
+    }
+
+    // MARK: - List-type helpers
+
+    /// True when `line` is a checklist item (`- [ ] ` or `- [x] `).
+    func isChecklistLine(_ line: String) -> Bool {
+        let ns = line as NSString
+        return ns.length >= 6
+            && ns.substring(to: 3) == "- ["
+            && ns.substring(with: NSRange(location: 4, length: 2)) == "] "
+    }
+
+    /// True when `line` is a plain bullet (`- `, `* `, `+ `) but NOT a checklist.
+    func isBulletLine(_ line: String) -> Bool {
+        guard line.count >= 2 else { return false }
+        let start = String(line.prefix(2))
+        return (start == "- " || start == "* " || start == "+ ") && !isChecklistLine(line)
+    }
+
+    /// Strips any leading list marker (checklist, bullet, numbered) from `line`,
+    /// leaving just the content. Returns `line` unchanged if none is detected.
+    func stripListPrefix(_ line: String) -> String {
+        if isChecklistLine(line) { return String(line.dropFirst(6)) }
+        if isBulletLine(line) { return String(line.dropFirst(2)) }
+        if leadingListNumber(line) != nil { return stripLeadingNumber(line) }
+        return line
+    }
+
+    // MARK: - Link detection
+
+    /// The range of the `[text](url)` link that contains the caret, or nil.
+    /// Handles carets in both the `[text]` and `(url)` parts.
+    func linkRangeAroundCaret() -> NSRange? {
+        let ns = rawSource as NSString
+        let caret = selectedRange().location
+        guard ns.length > 0, caret <= ns.length else { return nil }
+
+        // Try path A: caret is in [text]. Scan backward for '[', bail on ']'/newline.
+        var i = caret
+        while i > 0 {
+            i -= 1
+            let c = ns.character(at: i)
+            if c == 0x5B { break }
+            if c == 0x5D || c == 0x0A { i = -1; break }
+        }
+        if i >= 0, i < ns.length, ns.character(at: i) == 0x5B {
+            if let r = linkRange(ns: ns, from: i, mustContain: caret) { return r }
+        }
+
+        // Try path B: caret is in (url). Scan backward for '(', then locate '[' before ']'.
+        var p = caret
+        while p > 0 {
+            p -= 1
+            let c = ns.character(at: p)
+            if c == 0x28 { break }          // '('
+            if c == 0x0A { p = -1; break }
+        }
+        if p >= 0, ns.character(at: p) == 0x28,
+           p > 0, ns.character(at: p - 1) == 0x5D {  // '(' preceded by ']'
+            var q = p - 2
+            while q >= 0 {
+                let c = ns.character(at: q)
+                if c == 0x5B { break }
+                if c == 0x5D || c == 0x0A { q = -1; break }
+                q -= 1
+            }
+            if q >= 0, ns.character(at: q) == 0x5B {
+                if let r = linkRange(ns: ns, from: q, mustContain: caret) { return r }
+            }
+        }
+        return nil
+    }
+
+    private func linkRange(ns: NSString, from openBracket: Int, mustContain caret: Int) -> NSRange? {
+        var j = openBracket + 1
+        while j < ns.length, ns.character(at: j) != 0x5D, ns.character(at: j) != 0x0A { j += 1 }
+        guard j < ns.length, ns.character(at: j) == 0x5D else { return nil }
+        guard j + 1 < ns.length, ns.character(at: j + 1) == 0x28 else { return nil }
+        var k = j + 2
+        while k < ns.length, ns.character(at: k) != 0x29, ns.character(at: k) != 0x0A { k += 1 }
+        guard k < ns.length, ns.character(at: k) == 0x29 else { return nil }
+        let r = NSRange(location: openBracket, length: k - openBracket + 1)
+        return (caret >= r.location && caret <= r.upperBound) ? r : nil
     }
 
     /// Returns the link text when `s` is exactly `[text](dest)`, else nil.

--- a/Sources/EdmundCore/Editing/EditorTextView+FormattingCore.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+FormattingCore.swift
@@ -102,9 +102,12 @@ extension EditorTextView {
         return (range, lines, trailing)
     }
 
-    /// Apply a per-line `transform` over the selected line range. With a
-    /// selection the transformed lines stay selected; with a bare caret the
-    /// caret tracks its line (shifted by that line's length change).
+    /// Apply a per-line `transform` over the selected line range.
+    ///
+    /// Caret repositioning: the caret tracks the first line, shifted by however
+    /// many characters that line's prefix changed by (e.g. adding "- " moves the
+    /// caret two positions right). With a multi-line selection the whole new
+    /// content is re-selected (excluding any trailing newline).
     func transformSelectedLines(_ transform: ([String]) -> [String]) {
         let sel = selectedRange()
         let ctx = selectedLineContext()
@@ -128,14 +131,32 @@ extension EditorTextView {
 
     // MARK: - Inline wrap (toggle)
 
-    /// Wrap the selection (or caret) in `open`…`close`, or unwrap when already
-    /// wrapped. Span-aware:
-    ///   - With a selection: strips leading/trailing spaces before wrapping, so
-    ///     `" word "` → `" **word** "`. Toggle-off checks the trimmed range.
-    ///   - With a caret: removes empty delimiters straddling the caret; else
-    ///     unwraps the current word when it is already wrapped; else inserts
-    ///     empty delimiters (or, when `expandToWord` is true, wraps the current
-    ///     word instead of inserting empty delimiters).
+    /// Wrap the selection (or caret) in `open`…`close`, or unwrap when already wrapped.
+    ///
+    /// ## Whitespace stripping
+    /// Leading and trailing spaces are excluded from the delimiters, so selecting
+    /// `" word "` and pressing Cmd+B yields `" **word** "`, not `"** word **"`.
+    /// Toggle-off detection also uses the trimmed range.
+    ///
+    /// ## Toggle-off detection (selection path)
+    /// Three checks, tried in order:
+    ///  1. Delimiter pair sits immediately around the trimmed selection. An isolation
+    ///     guard prevents a false match when the selection content (`"word"` after Cmd+B)
+    ///     is inside a LONGER delimiter run: e.g. `*` at position 1 of `**word**` is not
+    ///     an italic delimiter — it is the inner character of the bold `**`. Without the
+    ///     guard, Cmd+B → Cmd+I would toggle italic OFF instead of adding it, producing
+    ///     `*word*` rather than `***word***`.
+    ///  2. The trimmed selection itself starts and ends with the delimiter strings
+    ///     (user selected `**word**` and pressed Cmd+B).
+    ///
+    /// ## Toggle-off detection (caret path)
+    /// Three checks, tried in order:
+    ///  1. Empty delimiters straddle the caret → remove them.
+    ///  2. The current word is wrapped by `open`/`close` (nearest-neighbour search) →
+    ///     unwrap. No isolation guard here, so peeling one layer from `***word***` works:
+    ///     Cmd+B finds `**` at word.location-2 and correctly removes it.
+    ///  3. Fallback: insert empty `open+close` with the caret centred. When
+    ///     `expandToWord` is true, the current word is wrapped instead.
     func toggleInlineWrap(open: String, close: String, expandToWord: Bool = false) {
         let ns = rawSource as NSString
         let sel = selectedRange()
@@ -145,7 +166,8 @@ extension EditorTextView {
         if sel.length > 0 {
             let selText = ns.substring(with: sel)
 
-            // Compute effective leading/trailing whitespace to strip.
+            // Whitespace stripping: exclude leading/trailing spaces from the wrap
+            // so "  word  " → "  **word**  " instead of "**  word  **".
             let leading = selText.prefix(while: { $0 == " " || $0 == "\t" }).count
             let trailing = selText.reversed().prefix(while: { $0 == " " || $0 == "\t" }).count
             let hasContent = leading + trailing < sel.length
@@ -155,8 +177,12 @@ extension EditorTextView {
                                      length: sel.length - effLead - effTrail)
             let trimmedText = ns.substring(with: trimmedSel)
 
-            // Check 1: delimiters sit immediately around the trimmed selection and are
-            // not part of a longer run of the same character (e.g. `*` inside `**`).
+            // Check 1: delimiters sit immediately around the trimmed selection.
+            // The isolation guard rejects matches where the found delimiter is part of
+            // a longer run: e.g. the `*` at offset 1 of `**word**` is the inner char
+            // of `**`, not a standalone `*`. Without the guard, selecting the bare
+            // content of a bold word and pressing Cmd+I would fire here and unwrap
+            // instead of compounding to `***word***`.
             let before = trimmedSel.location - openLen
             if before >= 0, trimmedSel.upperBound + closeLen <= ns.length,
                ns.substring(with: NSRange(location: before, length: openLen)) == open,
@@ -169,7 +195,7 @@ extension EditorTextView {
                 return
             }
 
-            // Check 2: the trimmed selection itself is the wrapped text.
+            // Check 2: the trimmed selection itself IS the wrapped text.
             let trimmedLen = (trimmedText as NSString).length
             if trimmedLen >= openLen + closeLen,
                trimmedText.hasPrefix(open), trimmedText.hasSuffix(close) {
@@ -180,10 +206,12 @@ extension EditorTextView {
                 return
             }
 
-            // Wrap on — apply only to the non-whitespace content.
+            // Wrap on — apply only to the non-whitespace content, leaving leading/
+            // trailing spaces outside the delimiters.
             let leadStr = String(selText.prefix(effLead))
             let trailStr = String(selText.suffix(effTrail))
             let replacement = leadStr + open + trimmedText + close + trailStr
+            // Caret: inside the new delimiters, on the first char of the content.
             applyFormattingEdit(rawRange: sel, replacement: replacement,
                                 select: NSRange(location: sel.location + effLead + openLen,
                                                 length: trimmedSel.length))
@@ -191,7 +219,8 @@ extension EditorTextView {
         }
 
         let caret = sel.location
-        // Empty delimiters straddling the caret → remove.
+        // Caret check 1: empty delimiters straddle the caret → remove.
+        // E.g. `**|**` → pressing Cmd+B again removes the pair.
         if caret - openLen >= 0, caret + closeLen <= ns.length,
            ns.substring(with: NSRange(location: caret - openLen, length: openLen)) == open,
            ns.substring(with: NSRange(location: caret, length: closeLen)) == close {
@@ -200,44 +229,51 @@ extension EditorTextView {
                                 select: NSRange(location: caret - openLen, length: 0))
             return
         }
-        // Current word already wrapped → unwrap (only when the delimiter is isolated,
-        // i.e. not embedded inside a longer run such as `*` inside `**`).
+        // Caret check 2: nearest word is wrapped → unwrap (nearest-neighbour, no
+        // isolation guard so peeling one layer from `***word***` works correctly).
+        // E.g. caret in `***word***` + Cmd+B: finds `**` at word.location-2 and peels
+        // it, giving `*word*`. The same caret + Cmd+I finds `*` at word.location-1
+        // and peels that, giving `**word**`.
         if let word = currentWordRange() {
             let before = word.location - openLen
             if before >= 0, word.upperBound + closeLen <= ns.length,
                ns.substring(with: NSRange(location: before, length: openLen)) == open,
-               ns.substring(with: NSRange(location: word.upperBound, length: closeLen)) == close,
-               delimiterIsIsolated(open: open, close: close,
-                                   openAt: before, closeAt: word.upperBound, in: ns) {
+               ns.substring(with: NSRange(location: word.upperBound, length: closeLen)) == close {
                 let inner = ns.substring(with: word)
                 let full = NSRange(location: before, length: openLen + word.length + closeLen)
+                // Caret lands where it was but shifted left by openLen (delimiters removed).
                 applyFormattingEdit(rawRange: full, replacement: inner,
                                     select: NSRange(location: caret - openLen, length: 0))
                 return
             }
-            // Expand to word when requested.
+            // Caret check 2b: no wrapping found — expand to word when requested
+            // (used by Wikilink/Link/Image which want to capture the word under the caret).
             if expandToWord {
                 let wordText = ns.substring(with: word)
                 let replacement = open + wordText + close
+                // Caret: after the word content, before the closing delimiter.
                 applyFormattingEdit(rawRange: word, replacement: replacement,
                                     select: NSRange(location: word.location + openLen
                                                         + (wordText as NSString).length, length: 0))
                 return
             }
         }
-        // Insert empty delimiters, caret centered.
+        // Fallback: insert empty delimiters; caret centred between them.
         applyFormattingEdit(rawRange: NSRange(location: caret, length: 0),
                             replacement: open + close,
                             select: NSRange(location: caret + openLen, length: 0))
     }
 
-    /// Returns false when the delimiter found at `openAt`/`closeAt` is embedded in a
-    /// longer run of the same character — e.g. a lone `*` at position 1 of `**word**`
-    /// is not an isolated italic delimiter; it is the inner character of the bold `**`.
+    /// Returns false when the delimiter at `openAt`/`closeAt` is part of a longer
+    /// run of the same character — indicating it is an inner char of a wider delimiter,
+    /// not a standalone one of the type we matched.
     ///
-    /// Rule: the character immediately before the opening delimiter must not equal the
-    /// opening's first character; the character immediately after the closing delimiter
-    /// must not equal the closing's last character.
+    /// Example: `*` at position 1 of `**word**` has `*` at position 0 to its left,
+    /// so it is NOT an isolated italic `*`; it is the inner character of the bold `**`.
+    ///
+    /// This guard is applied ONLY to the selection-path Check 1. The caret word-check
+    /// does NOT use it, so that pressing Cmd+B with the caret inside `***word***`
+    /// correctly finds and peels the `**` at word.location-2.
     private func delimiterIsIsolated(open: String, close: String,
                                      openAt: Int, closeAt: Int, in ns: NSString) -> Bool {
         let openFirst = (open as NSString).character(at: 0)
@@ -336,6 +372,10 @@ extension EditorTextView {
 
     /// Strips any leading list marker (checklist, bullet, numbered) from `line`,
     /// leaving just the content. Returns `line` unchanged if none is detected.
+    ///
+    /// Used by all three list commands to implement "replace" semantics: applying
+    /// any list type first strips the current marker so lists replace each other
+    /// instead of nesting (e.g. `- [ ] task` → Cmd+B → `- task`, not `- - [ ] task`).
     func stripListPrefix(_ line: String) -> String {
         if isChecklistLine(line) { return String(line.dropFirst(6)) }
         if isBulletLine(line) { return String(line.dropFirst(2)) }
@@ -352,7 +392,7 @@ extension EditorTextView {
         let caret = selectedRange().location
         guard ns.length > 0, caret <= ns.length else { return nil }
 
-        // Try path A: caret is in [text]. Scan backward for '[', bail on ']'/newline.
+        // Path A: caret is in [text]. Scan backward for '[', bail on ']'/newline.
         var i = caret
         while i > 0 {
             i -= 1
@@ -364,7 +404,7 @@ extension EditorTextView {
             if let r = linkRange(ns: ns, from: i, mustContain: caret) { return r }
         }
 
-        // Try path B: caret is in (url). Scan backward for '(', then locate '[' before ']'.
+        // Path B: caret is in (url). Scan backward for '(', then locate '[' before ']'.
         var p = caret
         while p > 0 {
             p -= 1

--- a/Sources/EdmundCore/Editing/EditorTextView+FormattingCore.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+FormattingCore.swift
@@ -246,15 +246,16 @@ extension EditorTextView {
                                     select: NSRange(location: caret - openLen, length: 0))
                 return
             }
-            // Caret check 2b: no wrapping found — expand to word when requested
-            // (used by Wikilink/Link/Image which want to capture the word under the caret).
+            // Caret check 2b: no wrapping found — wrap the whole word under the caret.
+            // Used by the symmetric inline styles (Bold, Italic, …) and Wikilink so
+            // that `anyth|ing` + Cmd+B → `**anyth|ing**`. The caret keeps its position
+            // within the word (shifted right by the opening delimiter), so the word
+            // text isn't disturbed and a second press re-detects + unwraps it.
             if expandToWord {
                 let wordText = ns.substring(with: word)
                 let replacement = open + wordText + close
-                // Caret: after the word content, before the closing delimiter.
                 applyFormattingEdit(rawRange: word, replacement: replacement,
-                                    select: NSRange(location: word.location + openLen
-                                                        + (wordText as NSString).length, length: 0))
+                                    select: NSRange(location: caret + openLen, length: 0))
                 return
             }
         }
@@ -262,6 +263,70 @@ extension EditorTextView {
         applyFormattingEdit(rawRange: NSRange(location: caret, length: 0),
                             replacement: open + close,
                             select: NSRange(location: caret + openLen, length: 0))
+    }
+
+    /// Toggle `*`-based emphasis using markdown's nesting semantics, where the run
+    /// of `*` around a span encodes both styles (1 = italic, 2 = bold, 3 = both).
+    /// `stars` is 2 for Bold, 1 for Italic. This lets the two compose at a caret:
+    ///
+    ///   plain     → Cmd+B → `**w**`     (bold on)
+    ///   `**w**`   → Cmd+I → `***w***`   (italic added — compound)
+    ///   `***w***` → Cmd+B → `*w*`       (bold removed)
+    ///   `***w***` → Cmd+I → `**w**`     (italic removed)
+    ///
+    /// With a selection it defers to `toggleInlineWrap`, which already compounds
+    /// (selecting the inner text adds a layer) and peels (selecting a `**…**` span
+    /// strips it). With a bare caret it reads the symmetric run of `*` surrounding
+    /// the current word and adds/removes exactly `stars` of them; when the caret is
+    /// not in a word it inserts/removes empty delimiters like `toggleInlineWrap`.
+    func toggleStarEmphasis(stars: Int) {
+        let delim = String(repeating: "*", count: stars)
+        let sel = selectedRange()
+        if sel.length > 0 {
+            toggleInlineWrap(open: delim, close: delim)
+            return
+        }
+
+        let ns = rawSource as NSString
+        let caret = sel.location
+
+        // Empty delimiters straddle the caret → remove them.
+        if caret - stars >= 0, caret + stars <= ns.length,
+           ns.substring(with: NSRange(location: caret - stars, length: stars)) == delim,
+           ns.substring(with: NSRange(location: caret, length: stars)) == delim {
+            applyFormattingEdit(rawRange: NSRange(location: caret - stars, length: stars * 2),
+                                replacement: "", select: NSRange(location: caret - stars, length: 0))
+            return
+        }
+
+        guard let word = currentWordRange() else {
+            // No word under the caret: insert empty delimiters, caret centred.
+            applyFormattingEdit(rawRange: NSRange(location: caret, length: 0),
+                                replacement: delim + delim,
+                                select: NSRange(location: caret + stars, length: 0))
+            return
+        }
+
+        // The symmetric run of `*` immediately surrounding the word.
+        var leftRun = 0
+        while word.location - leftRun - 1 >= 0,
+              ns.character(at: word.location - leftRun - 1) == 0x2A { leftRun += 1 }
+        var rightRun = 0
+        while word.upperBound + rightRun < ns.length,
+              ns.character(at: word.upperBound + rightRun) == 0x2A { rightRun += 1 }
+        let run = min(leftRun, rightRun)
+
+        // Bold present iff ≥2 stars; italic present iff an odd star count (1 or 3).
+        let present = (stars == 2) ? (run >= 2) : (run % 2 == 1)
+        let newRun = present ? run - stars : run + stars
+
+        let wordText = ns.substring(with: word)
+        let starsStr = String(repeating: "*", count: newRun)
+        let full = NSRange(location: word.location - run, length: run + word.length + run)
+        // Caret keeps its position within the word, shifted by the star-count change.
+        let newCaret = caret + (newRun - run)
+        applyFormattingEdit(rawRange: full, replacement: starsStr + wordText + starsStr,
+                            select: NSRange(location: newCaret, length: 0))
     }
 
     /// Returns false when the delimiter at `openAt`/`closeAt` is part of a longer

--- a/Sources/EdmundCore/Editing/EditorTextView+FormattingCore.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+FormattingCore.swift
@@ -155,11 +155,14 @@ extension EditorTextView {
                                      length: sel.length - effLead - effTrail)
             let trimmedText = ns.substring(with: trimmedSel)
 
-            // Check 1: delimiters sit immediately around the trimmed selection.
+            // Check 1: delimiters sit immediately around the trimmed selection and are
+            // not part of a longer run of the same character (e.g. `*` inside `**`).
             let before = trimmedSel.location - openLen
             if before >= 0, trimmedSel.upperBound + closeLen <= ns.length,
                ns.substring(with: NSRange(location: before, length: openLen)) == open,
-               ns.substring(with: NSRange(location: trimmedSel.upperBound, length: closeLen)) == close {
+               ns.substring(with: NSRange(location: trimmedSel.upperBound, length: closeLen)) == close,
+               delimiterIsIsolated(open: open, close: close,
+                                   openAt: before, closeAt: trimmedSel.upperBound, in: ns) {
                 let full = NSRange(location: before, length: openLen + trimmedSel.length + closeLen)
                 applyFormattingEdit(rawRange: full, replacement: trimmedText,
                                     select: NSRange(location: before, length: trimmedSel.length))
@@ -197,12 +200,15 @@ extension EditorTextView {
                                 select: NSRange(location: caret - openLen, length: 0))
             return
         }
-        // Current word already wrapped → unwrap.
+        // Current word already wrapped → unwrap (only when the delimiter is isolated,
+        // i.e. not embedded inside a longer run such as `*` inside `**`).
         if let word = currentWordRange() {
             let before = word.location - openLen
             if before >= 0, word.upperBound + closeLen <= ns.length,
                ns.substring(with: NSRange(location: before, length: openLen)) == open,
-               ns.substring(with: NSRange(location: word.upperBound, length: closeLen)) == close {
+               ns.substring(with: NSRange(location: word.upperBound, length: closeLen)) == close,
+               delimiterIsIsolated(open: open, close: close,
+                                   openAt: before, closeAt: word.upperBound, in: ns) {
                 let inner = ns.substring(with: word)
                 let full = NSRange(location: before, length: openLen + word.length + closeLen)
                 applyFormattingEdit(rawRange: full, replacement: inner,
@@ -223,6 +229,24 @@ extension EditorTextView {
         applyFormattingEdit(rawRange: NSRange(location: caret, length: 0),
                             replacement: open + close,
                             select: NSRange(location: caret + openLen, length: 0))
+    }
+
+    /// Returns false when the delimiter found at `openAt`/`closeAt` is embedded in a
+    /// longer run of the same character — e.g. a lone `*` at position 1 of `**word**`
+    /// is not an isolated italic delimiter; it is the inner character of the bold `**`.
+    ///
+    /// Rule: the character immediately before the opening delimiter must not equal the
+    /// opening's first character; the character immediately after the closing delimiter
+    /// must not equal the closing's last character.
+    private func delimiterIsIsolated(open: String, close: String,
+                                     openAt: Int, closeAt: Int, in ns: NSString) -> Bool {
+        let openFirst = (open as NSString).character(at: 0)
+        let closeLen = (close as NSString).length
+        let closeLast = (close as NSString).character(at: closeLen - 1)
+        if openAt > 0, ns.character(at: openAt - 1) == openFirst { return false }
+        let afterClose = closeAt + closeLen
+        if afterClose < ns.length, ns.character(at: afterClose) == closeLast { return false }
+        return true
     }
 
     /// The maximal run of alphanumerics around the caret, or nil when the caret

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -313,6 +313,18 @@ class Document: NSDocument, HeadingNavigable {
     @objc private func selectReadingMode(_ sender: Any?) { setViewMode(.reading) }
     @objc private func selectSourceMode(_ sender: Any?)  { setViewMode(.source) }
 
+    /// Cycle Edit → Read → Source → Edit (the View-menu ⌘E item). Keeps the
+    /// toolbar button in sync via `setViewMode`.
+    @objc func cycleViewMode(_ sender: Any?) {
+        let next: EditorTextView.ViewMode
+        switch editor.viewMode {
+        case .edit:    next = .reading
+        case .reading: next = .source
+        case .source:  next = .edit
+        }
+        setViewMode(next)
+    }
+
     /// Drops the mode menu down from the chevron button.
     @objc private func showViewModeMenu(_ sender: NSButton) {
         let menu = viewModeMenu()

--- a/Sources/edmd/App/FormatMenu.swift
+++ b/Sources/edmd/App/FormatMenu.swift
@@ -1,0 +1,182 @@
+import AppKit
+import EdmundCore
+
+// MARK: - Format menu (declarative command registry)
+//
+// The Format menu and its shortcuts are described by a single table of
+// `MenuCommand`s and built from it. Action methods live on `EditorTextView`
+// (and `Document` for the view-mode cycle); items use a nil target so they
+// route through the responder chain to the focused editor — exactly like the
+// undo/redo items in `setupMenuBar`.
+//
+// Groundwork for user-configurable shortcuts: every command carries a stable
+// `id` and a default `Shortcut`. A later pass can resolve a per-`id` override
+// from UserDefaults before building the item; nothing is persisted yet.
+
+/// A key equivalent: the (lowercased) key plus its modifier flags.
+struct Shortcut {
+    let key: String
+    let modifiers: NSEvent.ModifierFlags
+
+    static func cmd(_ key: String) -> Shortcut { Shortcut(key: key, modifiers: [.command]) }
+    static func cmdShift(_ key: String) -> Shortcut { Shortcut(key: key, modifiers: [.command, .shift]) }
+    static func cmdOpt(_ key: String) -> Shortcut { Shortcut(key: key, modifiers: [.command, .option]) }
+}
+
+/// One actionable menu command.
+struct MenuCommand {
+    let id: String
+    let title: String
+    let action: Selector
+    var shortcut: Shortcut? = nil
+    var tag: Int = 0
+    var representedObject: Any? = nil
+
+    func makeItem() -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: shortcut?.key ?? "")
+        item.keyEquivalentModifierMask = shortcut?.modifiers ?? []
+        item.tag = tag
+        item.representedObject = representedObject
+        // nil target → responder chain (focused EditorTextView / Document).
+        return item
+    }
+}
+
+@MainActor
+enum FormatMenu {
+
+    /// The top-level "Format" menu item (with its submenu).
+    static func build() -> NSMenuItem {
+        let formatItem = NSMenuItem()
+        let menu = NSMenu(title: "Format")
+
+        menu.addItem(headingSubmenuItem())
+        menu.addItem(.separator())
+
+        for cmd in listCommands { menu.addItem(cmd.makeItem()) }
+        menu.addItem(.separator())
+
+        for cmd in linkCommands { menu.addItem(cmd.makeItem()) }
+        menu.addItem(.separator())
+
+        for cmd in blockCommands { menu.addItem(cmd.makeItem()) }
+        menu.addItem(calloutSubmenuItem())
+        menu.addItem(.separator())
+
+        menu.addItem(fontSubmenuItem())
+
+        formatItem.submenu = menu
+        return formatItem
+    }
+
+    /// The "Cycle View Mode" item (⌘E) for the View menu — bracketed by
+    /// dividers by the caller.
+    static func viewModeCycleItem() -> NSMenuItem {
+        MenuCommand(id: "view.cycleMode", title: "Cycle View Mode",
+                    action: #selector(Document.cycleViewMode(_:)),
+                    shortcut: .cmd("e")).makeItem()
+    }
+
+    // MARK: - Groups
+
+    private static let listCommands: [MenuCommand] = [
+        MenuCommand(id: "format.bulletedList", title: "Bulleted List",
+                    action: #selector(EditorTextView.formatBulletedList(_:)), shortcut: .cmdOpt("b")),
+        MenuCommand(id: "format.numberedList", title: "Numbered List",
+                    action: #selector(EditorTextView.formatNumberedList(_:))),
+        MenuCommand(id: "format.checklist", title: "Checklist",
+                    action: #selector(EditorTextView.formatChecklist(_:)), shortcut: .cmd("l")),
+    ]
+
+    private static let linkCommands: [MenuCommand] = [
+        MenuCommand(id: "format.link", title: "Link",
+                    action: #selector(EditorTextView.formatLink(_:)), shortcut: .cmd("k")),
+        MenuCommand(id: "format.wikilink", title: "Wikilink",
+                    action: #selector(EditorTextView.formatWikilink(_:))),
+        MenuCommand(id: "format.image", title: "Image",
+                    action: #selector(EditorTextView.formatImage(_:))),
+        MenuCommand(id: "format.footnote", title: "Footnote",
+                    action: #selector(EditorTextView.formatFootnote(_:))),
+    ]
+
+    private static let blockCommands: [MenuCommand] = [
+        MenuCommand(id: "format.table", title: "Table",
+                    action: #selector(EditorTextView.formatTable(_:))),
+        MenuCommand(id: "format.codeBlock", title: "Code Block",
+                    action: #selector(EditorTextView.formatCodeBlock(_:))),
+        MenuCommand(id: "format.mathBlock", title: "Math Block",
+                    action: #selector(EditorTextView.formatMathBlock(_:))),
+        MenuCommand(id: "format.blockQuote", title: "Block Quote",
+                    action: #selector(EditorTextView.formatBlockQuote(_:)), shortcut: .cmdShift("b")),
+    ]
+
+    private static let fontCommands: [MenuCommand] = [
+        MenuCommand(id: "format.bold", title: "Bold",
+                    action: #selector(EditorTextView.formatBold(_:)), shortcut: .cmd("b")),
+        MenuCommand(id: "format.italic", title: "Italic",
+                    action: #selector(EditorTextView.formatItalic(_:)), shortcut: .cmd("i")),
+        MenuCommand(id: "format.underline", title: "Underline",
+                    action: #selector(EditorTextView.formatUnderline(_:)), shortcut: .cmd("u")),
+        MenuCommand(id: "format.strikethrough", title: "Strikethrough",
+                    action: #selector(EditorTextView.formatStrikethrough(_:))),
+        MenuCommand(id: "format.highlight", title: "Highlight",
+                    action: #selector(EditorTextView.formatHighlight(_:))),
+        MenuCommand(id: "format.code", title: "Code",
+                    action: #selector(EditorTextView.formatCode(_:))),
+        MenuCommand(id: "format.math", title: "Math",
+                    action: #selector(EditorTextView.formatInlineMath(_:))),
+        MenuCommand(id: "format.keyboard", title: "Keyboard",
+                    action: #selector(EditorTextView.formatKeyboard(_:))),
+        MenuCommand(id: "format.comment", title: "Comments",
+                    action: #selector(EditorTextView.formatComment(_:))),
+    ]
+
+    /// GitHub alert types (uppercase in source: `> [!NOTE]`).
+    private static let githubCalloutTypes = ["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"]
+
+    /// Obsidian callout types (lowercase in source: `> [!note]`).
+    private static let obsidianCalloutTypes = [
+        "note", "abstract", "info", "todo", "tip", "success", "question",
+        "warning", "failure", "danger", "bug", "example", "quote",
+    ]
+
+    // MARK: - Submenus
+
+    private static func headingSubmenuItem() -> NSMenuItem {
+        let item = NSMenuItem(title: "Heading", action: nil, keyEquivalent: "")
+        let menu = NSMenu(title: "Heading")
+        for level in 1...6 {
+            menu.addItem(MenuCommand(id: "format.heading\(level)", title: "Heading \(level)",
+                                     action: #selector(EditorTextView.formatHeading(_:)),
+                                     tag: level).makeItem())
+        }
+        item.submenu = menu
+        return item
+    }
+
+    private static func calloutSubmenuItem() -> NSMenuItem {
+        let item = NSMenuItem(title: "Alert / Callout", action: nil, keyEquivalent: "")
+        let menu = NSMenu(title: "Alert / Callout")
+        for type in githubCalloutTypes {
+            menu.addItem(MenuCommand(id: "format.callout.\(type)", title: type.capitalized,
+                                     action: #selector(EditorTextView.formatCallout(_:)),
+                                     representedObject: type).makeItem())
+        }
+        menu.addItem(.separator())
+        for type in obsidianCalloutTypes {
+            menu.addItem(MenuCommand(id: "format.callout.\(type)", title: type.capitalized,
+                                     action: #selector(EditorTextView.formatCallout(_:)),
+                                     representedObject: type).makeItem())
+        }
+        item.submenu = menu
+        return item
+    }
+
+    private static func fontSubmenuItem() -> NSMenuItem {
+        let item = NSMenuItem(title: "Font", action: nil, keyEquivalent: "")
+        let menu = NSMenu(title: "Font")
+        for cmd in fontCommands { menu.addItem(cmd.makeItem()) }
+        item.submenu = menu
+        return item
+    }
+}

--- a/Sources/edmd/App/FormatMenu.swift
+++ b/Sources/edmd/App/FormatMenu.swift
@@ -61,6 +61,7 @@ enum FormatMenu {
 
         for cmd in blockCommands { menu.addItem(cmd.makeItem()) }
         menu.addItem(calloutSubmenuItem())
+        menu.addItem(footnoteCommand.makeItem())
         menu.addItem(.separator())
 
         menu.addItem(fontSubmenuItem())
@@ -95,9 +96,10 @@ enum FormatMenu {
                     action: #selector(EditorTextView.formatWikilink(_:))),
         MenuCommand(id: "format.image", title: "Image",
                     action: #selector(EditorTextView.formatImage(_:))),
-        MenuCommand(id: "format.footnote", title: "Footnote",
-                    action: #selector(EditorTextView.formatFootnote(_:))),
     ]
+
+    private static let footnoteCommand = MenuCommand(id: "format.footnote", title: "Footnote",
+                    action: #selector(EditorTextView.formatFootnote(_:)))
 
     private static let blockCommands: [MenuCommand] = [
         MenuCommand(id: "format.table", title: "Table",
@@ -134,10 +136,11 @@ enum FormatMenu {
     /// GitHub alert types (uppercase in source: `> [!NOTE]`).
     private static let githubCalloutTypes = ["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"]
 
-    /// Obsidian callout types (lowercase in source: `> [!note]`).
+    /// Obsidian-only callout types (lowercase). note/tip/warning are omitted
+    /// since they duplicate NOTE/TIP/WARNING already in the GitHub group.
     private static let obsidianCalloutTypes = [
-        "note", "abstract", "info", "todo", "tip", "success", "question",
-        "warning", "failure", "danger", "bug", "example", "quote",
+        "abstract", "info", "todo", "success", "question",
+        "failure", "danger", "bug", "example", "quote",
     ]
 
     // MARK: - Submenus

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -219,6 +219,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         editMenuItem.submenu = editMenu
         mainMenu.addItem(editMenuItem)
 
+        // Format menu — built from the declarative command registry.
+        mainMenu.addItem(FormatMenu.build())
+
         // View menu
         let viewMenuItem = NSMenuItem()
         let viewMenu = NSMenu(title: "View")
@@ -228,6 +231,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
             action: #selector(AppDelegate.toggleTypewriterMode(_:)),
             keyEquivalent: "")
         typewriterItem.state = AppDelegate.typewriterModeEnabled() ? .on : .off
+
+        // View-mode cycle (Edit → Read → Source), bracketed by dividers.
+        viewMenu.addItem(.separator())
+        viewMenu.addItem(FormatMenu.viewModeCycleItem())
+        viewMenu.addItem(.separator())
 
         viewMenuItem.submenu = viewMenu
         mainMenu.addItem(viewMenuItem)

--- a/Tests/EdmundTests/FormattingTests.swift
+++ b/Tests/EdmundTests/FormattingTests.swift
@@ -411,3 +411,42 @@ private func mk(_ content: String, _ sel: NSRange) -> EditorTextView {
         assertMatchesFullRecomposeOracle(e)
     }
 }
+
+// MARK: - Compound emphasis
+
+@MainActor @Suite struct FormatCompoundEmphasisTests {
+
+    @Test func cmdBThenCmdIProducesTripleStar() {
+        let e = mk("word", NSRange(location: 0, length: 4))
+        e.formatBold(nil)
+        e.formatItalic(nil)
+        #expect(e.rawSource == "***word***")
+    }
+
+    @Test func cmdIThenCmdBAlsoProducesTripleStar() {
+        let e = mk("word", NSRange(location: 0, length: 4))
+        e.formatItalic(nil)
+        e.formatBold(nil)
+        #expect(e.rawSource == "***word***")
+    }
+
+    // Selecting the bold span inside ***word*** and pressing Cmd+B peels bold.
+    @Test func boldOffFromTripleStarBySelectingBoldSpan() {
+        let e = mk("***word***", NSRange(location: 1, length: 8))  // "**word**"
+        e.formatBold(nil)
+        #expect(e.rawSource == "*word*")
+    }
+
+    // Isolation must not block legitimate single-delimiter toggle-off.
+    @Test func italicToggleOffStillWorksOnPlainItalic() {
+        let e = mk("*word*", NSRange(location: 1, length: 4))
+        e.formatItalic(nil)
+        #expect(e.rawSource == "word")
+    }
+
+    @Test func boldToggleOffStillWorksOnPlainBold() {
+        let e = mk("**word**", NSRange(location: 2, length: 4))
+        e.formatBold(nil)
+        #expect(e.rawSource == "word")
+    }
+}

--- a/Tests/EdmundTests/FormattingTests.swift
+++ b/Tests/EdmundTests/FormattingTests.swift
@@ -33,13 +33,26 @@ private func mk(_ content: String, _ sel: NSRange) -> EditorTextView {
         #expect(e.selectedRange() == NSRange(location: 6, length: 5))
     }
 
-    @Test func boldEmptyInsertAndRemoveAtCaret() {
-        let e = mk("ab", NSRange(location: 1, length: 0))
+    @Test func boldWrapsWordAtCaret() {
+        // Caret inside a plain word wraps the whole word; caret keeps its spot.
+        let e = mk("anything", NSRange(location: 4, length: 0))  // "anyt|hing"
         e.formatBold(nil)
-        #expect(e.rawSource == "a****b")
-        #expect(e.selectedRange() == NSRange(location: 3, length: 0))  // caret between **|**
+        #expect(e.rawSource == "**anything**")
+        #expect(e.selectedRange() == NSRange(location: 6, length: 0))  // "**anyt|hing**"
+        // Pressing again unwraps.
         e.formatBold(nil)
-        #expect(e.rawSource == "ab")
+        #expect(e.rawSource == "anything")
+        #expect(e.selectedRange() == NSRange(location: 4, length: 0))
+    }
+
+    @Test func boldEmptyInsertAndRemoveWhenNoWord() {
+        // Caret not adjacent to a word → insert empty delimiters, caret centred.
+        let e = mk("()", NSRange(location: 1, length: 0))
+        e.formatBold(nil)
+        #expect(e.rawSource == "(****)")
+        #expect(e.selectedRange() == NSRange(location: 3, length: 0))  // (**|**)
+        e.formatBold(nil)
+        #expect(e.rawSource == "()")
         #expect(e.selectedRange() == NSRange(location: 1, length: 0))
     }
 
@@ -448,6 +461,34 @@ private func mk(_ content: String, _ sel: NSRange) -> EditorTextView {
         let e = mk("**word**", NSRange(location: 2, length: 4))
         e.formatBold(nil)
         #expect(e.rawSource == "word")
+    }
+
+    // Caret compound: bold word + Cmd+I adds italic (markdown star nesting).
+    @Test func caretBoldThenItalicCompounds() {
+        let e = mk("word", NSRange(location: 2, length: 0))
+        e.formatBold(nil)
+        #expect(e.rawSource == "**word**")
+        e.formatItalic(nil)
+        #expect(e.rawSource == "***word***")
+    }
+
+    @Test func caretItalicThenBoldCompounds() {
+        let e = mk("word", NSRange(location: 2, length: 0))
+        e.formatItalic(nil)
+        #expect(e.rawSource == "*word*")
+        e.formatBold(nil)
+        #expect(e.rawSource == "***word***")
+    }
+
+    // The exact sequence from the bug video: caret mid-word, B then I then B.
+    @Test func caretBIBSequence() {
+        let e = mk("anything", NSRange(location: 4, length: 0))
+        e.formatBold(nil)
+        #expect(e.rawSource == "**anything**")
+        e.formatItalic(nil)
+        #expect(e.rawSource == "***anything***")
+        e.formatBold(nil)        // removes bold, leaving italic
+        #expect(e.rawSource == "*anything*")
     }
 
     // Caret in ***word*** can peel one layer.

--- a/Tests/EdmundTests/FormattingTests.swift
+++ b/Tests/EdmundTests/FormattingTests.swift
@@ -449,4 +449,17 @@ private func mk(_ content: String, _ sel: NSRange) -> EditorTextView {
         e.formatBold(nil)
         #expect(e.rawSource == "word")
     }
+
+    // Caret in ***word*** can peel one layer.
+    @Test func tripleStarCaretCmdBPeelsBold() {
+        let e = mk("***word***", NSRange(location: 5, length: 0))
+        e.formatBold(nil)
+        #expect(e.rawSource == "*word*")
+    }
+
+    @Test func tripleStarCaretCmdIPeelsItalic() {
+        let e = mk("***word***", NSRange(location: 5, length: 0))
+        e.formatItalic(nil)
+        #expect(e.rawSource == "**word**")
+    }
 }

--- a/Tests/EdmundTests/FormattingTests.swift
+++ b/Tests/EdmundTests/FormattingTests.swift
@@ -1,0 +1,274 @@
+import Testing
+import AppKit
+@testable import EdmundCore
+
+// Tests for the Format-menu commands (EditorTextView+Formatting*). Each asserts
+// on `rawSource` and the resulting selection, and — for toggles — that applying
+// twice restores the original (invertibility), per the spec.
+
+@MainActor
+private func mk(_ content: String, _ sel: NSRange) -> EditorTextView {
+    let e = makeEditor()
+    e.loadContent(content)
+    e.setSelectedRange(sel)
+    return e
+}
+
+// MARK: - Inline font styles
+
+@MainActor @Suite struct FormatInlineWrapTests {
+
+    @Test func boldWrapsSelection() {
+        let e = mk("hello world", NSRange(location: 6, length: 5))
+        e.formatBold(nil)
+        #expect(e.rawSource == "hello **world**")
+        #expect(e.selectedRange() == NSRange(location: 8, length: 5))  // "world" still selected
+    }
+
+    @Test func boldIsInvertibleOnSelection() {
+        let e = mk("hello world", NSRange(location: 6, length: 5))
+        e.formatBold(nil)
+        e.formatBold(nil)
+        #expect(e.rawSource == "hello world")
+        #expect(e.selectedRange() == NSRange(location: 6, length: 5))
+    }
+
+    @Test func boldEmptyInsertAndRemoveAtCaret() {
+        let e = mk("ab", NSRange(location: 1, length: 0))
+        e.formatBold(nil)
+        #expect(e.rawSource == "a****b")
+        #expect(e.selectedRange() == NSRange(location: 3, length: 0))  // caret between **|**
+        e.formatBold(nil)
+        #expect(e.rawSource == "ab")
+        #expect(e.selectedRange() == NSRange(location: 1, length: 0))
+    }
+
+    @Test func boldUnwrapsCurrentWordAtCaret() {
+        let e = mk("**bold**", NSRange(location: 3, length: 0))  // caret inside "bold"
+        e.formatBold(nil)
+        #expect(e.rawSource == "bold")
+        #expect(e.selectedRange() == NSRange(location: 1, length: 0))
+    }
+
+    @Test func italicUnderlineStrikeHighlightCodeMath() {
+        func wrap(_ open: String, _ close: String, _ action: (EditorTextView) -> Void) -> String {
+            let e = mk("x", NSRange(location: 0, length: 1))
+            action(e)
+            return e.rawSource
+        }
+        #expect(wrap("*", "*") { $0.formatItalic(nil) } == "*x*")
+        #expect(wrap("<u>", "</u>") { $0.formatUnderline(nil) } == "<u>x</u>")
+        #expect(wrap("~~", "~~") { $0.formatStrikethrough(nil) } == "~~x~~")
+        #expect(wrap("==", "==") { $0.formatHighlight(nil) } == "==x==")
+        #expect(wrap("`", "`") { $0.formatCode(nil) } == "`x`")
+        #expect(wrap("$", "$") { $0.formatInlineMath(nil) } == "$x$")
+        #expect(wrap("<kbd>", "</kbd>") { $0.formatKeyboard(nil) } == "<kbd>x</kbd>")
+        #expect(wrap("%%", "%%") { $0.formatComment(nil) } == "%%x%%")
+    }
+
+    @Test func emptyInlineCaretCentersForMultiCharDelimiter() {
+        let e = mk("", NSRange(location: 0, length: 0))
+        e.formatKeyboard(nil)
+        #expect(e.rawSource == "<kbd></kbd>")
+        #expect(e.selectedRange() == NSRange(location: 5, length: 0))  // between <kbd>|</kbd>
+    }
+
+    @Test func mathBlockWrapsSelection() {
+        let e = mk("E=mc^2", NSRange(location: 0, length: 6))
+        e.formatMathBlock(nil)
+        #expect(e.rawSource == "$$E=mc^2$$")
+    }
+}
+
+// MARK: - Wikilink / link / image
+
+@MainActor @Suite struct FormatLinkTests {
+
+    @Test func wikilinkWrapsAndInverts() {
+        let e = mk("Page", NSRange(location: 0, length: 4))
+        e.formatWikilink(nil)
+        #expect(e.rawSource == "[[Page]]")
+        e.formatWikilink(nil)
+        #expect(e.rawSource == "Page")
+    }
+
+    @Test func wikilinkEmptyCaret() {
+        let e = mk("", NSRange(location: 0, length: 0))
+        e.formatWikilink(nil)
+        #expect(e.rawSource == "[[]]")
+        #expect(e.selectedRange() == NSRange(location: 2, length: 0))
+    }
+
+    @Test func linkWrapsSelectionCaretInParens() {
+        let e = mk("Anthropic", NSRange(location: 0, length: 9))
+        e.formatLink(nil)
+        #expect(e.rawSource == "[Anthropic]()")
+        #expect(e.selectedRange() == NSRange(location: 12, length: 0))  // inside ( | )
+    }
+
+    @Test func linkEmptyCaretInParens() {
+        let e = mk("", NSRange(location: 0, length: 0))
+        e.formatLink(nil)
+        #expect(e.rawSource == "[]()")
+        #expect(e.selectedRange() == NSRange(location: 3, length: 0))
+    }
+
+    @Test func linkUnwrapsWhenSelectionIsALink() {
+        let e = mk("[text](url)", NSRange(location: 0, length: 11))
+        e.formatLink(nil)
+        #expect(e.rawSource == "text")
+    }
+
+    @Test func imageWrapsSelectionCaretInParens() {
+        let e = mk("alt", NSRange(location: 0, length: 3))
+        e.formatImage(nil)
+        #expect(e.rawSource == "![alt]()")
+        #expect(e.selectedRange() == NSRange(location: 7, length: 0))  // inside ( | )
+    }
+
+    @Test func imageEmptyCaretInParens() {
+        let e = mk("", NSRange(location: 0, length: 0))
+        e.formatImage(nil)
+        #expect(e.rawSource == "![]()")
+        #expect(e.selectedRange() == NSRange(location: 4, length: 0))
+    }
+}
+
+// MARK: - Footnote (not invertible)
+
+@MainActor @Suite struct FormatFootnoteTests {
+
+    @Test func footnoteInsertsMarkerAndDefinition() {
+        let e = mk("word", NSRange(location: 4, length: 0))
+        e.formatFootnote(nil)
+        #expect(e.rawSource == "word[^1]\n[^1]: ")
+        #expect(e.selectedRange() == NSRange(location: e.rawSource.utf16.count, length: 0))
+    }
+
+    @Test func footnoteNumbersIncrementByExistingMax() {
+        let e = mk("a[^1] b\n[^1]: first", NSRange(location: 7, length: 0))
+        e.formatFootnote(nil)
+        #expect(e.rawSource.contains("b[^2]"))
+        #expect(e.rawSource.hasSuffix("[^2]: "))
+    }
+}
+
+// MARK: - Block prefixes (lists, quote, heading, checklist)
+
+@MainActor @Suite struct FormatBlockPrefixTests {
+
+    @Test func bulletedListAndInverse() {
+        let e = mk("a\nb", NSRange(location: 0, length: 3))
+        e.formatBulletedList(nil)
+        #expect(e.rawSource == "- a\n- b")
+        e.formatBulletedList(nil)
+        #expect(e.rawSource == "a\nb")
+    }
+
+    @Test func numberedListSequential() {
+        let e = mk("a\nb\nc", NSRange(location: 0, length: 5))
+        e.formatNumberedList(nil)
+        #expect(e.rawSource == "1. a\n2. b\n3. c")
+        e.formatNumberedList(nil)
+        #expect(e.rawSource == "a\nb\nc")
+    }
+
+    @Test func numberedListContinuesFromPrecedingNumber() {
+        // Select only the "a" and "b" lines; the line before is "1. x".
+        let e = mk("1. x\na\nb", NSRange(location: 5, length: 3))
+        e.formatNumberedList(nil)
+        #expect(e.rawSource == "1. x\n2. a\n3. b")
+    }
+
+    @Test func blockQuoteAndInverse() {
+        let e = mk("a\nb", NSRange(location: 0, length: 3))
+        e.formatBlockQuote(nil)
+        #expect(e.rawSource == "> a\n> b")
+        e.formatBlockQuote(nil)
+        #expect(e.rawSource == "a\nb")
+    }
+
+    @Test func headingApplyReplaceAndClear() {
+        let e = mk("Title", NSRange(location: 0, length: 0))
+        e.applyHeadingLevel(2)
+        #expect(e.rawSource == "## Title")
+        e.applyHeadingLevel(3)            // replaces #s, not stacks
+        #expect(e.rawSource == "### Title")
+        e.applyHeadingLevel(3)            // same level clears
+        #expect(e.rawSource == "Title")
+    }
+
+    @Test func checklistAddsThenTogglesMark() {
+        let e = mk("task", NSRange(location: 0, length: 0))
+        e.formatChecklist(nil)
+        #expect(e.rawSource == "- [ ] task")
+        e.formatChecklist(nil)
+        #expect(e.rawSource == "- [x] task")
+        e.formatChecklist(nil)
+        #expect(e.rawSource == "- [ ] task")  // toggles, never back to plain
+    }
+}
+
+// MARK: - Code block / math block / table / callout
+
+@MainActor @Suite struct FormatBlockInsertTests {
+
+    @Test func codeBlockWrapsAndInverts() {
+        let e = mk("let x = 1", NSRange(location: 0, length: 9))
+        e.formatCodeBlock(nil)
+        #expect(e.rawSource == "```\nlet x = 1\n```")
+        #expect(e.selectedRange() == NSRange(location: 3, length: 0))  // caret on info line
+        // Re-select the whole fence and toggle off.
+        e.setSelectedRange(NSRange(location: 0, length: (e.rawSource as NSString).length))
+        e.formatCodeBlock(nil)
+        #expect(e.rawSource == "let x = 1")
+    }
+
+    @Test func tableInsertsPlaceholderGrid() {
+        let e = mk("intro", NSRange(location: 5, length: 0))
+        e.formatTable(nil)
+        #expect(e.rawSource == "intro\n| Header 1 | Header 2 |\n| --- | --- |\n| Cell 1 | Cell 2 |\n")
+        #expect(e.blocks.contains { $0.kind == .table })
+    }
+
+    @Test func githubCalloutWrapsUppercase() {
+        let e = mk("line1\nline2", NSRange(location: 0, length: 11))
+        e.applyCalloutType("NOTE")
+        #expect(e.rawSource == "> [!NOTE]\n> line1\n> line2")
+        e.setSelectedRange(NSRange(location: 0, length: (e.rawSource as NSString).length))
+        e.applyCalloutType("NOTE")
+        #expect(e.rawSource == "line1\nline2")
+    }
+
+    @Test func obsidianCalloutWrapsLowercase() {
+        let e = mk("body", NSRange(location: 0, length: 4))
+        e.applyCalloutType("abstract")
+        #expect(e.rawSource == "> [!abstract]\n> body")
+    }
+}
+
+// MARK: - Storage integrity (oracle)
+
+@MainActor @Suite struct FormattingOracleTests {
+
+    @Test func storageMatchesAfterWrap() {
+        let e = mk("alpha beta gamma", NSRange(location: 6, length: 4))
+        e.formatBold(nil)
+        drainAllStyling(e)
+        assertMatchesFullRecomposeOracle(e)
+    }
+
+    @Test func storageMatchesAfterMultilineList() {
+        let e = mk("one\ntwo\nthree", NSRange(location: 0, length: 13))
+        e.formatBulletedList(nil)
+        drainAllStyling(e)
+        assertMatchesFullRecomposeOracle(e)
+    }
+
+    @Test func storageMatchesAfterCallout() {
+        let e = mk("a\nb", NSRange(location: 0, length: 3))
+        e.applyCalloutType("NOTE")
+        drainAllStyling(e)
+        assertMatchesFullRecomposeOracle(e)
+    }
+}

--- a/Tests/EdmundTests/FormattingTests.swift
+++ b/Tests/EdmundTests/FormattingTests.swift
@@ -73,10 +73,11 @@ private func mk(_ content: String, _ sel: NSRange) -> EditorTextView {
         #expect(e.selectedRange() == NSRange(location: 5, length: 0))  // between <kbd>|</kbd>
     }
 
-    @Test func mathBlockWrapsSelection() {
+    @Test func mathBlockWrapsSelectionAsBlock() {
         let e = mk("E=mc^2", NSRange(location: 0, length: 6))
         e.formatMathBlock(nil)
-        #expect(e.rawSource == "$$E=mc^2$$")
+        #expect(e.rawSource == "$$\nE=mc^2\n$$")
+        #expect(e.selectedRange() == NSRange(location: 3, length: 0))  // caret on content line
     }
 }
 
@@ -224,10 +225,14 @@ private func mk(_ content: String, _ sel: NSRange) -> EditorTextView {
         #expect(e.rawSource == "let x = 1")
     }
 
-    @Test func tableInsertsPlaceholderGrid() {
-        let e = mk("intro", NSRange(location: 5, length: 0))
+    @Test func tableInserts3x2WithPaddedDividers() {
+        let e = mk("", NSRange(location: 0, length: 0))
         e.formatTable(nil)
-        #expect(e.rawSource == "intro\n| Header 1 | Header 2 |\n| --- | --- |\n| Cell 1 | Cell 2 |\n")
+        let lines = e.rawSource.components(separatedBy: "\n")
+        #expect(lines[0] == "| Header 1 | Header 2 | Header 3 |")
+        #expect(lines[1] == "| -------- | -------- | -------- |")
+        #expect(lines[2] == "| Cell 1 | Cell 2 | Cell 3 |")
+        #expect(lines[3] == "| Cell 4 | Cell 5 | Cell 6 |")
         #expect(e.blocks.contains { $0.kind == .table })
     }
 
@@ -244,6 +249,140 @@ private func mk(_ content: String, _ sel: NSRange) -> EditorTextView {
         let e = mk("body", NSRange(location: 0, length: 4))
         e.applyCalloutType("abstract")
         #expect(e.rawSource == "> [!abstract]\n> body")
+    }
+}
+
+// MARK: - Whitespace stripping for inline wraps
+
+@MainActor @Suite struct FormatWhitespaceTests {
+
+    @Test func boldSkipsLeadingSpace() {
+        // Selection " world" — the leading space should stay outside the markers.
+        let e = mk("hello world", NSRange(location: 5, length: 6))
+        e.formatBold(nil)
+        #expect(e.rawSource == "hello **world**")
+    }
+
+    @Test func boldSkipsTrailingSpace() {
+        let e = mk("hello world", NSRange(location: 0, length: 6))  // "hello "
+        e.formatBold(nil)
+        #expect(e.rawSource == "**hello** world")
+    }
+
+    @Test func boldSkipsBothSides() {
+        let e = mk("a word b", NSRange(location: 1, length: 6))  // " word "
+        e.formatBold(nil)
+        #expect(e.rawSource == "a **word** b")
+    }
+
+    @Test func boldInvertibleWithLeadingSpace() {
+        let e = mk("a **word** b", NSRange(location: 1, length: 9))  // " **word**"
+        e.formatBold(nil)
+        #expect(e.rawSource == "a word b")
+    }
+}
+
+// MARK: - List-type replacement
+
+@MainActor @Suite struct FormatListReplacementTests {
+
+    @Test func checklistReplacesBullet() {
+        let e = mk("- item", NSRange(location: 0, length: 0))
+        e.formatChecklist(nil)
+        #expect(e.rawSource == "- [ ] item")
+    }
+
+    @Test func checklistReplacesNumbered() {
+        let e = mk("1. item", NSRange(location: 0, length: 0))
+        e.formatChecklist(nil)
+        #expect(e.rawSource == "- [ ] item")
+    }
+
+    @Test func bulletReplaceChecklist() {
+        let e = mk("- [ ] task", NSRange(location: 0, length: 10))
+        e.formatBulletedList(nil)
+        #expect(e.rawSource == "- task")
+    }
+
+    @Test func bulletReplaceNumbered() {
+        let e = mk("1. item", NSRange(location: 0, length: 7))
+        e.formatBulletedList(nil)
+        #expect(e.rawSource == "- item")
+    }
+
+    @Test func numberedReplacesBullet() {
+        let e = mk("- item", NSRange(location: 0, length: 6))
+        e.formatNumberedList(nil)
+        #expect(e.rawSource == "1. item")
+    }
+
+    @Test func numberedReplacesChecklist() {
+        let e = mk("- [ ] task", NSRange(location: 0, length: 10))
+        e.formatNumberedList(nil)
+        #expect(e.rawSource == "1. task")
+    }
+
+    @Test func bulletToggleOffIgnoresChecklists() {
+        // Checklist lines start with "- " so the old toggle-off would have fired.
+        // The new code only toggles off when they are *plain* bullets.
+        let e = mk("- [ ] task", NSRange(location: 0, length: 10))
+        e.formatBulletedList(nil)
+        // Should REPLACE (not strip "- " leaving "[ ] task").
+        #expect(e.rawSource == "- task")
+    }
+}
+
+// MARK: - Word expansion for link / wikilink / image
+
+@MainActor @Suite struct FormatWordExpansionTests {
+
+    @Test func wikilinkExpandsToWordAtCaret() {
+        let e = mk("hello world", NSRange(location: 7, length: 0))  // caret in "world"
+        e.formatWikilink(nil)
+        #expect(e.rawSource == "hello [[world]]")
+    }
+
+    @Test func linkExpandsToWordAtCaret() {
+        let e = mk("anthropic", NSRange(location: 4, length: 0))  // caret mid-word
+        e.formatLink(nil)
+        #expect(e.rawSource == "[anthropic]()")
+        #expect(e.selectedRange() == NSRange(location: 12, length: 0))  // inside ()
+    }
+
+    @Test func imageExpandsToWordAtCaret() {
+        let e = mk("logo", NSRange(location: 2, length: 0))
+        e.formatImage(nil)
+        #expect(e.rawSource == "![logo]()")
+    }
+
+    @Test func footnoteExpandsToWordEndAtCaret() {
+        let e = mk("word", NSRange(location: 2, length: 0))  // caret mid-word
+        e.formatFootnote(nil)
+        // Marker goes after "word" (the word end), not after the caret position.
+        #expect(e.rawSource.hasPrefix("word[^1]"))
+    }
+}
+
+// MARK: - Link invertibility at caret
+
+@MainActor @Suite struct FormatLinkCaretTests {
+
+    @Test func linkUnwrapsWhenCaretInsideLink() {
+        let e = mk("[text](url)", NSRange(location: 4, length: 0))  // caret in "text"
+        e.formatLink(nil)
+        #expect(e.rawSource == "text")
+    }
+
+    @Test func linkUnwrapsWhenCaretInUrl() {
+        let e = mk("[text](url)", NSRange(location: 8, length: 0))  // caret in "url"
+        e.formatLink(nil)
+        #expect(e.rawSource == "text")
+    }
+
+    @Test func mathBlockToggleOff() {
+        let e = mk("$$\nE=mc^2\n$$", NSRange(location: 0, length: 12))
+        e.formatMathBlock(nil)
+        #expect(e.rawSource == "E=mc^2")
     }
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -136,8 +136,9 @@ rawSource ──BlockParser──▶ [Block]  ──styleBlock per block──�
 | Block model | `Model/Block.swift`, `Callout.swift`, `EditorTheme.swift`, `ListIndentState.swift` |
 | Rendering | `Rendering/EditorTextView+*Rendering.swift` (Callout, Code, Image, List, Math, Table, WikiLinks) |
 | Edit behaviors | `Editing/EditorTextView+{List,Blockquote}Continuation.swift`, `+Indentation.swift` |
+| Formatting commands | `Editing/EditorTextView+Formatting{Core,Commands}.swift` (Format-menu actions: bold/lists/links/callouts/…); menu built from `edmd/App/FormatMenu.swift` |
 | Lazy/compose/undo/scroll | `TextView/EditorTextView+{Composition,LazyStyling,Undo,TypewriterScroll,SelectionTracking,ContentWidth,EditFlow}.swift` |
-| App shell | `edmd/App/{main,Document,DocumentController}.swift` |
+| App shell | `edmd/App/{main,Document,DocumentController}.swift`; menu bar in `main.swift` `setupMenuBar()` + `FormatMenu.swift` |
 | Settings (SwiftUI) | `edmd/Settings/*` (AppSettings = UserDefaults keys; FontSettings; Appearance/General views) |
 | Status bar | `edmd/Views/StatusBarView.swift` |
 | Build/packaging | `scripts/build-app.sh`, `Package.swift`, `Info.plist`, `Resources/` |
@@ -147,6 +148,17 @@ must lay out the viewport↔caret span before measuring or it reads stale TK2
 height estimates), **content width** (`+ContentWidth.swift`: a settings slider
 sets a symmetric `textContainerInset.width` for a centered reading column,
 recomputed on resize).
+
+**Format menu & shortcuts** are pure AppKit (the app has no SwiftUI scene, so
+SwiftUI `Commands` isn't an option). `FormatMenu.swift` is a declarative command
+table (`MenuCommand` + `Shortcut`, each with a stable `id` so a later pass can
+read per-command shortcut overrides from UserDefaults) that builds the menu; items
+use a nil target and route through the responder chain to the focused
+`EditorTextView`'s `@objc format…` actions — the same wiring as undo/redo. Those
+actions funnel through two primitives in `+FormattingCore.swift`
+(`applyFormattingEdit` for a single contiguous edit, modeled on the Tab-indent
+path; `applyWholeDocumentEdit` for non-contiguous edits like footnotes). The
+View-menu ⌘E item cycles Edit→Read→Source via `Document.cycleViewMode`.
 
 ---
 


### PR DESCRIPTION
## What

Adds a full **Format** menu to the menu bar with keyboard shortcuts, plus a **View ▸ Cycle View Mode** (⌘E) item.

**Format menu** (AppKit, nil-target → responder chain to the focused editor):
- Heading (H1–H6 submenu)
- Bulleted List (⌥⌘B), Numbered List, Checklist (⌘L)
- Link (⌘K), Wikilink, Image
- Table, Code Block, Math Block, Block Quote (⇧⌘B)
- Alert / Callout submenu (GitHub 5 uppercase + Obsidian-only types)
- Footnote
- Font submenu: Bold (⌘B), Italic (⌘I), Underline (⌘U), Strikethrough, Highlight, Code, Math, Keyboard, Comments

**View menu:** Cycle View Mode (⌘E) advances Edit → Read → Source and keeps the toolbar button in sync.

## Why

The editor had no formatting commands — every markdown construct had to be typed by hand. Commands are described by a single declarative registry (`FormatMenu.swift`) where each carries a stable `id` and default `Shortcut`, laying the groundwork for user-configurable shortcuts (no persistence yet).

## Behavior highlights

- **Invertibility:** most commands toggle (apply twice → original). Exceptions: Checklist (cycles `[ ]`↔`[x]`), Footnote, Table.
- **Whitespace stripping:** selecting `" word "` and bolding gives `" **word** "`, not `"** word **"`.
- **List replacement:** bullet/numbered/checklist replace each other rather than nesting.
- **Caret-in-word:** placing the caret inside a word and pressing a style acts on the whole word; Bold/Italic use markdown `*`-nesting so they compose (`**w**` + ⌘I → `***w***`) and peel (`***w***` + ⌘B → `*w*`).
- Formatting commands are disabled in Reading mode.

## Tests

700 tests pass (60+ new in `FormattingTests.swift`), covering each command, invertibility, whitespace stripping, list replacement, caret word-expansion, link unwrapping, and the star-nesting emphasis cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)