### PR TITLE
Add HTML/WKWebView Read mode and vector PDF export

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "swift test 2>&1 | tail -5",
+            "timeout": 120,
+            "statusMessage": "Running swift test…"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ misc/
 
 # Local work in progress
 README.md
+docs/ROADMAP.md

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Edmund
 
-> [!tip] Guidelines for Build and Contributing coming soon!
+> [!TIP] Guidelines for Build and Contributing coming soon!
 
-Edmund is a native, lightweight macOS markdown editor with Live Preview. 
+Edmund is a native, lightweight markdown editor with Live Preview made for macOS.  
 
 - **Requirements**: macOS Sonoma 14 or later
 - **Website**: <https://i7t5.com/edmund>
@@ -10,13 +10,13 @@ Edmund is a native, lightweight macOS markdown editor with Live Preview.
 ## Features
 
 - **Live Preview**: WYSIWYG. Render as you type. Hides delimiters outside active token / block. 
-- **Lightweight and fast**: App size ~5 MB. Lazy rendering via TextKit 2. Minimal dependencies. 
+- **Lightweight and fast**: Installer ~5 MB. Lazy rendering via TextKit 2. Minimal dependencies. 
 - **Keyboard-first**: Essential buttons only. Configurable keyboard shortcuts. 
-- **Powerful and compatible**: 
+- **Simple yet powerful**: 
   - Follows [cmark-gfm](https://github.com/github/cmark-gfm) through Apple's own [swift-markdown](https://github.com/swiftlang/swift-markdown). 
-  - Opt-in support for non-GFM syntax such as ==highlights==, [[WikiLinks]], footnotes `[^1]`, code blocks with syntax highlighting, as well as Obsidian-flavored comments and callouts through. 
-  - Renders both inline and display math in LaTex using [SwiftMath](https://github.com/mgriebling/SwiftMath). 
-- **Native UI/UX**: Respects Apple design guidelines. AppKit + SwiftUI. 
+  - Opt-in support for non-GFM syntax such as ==highlights==, [[WikiLinks]], footnotes `[^1]`, code blocks with syntax highlighting, Obsidian-flavored comments and callouts, etc.  
+  - Renders both inline and display math  using [SwiftMath](https://github.com/mgriebling/SwiftMath). Opt-in extension for more math syntax through [RaTeX](https://github.com/erweixin/RaTeX). 
+- **Native UI/UX**: Feels exactly like macOS. AppKit + SwiftUI core. 
 - **Secure and private**: Always offline. Network connection required for software updates only. 
 - **Open and free**: Apache License 2.0. Free of charge. 
 
@@ -61,7 +61,7 @@ If Edmund's not your thing, some of the following might be:
 
 The list is by no means exhaustive, and neither was it meant to be. I just wanted to give credit to the makers of these apps, esp. the aesthetic open sourced ones. If you want a comprehensive list, [this](https://github.com/mundimark/awesome-markdown-editors) might be more helpful. 
 
-## Motivation, philosophy, credits
+## Motivation, philosophy, acknowledgements
 
 I wanted to create an open source alternative to Typora that would be the [CotEditor](https://coteditor.com) of Markdown editors. See this [blog post](link TBD) for more design philosophy and behind-the-scenes. 
 
@@ -70,6 +70,7 @@ The following have greatly influenced my architecture and/or design choices. I o
 - [Swift Markdown Engine](https://github.com/nodes-app/swift-markdown-engine) / [Nodes](https://nodes-web.com) for the parser/token architecture and the TextKit 2 integration
 - [Typora](https://typora.io) for menu bar item organization
 - [Tomorrow Light](https://github.com/chriskempson/tomorrow-theme) and [One Dark](https://github.com/atom/atom/tree/master/packages/one-dark-syntax) for code syntax highlighting
+- [create-dmg](https://github.com/sindresorhus/create-dmg) for a Apple-looking `.dmg`
 
 ## License
 

--- a/Sources/EdmundCore/Export/DocumentHTML.swift
+++ b/Sources/EdmundCore/Export/DocumentHTML.swift
@@ -1,0 +1,187 @@
+import AppKit
+import SwiftMath
+
+// MARK: - DocumentHTML
+//
+// Assembles the full, self-contained HTML document for Read mode and PDF export:
+// the `HTMLRenderer` body, the `HTMLTheme` stylesheet, and a second pass that
+// fills the renderer's placeholder elements with inlined assets (SF-Symbol
+// callout icons and SwiftMath glyphs) as data URIs. Inlining everything keeps
+// the document self-contained — the webview needs no file/network access (§G).
+@MainActor
+enum DocumentHTML {
+
+    /// Builds a complete `<!DOCTYPE html>…` document for `markdown`.
+    static func full(markdown: String,
+                     theme: EditorTheme,
+                     callouts: [String: CalloutStyle],
+                     dark: Bool) -> String {
+        var body = HTMLRenderer.render(markdown: markdown)
+        body = fillCalloutIcons(body, callouts: callouts, dark: dark)
+        body = fillMath(body, theme: theme, dark: dark)
+        let css = HTMLTheme.css(theme, callouts: callouts, dark: dark)
+        return """
+        <!DOCTYPE html>
+        <html><head><meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <style>
+        \(css)
+        </style></head>
+        <body><div class="page">\(body)</div></body></html>
+        """
+    }
+
+    // MARK: Callout icons (SF Symbol → tinted PNG data URI)
+
+    private static let iconPattern =
+        "<span class=\"callout-icon\" data-symbol=\"([^\"]*)\" data-type=\"([^\"]*)\"></span>"
+
+    private static func fillCalloutIcons(_ html: String,
+                                         callouts: [String: CalloutStyle],
+                                         dark: Bool) -> String {
+        var cache: [String: String] = [:]   // "symbol|hex" → data URI
+        return replaceMatches(html, pattern: iconPattern) { groups in
+            let symbol = unescapeAttr(groups[1])
+            let type = unescapeAttr(groups[2])
+            let hex = (callouts[type] ?? Callout.defaultStyles[type])?.accentHex(dark: dark) ?? "#888888"
+            let key = "\(symbol)|\(hex)"
+            let uri: String
+            if let cached = cache[key] {
+                uri = cached
+            } else {
+                uri = iconDataURI(symbol: symbol, hex: hex) ?? ""
+                cache[key] = uri
+            }
+            guard !uri.isEmpty else { return "<span class=\"callout-icon\"></span>" }
+            return "<span class=\"callout-icon\"><img src=\"\(uri)\" alt=\"\"></span>"
+        }
+    }
+
+    /// Renders an SF Symbol tinted to `hex` and returns a PNG data URI (@2x).
+    private static func iconDataURI(symbol: String, hex: String) -> String? {
+        guard let base = NSImage(systemSymbolName: symbol, accessibilityDescription: nil),
+              let color = NSColor(hex: hex) else { return nil }
+        let config = NSImage.SymbolConfiguration(pointSize: 16, weight: .semibold)
+        let sized = base.withSymbolConfiguration(config) ?? base
+        let size = sized.size
+        let tinted = NSImage(size: size, flipped: false) { rect in
+            sized.draw(in: rect)
+            color.set()
+            rect.fill(using: .sourceAtop)
+            return true
+        }
+        guard let data = pngData(tinted, scale: 2) else { return nil }
+        return "data:image/png;base64,\(data.base64EncodedString())"
+    }
+
+    // MARK: Math (SwiftMath → PNG data URI)
+
+    private static let inlineMathPattern = "<span class=\"math-inline\" data-tex=\"([^\"]*)\"></span>"
+    private static let displayMathPattern = "<div class=\"math-display\" data-tex=\"([^\"]*)\"></div>"
+
+    private static func fillMath(_ html: String, theme: EditorTheme, dark: Bool) -> String {
+        let color = NSColor(hex: dark ? "#e6e6e6" : "#1a1a1a") ?? .textColor
+        var out = replaceMatches(html, pattern: displayMathPattern) { groups in
+            let tex = unescapeAttr(groups[1])
+            guard let r = mathImage(latex: tex, display: true,
+                                    fontSize: theme.fontSize, color: color),
+                  let data = pngData(r.image, scale: 2) else {
+                return "<div class=\"math-display\"><code>\(HTMLRenderer.escape(tex))</code></div>"
+            }
+            let uri = "data:image/png;base64,\(data.base64EncodedString())"
+            return "<div class=\"math-display\"><img class=\"math\" style=\"height:\(fmt(r.image.size.height))px\" src=\"\(uri)\" alt=\"\(HTMLRenderer.attr(tex))\"></div>"
+        }
+        out = replaceMatches(out, pattern: inlineMathPattern) { groups in
+            let tex = unescapeAttr(groups[1])
+            guard let r = mathImage(latex: tex, display: false,
+                                    fontSize: theme.fontSize, color: color),
+                  let data = pngData(r.image, scale: 2) else {
+                return "<code>\(HTMLRenderer.escape(tex))</code>"
+            }
+            let uri = "data:image/png;base64,\(data.base64EncodedString())"
+            // Drop the image so its baseline (descent above its bottom) lands on
+            // the text baseline — same alignment the editor computes.
+            return "<img class=\"math math-inline\" style=\"height:\(fmt(r.image.size.height))px; vertical-align:\(fmt(-r.descent))px\" src=\"\(uri)\" alt=\"\(HTMLRenderer.attr(tex))\">"
+        }
+        return out
+    }
+
+    /// Renders LaTeX with SwiftMath to an image + baseline descent. Standalone
+    /// (no `EditorTextView`) mirror of `EditorTextView.mathOverlay`'s core.
+    private static func mathImage(latex: String, display: Bool,
+                                  fontSize: CGFloat, color: NSColor)
+        -> (image: NSImage, descent: CGFloat)? {
+        let mode: MTMathUILabelMode = display ? .display : .text
+        let math = MTMathImage(latex: latex, fontSize: fontSize, textColor: color, labelMode: mode)
+        let insetPad: CGFloat = 2
+        math.contentInsets = MTEdgeInsets(top: insetPad, left: 0, bottom: insetPad, right: 0)
+        let (error, image) = math.asImage()
+        guard error == nil, let image else { return nil }
+
+        let label = MTMathUILabel()
+        label.latex = latex
+        label.fontSize = fontSize
+        label.labelMode = mode
+        label.layout()
+        let asc = label.displayList?.ascent ?? 0
+        let desc = label.displayList?.descent ?? 0
+        let clamped = max(asc + desc, fontSize / 2)
+        let descent = (asc + desc - clamped) / 2 + desc + insetPad
+        return (image, descent)
+    }
+
+    // MARK: Bitmap / escaping helpers
+
+    /// Rasterizes an `NSImage` to PNG `Data` at `scale`× its point size.
+    private static func pngData(_ image: NSImage, scale: CGFloat) -> Data? {
+        let size = image.size
+        guard size.width > 0, size.height > 0,
+              let rep = NSBitmapImageRep(
+                bitmapDataPlanes: nil,
+                pixelsWide: Int((size.width * scale).rounded()),
+                pixelsHigh: Int((size.height * scale).rounded()),
+                bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+                colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0) else { return nil }
+        rep.size = size
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
+        image.draw(in: NSRect(origin: .zero, size: size))
+        NSGraphicsContext.restoreGraphicsState()
+        return rep.representation(using: .png, properties: [:])
+    }
+
+    /// Reverses the HTML-attribute escaping done by `HTMLRenderer.attr` so the
+    /// raw LaTeX/symbol can be recovered from a placeholder attribute.
+    private static func unescapeAttr(_ s: String) -> String {
+        s.replacingOccurrences(of: "&lt;", with: "<")
+         .replacingOccurrences(of: "&gt;", with: ">")
+         .replacingOccurrences(of: "&quot;", with: "\"")
+         .replacingOccurrences(of: "&#39;", with: "'")
+         .replacingOccurrences(of: "&amp;", with: "&")   // last, by convention
+    }
+
+    /// Finds every match of `pattern` and replaces it with `transform(groups)`,
+    /// where `groups[0]` is the whole match. Replaces back-to-front so ranges
+    /// stay valid.
+    private static func replaceMatches(_ html: String, pattern: String,
+                                       _ transform: ([String]) -> String) -> String {
+        guard let regex = try? NSRegularExpression(
+            pattern: pattern, options: [.dotMatchesLineSeparators]) else { return html }
+        let ns = html as NSString
+        let result = NSMutableString(string: html)
+        let matches = regex.matches(in: html, range: NSRange(location: 0, length: ns.length))
+        for m in matches.reversed() {
+            var groups: [String] = []
+            for i in 0..<m.numberOfRanges {
+                let r = m.range(at: i)
+                groups.append(r.location == NSNotFound ? "" : ns.substring(with: r))
+            }
+            result.replaceCharacters(in: m.range(at: 0), with: transform(groups))
+        }
+        return result as String
+    }
+
+    private static func fmt(_ v: CGFloat) -> String {
+        v == v.rounded() ? String(Int(v)) : String(format: "%.1f", v)
+    }
+}

--- a/Sources/EdmundCore/Export/DocumentHTML.swift
+++ b/Sources/EdmundCore/Export/DocumentHTML.swift
@@ -15,8 +15,9 @@ enum DocumentHTML {
     static func full(markdown: String,
                      theme: EditorTheme,
                      callouts: [String: CalloutStyle],
-                     dark: Bool) -> String {
-        var body = HTMLRenderer.render(markdown: markdown)
+                     dark: Bool,
+                     options: ReadRenderOptions = .default) -> String {
+        var body = HTMLRenderer.render(markdown: markdown, options: options)
         body = fillCalloutIcons(body, callouts: callouts, dark: dark)
         body = fillMath(body, theme: theme, dark: dark)
         let css = HTMLTheme.css(theme, callouts: callouts, dark: dark)
@@ -58,19 +59,41 @@ enum DocumentHTML {
     }
 
     /// Renders an SF Symbol tinted to `hex` and returns a PNG data URI (@2x).
+    ///
+    /// The tint is applied in the **sRGB** color space and the PNG is tagged
+    /// sRGB, so the icon color exactly matches the CSS `#RRGGBB` (which the
+    /// webview interprets as sRGB). Going through `NSColor(hex:)` — which builds
+    /// a *calibrated* RGB color — and a device-RGB bitmap shifts saturated hues
+    /// (most visibly the TIP teal), making the icon disagree with the title text.
     private static func iconDataURI(symbol: String, hex: String) -> String? {
         guard let base = NSImage(systemSymbolName: symbol, accessibilityDescription: nil),
-              let color = NSColor(hex: hex) else { return nil }
+              let (r, g, b) = rgbComponents(hex) else { return nil }
         let config = NSImage.SymbolConfiguration(pointSize: 16, weight: .semibold)
         let sized = base.withSymbolConfiguration(config) ?? base
-        let size = sized.size
-        let tinted = NSImage(size: size, flipped: false) { rect in
-            sized.draw(in: rect)
-            color.set()
-            rect.fill(using: .sourceAtop)
-            return true
-        }
-        guard let data = pngData(tinted, scale: 2) else { return nil }
+        let scale: CGFloat = 2
+        let w = Int((sized.size.width * scale).rounded())
+        let h = Int((sized.size.height * scale).rounded())
+        guard w > 0, h > 0,
+              let space = CGColorSpace(name: CGColorSpace.sRGB),
+              let ctx = CGContext(data: nil, width: w, height: h, bitsPerComponent: 8,
+                                  bytesPerRow: 0, space: space,
+                                  bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+        else { return nil }
+
+        let rect = NSRect(x: 0, y: 0, width: CGFloat(w), height: CGFloat(h))
+        let gctx = NSGraphicsContext(cgContext: ctx, flipped: false)
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = gctx
+        sized.draw(in: rect)                                  // template glyph alpha
+        ctx.setBlendMode(.sourceAtop)                         // tint where it drew
+        ctx.setFillColor(CGColor(srgbRed: CGFloat(r) / 255, green: CGFloat(g) / 255,
+                                 blue: CGFloat(b) / 255, alpha: 1))
+        ctx.fill(rect)
+        NSGraphicsContext.restoreGraphicsState()
+
+        guard let cgImage = ctx.makeImage() else { return nil }
+        let rep = NSBitmapImageRep(cgImage: cgImage)
+        guard let data = rep.representation(using: .png, properties: [:]) else { return nil }
         return "data:image/png;base64,\(data.base64EncodedString())"
     }
 
@@ -183,5 +206,13 @@ enum DocumentHTML {
 
     private static func fmt(_ v: CGFloat) -> String {
         v == v.rounded() ? String(Int(v)) : String(format: "%.1f", v)
+    }
+
+    /// Parses "#RRGGBB" (or "RRGGBB") into 0–255 components.
+    private static func rgbComponents(_ hex: String) -> (Int, Int, Int)? {
+        var h = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if h.hasPrefix("#") { h.removeFirst() }
+        guard h.count == 6, let rgb = UInt64(h, radix: 16) else { return nil }
+        return (Int((rgb >> 16) & 0xFF), Int((rgb >> 8) & 0xFF), Int(rgb & 0xFF))
     }
 }

--- a/Sources/EdmundCore/Export/DocumentHTML.swift
+++ b/Sources/EdmundCore/Export/DocumentHTML.swift
@@ -60,11 +60,12 @@ enum DocumentHTML {
 
     /// Renders an SF Symbol tinted to `hex` and returns a PNG data URI (@2x).
     ///
-    /// The tint is applied in the **sRGB** color space and the PNG is tagged
-    /// sRGB, so the icon color exactly matches the CSS `#RRGGBB` (which the
-    /// webview interprets as sRGB). Going through `NSColor(hex:)` — which builds
-    /// a *calibrated* RGB color — and a device-RGB bitmap shifts saturated hues
-    /// (most visibly the TIP teal), making the icon disagree with the title text.
+    /// QUIRK: tint in **sRGB** via a `CGColorSpace.sRGB` CGContext and tag the
+    /// PNG sRGB. `NSColor(hex:)` creates a *calibrated* RGB color, which rounds
+    /// trips through a device-RGB bitmap context and shifts saturated hues —
+    /// most visibly TIP's teal (`#00BFBC`) renders noticeably greener, making
+    /// the icon and CSS title text disagree. Using sRGB throughout keeps them
+    /// pixel-matched because CSS `#RRGGBB` is interpreted as sRGB by WebKit.
     private static func iconDataURI(symbol: String, hex: String) -> String? {
         guard let base = NSImage(systemSymbolName: symbol, accessibilityDescription: nil),
               let (r, g, b) = rgbComponents(hex) else { return nil }

--- a/Sources/EdmundCore/Export/HTMLRenderer.swift
+++ b/Sources/EdmundCore/Export/HTMLRenderer.swift
@@ -41,18 +41,25 @@ struct HTMLRenderer: MarkupVisitor {
         return r.visit(doc)
     }
 
-    /// Top-level block iteration. When `preserveBlankLines` is on, each blank
-    /// source line between two blocks emits one `.blank-line` spacer (one line of
-    /// vertical space), so the author's spacing shows the way it does in Edit
-    /// mode — instead of Markdown collapsing every run of blank lines to a single
-    /// block separation.
+    /// Top-level block iteration. When `preserveBlankLines` is on, a *run* of
+    /// blank source lines between two blocks emits one `.blank-line` spacer for
+    /// every blank line beyond the first — i.e. standard Markdown keeps a single
+    /// blank line as the normal block separator and only renders the 2nd, 3rd, …
+    /// blank lines as extra vertical space.
+    ///
+    /// REFERENCE (future "rigorous" Read mode): to mimic Edit mode's layout
+    /// exactly, emit a spacer for EVERY blank line (`spacers = blanks`, not
+    /// `blanks - 1`). That preserves the author's spacing literally but fights
+    /// the HTML/CSS box model (blocks already carry their own margins), so it's
+    /// parked until Read mode commits to a styled-source rather than a rendered-
+    /// document model. See the discussion in the handoff notes.
     ///
     /// QUIRK: a block's `range.upperBound.line` is NOT reliably its last content
     /// line — cmark folds trailing blank lines into some block ranges (lists in
     /// particular), so a list followed by a blank line then a paragraph reports
     /// the list ending on the blank line. We therefore clamp each block's end
-    /// back to its last non-blank source line; the blanks between blocks A and B
-    /// are then `B.firstLine - clamp(A.end) - 1`.
+    /// back to its last non-blank source line; the blank run between blocks A and
+    /// B is then `B.firstLine - clamp(A.end) - 1`.
     mutating func visitDocument(_ document: Document) -> String {
         guard options.preserveBlankLines else { return renderChildren(of: document) }
         var out = ""
@@ -60,8 +67,8 @@ struct HTMLRenderer: MarkupVisitor {
         for child in document.children {
             if let prevEndLine, let range = child.range {
                 let blanks = range.lowerBound.line - prevEndLine - 1
-                if blanks > 0 {
-                    out += String(repeating: "<div class=\"blank-line\"></div>", count: blanks)
+                if blanks > 1 {
+                    out += String(repeating: "<div class=\"blank-line\"></div>", count: blanks - 1)
                 }
             }
             out += visit(child)

--- a/Sources/EdmundCore/Export/HTMLRenderer.swift
+++ b/Sources/EdmundCore/Export/HTMLRenderer.swift
@@ -41,25 +41,45 @@ struct HTMLRenderer: MarkupVisitor {
         return r.visit(doc)
     }
 
-    /// Top-level block iteration. When `preserveBlankLines` is on, runs of blank
-    /// source lines between consecutive blocks add proportional vertical space:
-    /// one blank line is the normal block separator, each *additional* blank line
-    /// emits one `.blank-line` spacer.
+    /// Top-level block iteration. When `preserveBlankLines` is on, each blank
+    /// source line between two blocks emits one `.blank-line` spacer (one line of
+    /// vertical space), so the author's spacing shows the way it does in Edit
+    /// mode — instead of Markdown collapsing every run of blank lines to a single
+    /// block separation.
+    ///
+    /// QUIRK: a block's `range.upperBound.line` is NOT reliably its last content
+    /// line — cmark folds trailing blank lines into some block ranges (lists in
+    /// particular), so a list followed by a blank line then a paragraph reports
+    /// the list ending on the blank line. We therefore clamp each block's end
+    /// back to its last non-blank source line; the blanks between blocks A and B
+    /// are then `B.firstLine - clamp(A.end) - 1`.
     mutating func visitDocument(_ document: Document) -> String {
         guard options.preserveBlankLines else { return renderChildren(of: document) }
         var out = ""
         var prevEndLine: Int?
         for child in document.children {
             if let prevEndLine, let range = child.range {
-                let extraBlanks = range.lowerBound.line - prevEndLine - 2
-                if extraBlanks > 0 {
-                    out += String(repeating: "<div class=\"blank-line\"></div>", count: extraBlanks)
+                let blanks = range.lowerBound.line - prevEndLine - 1
+                if blanks > 0 {
+                    out += String(repeating: "<div class=\"blank-line\"></div>", count: blanks)
                 }
             }
             out += visit(child)
-            if let range = child.range { prevEndLine = range.upperBound.line }
+            if let range = child.range {
+                prevEndLine = lastContentLine(atOrBefore: range.upperBound.line)
+            }
         }
         return out
+    }
+
+    /// The last source line at or before `line` (1-indexed) that has non-blank
+    /// content. Used to undo cmark folding trailing blank lines into a block.
+    private func lastContentLine(atOrBefore line: Int) -> Int {
+        var l = min(line, sourceLines.count)
+        while l >= 1, sourceLines[l - 1].trimmingCharacters(in: .whitespaces).isEmpty {
+            l -= 1
+        }
+        return l
     }
 
     // MARK: Default / children

--- a/Sources/EdmundCore/Export/HTMLRenderer.swift
+++ b/Sources/EdmundCore/Export/HTMLRenderer.swift
@@ -25,18 +25,41 @@ struct HTMLRenderer: MarkupVisitor {
     /// editor's styling layer does.
     private let source: String
     private let sourceLines: [String]
+    private let options: ReadRenderOptions
 
-    private init(source: String) {
+    private init(source: String, options: ReadRenderOptions) {
         self.source = source
         self.sourceLines = source.components(separatedBy: "\n")
+        self.options = options
     }
 
     /// Parses `markdown` and returns the rendered HTML body (no `<html>`/`<head>`
     /// wrapper — `DocumentHTML` adds that).
-    static func render(markdown: String) -> String {
-        var r = HTMLRenderer(source: markdown)
+    static func render(markdown: String, options: ReadRenderOptions = .default) -> String {
+        var r = HTMLRenderer(source: markdown, options: options)
         let doc = Document(parsing: markdown, options: [.disableSmartOpts])
         return r.visit(doc)
+    }
+
+    /// Top-level block iteration. When `preserveBlankLines` is on, runs of blank
+    /// source lines between consecutive blocks add proportional vertical space:
+    /// one blank line is the normal block separator, each *additional* blank line
+    /// emits one `.blank-line` spacer.
+    mutating func visitDocument(_ document: Document) -> String {
+        guard options.preserveBlankLines else { return renderChildren(of: document) }
+        var out = ""
+        var prevEndLine: Int?
+        for child in document.children {
+            if let prevEndLine, let range = child.range {
+                let extraBlanks = range.lowerBound.line - prevEndLine - 2
+                if extraBlanks > 0 {
+                    out += String(repeating: "<div class=\"blank-line\"></div>", count: extraBlanks)
+                }
+            }
+            out += visit(child)
+            if let range = child.range { prevEndLine = range.upperBound.line }
+        }
+        return out
     }
 
     // MARK: Default / children
@@ -188,7 +211,7 @@ struct HTMLRenderer: MarkupVisitor {
         }
         let bodyHTML = body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             ? ""
-            : HTMLRenderer.render(markdown: body)
+            : HTMLRenderer.render(markdown: body, options: options)
 
         // Icon is filled by DocumentHTML's asset pass (SF Symbol → data URI),
         // keyed by symbol + type so it can resolve the right accent for the

--- a/Sources/EdmundCore/Export/HTMLRenderer.swift
+++ b/Sources/EdmundCore/Export/HTMLRenderer.swift
@@ -1,0 +1,337 @@
+import Foundation
+import Markdown
+
+// MARK: - HTMLRenderer
+//
+// Renders the *same* swift-markdown `Document` the editor parses into an HTML
+// body string. This is the Read-mode / Print-export counterpart to
+// `SpanCollector` (which produces editor attribute spans): one parser, one set
+// of element semantics, two back-ends. It mirrors SpanCollector's element
+// coverage so Read mode shows exactly what Edit mode highlights.
+//
+// The renderer is intentionally **pure** — AST → string, no AppKit. Assets that
+// need AppKit (callout icons, math glyphs) are emitted as placeholder elements
+// that `DocumentHTML` fills in a second pass, so this type stays unit-testable
+// with plain string assertions.
+//
+// Non-GFM inline constructs (==highlight==, $math$, [[wikilink]], %%comment%%)
+// are detected by reusing the exact regex passes in
+// `SyntaxHighlighter+CustomParsers` — no second source of truth.
+struct HTMLRenderer: MarkupVisitor {
+    typealias Result = String
+
+    /// The markdown this instance is rendering. Held so block-level constructs
+    /// (callouts) can recover their *raw* source text by range, the way the
+    /// editor's styling layer does.
+    private let source: String
+    private let sourceLines: [String]
+
+    private init(source: String) {
+        self.source = source
+        self.sourceLines = source.components(separatedBy: "\n")
+    }
+
+    /// Parses `markdown` and returns the rendered HTML body (no `<html>`/`<head>`
+    /// wrapper — `DocumentHTML` adds that).
+    static func render(markdown: String) -> String {
+        var r = HTMLRenderer(source: markdown)
+        let doc = Document(parsing: markdown, options: [.disableSmartOpts])
+        return r.visit(doc)
+    }
+
+    // MARK: Default / children
+
+    mutating func defaultVisit(_ markup: Markup) -> String {
+        renderChildren(of: markup)
+    }
+
+    private mutating func renderChildren(of markup: Markup) -> String {
+        var out = ""
+        for child in markup.children { out += visit(child) }
+        return out
+    }
+
+    // MARK: Block-level
+
+    mutating func visitParagraph(_ paragraph: Paragraph) -> String {
+        // A paragraph that is wholly `$$…$$` is a display-math block. Reuse the
+        // editor's detector so Read mode and Edit mode agree on what's math.
+        let raw = Self.plainText(of: paragraph)
+        var dm: [SyntaxHighlighter.Span] = []
+        SyntaxHighlighter.parseDisplayMath(raw, into: &dm)
+        if let span = dm.first(where: { if case .math(true) = $0.kind { return true }; return false }) {
+            let tex = (raw as NSString).substring(with: span.contentRange)
+            return "<div class=\"math-display\" data-tex=\"\(Self.attr(tex))\"></div>"
+        }
+        return "<p>\(renderChildren(of: paragraph))</p>"
+    }
+
+    mutating func visitHeading(_ heading: Heading) -> String {
+        let level = min(max(heading.level, 1), 6)
+        return "<h\(level)>\(renderChildren(of: heading))</h\(level)>"
+    }
+
+    mutating func visitCodeBlock(_ codeBlock: CodeBlock) -> String {
+        // Code text is shown verbatim (escaped). Per-token syntax coloring is a
+        // deferred follow-up; the language class is emitted for it to hook later.
+        let lang = codeBlock.language.map { " class=\"language-\(Self.attr($0))\"" } ?? ""
+        // swift-markdown includes a trailing newline on the block's code.
+        let code = codeBlock.code.hasSuffix("\n") ? String(codeBlock.code.dropLast()) : codeBlock.code
+        return "<pre><code\(lang)>\(Self.escape(code))</code></pre>"
+    }
+
+    mutating func visitThematicBreak(_ thematicBreak: ThematicBreak) -> String { "<hr>" }
+
+    mutating func visitBlockQuote(_ blockQuote: BlockQuote) -> String {
+        // Detect a GFM callout (`> [!type] …`) on the first line, the same way
+        // the editor does (Callout.parseMarker over the de-quoted first line).
+        if let inner = deQuoted(blockQuote) {
+            let firstLine = String(inner.prefix(while: { $0 != "\n" }))
+            if let marker = Callout.parseMarker(firstLine),
+               let style = Callout.style(for: marker.type) {
+                return renderCallout(marker: marker, style: style,
+                                     firstLine: firstLine, inner: inner)
+            }
+        }
+        return "<blockquote>\(renderChildren(of: blockQuote))</blockquote>"
+    }
+
+    mutating func visitUnorderedList(_ list: UnorderedList) -> String {
+        "<ul>\(renderChildren(of: list))</ul>"
+    }
+
+    mutating func visitOrderedList(_ list: OrderedList) -> String {
+        let start = list.startIndex == 1 ? "" : " start=\"\(list.startIndex)\""
+        return "<ol\(start)>\(renderChildren(of: list))</ol>"
+    }
+
+    mutating func visitListItem(_ listItem: ListItem) -> String {
+        if let checkbox = listItem.checkbox {
+            let checked = checkbox == .checked ? " checked" : ""
+            return "<li class=\"task\"><input type=\"checkbox\" disabled\(checked)>\(renderChildren(of: listItem))</li>"
+        }
+        return "<li>\(renderChildren(of: listItem))</li>"
+    }
+
+    mutating func visitTable(_ table: Table) -> String {
+        let aligns = table.columnAlignments
+        func cellStyle(_ col: Int) -> String {
+            guard col < aligns.count, let a = aligns[col] else { return "" }
+            switch a {
+            case .left:   return " style=\"text-align:left\""
+            case .center: return " style=\"text-align:center\""
+            case .right:  return " style=\"text-align:right\""
+            }
+        }
+        var html = "<table><thead><tr>"
+        for (col, cell) in table.head.cells.enumerated() {
+            html += "<th\(cellStyle(col))>\(renderChildren(of: cell))</th>"
+        }
+        html += "</tr></thead><tbody>"
+        for row in table.body.rows {
+            html += "<tr>"
+            for (col, cell) in row.cells.enumerated() {
+                html += "<td\(cellStyle(col))>\(renderChildren(of: cell))</td>"
+            }
+            html += "</tr>"
+        }
+        html += "</tbody></table>"
+        return html
+    }
+
+    // MARK: Inline
+
+    mutating func visitText(_ text: Text) -> String { Self.renderInline(text.string) }
+    mutating func visitEmphasis(_ emphasis: Emphasis) -> String { "<em>\(renderChildren(of: emphasis))</em>" }
+    mutating func visitStrong(_ strong: Strong) -> String { "<strong>\(renderChildren(of: strong))</strong>" }
+    mutating func visitStrikethrough(_ s: Strikethrough) -> String { "<del>\(renderChildren(of: s))</del>" }
+    mutating func visitInlineCode(_ code: InlineCode) -> String { "<code>\(Self.escape(code.code))</code>" }
+    mutating func visitLineBreak(_ lineBreak: LineBreak) -> String { "<br>\n" }
+    mutating func visitSoftBreak(_ softBreak: SoftBreak) -> String { "\n" }
+
+    mutating func visitLink(_ link: Link) -> String {
+        let href = Self.attr(link.destination ?? "")
+        return "<a href=\"\(href)\">\(renderChildren(of: link))</a>"
+    }
+
+    mutating func visitImage(_ image: Image) -> String {
+        // Local image inlining is a deferred follow-up; for now emit a plain
+        // <img> with the alt text so the structure is present (no src ⇒ the
+        // browser shows the alt). The alt is the image's child text.
+        let alt = Self.attr(Self.plainText(of: image))
+        return "<img alt=\"\(alt)\">"
+    }
+
+    // Never pass raw author HTML through — escape it so a document can't inject
+    // markup/script (§G). Render as literal text.
+    mutating func visitInlineHTML(_ inlineHTML: InlineHTML) -> String { Self.escape(inlineHTML.rawHTML) }
+    mutating func visitHTMLBlock(_ html: HTMLBlock) -> String { "<p>\(Self.escape(html.rawHTML))</p>" }
+
+    // MARK: - Callouts
+
+    private mutating func renderCallout(marker: Callout.Marker, style: CalloutStyle,
+                                        firstLine: String, inner: String) -> String {
+        // Custom title = whatever follows `]` on the first line.
+        let ns = firstLine as NSString
+        let afterMarker = marker.closeBracket.upperBound <= ns.length
+            ? ns.substring(from: marker.closeBracket.upperBound)
+            : ""
+        let title = Callout.title(type: marker.type, customTitle: afterMarker)
+
+        // Body = the de-quoted content after the first line, re-parsed and
+        // rendered fresh (mirrors the editor stripping `>` and re-parsing).
+        let body: String
+        if let nl = inner.firstIndex(of: "\n") {
+            body = String(inner[inner.index(after: nl)...])
+        } else {
+            body = ""
+        }
+        let bodyHTML = body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? ""
+            : HTMLRenderer.render(markdown: body)
+
+        // Icon is filled by DocumentHTML's asset pass (SF Symbol → data URI),
+        // keyed by symbol + type so it can resolve the right accent for the
+        // current appearance.
+        let icon = "<span class=\"callout-icon\" data-symbol=\"\(Self.attr(style.symbolName))\" data-type=\"\(Self.attr(marker.type))\"></span>"
+        return "<div class=\"callout callout-\(Self.attr(marker.type))\">"
+            + "<div class=\"callout-title\">\(icon)<span class=\"callout-title-text\">\(Self.escape(title))</span></div>"
+            + "<div class=\"callout-body\">\(bodyHTML)</div></div>"
+    }
+
+    /// The raw source text of a block quote with each line's `>` prefix removed.
+    private func deQuoted(_ blockQuote: BlockQuote) -> String? {
+        guard let quoted = sourceText(blockQuote) else { return nil }
+        let lines = quoted.components(separatedBy: "\n").map { line -> String in
+            var l = Substring(line)
+            while l.first == " " { l = l.dropFirst() }
+            if l.first == ">" {
+                l = l.dropFirst()
+                if l.first == " " { l = l.dropFirst() }
+            }
+            return String(l)
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: - Inline non-GFM (highlight / math / wikilink / comment)
+
+    /// Renders a leaf text run, recognizing the non-GFM inline constructs the
+    /// editor supports by reusing the same custom-parser regexes. Everything not
+    /// matched is HTML-escaped.
+    private static func renderInline(_ s: String) -> String {
+        guard !s.isEmpty else { return "" }
+        var spans: [SyntaxHighlighter.Span] = []
+        SyntaxHighlighter.parseHighlight(s, into: &spans)
+        SyntaxHighlighter.parseMath(s, into: &spans)        // inline $…$ only
+        SyntaxHighlighter.parseWikiLinks(s, into: &spans)
+        SyntaxHighlighter.parseComments(s, into: &spans)
+
+        // Keep only the kinds we emit, ordered, non-overlapping (earliest wins).
+        let relevant = spans.filter {
+            switch $0.kind {
+            case .highlight, .math(false), .wikilink, .comment: return true
+            default: return false
+            }
+        }.sorted { $0.fullRange.location < $1.fullRange.location }
+
+        let ns = s as NSString
+        var out = ""
+        var cursor = 0
+        for span in relevant {
+            let r = span.fullRange
+            if r.location < cursor { continue }   // overlaps a prior span
+            if r.location > cursor {
+                out += escape(ns.substring(with: NSRange(location: cursor, length: r.location - cursor)))
+            }
+            switch span.kind {
+            case .highlight:
+                out += "<mark>\(escape(ns.substring(with: span.contentRange)))</mark>"
+            case .math(false):
+                let tex = ns.substring(with: span.contentRange)
+                out += "<span class=\"math-inline\" data-tex=\"\(attr(tex))\"></span>"
+            case .wikilink:
+                // Routing deferred — render the visible display text as plain text.
+                out += escape(ns.substring(with: span.contentRange))
+            case .comment:
+                break   // hidden in reading, like the editor
+            default:
+                break
+            }
+            cursor = r.upperBound
+        }
+        if cursor < ns.length {
+            out += escape(ns.substring(with: NSRange(location: cursor, length: ns.length - cursor)))
+        }
+        return out
+    }
+
+    // MARK: - Source-offset helpers (UTF-8 SourceLocation → UTF-16 NSRange)
+
+    private func sourceText(_ markup: Markup) -> String? {
+        guard let range = markup.range else { return nil }
+        let lo = utf16Offset(for: range.lowerBound)
+        let hi = utf16Offset(for: range.upperBound)
+        let ns = source as NSString
+        guard lo <= hi, hi <= ns.length else { return nil }
+        return ns.substring(with: NSRange(location: lo, length: hi - lo))
+    }
+
+    private func utf16Offset(for loc: SourceLocation) -> Int {
+        var utf8Offset = 0
+        for i in 0..<(loc.line - 1) where i < sourceLines.count {
+            utf8Offset += sourceLines[i].utf8.count + 1
+        }
+        utf8Offset += loc.column - 1
+        let utf8View = source.utf8
+        let targetIdx = utf8View.index(utf8View.startIndex,
+                                       offsetBy: min(utf8Offset, utf8View.count))
+        return source.utf16.distance(
+            from: source.utf16.startIndex,
+            to: String.Index(targetIdx, within: source.utf16) ?? source.utf16.endIndex)
+    }
+
+    // MARK: - Escaping
+
+    /// Escapes text content for HTML.
+    static func escape(_ s: String) -> String {
+        var out = ""
+        out.reserveCapacity(s.count)
+        for ch in s {
+            switch ch {
+            case "&": out += "&amp;"
+            case "<": out += "&lt;"
+            case ">": out += "&gt;"
+            default:  out.append(ch)
+            }
+        }
+        return out
+    }
+
+    /// Escapes a string for use inside a double-quoted HTML attribute.
+    static func attr(_ s: String) -> String {
+        var out = ""
+        out.reserveCapacity(s.count)
+        for ch in s {
+            switch ch {
+            case "&":  out += "&amp;"
+            case "<":  out += "&lt;"
+            case ">":  out += "&gt;"
+            case "\"": out += "&quot;"
+            case "'":  out += "&#39;"
+            default:   out.append(ch)
+            }
+        }
+        return out
+    }
+
+    /// Concatenates the literal text of a subtree (Text/InlineCode joined,
+    /// soft/line breaks as newlines). Used for display-math detection and image
+    /// alt text — not for general rendering.
+    static func plainText(of markup: Markup) -> String {
+        if let t = markup as? Text { return t.string }
+        if let c = markup as? InlineCode { return c.code }
+        if markup is SoftBreak || markup is LineBreak { return "\n" }
+        return markup.children.map { plainText(of: $0) }.joined()
+    }
+}

--- a/Sources/EdmundCore/Export/HTMLRenderer.swift
+++ b/Sources/EdmundCore/Export/HTMLRenderer.swift
@@ -125,8 +125,16 @@ struct HTMLRenderer: MarkupVisitor {
         // Code text is shown verbatim (escaped). Per-token syntax coloring is a
         // deferred follow-up; the language class is emitted for it to hook later.
         let lang = codeBlock.language.map { " class=\"language-\(Self.attr($0))\"" } ?? ""
+        // QUIRK: U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR are valid
+        // Unicode line-ending characters that appear in macOS-pasted text (e.g.
+        // from Notes or Safari). In HTML they are NOT newline characters — inside
+        // a <pre> block they render as spaces or nothing, concatenating lines that
+        // should appear on separate rows. Normalize to plain U+000A before escaping.
+        let raw = codeBlock.code
+            .replacingOccurrences(of: "\u{2028}", with: "\n")
+            .replacingOccurrences(of: "\u{2029}", with: "\n")
         // swift-markdown includes a trailing newline on the block's code.
-        let code = codeBlock.code.hasSuffix("\n") ? String(codeBlock.code.dropLast()) : codeBlock.code
+        let code = raw.hasSuffix("\n") ? String(raw.dropLast()) : raw
         return "<pre><code\(lang)>\(Self.escape(code))</code></pre>"
     }
 

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -161,7 +161,14 @@ enum HTMLTheme {
     li.task { list-style: none; }
     li.task > input[type=checkbox] {
       float: left; width: 1em; height: 1em;
-      margin-top: 0.5em; /* empirically calibrated for Iowan Old Style; see formula above */
+      /* TODO: this value is only calibrated for Iowan Old Style at 16pt. For
+         other fonts or sizes the checkbox will be misaligned — the ascent ratio
+         `a` in the formula varies per font and is not queryable from CSS without
+         `1cap`/`1ex` units, which don't resolve in loadHTMLString context either.
+         Proper fix: compute the margin-top at render time in Swift by measuring
+         the font's actual ascent (via NSFont.ascender) and inserting it as an
+         inline style, so it adapts to any EditorTheme font and size. */
+      margin-top: 0.5em;
       margin-right: 0.4em;
       margin-left: -1.65em;
     }

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -147,15 +147,21 @@ enum HTMLTheme {
        loaded via `loadHTMLString(_:baseURL:nil)` — there is no URL origin, so
        WebKit skips font metric resolution and `lh` falls back to 0. With 0,
        `calc((1lh - 1em)/2) = -0.5em`, pushing the checkbox well above the line.
-       Use the CSS custom-property equivalent instead: `--body-size * --line-height`
-       gives the same 23.2px at the default theme and is reliable in all contexts.
-       0.35em is chosen over the pure line-box center (0.225em) because Iowan Old
-       Style's visual text center sits lower in the line box than average — 0.35em
-       aligns the checkbox with the approximate x-height/cap-height midpoint. */
+       Closed-form derivation (for reference when changing font or line-height):
+         margin_top = F × ((L−1)/2 + a − 0.5)
+       where F = font-size, L = CSS line-height, a = font's CSS ascent ratio.
+       Goal: align the checkbox center with the text baseline, which is the
+       perceptually correct position for a form element next to running text.
+       For the default theme (F=16px, L=1.45) and Iowan Old Style (a≈0.775):
+         16 × ((1.45−1)/2 + 0.775 − 0.5) = 16 × 0.5 = 8px = 0.5em ✓
+       In CSS-variable form: calc(var(--body-size) * ((var(--line-height) − 1) / 2 + 0.275))
+       where 0.275 = a − 0.5 is the font-specific ascent offset for Iowan Old Style.
+       (Geometric line-box center would be (L−1)/2 × F = 0.225em, which sits above
+       the baseline and looks too high for this font's tall ascenders.) */
     li.task { list-style: none; }
     li.task > input[type=checkbox] {
       float: left; width: 1em; height: 1em;
-      margin-top: 0.5em;
+      margin-top: 0.5em; /* empirically calibrated for Iowan Old Style; see formula above */
       margin-right: 0.4em;
       margin-left: -1.65em;
     }
@@ -172,7 +178,10 @@ enum HTMLTheme {
     /* Callouts: tinted box + colored title; the icon sits as a non-shrinking
        flex child so a long custom title wraps under the title text, never under
        the icon — the layout the TextKit editor can't achieve. */
-    .callout { background: var(--c-bg); border-radius: 8px; padding: 10px 14px; margin: 0.75em 0; }
+    /* Outer margin matches the gap between two consecutive <pre> blocks (UA
+       stylesheet gives pre { margin: 1em 0 }; collapsing → 1em gap). Using
+       the same value here means neighboring callouts look equally spaced. */
+    .callout { background: var(--c-bg); border-radius: 8px; padding: 10px 14px; margin: 1em 0; }
     /* Icon sits at the top so it stays on the first line of a wrapped title; its
        box is exactly one line tall and centers the glyph, so it lines up with the
        first line's text rather than floating above it. */
@@ -190,6 +199,11 @@ enum HTMLTheme {
     .callout-body > p { margin-bottom: 0.5em; }
     .callout-body > :first-child { margin-top: 0; }
     .callout-body > :last-child { margin-bottom: 0; }
+    /* A callout that is the last child of a callout body (e.g. the nested TIP
+       inside the NOTE) has its top margin removed so the space above it is
+       governed only by the preceding element's bottom margin (0.5em for a <p>
+       from .callout-body > p), not the combined margin collapse of 1em. */
+    .callout-body > .callout:last-child { margin-top: 0; }
 
     @media print {
       body { padding: 0; }

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -41,6 +41,7 @@ enum HTMLTheme {
           --faint: \(faint);
           --rule: \(rule);
           --code-bg: \(codeBg);
+          --marker: \(resolvedRGBA(.tertiaryLabelColor, dark: dark));
           --line-height: \(trim(lineHeight));
           --para-space: \(trim(max(theme.paragraphSpacingBefore, 0)))px;
         }
@@ -119,13 +120,18 @@ enum HTMLTheme {
     .page > ul, .page > ol { padding-left: 2.25em; }
     ul { list-style-type: disc; }
     li { margin: 0.15em 0; }
-    li::marker { color: var(--faint); font-size: 0.85em; }
+    li::marker { color: var(--marker); font-size: 0.85em; }
     li > p { margin: 0; }
-    /* Task items: the checkbox hangs in the indent so wrapped lines and the
-       label align, never tucking under the checkbox. */
-    li.task { list-style: none; padding-left: 1.4em; }
-    li.task > input[type=checkbox] { margin-left: -1.4em; margin-right: 0.45em; vertical-align: -0.1em; }
+    /* Task items align with bullet/number lists: the checkbox is floated into
+       the marker slot (negative margin) rather than adding indent, so the label
+       and wrapped lines sit at the same content edge as a bullet's text — and
+       wrapped lines never tuck under the checkbox. */
+    li.task { list-style: none; }
+    li.task > input[type=checkbox] {
+      float: left; width: 1em; height: 1em; margin: 0.25em 0.4em 0 -1.4em;
+    }
     li.task > p { display: inline; margin: 0; }
+    li.task > ul, li.task > ol { clear: left; }
     .blank-line { height: calc(var(--body-size) * var(--line-height)); }
     table { border-collapse: collapse; margin: 1em 0; width: 100%; }
     th, td { border: 1px solid var(--rule); padding: 6px 10px; }
@@ -173,6 +179,24 @@ enum HTMLTheme {
             return "ui-monospace, \(generic)"
         }
         return "\"\(trimmed)\", -apple-system, \(generic)"
+    }
+
+    /// Resolves a (possibly dynamic/catalog) `NSColor` for the given appearance
+    /// to a CSS `rgba(...)`, preserving alpha. Used so list markers use the exact
+    /// same dim as the editor (`NSColor.tertiaryLabelColor`) and can't drift.
+    @MainActor
+    private static func resolvedRGBA(_ color: NSColor, dark: Bool) -> String {
+        var resolved = color
+        NSAppearance(named: dark ? .darkAqua : .aqua)?.performAsCurrentDrawingAppearance {
+            resolved = color.usingColorSpace(.sRGB) ?? color
+        }
+        guard let c = resolved.usingColorSpace(.sRGB) else {
+            return dark ? "rgba(235,235,245,0.25)" : "rgba(60,60,67,0.3)"
+        }
+        let r = Int((c.redComponent * 255).rounded())
+        let g = Int((c.greenComponent * 255).rounded())
+        let b = Int((c.blueComponent * 255).rounded())
+        return "rgba(\(r), \(g), \(b), \(trim(c.alphaComponent)))"
     }
 
     /// rgba(...) from a "#RRGGBB" hex and an alpha.

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -23,9 +23,10 @@ enum HTMLTheme {
         let rule = dark ? "#3a3a3a" : "#e0e0e0"
         let codeBg = dark ? "#2a2a2a" : "#f4f4f4"
 
-        // line-height: editor `lineSpacing` is extra points between lines, so the
-        // matching CSS multiplier is (fontSize + lineSpacing) / fontSize.
-        let lineHeight = (theme.fontSize + theme.lineSpacing) / theme.fontSize
+        // line-height: editor `NSParagraphStyle.lineSpacing` adds extra points
+        // *between* lines on top of the font's natural leading (~1.2×). The CSS
+        // equivalent is 1.2 + (lineSpacing / fontSize).
+        let lineHeight = 1.2 + theme.lineSpacing / theme.fontSize
 
         return """
         :root {
@@ -111,13 +112,12 @@ enum HTMLTheme {
     pre code { color: var(--fg); background: none; padding: 0; font-size: var(--mono-size); }
     blockquote { margin: 1em 0; padding: 0.2em 1em; border-left: 3px solid var(--rule); color: var(--faint); }
     hr { border: none; border-top: 1px solid var(--rule); margin: 1.6em 0; }
-    mark { background: color-mix(in srgb, var(--accent) 28%, transparent); color: inherit;
-           padding: 0 0.1em; border-radius: 3px; }
+    mark { background: rgba(255, 200, 0, 0.3); color: inherit; padding: 0 0.1em; }
     ul, ol { margin: 0 0 var(--para-space); padding-left: 1.6em; }
     li { margin: 0.15em 0; }
     li > p { margin: 0; }
-    li.task { list-style: none; margin-left: -1.3em; }
-    li.task > input { margin-right: 0.4em; }
+    li.task { list-style: none; }
+    li.task > input[type=checkbox] { vertical-align: -0.1em; margin-right: 0.4em; }
     li.task > p { display: inline; margin: 0; }
     table { border-collapse: collapse; margin: 1em 0; width: 100%; }
     th, td { border: 1px solid var(--rule); padding: 6px 10px; }
@@ -130,7 +130,7 @@ enum HTMLTheme {
        flex child so a long custom title wraps under the title text, never under
        the icon — the layout the TextKit editor can't achieve. */
     .callout { background: var(--c-bg); border-radius: 8px; padding: 10px 14px; margin: 1em 0; }
-    .callout-title { display: flex; align-items: flex-start; gap: 0.5em;
+    .callout-title { display: flex; align-items: center; gap: 0.5em;
                      font-weight: 600; color: var(--c-accent); }
     .callout-icon { flex: 0 0 auto; display: inline-flex; line-height: var(--line-height); }
     .callout-icon img { width: 1em; height: 1em; }

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -100,7 +100,10 @@ enum HTMLTheme {
       padding: 48px 24px;
     }
     .page { max-width: 46em; margin: 0 auto; }
-    p { margin: 0 0 var(--para-space); }
+    /* Styled-source spacing: paragraphs and blocks get a full line's breathing
+       room, so the cadence feels like a clean, readable version of Edit mode
+       rather than a collapsed publication layout. */
+    p { margin: 0 0 1em; }
     h1, h2, h3, h4, h5, h6 { line-height: 1.25; font-weight: 600; margin: 1.4em 0 0.5em; }
     h1 { font-size: 1.9em; } h2 { font-size: 1.55em; } h3 { font-size: 1.3em; }
     h4 { font-size: 1.1em; } h5 { font-size: 1em; } h6 { font-size: 0.9em; color: var(--faint); }
@@ -116,19 +119,29 @@ enum HTMLTheme {
     /* Match the editor's list indentation: level-1 text begins at one marker
        slot past the marker (~2.25em), and each nesting level steps in by one
        slot (~1.25em). Same dot at every level, like Edit mode. */
-    ul, ol { margin: 0 0 var(--para-space); padding-left: 1.25em; }
+    ul, ol { margin: 1em 0; padding-left: 1.25em; }
     .page > ul, .page > ol { padding-left: 2.25em; }
     ul { list-style-type: disc; }
-    li { margin: 0.15em 0; }
+    li { margin: 0.2em 0; }
     li::marker { color: var(--marker); font-size: 0.85em; }
     li > p { margin: 0; }
-    /* Task items align with bullet/number lists: the checkbox is floated into
-       the marker slot (negative margin) rather than adding indent, so the label
-       and wrapped lines sit at the same content edge as a bullet's text — and
-       wrapped lines never tuck under the checkbox. */
+    /* Task items: float the checkbox into the marker slot so the label and
+       wrapped lines sit at the same content edge as bullet/number text.
+       The negative margin-left pulls the checkbox into the (list's) padding
+       area; the nested <ul>/<ol> clears the float so it falls below.
+       QUIRK: use the CSS `1lh` unit (= computed line-height, ≈ 23px at
+       default theme) to precisely center a 1em checkbox on the first text
+       line — `(1lh - 1em) / 2` is exact regardless of the font or line-
+       height setting. `var(--body-size) * var(--line-height)` gives the
+       same number mathematically but relies on the CSS variables being in
+       sync; `1lh` is what the browser actually uses and is supported in
+       WKWebView on macOS 14 (Safari 17.2+). */
     li.task { list-style: none; }
     li.task > input[type=checkbox] {
-      float: left; width: 1em; height: 1em; margin: 0.25em 0.4em 0 -1.4em;
+      float: left; width: 1em; height: 1em;
+      margin-top: calc((1lh - 1em) / 2);
+      margin-right: 0.4em;
+      margin-left: -1.65em;
     }
     li.task > p { display: inline; margin: 0; }
     li.task > ul, li.task > ol { clear: left; }
@@ -159,8 +172,10 @@ enum HTMLTheme {
 
     @media print {
       body { padding: 0; }
-      /* Force WebKit to keep background colors (highlight, code, callouts) when
-         printing — it strips them by default, unlike createPDF. */
+      /* QUIRK: WebKit strips background colors when printing by default (it
+         follows the user's browser setting), even though WKWebView.createPDF
+         keeps them. `print-color-adjust: exact` forces faithful color output
+         so callout backgrounds, code blocks, and highlights survive printing. */
       * { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
       .callout, pre, blockquote, table, .math-display { break-inside: avoid; }
       h1, h2, h3, h4, h5, h6 { break-after: avoid; }
@@ -184,6 +199,12 @@ enum HTMLTheme {
     /// Resolves a (possibly dynamic/catalog) `NSColor` for the given appearance
     /// to a CSS `rgba(...)`, preserving alpha. Used so list markers use the exact
     /// same dim as the editor (`NSColor.tertiaryLabelColor`) and can't drift.
+    ///
+    /// QUIRK: dynamic system colors like `tertiaryLabelColor` store a catalog
+    /// reference, not actual RGBA components — calling `usingColorSpace(.sRGB)`
+    /// on one outside a drawing context resolves to nil or returns the wrong
+    /// variant. `performAsCurrentDrawingAppearance` sets the appearance context
+    /// so the catalog resolves to the correct light or dark concrete color.
     @MainActor
     private static func resolvedRGBA(_ color: NSColor, dark: Bool) -> String {
         var resolved = color

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -113,14 +113,22 @@ enum HTMLTheme {
            background: var(--code-bg); padding: 0.1em 0.35em; border-radius: 4px; }
     pre { background: var(--code-bg); padding: 12px 14px; border-radius: 8px; overflow-x: auto; }
     pre code { color: var(--fg); background: none; padding: 0; font-size: var(--mono-size); }
-    blockquote { margin: 1em 0; padding: 0.2em 1em; border-left: 3px solid var(--rule); color: var(--faint); }
+    blockquote { margin: 1em 0; padding: 0.5em 1em; border-left: 3px solid var(--rule); color: var(--faint); }
+    /* Without this, the 1em bottom margin on the last <p> inside a blockquote
+       creates asymmetric vertical padding — the blockquote looks heavier at the
+       bottom than at the top. Reset it so padding alone controls the spacing. */
+    blockquote > p:last-child { margin-bottom: 0; }
     hr { border: none; border-top: 1px solid var(--rule); margin: 1.6em 0; }
     mark { background: rgba(255, 200, 0, 0.3); color: inherit; padding: 0 0.1em; }
     /* Match the editor's list indentation: level-1 text begins at one marker
        slot past the marker (~2.25em), and each nesting level steps in by one
        slot (~1.25em). Same dot at every level, like Edit mode. */
-    ul, ol { margin: 1em 0; padding-left: 1.25em; }
-    .page > ul, .page > ol { padding-left: 2.25em; }
+    /* Only the outermost list (direct child of .page) gets block margin; nested
+       lists inside list items get none — otherwise each nesting level adds its
+       own 1em, creating compounding space for multi-level structures. */
+    ul, ol { margin: 0; padding-left: 1.25em; }
+    .page > ul, .page > ol { margin: 1em 0; padding-left: 2.25em; }
+    li > ul, li > ol { margin: 0; }
     ul { list-style-type: disc; }
     li { margin: 0.2em 0; }
     li::marker { color: var(--marker); font-size: 0.85em; }
@@ -129,17 +137,19 @@ enum HTMLTheme {
        wrapped lines sit at the same content edge as bullet/number text.
        The negative margin-left pulls the checkbox into the (list's) padding
        area; the nested <ul>/<ol> clears the float so it falls below.
-       QUIRK: use the CSS `1lh` unit (= computed line-height, ≈ 23px at
-       default theme) to precisely center a 1em checkbox on the first text
-       line — `(1lh - 1em) / 2` is exact regardless of the font or line-
-       height setting. `var(--body-size) * var(--line-height)` gives the
-       same number mathematically but relies on the CSS variables being in
-       sync; `1lh` is what the browser actually uses and is supported in
-       WKWebView on macOS 14 (Safari 17.2+). */
+       QUIRK: the CSS `1lh` unit (Safari 17.2+) resolves to 0 when the page is
+       loaded via `loadHTMLString(_:baseURL:nil)` — there is no URL origin, so
+       WebKit skips font metric resolution and `lh` falls back to 0. With 0,
+       `calc((1lh - 1em)/2) = -0.5em`, pushing the checkbox well above the line.
+       Use the CSS custom-property equivalent instead: `--body-size * --line-height`
+       gives the same 23.2px at the default theme and is reliable in all contexts.
+       0.35em is chosen over the pure line-box center (0.225em) because Iowan Old
+       Style's visual text center sits lower in the line box than average — 0.35em
+       aligns the checkbox with the approximate x-height/cap-height midpoint. */
     li.task { list-style: none; }
     li.task > input[type=checkbox] {
       float: left; width: 1em; height: 1em;
-      margin-top: calc((1lh - 1em) / 2);
+      margin-top: 0.35em;
       margin-right: 0.4em;
       margin-left: -1.65em;
     }
@@ -156,7 +166,7 @@ enum HTMLTheme {
     /* Callouts: tinted box + colored title; the icon sits as a non-shrinking
        flex child so a long custom title wraps under the title text, never under
        the icon — the layout the TextKit editor can't achieve. */
-    .callout { background: var(--c-bg); border-radius: 8px; padding: 10px 14px; margin: 0.5em 0; }
+    .callout { background: var(--c-bg); border-radius: 8px; padding: 14px 16px; margin: 0.5em 0; }
     /* Icon sits at the top so it stays on the first line of a wrapped title; its
        box is exactly one line tall and centers the glyph, so it lines up with the
        first line's text rather than floating above it. */
@@ -167,6 +177,11 @@ enum HTMLTheme {
     .callout-icon img { width: 1em; height: 1em; }
     .callout-title-text { flex: 1 1 auto; }
     .callout-body { margin-top: 0.4em; }
+    /* Reduce paragraph spacing inside callout bodies so nested callouts and
+       body text don't sit too far apart. The full 1em bottom margin (from the
+       global <p> rule) + the nested callout's 0.5em top margin would give
+       1.5em gap — halving the paragraph bottom margin brings it to ~1em. */
+    .callout-body > p { margin-bottom: 0.5em; }
     .callout-body > :first-child { margin-top: 0; }
     .callout-body > :last-child { margin-bottom: 0; }
 

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -118,16 +118,22 @@ enum HTMLTheme {
        creates asymmetric vertical padding — the blockquote looks heavier at the
        bottom than at the top. Reset it so padding alone controls the spacing. */
     blockquote > p:last-child { margin-bottom: 0; }
+    /* A nested blockquote that is the last child of its parent blockquote (or
+       callout body) would otherwise leave 1em of extra space below itself inside
+       the parent's padding. Collapse it. */
+    blockquote > blockquote:last-child,
+    .callout-body > blockquote:last-child { margin-bottom: 0; }
     hr { border: none; border-top: 1px solid var(--rule); margin: 1.6em 0; }
     mark { background: rgba(255, 200, 0, 0.3); color: inherit; padding: 0 0.1em; }
     /* Match the editor's list indentation: level-1 text begins at one marker
        slot past the marker (~2.25em), and each nesting level steps in by one
        slot (~1.25em). Same dot at every level, like Edit mode. */
-    /* Only the outermost list (direct child of .page) gets block margin; nested
-       lists inside list items get none — otherwise each nesting level adds its
-       own 1em, creating compounding space for multi-level structures. */
+    /* Only direct children of .page and .callout-body get block margin (1em top
+       + bottom) and the wider level-1 indent (2.25em). Nested lists inside list
+       items stay at 0 margin — otherwise each level compounds to large gaps. */
     ul, ol { margin: 0; padding-left: 1.25em; }
-    .page > ul, .page > ol { margin: 1em 0; padding-left: 2.25em; }
+    .page > ul, .page > ol,
+    .callout-body > ul, .callout-body > ol { margin: 1em 0; padding-left: 2.25em; }
     li > ul, li > ol { margin: 0; }
     ul { list-style-type: disc; }
     li { margin: 0.2em 0; }
@@ -149,7 +155,7 @@ enum HTMLTheme {
     li.task { list-style: none; }
     li.task > input[type=checkbox] {
       float: left; width: 1em; height: 1em;
-      margin-top: 0.35em;
+      margin-top: 0.5em;
       margin-right: 0.4em;
       margin-left: -1.65em;
     }
@@ -166,7 +172,7 @@ enum HTMLTheme {
     /* Callouts: tinted box + colored title; the icon sits as a non-shrinking
        flex child so a long custom title wraps under the title text, never under
        the icon — the layout the TextKit editor can't achieve. */
-    .callout { background: var(--c-bg); border-radius: 8px; padding: 14px 16px; margin: 0.5em 0; }
+    .callout { background: var(--c-bg); border-radius: 8px; padding: 10px 14px; margin: 0.75em 0; }
     /* Icon sits at the top so it stays on the first line of a wrapped title; its
        box is exactly one line tall and centers the glyph, so it lines up with the
        first line's text rather than floating above it. */

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -104,8 +104,7 @@ enum HTMLTheme {
     h1 { font-size: 1.9em; } h2 { font-size: 1.55em; } h3 { font-size: 1.3em; }
     h4 { font-size: 1.1em; } h5 { font-size: 1em; } h6 { font-size: 0.9em; color: var(--faint); }
     :is(h1, h2, h3, h4, h5, h6):first-child { margin-top: 0; }
-    a { color: var(--accent); text-decoration: none; }
-    a:hover { text-decoration: underline; }
+    a { color: var(--accent); text-decoration: underline; }
     code { font-family: var(--mono-font); font-size: 0.92em; color: var(--code);
            background: var(--code-bg); padding: 0.1em 0.35em; border-radius: 4px; }
     pre { background: var(--code-bg); padding: 12px 14px; border-radius: 8px; overflow-x: auto; }
@@ -113,12 +112,21 @@ enum HTMLTheme {
     blockquote { margin: 1em 0; padding: 0.2em 1em; border-left: 3px solid var(--rule); color: var(--faint); }
     hr { border: none; border-top: 1px solid var(--rule); margin: 1.6em 0; }
     mark { background: rgba(255, 200, 0, 0.3); color: inherit; padding: 0 0.1em; }
-    ul, ol { margin: 0 0 var(--para-space); padding-left: 1.6em; }
+    /* Match the editor's list indentation: level-1 text begins at one marker
+       slot past the marker (~2.25em), and each nesting level steps in by one
+       slot (~1.25em). Same dot at every level, like Edit mode. */
+    ul, ol { margin: 0 0 var(--para-space); padding-left: 1.25em; }
+    .page > ul, .page > ol { padding-left: 2.25em; }
+    ul { list-style-type: disc; }
     li { margin: 0.15em 0; }
+    li::marker { color: var(--faint); font-size: 0.85em; }
     li > p { margin: 0; }
-    li.task { list-style: none; }
-    li.task > input[type=checkbox] { vertical-align: -0.1em; margin-right: 0.4em; }
+    /* Task items: the checkbox hangs in the indent so wrapped lines and the
+       label align, never tucking under the checkbox. */
+    li.task { list-style: none; padding-left: 1.4em; }
+    li.task > input[type=checkbox] { margin-left: -1.4em; margin-right: 0.45em; vertical-align: -0.1em; }
     li.task > p { display: inline; margin: 0; }
+    .blank-line { height: calc(var(--body-size) * var(--line-height)); }
     table { border-collapse: collapse; margin: 1em 0; width: 100%; }
     th, td { border: 1px solid var(--rule); padding: 6px 10px; }
     thead th { background: var(--code-bg); }
@@ -129,10 +137,14 @@ enum HTMLTheme {
     /* Callouts: tinted box + colored title; the icon sits as a non-shrinking
        flex child so a long custom title wraps under the title text, never under
        the icon — the layout the TextKit editor can't achieve. */
-    .callout { background: var(--c-bg); border-radius: 8px; padding: 10px 14px; margin: 1em 0; }
-    .callout-title { display: flex; align-items: center; gap: 0.5em;
+    .callout { background: var(--c-bg); border-radius: 8px; padding: 10px 14px; margin: 0.5em 0; }
+    /* Icon sits at the top so it stays on the first line of a wrapped title; its
+       box is exactly one line tall and centers the glyph, so it lines up with the
+       first line's text rather than floating above it. */
+    .callout-title { display: flex; align-items: flex-start; gap: 0.5em;
                      font-weight: 600; color: var(--c-accent); }
-    .callout-icon { flex: 0 0 auto; display: inline-flex; line-height: var(--line-height); }
+    .callout-icon { flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center;
+                    height: calc(var(--body-size) * var(--line-height)); }
     .callout-icon img { width: 1em; height: 1em; }
     .callout-title-text { flex: 1 1 auto; }
     .callout-body { margin-top: 0.4em; }
@@ -141,6 +153,9 @@ enum HTMLTheme {
 
     @media print {
       body { padding: 0; }
+      /* Force WebKit to keep background colors (highlight, code, callouts) when
+         printing — it strips them by default, unlike createPDF. */
+      * { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
       .callout, pre, blockquote, table, .math-display { break-inside: avoid; }
       h1, h2, h3, h4, h5, h6 { break-after: avoid; }
       thead { display: table-header-group; }

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -1,0 +1,180 @@
+import AppKit
+
+// MARK: - HTMLTheme
+//
+// Emits the CSS for Read mode / PDF export from the *same* `EditorTheme` and
+// `CalloutStyle` models the editor renders from, so the two can't drift. The
+// theme is the single source of truth for the values it carries (body font/size,
+// accent, code color, line/paragraph spacing, callout colors); spacing for
+// elements the theme doesn't model (headings, list indent) uses tasteful
+// document defaults.
+//
+// Colors are resolved for one appearance (`dark`); the Read view re-renders when
+// the system appearance flips.
+enum HTMLTheme {
+
+    @MainActor
+    static func css(_ theme: EditorTheme,
+                    callouts: [String: CalloutStyle],
+                    dark: Bool) -> String {
+        let bg = dark ? "#1e1e1e" : "#ffffff"
+        let fg = dark ? "#e6e6e6" : "#1a1a1a"
+        let faint = dark ? "#9a9a9a" : "#6a6a6a"
+        let rule = dark ? "#3a3a3a" : "#e0e0e0"
+        let codeBg = dark ? "#2a2a2a" : "#f4f4f4"
+
+        // line-height: editor `lineSpacing` is extra points between lines, so the
+        // matching CSS multiplier is (fontSize + lineSpacing) / fontSize.
+        let lineHeight = (theme.fontSize + theme.lineSpacing) / theme.fontSize
+
+        return """
+        :root {
+          --body-font: \(cssFontStack(theme.fontName, generic: "serif"));
+          --body-size: \(trim(theme.fontSize))px;
+          --mono-font: \(cssFontStack(theme.monospaceFontName.isEmpty ? "ui-monospace" : theme.monospaceFontName, generic: "monospace"));
+          --mono-size: \(trim(theme.monospaceFontSize))px;
+          --accent: \(theme.accentHex);
+          --code: \(theme.codeHex);
+          --bg: \(bg);
+          --fg: \(fg);
+          --faint: \(faint);
+          --rule: \(rule);
+          --code-bg: \(codeBg);
+          --line-height: \(trim(lineHeight));
+          --para-space: \(trim(max(theme.paragraphSpacingBefore, 0)))px;
+        }
+        \(calloutVars(callouts, dark: dark))
+        \(staticRules)
+        """
+    }
+
+    // MARK: Callout custom properties
+
+    @MainActor
+    private static func calloutVars(_ callouts: [String: CalloutStyle], dark: Bool) -> String {
+        // De-dup styles shared by aliases: emit one rule block per type key.
+        var out = ""
+        for type in callouts.keys.sorted() {
+            let style = callouts[type]!
+            let accent = style.accentHex(dark: dark)
+            let border = style.resolvedBorderHex(dark: dark)
+            let bg = style.explicitBackgroundHex(dark: dark)
+                ?? rgba(accent, alpha: style.backgroundAlpha)
+            out += """
+            .callout-\(type) {
+              --c-accent: \(accent);
+              --c-border: \(border);
+              --c-bg: \(bg);
+              --c-border-width: \(trim(style.borderWidth))px;
+              \(borderEdgeRules(style.borderEdges))
+            }
+
+            """
+        }
+        return out
+    }
+
+    private static func borderEdgeRules(_ edges: CalloutStyle.Edges) -> String {
+        var parts: [String] = []
+        if edges.contains(.left)   { parts.append("border-left: var(--c-border-width) solid var(--c-border);") }
+        if edges.contains(.top)    { parts.append("border-top: var(--c-border-width) solid var(--c-border);") }
+        if edges.contains(.right)  { parts.append("border-right: var(--c-border-width) solid var(--c-border);") }
+        if edges.contains(.bottom) { parts.append("border-bottom: var(--c-border-width) solid var(--c-border);") }
+        return parts.joined(separator: " ")
+    }
+
+    // MARK: Static element rules
+
+    private static let staticRules = """
+    * { box-sizing: border-box; }
+    html { -webkit-text-size-adjust: 100%; }
+    body {
+      font-family: var(--body-font);
+      font-size: var(--body-size);
+      line-height: var(--line-height);
+      color: var(--fg);
+      background: var(--bg);
+      margin: 0;
+      padding: 48px 24px;
+    }
+    .page { max-width: 46em; margin: 0 auto; }
+    p { margin: 0 0 var(--para-space); }
+    h1, h2, h3, h4, h5, h6 { line-height: 1.25; font-weight: 600; margin: 1.4em 0 0.5em; }
+    h1 { font-size: 1.9em; } h2 { font-size: 1.55em; } h3 { font-size: 1.3em; }
+    h4 { font-size: 1.1em; } h5 { font-size: 1em; } h6 { font-size: 0.9em; color: var(--faint); }
+    :is(h1, h2, h3, h4, h5, h6):first-child { margin-top: 0; }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code { font-family: var(--mono-font); font-size: 0.92em; color: var(--code);
+           background: var(--code-bg); padding: 0.1em 0.35em; border-radius: 4px; }
+    pre { background: var(--code-bg); padding: 12px 14px; border-radius: 8px; overflow-x: auto; }
+    pre code { color: var(--fg); background: none; padding: 0; font-size: var(--mono-size); }
+    blockquote { margin: 1em 0; padding: 0.2em 1em; border-left: 3px solid var(--rule); color: var(--faint); }
+    hr { border: none; border-top: 1px solid var(--rule); margin: 1.6em 0; }
+    mark { background: color-mix(in srgb, var(--accent) 28%, transparent); color: inherit;
+           padding: 0 0.1em; border-radius: 3px; }
+    ul, ol { margin: 0 0 var(--para-space); padding-left: 1.6em; }
+    li { margin: 0.15em 0; }
+    li > p { margin: 0; }
+    li.task { list-style: none; margin-left: -1.3em; }
+    li.task > input { margin-right: 0.4em; }
+    li.task > p { display: inline; margin: 0; }
+    table { border-collapse: collapse; margin: 1em 0; width: 100%; }
+    th, td { border: 1px solid var(--rule); padding: 6px 10px; }
+    thead th { background: var(--code-bg); }
+    img { max-width: 100%; }
+    img.math { vertical-align: middle; }
+    .math-display { text-align: center; margin: 1em 0; }
+
+    /* Callouts: tinted box + colored title; the icon sits as a non-shrinking
+       flex child so a long custom title wraps under the title text, never under
+       the icon — the layout the TextKit editor can't achieve. */
+    .callout { background: var(--c-bg); border-radius: 8px; padding: 10px 14px; margin: 1em 0; }
+    .callout-title { display: flex; align-items: flex-start; gap: 0.5em;
+                     font-weight: 600; color: var(--c-accent); }
+    .callout-icon { flex: 0 0 auto; display: inline-flex; line-height: var(--line-height); }
+    .callout-icon img { width: 1em; height: 1em; }
+    .callout-title-text { flex: 1 1 auto; }
+    .callout-body { margin-top: 0.4em; }
+    .callout-body > :first-child { margin-top: 0; }
+    .callout-body > :last-child { margin-bottom: 0; }
+
+    @media print {
+      body { padding: 0; }
+      .callout, pre, blockquote, table, .math-display { break-inside: avoid; }
+      h1, h2, h3, h4, h5, h6 { break-after: avoid; }
+      thead { display: table-header-group; }
+    }
+    """
+
+    // MARK: Helpers
+
+    /// A CSS font stack: the (possibly multi-word) macOS family name quoted, then
+    /// a system fallback and a generic. WKWebView resolves installed families
+    /// (e.g. "Iowan Old Style") by name; the generic guards the rest.
+    private static func cssFontStack(_ family: String, generic: String) -> String {
+        let trimmed = family.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty || trimmed == "ui-monospace" {
+            return "ui-monospace, \(generic)"
+        }
+        return "\"\(trimmed)\", -apple-system, \(generic)"
+    }
+
+    /// rgba(...) from a "#RRGGBB" hex and an alpha.
+    private static func rgba(_ hex: String, alpha: CGFloat) -> String {
+        guard let (r, g, b) = rgbComponents(hex) else { return hex }
+        return "rgba(\(r), \(g), \(b), \(trim(alpha)))"
+    }
+
+    private static func rgbComponents(_ hex: String) -> (Int, Int, Int)? {
+        var h = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if h.hasPrefix("#") { h.removeFirst() }
+        guard h.count == 6, let rgb = UInt64(h, radix: 16) else { return nil }
+        return (Int((rgb >> 16) & 0xFF), Int((rgb >> 8) & 0xFF), Int(rgb & 0xFF))
+    }
+
+    /// Formats a CGFloat without a trailing ".0" so CSS reads cleanly.
+    private static func trim(_ v: CGFloat) -> String {
+        v == v.rounded() ? String(Int(v)) : String(format: "%g", v)
+    }
+}

--- a/Sources/EdmundCore/Export/MarkdownPrinter.swift
+++ b/Sources/EdmundCore/Export/MarkdownPrinter.swift
@@ -1,0 +1,119 @@
+import AppKit
+import WebKit
+import UniformTypeIdentifiers
+
+// MARK: - MarkdownPrinter
+//
+// Print and Export-to-PDF over the same themed HTML the Read mode renders. Both
+// go through `WKWebView.printOperation`, which lays the document out as **real
+// vector text** with native pagination — Print shows the system dialog; Export
+// writes the PDF headlessly via `jobDisposition = .save`. This replaces the
+// older rasterized (bitmap-page) approach.
+@MainActor
+public enum MarkdownPrinter {
+
+    /// Shows the native Print dialog for `markdown`.
+    public static func print(markdown: String,
+                             theme: EditorTheme,
+                             callouts: [String: CalloutStyle]) {
+        // Print on white paper regardless of the screen appearance.
+        let html = DocumentHTML.full(markdown: markdown, theme: theme,
+                                     callouts: callouts, dark: false)
+        PrintJob.start(html: html, printInfo: makePrintInfo(), showsPanel: true)
+    }
+
+    /// Prompts for a destination and writes a vector PDF of `markdown`.
+    public static func exportPDF(markdown: String,
+                                 theme: EditorTheme,
+                                 callouts: [String: CalloutStyle],
+                                 suggestedName: String,
+                                 window: NSWindow?) {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.pdf]
+        panel.nameFieldStringValue = suggestedName + ".pdf"
+
+        let begin: (URL) -> Void = { url in
+            let info = makePrintInfo()
+            info.jobDisposition = .save
+            info.dictionary()[NSPrintInfo.AttributeKey.jobSavingURL] = url
+            let html = DocumentHTML.full(markdown: markdown, theme: theme,
+                                         callouts: callouts, dark: false)
+            PrintJob.start(html: html, printInfo: info, showsPanel: false)
+        }
+
+        if let window {
+            panel.beginSheetModal(for: window) { if $0 == .OK, let url = panel.url { begin(url) } }
+        } else if panel.runModal() == .OK, let url = panel.url {
+            begin(url)
+        }
+    }
+
+    /// US-Letter with 0.75" margins; WKWebView reflows content to the imageable
+    /// width and paginates.
+    private static func makePrintInfo() -> NSPrintInfo {
+        let info = (NSPrintInfo.shared.copy() as? NSPrintInfo) ?? NSPrintInfo.shared
+        let margin: CGFloat = 54
+        info.topMargin = margin
+        info.bottomMargin = margin
+        info.leftMargin = margin
+        info.rightMargin = margin
+        info.horizontalPagination = .automatic
+        info.verticalPagination = .automatic
+        info.isHorizontallyCentered = false
+        info.isVerticallyCentered = false
+        return info
+    }
+}
+
+// MARK: - PrintJob
+//
+// Loads the HTML into an offscreen WKWebView and runs the print operation once
+// the page finishes laying out. Retains itself until the op completes so the
+// async load isn't torn down early.
+@MainActor
+private final class PrintJob: NSObject, WKNavigationDelegate {
+
+    private static var live: Set<PrintJob> = []
+
+    private let webView: WKWebView
+    private let printInfo: NSPrintInfo
+    private let showsPanel: Bool
+
+    static func start(html: String, printInfo: NSPrintInfo, showsPanel: Bool) {
+        let job = PrintJob(html: html, printInfo: printInfo, showsPanel: showsPanel)
+        live.insert(job)
+    }
+
+    private init(html: String, printInfo: NSPrintInfo, showsPanel: Bool) {
+        let config = WKWebViewConfiguration()
+        config.defaultWebpagePreferences.allowsContentJavaScript = false
+        // A comfortable layout width; printOperation scales/paginates to paper.
+        self.webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 800, height: 1000),
+                                 configuration: config)
+        self.printInfo = printInfo
+        self.showsPanel = showsPanel
+        super.init()
+        webView.navigationDelegate = self
+        webView.loadHTMLString(html, baseURL: nil)
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        // Let layout settle a runloop turn before printing.
+        DispatchQueue.main.async { [self] in
+            let op = webView.printOperation(with: printInfo)
+            op.showsPrintPanel = showsPanel
+            op.showsProgressPanel = showsPanel
+            op.run()
+            PrintJob.live.remove(self)
+        }
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        PrintJob.live.remove(self)
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!,
+                 withError error: Error) {
+        PrintJob.live.remove(self)
+    }
+}

--- a/Sources/EdmundCore/Export/MarkdownPrinter.swift
+++ b/Sources/EdmundCore/Export/MarkdownPrinter.swift
@@ -4,26 +4,24 @@ import UniformTypeIdentifiers
 
 // MARK: - MarkdownPrinter
 //
-// Export-to-PDF and Print over the same themed HTML the Read mode renders.
+// Export-to-PDF and Print over the same themed HTML the Read mode renders, using
+// the same PDF *creator* — `WKWebView.printOperation` — so both are real vector
+// text with native pagination. Export sets `jobDisposition = .save` to write the
+// file headlessly; Print shows the system dialog. They remain separate entry
+// points so Export can grow its own settings (margins, page size, …) later.
 //
-// Export:  WKWebView.createPDF — async, non-blocking, returns PDF Data without
-//          involving NSPrintOperation. Produces vector text (selectable in
-//          Preview), self-contained (all assets inlined by DocumentHTML).
-//
-// Print:   WKWebView.printOperation — vector text, native pagination, native
-//          print dialog. The webview is placed in a real (but off-screen, non-
-//          activating) window so AppKit can draw it for the operation; the print
-//          panel is presented as a sheet on the document window via
-//          runModal(for:), which uses a nested event loop and avoids the deadlock
-//          that op.run() causes (op.run() blocks the main thread; WKWebView
-//          rendering needs the main thread; the two deadlock).
+// `printOperation` is run via `runModal(for:)` (a nested event loop) rather than
+// `op.run()` — the latter blocks the main thread inside the WKWebView load
+// callback and deadlocks, since WebKit rendering also needs the main thread.
 @MainActor
 public enum MarkdownPrinter {
 
-    /// Prompts for a PDF destination and writes the document as a vector PDF.
+    /// Prompts for a PDF destination and writes the document as a paginated
+    /// vector PDF.
     public static func exportPDF(markdown: String,
                                  theme: EditorTheme,
                                  callouts: [String: CalloutStyle],
+                                 options: ReadRenderOptions = .default,
                                  suggestedName: String,
                                  window: NSWindow?) {
         let panel = NSSavePanel()
@@ -31,9 +29,12 @@ public enum MarkdownPrinter {
         panel.nameFieldStringValue = suggestedName + ".pdf"
 
         let html = DocumentHTML.full(markdown: markdown, theme: theme,
-                                     callouts: callouts, dark: false)
+                                     callouts: callouts, dark: false, options: options)
         let begin: (URL) -> Void = { url in
-            PDFExportJob.start(html: html, outputURL: url)
+            let info = makePrintInfo()
+            info.jobDisposition = .save
+            info.dictionary()[NSPrintInfo.AttributeKey.jobSavingURL] = url
+            PrintJob.start(html: html, parentWindow: window, printInfo: info, showsPanel: false)
         }
 
         if let window {
@@ -47,15 +48,18 @@ public enum MarkdownPrinter {
     public static func print(markdown: String,
                              theme: EditorTheme,
                              callouts: [String: CalloutStyle],
+                             options: ReadRenderOptions = .default,
                              window: NSWindow?) {
         let html = DocumentHTML.full(markdown: markdown, theme: theme,
-                                     callouts: callouts, dark: false)
-        PrintJob.start(html: html, parentWindow: window, printInfo: makePrintInfo())
+                                     callouts: callouts, dark: false, options: options)
+        PrintJob.start(html: html, parentWindow: window, printInfo: makePrintInfo(), showsPanel: true)
     }
 
+    /// US-Letter with 0.75" margins; WKWebView reflows content to the imageable
+    /// width and paginates.
     static func makePrintInfo() -> NSPrintInfo {
         let info = (NSPrintInfo.shared.copy() as? NSPrintInfo) ?? NSPrintInfo.shared
-        let margin: CGFloat = 54   // 0.75"
+        let margin: CGFloat = 54
         info.topMargin = margin; info.bottomMargin = margin
         info.leftMargin = margin;  info.rightMargin = margin
         info.horizontalPagination = .automatic
@@ -66,58 +70,11 @@ public enum MarkdownPrinter {
     }
 }
 
-// MARK: - PDFExportJob
-//
-// Loads HTML into an offscreen WKWebView, waits for the page to finish, then
-// calls WKWebView.createPDF — the blessed async API for programmatic PDF
-// generation. Unlike NSPrintOperation, createPDF doesn't block the main thread.
-@MainActor
-private final class PDFExportJob: NSObject, WKNavigationDelegate {
-
-    private static var live: Set<PDFExportJob> = []
-
-    private let webView: WKWebView
-    private let outputURL: URL
-
-    static func start(html: String, outputURL: URL) {
-        let job = PDFExportJob(html: html, outputURL: outputURL)
-        live.insert(job)
-    }
-
-    private init(html: String, outputURL: URL) {
-        let config = WKWebViewConfiguration()
-        config.defaultWebpagePreferences.allowsContentJavaScript = false
-        webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 612, height: 792),
-                            configuration: config)
-        self.outputURL = outputURL
-        super.init()
-        webView.navigationDelegate = self
-        webView.loadHTMLString(html, baseURL: nil)
-    }
-
-    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        webView.createPDF(configuration: WKPDFConfiguration()) { [self] result in
-            if case .success(let data) = result {
-                try? data.write(to: outputURL)
-            }
-            PDFExportJob.live.remove(self)
-        }
-    }
-
-    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-        PDFExportJob.live.remove(self)
-    }
-    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-        PDFExportJob.live.remove(self)
-    }
-}
-
 // MARK: - PrintJob
 //
-// Loads HTML into a WKWebView that's placed in a real (off-screen, non-
-// activating) window so AppKit can draw it, then calls printOperation.runModal
-// — a sheet-based API that runs a nested event loop, allowing WebKit IPC to
-// proceed without deadlocking the main thread.
+// Loads HTML into a WKWebView placed in a real (off-screen, non-activating)
+// window so AppKit can draw it, then runs printOperation via runModal(for:).
+// Retains itself until the operation completes.
 @MainActor
 private final class PrintJob: NSObject, WKNavigationDelegate {
 
@@ -127,31 +84,32 @@ private final class PrintJob: NSObject, WKNavigationDelegate {
     private let offscreenWindow: NSWindow
     private let parentWindow: NSWindow?
     private let printInfo: NSPrintInfo
+    private let showsPanel: Bool
 
-    static func start(html: String, parentWindow: NSWindow?, printInfo: NSPrintInfo) {
-        let job = PrintJob(html: html, parentWindow: parentWindow, printInfo: printInfo)
+    static func start(html: String, parentWindow: NSWindow?,
+                      printInfo: NSPrintInfo, showsPanel: Bool) {
+        let job = PrintJob(html: html, parentWindow: parentWindow,
+                           printInfo: printInfo, showsPanel: showsPanel)
         live.insert(job)
     }
 
-    private init(html: String, parentWindow: NSWindow?, printInfo: NSPrintInfo) {
+    private init(html: String, parentWindow: NSWindow?,
+                 printInfo: NSPrintInfo, showsPanel: Bool) {
         let config = WKWebViewConfiguration()
         config.defaultWebpagePreferences.allowsContentJavaScript = false
         webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 800, height: 1000),
                             configuration: config)
 
-        // Place the webview in a real window far off-screen so AppKit's print
-        // rendering path can draw into it (a windowless WKWebView renders blank).
         offscreenWindow = NSWindow(
             contentRect: NSRect(x: -20000, y: -20000, width: 800, height: 1000),
-            styleMask: [.borderless],
-            backing: .buffered,
-            defer: false)
+            styleMask: [.borderless], backing: .buffered, defer: false)
         offscreenWindow.isReleasedWhenClosed = false
         offscreenWindow.contentView = webView
         offscreenWindow.orderBack(nil)
 
         self.parentWindow = parentWindow
         self.printInfo = printInfo
+        self.showsPanel = showsPanel
         super.init()
         webView.navigationDelegate = self
         webView.loadHTMLString(html, baseURL: nil)
@@ -159,16 +117,12 @@ private final class PrintJob: NSObject, WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         let op = webView.printOperation(with: printInfo)
-        op.showsPrintPanel = true
-        op.showsProgressPanel = true
+        op.showsPrintPanel = showsPanel
+        op.showsProgressPanel = showsPanel
         if let parentWindow {
             op.runModal(for: parentWindow, delegate: self,
-                        didRun: #selector(printDidRun(_:success:contextInfo:)),
-                        contextInfo: nil)
+                        didRun: #selector(printDidRun(_:success:contextInfo:)), contextInfo: nil)
         } else {
-            // No parent window: run without a sheet. This uses a nested event
-            // loop, so it doesn't deadlock (unlike op.run() called on the main
-            // thread from a navigation delegate).
             op.run()
             cleanup()
         }

--- a/Sources/EdmundCore/Export/MarkdownPrinter.swift
+++ b/Sources/EdmundCore/Export/MarkdownPrinter.swift
@@ -128,8 +128,15 @@ private final class PrintJob: NSObject, WKNavigationDelegate {
         }
     }
 
-    @objc func printDidRun(_ op: NSPrintOperation, success: Bool, contextInfo: UnsafeMutableRawPointer?) {
-        cleanup()
+    // QUIRK: for a `.save` (headless export) job, NSPrintOperation runs
+    // `_continueModalOperationToTheEnd` on a *spawned* thread and invokes this
+    // didRun callback off the main thread. `cleanup()` closes an NSWindow, which
+    // must happen on main — so this callback is `nonisolated` (otherwise the
+    // Swift-6 main-actor check traps when AppKit calls it off-main) and hops back
+    // to the main actor before touching any AppKit state.
+    @objc nonisolated func printDidRun(_ op: NSPrintOperation, success: Bool,
+                                       contextInfo: UnsafeMutableRawPointer?) {
+        Task { @MainActor in self.cleanup() }
     }
 
     private func cleanup() {

--- a/Sources/EdmundCore/Export/MarkdownPrinter.swift
+++ b/Sources/EdmundCore/Export/MarkdownPrinter.swift
@@ -4,25 +4,23 @@ import UniformTypeIdentifiers
 
 // MARK: - MarkdownPrinter
 //
-// Print and Export-to-PDF over the same themed HTML the Read mode renders. Both
-// go through `WKWebView.printOperation`, which lays the document out as **real
-// vector text** with native pagination — Print shows the system dialog; Export
-// writes the PDF headlessly via `jobDisposition = .save`. This replaces the
-// older rasterized (bitmap-page) approach.
+// Export-to-PDF and Print over the same themed HTML the Read mode renders.
+//
+// Export:  WKWebView.createPDF — async, non-blocking, returns PDF Data without
+//          involving NSPrintOperation. Produces vector text (selectable in
+//          Preview), self-contained (all assets inlined by DocumentHTML).
+//
+// Print:   WKWebView.printOperation — vector text, native pagination, native
+//          print dialog. The webview is placed in a real (but off-screen, non-
+//          activating) window so AppKit can draw it for the operation; the print
+//          panel is presented as a sheet on the document window via
+//          runModal(for:), which uses a nested event loop and avoids the deadlock
+//          that op.run() causes (op.run() blocks the main thread; WKWebView
+//          rendering needs the main thread; the two deadlock).
 @MainActor
 public enum MarkdownPrinter {
 
-    /// Shows the native Print dialog for `markdown`.
-    public static func print(markdown: String,
-                             theme: EditorTheme,
-                             callouts: [String: CalloutStyle]) {
-        // Print on white paper regardless of the screen appearance.
-        let html = DocumentHTML.full(markdown: markdown, theme: theme,
-                                     callouts: callouts, dark: false)
-        PrintJob.start(html: html, printInfo: makePrintInfo(), showsPanel: true)
-    }
-
-    /// Prompts for a destination and writes a vector PDF of `markdown`.
+    /// Prompts for a PDF destination and writes the document as a vector PDF.
     public static func exportPDF(markdown: String,
                                  theme: EditorTheme,
                                  callouts: [String: CalloutStyle],
@@ -32,13 +30,10 @@ public enum MarkdownPrinter {
         panel.allowedContentTypes = [.pdf]
         panel.nameFieldStringValue = suggestedName + ".pdf"
 
+        let html = DocumentHTML.full(markdown: markdown, theme: theme,
+                                     callouts: callouts, dark: false)
         let begin: (URL) -> Void = { url in
-            let info = makePrintInfo()
-            info.jobDisposition = .save
-            info.dictionary()[NSPrintInfo.AttributeKey.jobSavingURL] = url
-            let html = DocumentHTML.full(markdown: markdown, theme: theme,
-                                         callouts: callouts, dark: false)
-            PrintJob.start(html: html, printInfo: info, showsPanel: false)
+            PDFExportJob.start(html: html, outputURL: url)
         }
 
         if let window {
@@ -48,15 +43,21 @@ public enum MarkdownPrinter {
         }
     }
 
-    /// US-Letter with 0.75" margins; WKWebView reflows content to the imageable
-    /// width and paginates.
-    private static func makePrintInfo() -> NSPrintInfo {
+    /// Shows the native Print dialog for `markdown`.
+    public static func print(markdown: String,
+                             theme: EditorTheme,
+                             callouts: [String: CalloutStyle],
+                             window: NSWindow?) {
+        let html = DocumentHTML.full(markdown: markdown, theme: theme,
+                                     callouts: callouts, dark: false)
+        PrintJob.start(html: html, parentWindow: window, printInfo: makePrintInfo())
+    }
+
+    static func makePrintInfo() -> NSPrintInfo {
         let info = (NSPrintInfo.shared.copy() as? NSPrintInfo) ?? NSPrintInfo.shared
-        let margin: CGFloat = 54
-        info.topMargin = margin
-        info.bottomMargin = margin
-        info.leftMargin = margin
-        info.rightMargin = margin
+        let margin: CGFloat = 54   // 0.75"
+        info.topMargin = margin; info.bottomMargin = margin
+        info.leftMargin = margin;  info.rightMargin = margin
         info.horizontalPagination = .automatic
         info.verticalPagination = .automatic
         info.isHorizontallyCentered = false
@@ -65,55 +66,123 @@ public enum MarkdownPrinter {
     }
 }
 
-// MARK: - PrintJob
+// MARK: - PDFExportJob
 //
-// Loads the HTML into an offscreen WKWebView and runs the print operation once
-// the page finishes laying out. Retains itself until the op completes so the
-// async load isn't torn down early.
+// Loads HTML into an offscreen WKWebView, waits for the page to finish, then
+// calls WKWebView.createPDF — the blessed async API for programmatic PDF
+// generation. Unlike NSPrintOperation, createPDF doesn't block the main thread.
 @MainActor
-private final class PrintJob: NSObject, WKNavigationDelegate {
+private final class PDFExportJob: NSObject, WKNavigationDelegate {
 
-    private static var live: Set<PrintJob> = []
+    private static var live: Set<PDFExportJob> = []
 
     private let webView: WKWebView
-    private let printInfo: NSPrintInfo
-    private let showsPanel: Bool
+    private let outputURL: URL
 
-    static func start(html: String, printInfo: NSPrintInfo, showsPanel: Bool) {
-        let job = PrintJob(html: html, printInfo: printInfo, showsPanel: showsPanel)
+    static func start(html: String, outputURL: URL) {
+        let job = PDFExportJob(html: html, outputURL: outputURL)
         live.insert(job)
     }
 
-    private init(html: String, printInfo: NSPrintInfo, showsPanel: Bool) {
+    private init(html: String, outputURL: URL) {
         let config = WKWebViewConfiguration()
         config.defaultWebpagePreferences.allowsContentJavaScript = false
-        // A comfortable layout width; printOperation scales/paginates to paper.
-        self.webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 800, height: 1000),
-                                 configuration: config)
-        self.printInfo = printInfo
-        self.showsPanel = showsPanel
+        webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 612, height: 792),
+                            configuration: config)
+        self.outputURL = outputURL
         super.init()
         webView.navigationDelegate = self
         webView.loadHTMLString(html, baseURL: nil)
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        // Let layout settle a runloop turn before printing.
-        DispatchQueue.main.async { [self] in
-            let op = webView.printOperation(with: printInfo)
-            op.showsPrintPanel = showsPanel
-            op.showsProgressPanel = showsPanel
-            op.run()
-            PrintJob.live.remove(self)
+        webView.createPDF(configuration: WKPDFConfiguration()) { [self] result in
+            if case .success(let data) = result {
+                try? data.write(to: outputURL)
+            }
+            PDFExportJob.live.remove(self)
         }
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        PDFExportJob.live.remove(self)
+    }
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        PDFExportJob.live.remove(self)
+    }
+}
+
+// MARK: - PrintJob
+//
+// Loads HTML into a WKWebView that's placed in a real (off-screen, non-
+// activating) window so AppKit can draw it, then calls printOperation.runModal
+// — a sheet-based API that runs a nested event loop, allowing WebKit IPC to
+// proceed without deadlocking the main thread.
+@MainActor
+private final class PrintJob: NSObject, WKNavigationDelegate {
+
+    private static var live: Set<PrintJob> = []
+
+    private let webView: WKWebView
+    private let offscreenWindow: NSWindow
+    private let parentWindow: NSWindow?
+    private let printInfo: NSPrintInfo
+
+    static func start(html: String, parentWindow: NSWindow?, printInfo: NSPrintInfo) {
+        let job = PrintJob(html: html, parentWindow: parentWindow, printInfo: printInfo)
+        live.insert(job)
+    }
+
+    private init(html: String, parentWindow: NSWindow?, printInfo: NSPrintInfo) {
+        let config = WKWebViewConfiguration()
+        config.defaultWebpagePreferences.allowsContentJavaScript = false
+        webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 800, height: 1000),
+                            configuration: config)
+
+        // Place the webview in a real window far off-screen so AppKit's print
+        // rendering path can draw into it (a windowless WKWebView renders blank).
+        offscreenWindow = NSWindow(
+            contentRect: NSRect(x: -20000, y: -20000, width: 800, height: 1000),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false)
+        offscreenWindow.isReleasedWhenClosed = false
+        offscreenWindow.contentView = webView
+        offscreenWindow.orderBack(nil)
+
+        self.parentWindow = parentWindow
+        self.printInfo = printInfo
+        super.init()
+        webView.navigationDelegate = self
+        webView.loadHTMLString(html, baseURL: nil)
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        let op = webView.printOperation(with: printInfo)
+        op.showsPrintPanel = true
+        op.showsProgressPanel = true
+        if let parentWindow {
+            op.runModal(for: parentWindow, delegate: self,
+                        didRun: #selector(printDidRun(_:success:contextInfo:)),
+                        contextInfo: nil)
+        } else {
+            // No parent window: run without a sheet. This uses a nested event
+            // loop, so it doesn't deadlock (unlike op.run() called on the main
+            // thread from a navigation delegate).
+            op.run()
+            cleanup()
+        }
+    }
+
+    @objc func printDidRun(_ op: NSPrintOperation, success: Bool, contextInfo: UnsafeMutableRawPointer?) {
+        cleanup()
+    }
+
+    private func cleanup() {
+        offscreenWindow.close()
         PrintJob.live.remove(self)
     }
 
-    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!,
-                 withError error: Error) {
-        PrintJob.live.remove(self)
-    }
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) { cleanup() }
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) { cleanup() }
 }

--- a/Sources/EdmundCore/Export/ReadModeWebView.swift
+++ b/Sources/EdmundCore/Export/ReadModeWebView.swift
@@ -8,14 +8,24 @@ import WebKit
 // reach), and navigation is intercepted — internal scrolling stays, external
 // links open in the default browser, and the view never navigates away from the
 // rendered document (§G).
+//
+// The navigation delegate is a *separate* object (not the webview itself). A
+// WKWebView that is its own `navigationDelegate` does not reliably receive the
+// policy callbacks, so link clicks would navigate in-view instead of opening
+// externally; a dedicated, retained coordinator fixes that.
 @MainActor
-public final class ReadModeWebView: WKWebView, WKNavigationDelegate {
+public final class ReadModeWebView: WKWebView {
+
+    private let coordinator = ReadModeNavigationCoordinator()
 
     public init() {
         let config = WKWebViewConfiguration()
         config.defaultWebpagePreferences.allowsContentJavaScript = false
         super.init(frame: .zero, configuration: config)
-        navigationDelegate = self
+        navigationDelegate = coordinator
+        // Allow the Web Inspector (⌥⌘I). Inspecting HTML/CSS is safe: page
+        // JavaScript stays disabled, so this opens no execution vector.
+        if #available(macOS 13.3, *) { isInspectable = true }
     }
 
     @available(*, unavailable)
@@ -23,14 +33,16 @@ public final class ReadModeWebView: WKWebView, WKNavigationDelegate {
 
     /// The most recent render inputs, so the view can re-render itself when the
     /// system appearance flips (light ↔ dark) without the document re-driving it.
-    private var pending: (markdown: String, theme: EditorTheme, callouts: [String: CalloutStyle])?
+    private var pending: (markdown: String, theme: EditorTheme,
+                          callouts: [String: CalloutStyle], options: ReadRenderOptions)?
 
     /// Renders `markdown` with the given theme; appearance is resolved from the
     /// view itself.
     public func render(markdown: String,
                        theme: EditorTheme,
-                       callouts: [String: CalloutStyle]) {
-        pending = (markdown, theme, callouts)
+                       callouts: [String: CalloutStyle],
+                       options: ReadRenderOptions = .default) {
+        pending = (markdown, theme, callouts, options)
         reloadHTML()
     }
 
@@ -38,7 +50,7 @@ public final class ReadModeWebView: WKWebView, WKNavigationDelegate {
         guard let p = pending else { return }
         let dark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         let html = DocumentHTML.full(markdown: p.markdown, theme: p.theme,
-                                     callouts: p.callouts, dark: dark)
+                                     callouts: p.callouts, dark: dark, options: p.options)
         loadHTMLString(html, baseURL: nil)
     }
 
@@ -46,29 +58,29 @@ public final class ReadModeWebView: WKWebView, WKNavigationDelegate {
         super.viewDidChangeEffectiveAppearance()
         reloadHTML()
     }
+}
 
-    // MARK: Navigation policy
+// MARK: - Navigation policy
 
-    public func webView(_ webView: WKWebView,
-                        decidePolicyFor navigationAction: WKNavigationAction,
-                        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-        guard let url = navigationAction.request.url else {
+/// Intercepts navigation for Read mode: the initial load and in-page anchor
+/// scrolls proceed; any link the user activates opens in the default browser and
+/// the read view stays put.
+@MainActor
+private final class ReadModeNavigationCoordinator: NSObject, WKNavigationDelegate {
+
+    func webView(_ webView: WKWebView,
+                 decidePolicyFor navigationAction: WKNavigationAction,
+                 decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        guard navigationAction.navigationType == .linkActivated else {
+            // Initial loadHTMLString, reloads, in-page fragment scrolls, etc.
             decisionHandler(.allow)
             return
         }
-        let scheme = url.scheme ?? ""
-
-        // Allow the initial loadHTMLString load and in-page anchor scrolls.
-        // When baseURL is nil, both come through as about:blank (or about:blank#anchor),
-        // not as .linkActivated — so checking navigationType alone is not reliable;
-        // check the URL scheme instead.
-        if scheme == "about" || scheme == "blob" {
-            decisionHandler(.allow)
-            return
-        }
-
-        // External links → default browser. The read view never navigates away.
-        if scheme == "http" || scheme == "https" {
+        // A clicked link: open external schemes in the default browser; never
+        // navigate the read view away from the document.
+        if let url = navigationAction.request.url,
+           let scheme = url.scheme?.lowercased(),
+           scheme == "http" || scheme == "https" || scheme == "mailto" {
             NSWorkspace.shared.open(url)
         }
         decisionHandler(.cancel)

--- a/Sources/EdmundCore/Export/ReadModeWebView.swift
+++ b/Sources/EdmundCore/Export/ReadModeWebView.swift
@@ -71,18 +71,23 @@ private final class ReadModeNavigationCoordinator: NSObject, WKNavigationDelegat
     func webView(_ webView: WKWebView,
                  decidePolicyFor navigationAction: WKNavigationAction,
                  decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-        guard navigationAction.navigationType == .linkActivated else {
-            // Initial loadHTMLString, reloads, in-page fragment scrolls, etc.
-            decisionHandler(.allow)
-            return
-        }
-        // A clicked link: open external schemes in the default browser; never
-        // navigate the read view away from the document.
-        if let url = navigationAction.request.url,
-           let scheme = url.scheme?.lowercased(),
+        let url = navigationAction.request.url
+        // DIAGNOSTIC (temporary): confirms the delegate fires and shows what
+        // WebKit reports for a click. Remove once link nav is confirmed.
+        NSLog("READMODE-NAV type=\(navigationAction.navigationType.rawValue) url=\(url?.absoluteString ?? "nil")")
+
+        // QUIRK: with `loadHTMLString(_, baseURL: nil)` the document base is
+        // about:blank, and a link click does NOT reliably report
+        // `.linkActivated` — it can come through as `.other`. So decide by URL
+        // scheme, not navigation type: any real web scheme is an external link
+        // to hand off; everything else (about:blank initial load, fragment
+        // scrolls, data:) loads in place.
+        if let url, let scheme = url.scheme?.lowercased(),
            scheme == "http" || scheme == "https" || scheme == "mailto" {
             NSWorkspace.shared.open(url)
+            decisionHandler(.cancel)
+            return
         }
-        decisionHandler(.cancel)
+        decisionHandler(.allow)
     }
 }

--- a/Sources/EdmundCore/Export/ReadModeWebView.swift
+++ b/Sources/EdmundCore/Export/ReadModeWebView.swift
@@ -21,10 +21,15 @@ public final class ReadModeWebView: WKWebView {
     public init() {
         let config = WKWebViewConfiguration()
         config.defaultWebpagePreferences.allowsContentJavaScript = false
+        // QUIRK: `isInspectable` (macOS 13.3+) marks the webview as inspectable
+        // but does NOT add the "Inspect Element" context menu on its own. The
+        // legacy `developerExtrasEnabled` preference key is what actually shows
+        // the menu item. Both must be set for right-click → Inspect Element to
+        // work; the developer tools must also be enabled in Safari's settings.
+        config.preferences.setValue(true, forKey: "developerExtrasEnabled")
         super.init(frame: .zero, configuration: config)
+        coordinator.owner = self
         navigationDelegate = coordinator
-        // Allow the Web Inspector (⌥⌘I). Inspecting HTML/CSS is safe: page
-        // JavaScript stays disabled, so this opens no execution vector.
         if #available(macOS 13.3, *) { isInspectable = true }
     }
 
@@ -46,7 +51,7 @@ public final class ReadModeWebView: WKWebView {
         reloadHTML()
     }
 
-    private func reloadHTML() {
+    func reloadHTML() {
         guard let p = pending else { return }
         let dark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         let html = DocumentHTML.full(markdown: p.markdown, theme: p.theme,
@@ -68,6 +73,10 @@ public final class ReadModeWebView: WKWebView {
 @MainActor
 private final class ReadModeNavigationCoordinator: NSObject, WKNavigationDelegate {
 
+    /// Weak back-reference so the coordinator can re-inject HTML on reload
+    /// without needing the webview to be its own delegate.
+    weak var owner: ReadModeWebView?
+
     // QUIRK: use the *async* form of this delegate method, not the
     // completion-handler form. Under Swift 6 the SDK annotates the
     // completion-handler's closure (`@MainActor @Sendable`); a plain
@@ -80,6 +89,14 @@ private final class ReadModeNavigationCoordinator: NSObject, WKNavigationDelegat
     // (`webView(_:decidePolicyFor:)`) exactly and registers the correct selector.
     func webView(_ webView: WKWebView,
                  decidePolicyFor navigationAction: WKNavigationAction) async -> WKNavigationActionPolicy {
+        // QUIRK: the page is loaded via `loadHTMLString(_, baseURL: nil)`, so the
+        // document URL is `about:blank`. A user-triggered or WebKit-triggered
+        // reload navigates back to `about:blank` and clears the content. Intercept
+        // it and re-inject the HTML ourselves instead of allowing the blank reload.
+        if navigationAction.navigationType == .reload {
+            owner?.reloadHTML()
+            return .cancel
+        }
         // Decide by URL scheme, not navigation type: with `baseURL: nil` a click
         // does not reliably report `.linkActivated`. Any real web scheme is an
         // external link to hand off to the browser; everything else (the

--- a/Sources/EdmundCore/Export/ReadModeWebView.swift
+++ b/Sources/EdmundCore/Export/ReadModeWebView.swift
@@ -52,15 +52,23 @@ public final class ReadModeWebView: WKWebView, WKNavigationDelegate {
     public func webView(_ webView: WKWebView,
                         decidePolicyFor navigationAction: WKNavigationAction,
                         decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-        // The initial loadHTMLString (and in-page anchor scrolls) are `.other`.
-        if navigationAction.navigationType == .other {
+        guard let url = navigationAction.request.url else {
             decisionHandler(.allow)
             return
         }
-        // Any link the user activates: open http(s) in the default browser; the
-        // read view itself never leaves the document.
-        if let url = navigationAction.request.url,
-           url.scheme == "http" || url.scheme == "https" {
+        let scheme = url.scheme ?? ""
+
+        // Allow the initial loadHTMLString load and in-page anchor scrolls.
+        // When baseURL is nil, both come through as about:blank (or about:blank#anchor),
+        // not as .linkActivated — so checking navigationType alone is not reliable;
+        // check the URL scheme instead.
+        if scheme == "about" || scheme == "blob" {
+            decisionHandler(.allow)
+            return
+        }
+
+        // External links → default browser. The read view never navigates away.
+        if scheme == "http" || scheme == "https" {
             NSWorkspace.shared.open(url)
         }
         decisionHandler(.cancel)

--- a/Sources/EdmundCore/Export/ReadModeWebView.swift
+++ b/Sources/EdmundCore/Export/ReadModeWebView.swift
@@ -68,26 +68,28 @@ public final class ReadModeWebView: WKWebView {
 @MainActor
 private final class ReadModeNavigationCoordinator: NSObject, WKNavigationDelegate {
 
+    // QUIRK: use the *async* form of this delegate method, not the
+    // completion-handler form. Under Swift 6 the SDK annotates the
+    // completion-handler's closure (`@MainActor @Sendable`); a plain
+    // `@escaping (WKNavigationActionPolicy) -> Void` does NOT match the
+    // requirement, so the compiler exposes it under the naïve selector
+    // `webView:decidePolicyFor:decisionHandler:` instead of the real
+    // `webView:decidePolicyForNavigationAction:decisionHandler:`. WebKit's
+    // `respondsToSelector:` check then fails and the method is never called —
+    // every link navigates in-view. The async form matches the requirement
+    // (`webView(_:decidePolicyFor:)`) exactly and registers the correct selector.
     func webView(_ webView: WKWebView,
-                 decidePolicyFor navigationAction: WKNavigationAction,
-                 decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-        let url = navigationAction.request.url
-        // DIAGNOSTIC (temporary): confirms the delegate fires and shows what
-        // WebKit reports for a click. Remove once link nav is confirmed.
-        NSLog("READMODE-NAV type=\(navigationAction.navigationType.rawValue) url=\(url?.absoluteString ?? "nil")")
-
-        // QUIRK: with `loadHTMLString(_, baseURL: nil)` the document base is
-        // about:blank, and a link click does NOT reliably report
-        // `.linkActivated` — it can come through as `.other`. So decide by URL
-        // scheme, not navigation type: any real web scheme is an external link
-        // to hand off; everything else (about:blank initial load, fragment
-        // scrolls, data:) loads in place.
-        if let url, let scheme = url.scheme?.lowercased(),
+                 decidePolicyFor navigationAction: WKNavigationAction) async -> WKNavigationActionPolicy {
+        // Decide by URL scheme, not navigation type: with `baseURL: nil` a click
+        // does not reliably report `.linkActivated`. Any real web scheme is an
+        // external link to hand off to the browser; everything else (the
+        // about:blank initial load, fragment scrolls, data:) loads in place.
+        if let url = navigationAction.request.url,
+           let scheme = url.scheme?.lowercased(),
            scheme == "http" || scheme == "https" || scheme == "mailto" {
             NSWorkspace.shared.open(url)
-            decisionHandler(.cancel)
-            return
+            return .cancel
         }
-        decisionHandler(.allow)
+        return .allow
     }
 }

--- a/Sources/EdmundCore/Export/ReadModeWebView.swift
+++ b/Sources/EdmundCore/Export/ReadModeWebView.swift
@@ -1,0 +1,68 @@
+import AppKit
+import WebKit
+
+// MARK: - ReadModeWebView
+//
+// The WKWebView that backs Read mode. It is a pure renderer of the user's own
+// document: JavaScript is disabled, all assets are inlined (so no file/network
+// reach), and navigation is intercepted — internal scrolling stays, external
+// links open in the default browser, and the view never navigates away from the
+// rendered document (§G).
+@MainActor
+public final class ReadModeWebView: WKWebView, WKNavigationDelegate {
+
+    public init() {
+        let config = WKWebViewConfiguration()
+        config.defaultWebpagePreferences.allowsContentJavaScript = false
+        super.init(frame: .zero, configuration: config)
+        navigationDelegate = self
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    /// The most recent render inputs, so the view can re-render itself when the
+    /// system appearance flips (light ↔ dark) without the document re-driving it.
+    private var pending: (markdown: String, theme: EditorTheme, callouts: [String: CalloutStyle])?
+
+    /// Renders `markdown` with the given theme; appearance is resolved from the
+    /// view itself.
+    public func render(markdown: String,
+                       theme: EditorTheme,
+                       callouts: [String: CalloutStyle]) {
+        pending = (markdown, theme, callouts)
+        reloadHTML()
+    }
+
+    private func reloadHTML() {
+        guard let p = pending else { return }
+        let dark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let html = DocumentHTML.full(markdown: p.markdown, theme: p.theme,
+                                     callouts: p.callouts, dark: dark)
+        loadHTMLString(html, baseURL: nil)
+    }
+
+    public override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        reloadHTML()
+    }
+
+    // MARK: Navigation policy
+
+    public func webView(_ webView: WKWebView,
+                        decidePolicyFor navigationAction: WKNavigationAction,
+                        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        // The initial loadHTMLString (and in-page anchor scrolls) are `.other`.
+        if navigationAction.navigationType == .other {
+            decisionHandler(.allow)
+            return
+        }
+        // Any link the user activates: open http(s) in the default browser; the
+        // read view itself never leaves the document.
+        if let url = navigationAction.request.url,
+           url.scheme == "http" || url.scheme == "https" {
+            NSWorkspace.shared.open(url)
+        }
+        decisionHandler(.cancel)
+    }
+}

--- a/Sources/EdmundCore/Export/ReadRenderOptions.swift
+++ b/Sources/EdmundCore/Export/ReadRenderOptions.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// User-configurable options for the Read-mode / export HTML rendering. Kept in
+/// EdmundCore (no AppKit/UserDefaults dependency) so the renderer stays pure;
+/// the app layer reads the values from `AppSettings` and passes them in.
+public struct ReadRenderOptions: Sendable, Equatable {
+
+    /// When true, runs of blank lines in the source add proportional vertical
+    /// space in the output (one extra blank line → one extra line of space),
+    /// preserving the author's intentional spacing instead of collapsing it the
+    /// way Markdown normally does.
+    public var preserveBlankLines: Bool
+
+    public init(preserveBlankLines: Bool = true) {
+        self.preserveBlankLines = preserveBlankLines
+    }
+
+    public static let `default` = ReadRenderOptions()
+}

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -332,7 +332,8 @@ class Document: NSDocument, HeadingNavigable {
             }()
             read.render(markdown: editor.rawSource,
                         theme: editor.theme,
-                        callouts: mergedCallouts)
+                        callouts: mergedCallouts,
+                        options: renderOptions)
             read.isHidden = false
             scrollView.isHidden = true
             editor.window?.makeFirstResponder(read)
@@ -351,6 +352,11 @@ class Document: NSDocument, HeadingNavigable {
         return m
     }
 
+    /// Read-mode/export render options derived from user settings.
+    private var renderOptions: ReadRenderOptions {
+        ReadRenderOptions(preserveBlankLines: AppSettings.renderBlankLinesAsBreaks)
+    }
+
     // MARK: - Export / Print
 
     @objc func exportToPDF(_ sender: Any?) {
@@ -358,6 +364,7 @@ class Document: NSDocument, HeadingNavigable {
         MarkdownPrinter.exportPDF(markdown: editor.rawSource,
                                   theme: editor.theme,
                                   callouts: mergedCallouts,
+                                  options: renderOptions,
                                   suggestedName: name.isEmpty ? "Untitled" : name,
                                   window: windowControllers.first?.window)
     }
@@ -366,6 +373,7 @@ class Document: NSDocument, HeadingNavigable {
         MarkdownPrinter.print(markdown: editor.rawSource,
                               theme: editor.theme,
                               callouts: mergedCallouts,
+                              options: renderOptions,
                               window: windowControllers.first?.window)
     }
 

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -365,7 +365,8 @@ class Document: NSDocument, HeadingNavigable {
     @objc override func printDocument(_ sender: Any?) {
         MarkdownPrinter.print(markdown: editor.rawSource,
                               theme: editor.theme,
-                              callouts: mergedCallouts)
+                              callouts: mergedCallouts,
+                              window: windowControllers.first?.window)
     }
 
     @objc private func selectEditMode(_ sender: Any?)    { setViewMode(.edit) }

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -14,6 +14,12 @@ class Document: NSDocument, HeadingNavigable {
     private var viewModeButton: NSButton?
     private static let viewModeItemID = NSToolbarItem.Identifier("viewMode")
 
+    /// Editor scroll view and its container, held so Read mode can swap the
+    /// editor out for a `ReadModeWebView` (created lazily on first read).
+    private var scrollView: NSScrollView!
+    private var containerView: NSView!
+    private var readView: ReadModeWebView?
+
     /// Content loaded from disk before the editor window exists.
     /// `nonisolated(unsafe)` because `read(from:ofType:)` may be called
     /// off the main actor, but the value is only consumed on main via `showWindows`.
@@ -123,7 +129,7 @@ class Document: NSDocument, HeadingNavigable {
 
         // The text view fills the whole window; the status bar floats over its
         // bottom edge, revealed on hover.
-        let scrollView = NSScrollView(frame: contentBounds)
+        scrollView = NSScrollView(frame: contentBounds)
         scrollView.autoresizingMask = [.width, .height]
         scrollView.hasVerticalScroller = true
         scrollView.scrollerStyle = .overlay
@@ -137,12 +143,12 @@ class Document: NSDocument, HeadingNavigable {
         ))
         statusBar.autoresizingMask = [.width]
 
-        let container = NSView(frame: contentBounds)
-        container.autoresizesSubviews = true
-        container.addSubview(scrollView)
-        container.addSubview(statusBar)   // overlay, on top of the text
+        containerView = NSView(frame: contentBounds)
+        containerView.autoresizesSubviews = true
+        containerView.addSubview(scrollView)
+        containerView.addSubview(statusBar)   // overlay, on top of the text
 
-        window.contentView = container
+        window.contentView = containerView
 
         NotificationCenter.default.addObserver(
             self, selector: #selector(editorDidChange(_:)),
@@ -306,7 +312,60 @@ class Document: NSDocument, HeadingNavigable {
 
     private func setViewMode(_ mode: EditorTextView.ViewMode) {
         editor.viewMode = mode
+        applyViewMode(mode)
         refreshViewModeButton()
+    }
+
+    /// Swaps the on-screen view for the mode: Read mode shows the rendered-HTML
+    /// `ReadModeWebView`; Edit and Source stay on the editor's scroll view.
+    private func applyViewMode(_ mode: EditorTextView.ViewMode) {
+        guard let containerView else { return }
+        if mode == .reading {
+            let read = readView ?? {
+                let v = ReadModeWebView()
+                v.frame = scrollView.frame
+                v.autoresizingMask = [.width, .height]
+                // Below the floating status bar so counts stay visible.
+                containerView.addSubview(v, positioned: .below, relativeTo: statusBar)
+                readView = v
+                return v
+            }()
+            read.render(markdown: editor.rawSource,
+                        theme: editor.theme,
+                        callouts: mergedCallouts)
+            read.isHidden = false
+            scrollView.isHidden = true
+            editor.window?.makeFirstResponder(read)
+        } else {
+            readView?.isHidden = true
+            scrollView.isHidden = false
+            editor.window?.makeFirstResponder(editor)
+        }
+    }
+
+    /// Built-in callout styles merged with the editor's user overrides, so Read
+    /// mode and the PDF match exactly what the editor draws.
+    private var mergedCallouts: [String: CalloutStyle] {
+        var m = Callout.defaultStyles
+        for (k, v) in editor.calloutStyleOverrides { m[k] = v }
+        return m
+    }
+
+    // MARK: - Export / Print
+
+    @objc func exportToPDF(_ sender: Any?) {
+        let name = (displayName as NSString).deletingPathExtension
+        MarkdownPrinter.exportPDF(markdown: editor.rawSource,
+                                  theme: editor.theme,
+                                  callouts: mergedCallouts,
+                                  suggestedName: name.isEmpty ? "Untitled" : name,
+                                  window: windowControllers.first?.window)
+    }
+
+    @objc override func printDocument(_ sender: Any?) {
+        MarkdownPrinter.print(markdown: editor.rawSource,
+                              theme: editor.theme,
+                              callouts: mergedCallouts)
     }
 
     @objc private func selectEditMode(_ sender: Any?)    { setViewMode(.edit) }

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -182,6 +182,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
                          action: #selector(Document.move(_:)),
                          keyEquivalent: "")
 
+        fileMenu.addItem(NSMenuItem.separator())
+
+        fileMenu.addItem(withTitle: "Export as PDF\u{2026}",
+                         action: #selector(Document.exportToPDF(_:)),
+                         keyEquivalent: "")
+
+        fileMenu.addItem(withTitle: "Print\u{2026}",
+                         action: #selector(Document.printDocument(_:)),
+                         keyEquivalent: "p")
+
         fileMenuItem.submenu = fileMenu
         mainMenu.addItem(fileMenuItem)
 

--- a/Sources/edmd/Settings/AppSettings.swift
+++ b/Sources/edmd/Settings/AppSettings.swift
@@ -99,6 +99,7 @@ enum AppSettings {
         static let suppressInconsistentLineEndingWarning = "settings.general.suppressInconsistentLineEndingWarning"
         static let diagnosticLogging = "settings.general.diagnosticLogging"
         static let logRetention = "settings.general.logRetention"
+        static let renderBlankLinesAsBreaks = "settings.reading.renderBlankLinesAsBreaks"
     }
 
     /// Text-column width as a fraction of the available width (`0...1`). `1`
@@ -118,6 +119,19 @@ enum AppSettings {
     static var reopenWindows: Bool {
         get { UserDefaults.standard.bool(forKey: Key.reopenWindows) }
         set { UserDefaults.standard.set(newValue, forKey: Key.reopenWindows) }
+    }
+
+    /// Read mode: render runs of blank lines as proportional vertical space
+    /// (preserving the author's spacing). Defaults on. The toggle UI lives in a
+    /// future Reading-settings tab; the value is already honored here.
+    static var renderBlankLinesAsBreaks: Bool {
+        get {
+            guard UserDefaults.standard.object(forKey: Key.renderBlankLinesAsBreaks) != nil else {
+                return true
+            }
+            return UserDefaults.standard.bool(forKey: Key.renderBlankLinesAsBreaks)
+        }
+        set { UserDefaults.standard.set(newValue, forKey: Key.renderBlankLinesAsBreaks) }
     }
 
     static var startupAction: StartupAction {

--- a/Tests/EdmundTests/DocumentHTMLTests.swift
+++ b/Tests/EdmundTests/DocumentHTMLTests.swift
@@ -1,0 +1,50 @@
+import Testing
+import AppKit
+@testable import EdmundCore
+
+@Suite("DocumentHTML — assembly & asset inlining")
+@MainActor
+struct DocumentHTMLTests {
+
+    private func doc(_ md: String, dark: Bool = false) -> String {
+        DocumentHTML.full(markdown: md, theme: .default,
+                          callouts: Callout.defaultStyles, dark: dark)
+    }
+
+    @Test("Wraps body in a full self-contained document")
+    func wrapper() {
+        let out = doc("# Hi")
+        #expect(out.hasPrefix("<!DOCTYPE html>"))
+        #expect(out.contains("<style>"))
+        #expect(out.contains("<div class=\"page\"><h1>Hi</h1></div>"))
+    }
+
+    @Test("Callout icon placeholder becomes an inlined PNG data URI")
+    func calloutIcon() {
+        let out = doc("> [!note]\n> body")
+        #expect(!out.contains("data-symbol"))   // placeholder consumed
+        #expect(out.contains("<span class=\"callout-icon\"><img src=\"data:image/png;base64,"))
+    }
+
+    @Test("Inline math placeholder becomes an inlined image with baseline align")
+    func inlineMath() {
+        let out = doc("value $x^2$ here")
+        #expect(!out.contains("data-tex"))
+        #expect(out.contains("<img class=\"math math-inline\""))
+        #expect(out.contains("vertical-align:"))
+        #expect(out.contains("src=\"data:image/png;base64,"))
+    }
+
+    @Test("Display math placeholder becomes a centered image")
+    func displayMath() {
+        let out = doc("$$\nx^2\n$$")
+        #expect(out.contains("<div class=\"math-display\"><img class=\"math\""))
+        #expect(out.contains("src=\"data:image/png;base64,"))
+    }
+
+    @Test("Unparseable math falls back to showing the source")
+    func mathFallback() {
+        let out = doc("bad $\\frac{$ math")
+        #expect(out.contains("<code>\\frac{</code>"))
+    }
+}

--- a/Tests/EdmundTests/HTMLRendererTests.swift
+++ b/Tests/EdmundTests/HTMLRendererTests.swift
@@ -1,0 +1,161 @@
+import Testing
+import Foundation
+@testable import EdmundCore
+
+// String-assertion tests for the HTML renderer: parse markdown → render → assert
+// HTML. Pure logic, no AppKit/window needed.
+
+@Suite("HTMLRenderer — core GFM")
+struct HTMLRendererCoreTests {
+
+    private func html(_ md: String) -> String { HTMLRenderer.render(markdown: md) }
+
+    @Test("Headings render h1…h6")
+    func headings() {
+        #expect(html("# Title") == "<h1>Title</h1>")
+        #expect(html("### Sub") == "<h3>Sub</h3>")
+        #expect(html("###### Six") == "<h6>Six</h6>")
+    }
+
+    @Test("Paragraph wraps in <p>")
+    func paragraph() {
+        #expect(html("hello world") == "<p>hello world</p>")
+    }
+
+    @Test("Emphasis, strong, strikethrough, inline code")
+    func inlineMarks() {
+        #expect(html("*i*") == "<p><em>i</em></p>")
+        #expect(html("**b**") == "<p><strong>b</strong></p>")
+        #expect(html("~~s~~") == "<p><del>s</del></p>")
+        #expect(html("`x`") == "<p><code>x</code></p>")
+    }
+
+    @Test("Fenced code block keeps language class and escapes content")
+    func codeBlock() {
+        let out = html("```swift\nlet x = a < b && c > d\n```")
+        #expect(out.contains("<pre><code class=\"language-swift\">"))
+        #expect(out.contains("a &lt; b &amp;&amp; c &gt; d"))
+        #expect(!out.contains("a < b"))
+    }
+
+    @Test("Unordered, ordered, and task lists")
+    func lists() {
+        #expect(html("- a\n- b") == "<ul><li><p>a</p></li><li><p>b</p></li></ul>")
+        #expect(html("1. a").hasPrefix("<ol>"))
+        #expect(html("3. a\n4. b").hasPrefix("<ol start=\"3\">"))
+        let task = html("- [ ] todo\n- [x] done")
+        #expect(task.contains("<li class=\"task\"><input type=\"checkbox\" disabled>"))
+        #expect(task.contains("<input type=\"checkbox\" disabled checked>"))
+    }
+
+    @Test("Table emits thead/tbody with per-column alignment")
+    func table() {
+        let out = html("| a | b | c |\n|:--|:-:|--:|\n| 1 | 2 | 3 |")
+        #expect(out.contains("<table><thead><tr>"))
+        #expect(out.contains("<th style=\"text-align:left\">a</th>"))
+        #expect(out.contains("<th style=\"text-align:center\">b</th>"))
+        #expect(out.contains("<th style=\"text-align:right\">c</th>"))
+        #expect(out.contains("<tbody><tr><td style=\"text-align:left\">1</td>"))
+    }
+
+    @Test("Thematic break → <hr>")
+    func thematicBreak() {
+        #expect(html("---").contains("<hr>"))
+    }
+
+    @Test("Links render as <a href>")
+    func links() {
+        #expect(html("[text](https://example.com)") == "<p><a href=\"https://example.com\">text</a></p>")
+    }
+
+    @Test("Plain block quote stays a blockquote")
+    func blockQuote() {
+        #expect(html("> quoted") == "<blockquote><p>quoted</p></blockquote>")
+    }
+}
+
+@Suite("HTMLRenderer — escaping & security")
+struct HTMLRendererEscapingTests {
+
+    private func html(_ md: String) -> String { HTMLRenderer.render(markdown: md) }
+
+    @Test("Leaf text is HTML-escaped (no script injection)")
+    func escapesText() {
+        let out = html("a <script>alert(1)</script> & b")
+        #expect(!out.contains("<script>"))
+        #expect(out.contains("&lt;script&gt;"))
+        #expect(out.contains("&amp;"))
+    }
+
+    @Test("Raw HTML block is escaped, not passed through")
+    func escapesHTMLBlock() {
+        let out = html("<div onclick=\"x\">hi</div>")
+        #expect(!out.contains("<div onclick"))
+        #expect(out.contains("&lt;div"))
+    }
+}
+
+@Suite("HTMLRenderer — non-GFM inline")
+struct HTMLRendererInlineTests {
+
+    private func html(_ md: String) -> String { HTMLRenderer.render(markdown: md) }
+
+    @Test("==highlight== → <mark>")
+    func highlight() {
+        #expect(html("a ==hi== b").contains("<mark>hi</mark>"))
+    }
+
+    @Test("Inline $math$ → placeholder span with escaped data-tex")
+    func inlineMath() {
+        let out = html("energy $E=mc^2$ here")
+        #expect(out.contains("<span class=\"math-inline\" data-tex=\"E=mc^2\"></span>"))
+    }
+
+    @Test("Display $$math$$ → math-display div")
+    func displayMath() {
+        let out = html("$$\n\\int_0^1 x\\,dx\n$$")
+        #expect(out.contains("<div class=\"math-display\" data-tex=\""))
+        #expect(out.contains("\\int_0^1"))
+    }
+
+    @Test("Wikilink renders display text (routing deferred)")
+    func wikilink() {
+        #expect(html("see [[Note|the note]]").contains("the note"))
+        #expect(!html("see [[Note|the note]]").contains("[["))
+    }
+
+    @Test("Comment is hidden")
+    func comment() {
+        #expect(!html("before %%secret%% after").contains("secret"))
+    }
+}
+
+@Suite("HTMLRenderer — callouts")
+struct HTMLRendererCalloutTests {
+
+    private func html(_ md: String) -> String { HTMLRenderer.render(markdown: md) }
+
+    @Test("Known callout type → callout div with title and body")
+    func basicCallout() {
+        let out = html("> [!note]\n> Body text.")
+        #expect(out.contains("<div class=\"callout callout-note\">"))
+        #expect(out.contains("<div class=\"callout-title\">"))
+        #expect(out.contains("data-symbol=\"pencil.tip\""))
+        #expect(out.contains("<span class=\"callout-title-text\">Note</span>"))
+        #expect(out.contains("<div class=\"callout-body\"><p>Body text.</p></div>"))
+    }
+
+    @Test("Custom title is used verbatim")
+    func customTitle() {
+        let out = html("> [!warning] Watch out here\n> Careful.")
+        #expect(out.contains("callout callout-warning"))
+        #expect(out.contains("<span class=\"callout-title-text\">Watch out here</span>"))
+    }
+
+    @Test("Unknown type stays a plain block quote")
+    func unknownType() {
+        let out = html("> [!bogus]\n> hi")
+        #expect(out.hasPrefix("<blockquote>"))
+        #expect(!out.contains("callout"))
+    }
+}

--- a/Tests/EdmundTests/HTMLThemeTests.swift
+++ b/Tests/EdmundTests/HTMLThemeTests.swift
@@ -1,0 +1,44 @@
+import Testing
+import AppKit
+@testable import EdmundCore
+
+@Suite("HTMLTheme — CSS emission")
+@MainActor
+struct HTMLThemeTests {
+
+    private func css(dark: Bool) -> String {
+        let theme = EditorTheme(fontName: "Iowan Old Style", fontSize: 16,
+                                accentHex: "#3366E6", codeHex: "#8A2425",
+                                lineSpacing: 4, paragraphSpacingBefore: 2)
+        return HTMLTheme.css(theme, callouts: Callout.defaultStyles, dark: dark)
+    }
+
+    @Test("Derives custom properties from the theme")
+    func vars() {
+        let out = css(dark: false)
+        #expect(out.contains("--accent: #3366E6;"))
+        #expect(out.contains("--code: #8A2425;"))
+        #expect(out.contains("--body-size: 16px;"))
+        // (16 + 4) / 16 = 1.25
+        #expect(out.contains("--line-height: 1.25;"))
+        // Multi-word family is quoted with a fallback stack.
+        #expect(out.contains("\"Iowan Old Style\""))
+    }
+
+    @Test("Emits per-callout-type colors with derived rgba background")
+    func calloutVars() {
+        let out = css(dark: false)
+        #expect(out.contains(".callout-note {"))
+        #expect(out.contains("--c-accent: #086DDD;"))
+        // note's background is derived from the accent at backgroundAlpha 0.08.
+        #expect(out.contains("rgba(8, 109, 221, 0.08)"))
+    }
+
+    @Test("Dark appearance picks dark color variants")
+    func darkVariant() {
+        // 'caution' has darkColorHex #F85149.
+        #expect(css(dark: true).contains("--c-accent: #F85149;"))
+        #expect(css(dark: false).contains("--c-accent: #CF222E;"))
+        #expect(css(dark: true).contains("--bg: #1e1e1e;"))
+    }
+}

--- a/Tests/EdmundTests/HTMLThemeTests.swift
+++ b/Tests/EdmundTests/HTMLThemeTests.swift
@@ -19,8 +19,8 @@ struct HTMLThemeTests {
         #expect(out.contains("--accent: #3366E6;"))
         #expect(out.contains("--code: #8A2425;"))
         #expect(out.contains("--body-size: 16px;"))
-        // (16 + 4) / 16 = 1.25
-        #expect(out.contains("--line-height: 1.25;"))
+        // 1.2 + 4/16 = 1.45
+        #expect(out.contains("--line-height: 1.45;"))
         // Multi-word family is quoted with a fallback stack.
         #expect(out.contains("\"Iowan Old Style\""))
     }

--- a/Tests/EdmundTests/ReadModeWebViewTests.swift
+++ b/Tests/EdmundTests/ReadModeWebViewTests.swift
@@ -1,0 +1,23 @@
+import Testing
+import WebKit
+@testable import EdmundCore
+
+@Suite("ReadModeWebView — navigation delegate")
+@MainActor
+struct ReadModeWebViewTests {
+
+    // Regression guard: WebKit only calls a delegate method it passes
+    // `respondsToSelector:`. Under Swift 6 the completion-handler form of
+    // `decidePolicyFor` fails to satisfy the (concurrency-annotated) protocol
+    // requirement and gets registered under the wrong selector, so WebKit never
+    // calls it and every link navigates in-view. The async form registers the
+    // correct selector — assert that here so the fix can't silently regress.
+    @Test("nav delegate responds to the real decidePolicyFor selector")
+    func decidePolicySelectorRegistered() {
+        let webView = ReadModeWebView()
+        let delegate = webView.navigationDelegate as? NSObject
+        #expect(delegate != nil)
+        let selector = NSSelectorFromString("webView:decidePolicyForNavigationAction:decisionHandler:")
+        #expect(delegate?.responds(to: selector) == true)
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -135,6 +135,7 @@ rawSource ──BlockParser──▶ [Block]  ──styleBlock per block──�
 | Parsing | `Parsing/BlockParser.swift`, `SyntaxHighlighter*.swift`, `CodeHighlighter.swift` |
 | Block model | `Model/Block.swift`, `Callout.swift`, `EditorTheme.swift`, `ListIndentState.swift` |
 | Rendering | `Rendering/EditorTextView+*Rendering.swift` (Callout, Code, Image, List, Math, Table, WikiLinks) |
+| Read mode / Export | `Export/` — `HTMLRenderer` (MarkupVisitor → HTML), `HTMLTheme` (EditorTheme → CSS), `DocumentHTML` (assembly + SF-Symbol/math data-URI inlining), `ReadModeWebView`, `MarkdownPrinter` (PDF/Print) |
 | Edit behaviors | `Editing/EditorTextView+{List,Blockquote}Continuation.swift`, `+Indentation.swift` |
 | Formatting commands | `Editing/EditorTextView+Formatting{Core,Commands}.swift` (Format-menu actions: bold/lists/links/callouts/…); menu built from `edmd/App/FormatMenu.swift` |
 | Lazy/compose/undo/scroll | `TextView/EditorTextView+{Composition,LazyStyling,Undo,TypewriterScroll,SelectionTracking,ContentWidth,EditFlow}.swift` |
@@ -159,6 +160,20 @@ actions funnel through two primitives in `+FormattingCore.swift`
 (`applyFormattingEdit` for a single contiguous edit, modeled on the Tab-indent
 path; `applyWholeDocumentEdit` for non-contiguous edits like footnotes). The
 View-menu ⌘E item cycles Edit→Read→Source via `Document.cycleViewMode`.
+
+**Read mode is a separate WKWebView**, not an editor styling mode. Entering
+`.reading` swaps the editor's scroll view for a `ReadModeWebView` that renders
+the document as themed HTML (the `Export/` group); Edit and Source stay on the
+`EditorTextView`. The HTML path walks the *same* swift-markdown `Document` the
+editor parses (one parser, two back-ends: `SpanCollector` → editor attributes,
+`HTMLRenderer` → HTML), themed from the *same* `EditorTheme`/`CalloutStyle` via
+`HTMLTheme`, so the two can't drift. The webview disables JavaScript and inlines
+every asset (math/icons as data URIs) so it needs no file/network reach; external
+links open in the default browser. **File ▸ Export as PDF… / Print… (⌘P)** run
+the same HTML through `WKWebView.printOperation` for real vector (selectable)
+text — `MarkdownPrinter`. Math glyphs are high-DPI PNG (SwiftMath has no SVG
+path yet); everything else is vector. Deferred: code syntax-color spans, local
+image inlining, wikilink routing.
 
 ---
 


### PR DESCRIPTION
## What

Replaces the attribute-only Read mode (same NSTextView with delimiters hidden) with a real WKWebView renderer, and adds vector PDF export and Print — both producing selectable text rather than rasterized images.

## Why

The existing Read mode couldn't do real document presentation: no callout boxes that wrap titles, no paginated print, no selectable export. TextKit 2 forbids AppKit's vector PDF paths (`NSPrintOperation(view:)`/`dataWithPDF`) because they route through TextKit 1 and drop all custom chrome. WKWebView sidesteps that entirely.

## How

One renderer shared by Read mode, Export, and Print:

- `HTMLRenderer` — pure `MarkupVisitor` over the same swift-markdown `Document` the editor already parses, reusing the editor's custom-parser regexes (highlight, math placeholders, wikilinks, comments). One parser, two back-ends.
- `HTMLTheme` — `EditorTheme` + `CalloutStyle` → CSS. Resolves `NSColor.tertiaryLabelColor` per-appearance for exact marker dim. Callout icons rendered as sRGB PNG data URIs (exact CSS hex match).
- `DocumentHTML` — assembly + asset inlining (SF-Symbol icons, SwiftMath glyphs).
- `ReadModeWebView` — JS disabled, nav policy opens external links in default browser, Web Inspector enabled (`developerExtrasEnabled` + `isInspectable`), reload intercepted to re-inject HTML.
- `MarkdownPrinter` — Export PDF and Print both via `WKWebView.printOperation` (vector, paginated). Export uses `jobDisposition = .save`; Print uses `runModal(for:)` to avoid main-thread deadlock.

Key quirks fixed along the way: Swift 6 `decidePolicyFor` async form required for correct ObjC selector registration; `printDidRun` fires off-main for `.save` jobs; `1lh` unit resolves to 0 in `loadHTMLString` context; U+2028 LINE SEPARATOR not an HTML newline.

28 new tests covering renderer element coverage, escaping/security, callout structure, CSS property derivation, asset inlining, and the nav-delegate selector regression.

## Deferred to stage 2
Code syntax coloring, local image inlining, wikilink routing, SVG math, footnote rendering — see handoff doc at `~/Developer/md_claude/handoff/read-mode-stage2-handoff.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)