### PR TITLE
Read mode Stage 2: code highlighting, image inlining, wikilink routing, live settings

### DIFF
--- a/Sources/EdmundCore/Export/DocumentHTML.swift
+++ b/Sources/EdmundCore/Export/DocumentHTML.swift
@@ -11,15 +11,18 @@ import SwiftMath
 @MainActor
 enum DocumentHTML {
 
-    /// Builds a complete `<!DOCTYPE html>…` document for `markdown`.
+    /// Builds a complete `<!DOCTYPE html>…` document for `markdown`. `baseURL` is
+    /// the document's directory, used to resolve relative image paths for inlining.
     static func full(markdown: String,
                      theme: EditorTheme,
                      callouts: [String: CalloutStyle],
                      dark: Bool,
+                     baseURL: URL? = nil,
                      options: ReadRenderOptions = .default) -> String {
         var body = HTMLRenderer.render(markdown: markdown, options: options)
         body = fillCalloutIcons(body, callouts: callouts, dark: dark)
         body = fillMath(body, theme: theme, dark: dark)
+        body = fillImages(body, baseURL: baseURL, options: options)
         let css = HTMLTheme.css(theme, callouts: callouts, dark: dark)
         return """
         <!DOCTYPE html>
@@ -152,6 +155,77 @@ enum DocumentHTML {
         let clamped = max(asc + desc, fontSize / 2)
         let descent = (asc + desc - clamped) / 2 + desc + insetPad
         return (image, descent)
+    }
+
+    // MARK: Images (local → inlined data URI; remote → off by default)
+
+    private static let imagePattern =
+        "<img class=\"md-image\" data-src=\"([^\"]*)\" alt=\"([^\"]*)\">"
+
+    /// Resolves each `md-image` placeholder: local/relative paths are read and
+    /// inlined as a data URI (self-contained, no file access needed at render
+    /// time); a `data:` source passes through; remote `http(s)` sources load
+    /// only when `options.allowRemoteImages` is set, else the alt text shows.
+    private static func fillImages(_ html: String, baseURL: URL?,
+                                   options: ReadRenderOptions) -> String {
+        var cache: [String: String] = [:]   // resolved path → data URI
+        return replaceMatches(html, pattern: imagePattern) { groups in
+            let src = unescapeAttr(groups[1])
+            let alt = groups[2]   // already attribute-escaped by the renderer
+            func placeholder() -> String { "<img class=\"md-image\" alt=\"\(alt)\">" }
+
+            if src.isEmpty { return placeholder() }
+            let lower = src.lowercased()
+            if lower.hasPrefix("data:") {
+                return "<img class=\"md-image\" src=\"\(HTMLRenderer.attr(src))\" alt=\"\(alt)\">"
+            }
+            if lower.hasPrefix("http://") || lower.hasPrefix("https://") {
+                guard options.allowRemoteImages else { return placeholder() }
+                return "<img class=\"md-image\" src=\"\(HTMLRenderer.attr(src))\" alt=\"\(alt)\">"
+            }
+            // Local: resolve against the document directory, read, inline.
+            guard let fileURL = resolveLocalImage(src, baseURL: baseURL) else { return placeholder() }
+            let uri: String
+            if let cached = cache[fileURL.path] {
+                uri = cached
+            } else {
+                uri = imageDataURI(fileURL) ?? ""
+                cache[fileURL.path] = uri
+            }
+            guard !uri.isEmpty else { return placeholder() }
+            return "<img class=\"md-image\" src=\"\(uri)\" alt=\"\(alt)\">"
+        }
+    }
+
+    /// Resolves a local image `path` to a file URL: absolute / `~` / `file:`
+    /// load directly; a relative path resolves against the document's directory.
+    private static func resolveLocalImage(_ path: String, baseURL: URL?) -> URL? {
+        if let url = URL(string: path), url.scheme == "file" { return url }
+        // A markdown image destination may be percent-encoded (e.g. `%20`).
+        let decoded = path.removingPercentEncoding ?? path
+        if decoded.hasPrefix("/") { return URL(fileURLWithPath: decoded) }
+        if decoded.hasPrefix("~") { return URL(fileURLWithPath: (decoded as NSString).expandingTildeInPath) }
+        guard let baseURL else { return nil }
+        let resolved = baseURL.appendingPathComponent(decoded)
+        return FileManager.default.fileExists(atPath: resolved.path) ? resolved : nil
+    }
+
+    /// Reads an image file and returns a `data:` URI, with the MIME type guessed
+    /// from the file extension (covers the common web image formats).
+    private static func imageDataURI(_ url: URL) -> String? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        let mime: String
+        switch url.pathExtension.lowercased() {
+        case "png":          mime = "image/png"
+        case "jpg", "jpeg":  mime = "image/jpeg"
+        case "gif":          mime = "image/gif"
+        case "svg":          mime = "image/svg+xml"
+        case "webp":         mime = "image/webp"
+        case "bmp":          mime = "image/bmp"
+        case "tiff", "tif":  mime = "image/tiff"
+        default:             mime = "application/octet-stream"
+        }
+        return "data:\(mime);base64,\(data.base64EncodedString())"
     }
 
     // MARK: Bitmap / escaping helpers

--- a/Sources/EdmundCore/Export/HTMLRenderer.swift
+++ b/Sources/EdmundCore/Export/HTMLRenderer.swift
@@ -20,6 +20,16 @@ import Markdown
 struct HTMLRenderer: MarkupVisitor {
     typealias Result = String
 
+    /// Private URL scheme for `[[wikilink]]` hrefs. The read view's navigation
+    /// policy intercepts this scheme and routes the (percent-decoded) target
+    /// through the app's document graph instead of navigating the webview.
+    static let wikiScheme = "x-edmund-wiki"
+
+    /// Private URL scheme for relative/internal regular markdown links
+    /// (`[text](other.md)`). Routed like wikilinks; external links (http/https/
+    /// mailto) and in-page `#fragment` anchors keep their real hrefs.
+    static let linkScheme = "x-edmund-link"
+
     /// The markdown this instance is rendering. Held so block-level constructs
     /// (callouts) can recover their *raw* source text by range, the way the
     /// editor's styling layer does.
@@ -122,8 +132,9 @@ struct HTMLRenderer: MarkupVisitor {
     }
 
     mutating func visitCodeBlock(_ codeBlock: CodeBlock) -> String {
-        // Code text is shown verbatim (escaped). Per-token syntax coloring is a
-        // deferred follow-up; the language class is emitted for it to hook later.
+        // Per-token syntax coloring reuses the editor's `CodeHighlighter`, so
+        // Edit mode and Read mode color the same tokens identically (the actual
+        // colors live in CSS, from the shared `CodeSyntaxPalette` via HTMLTheme).
         let lang = codeBlock.language.map { " class=\"language-\(Self.attr($0))\"" } ?? ""
         // QUIRK: U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR are valid
         // Unicode line-ending characters that appear in macOS-pasted text (e.g.
@@ -135,7 +146,44 @@ struct HTMLRenderer: MarkupVisitor {
             .replacingOccurrences(of: "\u{2029}", with: "\n")
         // swift-markdown includes a trailing newline on the block's code.
         let code = raw.hasSuffix("\n") ? String(raw.dropLast()) : raw
-        return "<pre><code\(lang)>\(Self.escape(code))</code></pre>"
+        return "<pre><code\(lang)>\(Self.highlightCode(code, language: codeBlock.language))</code></pre>"
+    }
+
+    /// CSS class for a code token kind (consumed by `HTMLTheme`'s `.tok-*` rules).
+    private static func tokenClass(_ type: CodeHighlighter.TokenType) -> String {
+        switch type {
+        case .keyword:  return "tok-keyword"
+        case .type:     return "tok-type"
+        case .string:   return "tok-string"
+        case .number:   return "tok-number"
+        case .comment:  return "tok-comment"
+        case .function: return "tok-function"
+        }
+    }
+
+    /// Escapes `code` and wraps each `CodeHighlighter` token in a colored
+    /// `<span class="tok-…">`. Gaps between tokens stay plain (escaped) text and
+    /// inherit the plain `pre code` color, mirroring the editor's "plain first,
+    /// tokens paint over" model.
+    static func highlightCode(_ code: String, language: String?) -> String {
+        let tokens = CodeHighlighter.tokenize(code, language: language)
+        guard !tokens.isEmpty else { return escape(code) }
+        let ns = code as NSString
+        var out = ""
+        var cursor = 0
+        for token in tokens {
+            let r = token.range
+            guard r.location >= cursor, r.upperBound <= ns.length else { continue }
+            if r.location > cursor {
+                out += escape(ns.substring(with: NSRange(location: cursor, length: r.location - cursor)))
+            }
+            out += "<span class=\"\(tokenClass(token.type))\">\(escape(ns.substring(with: r)))</span>"
+            cursor = r.upperBound
+        }
+        if cursor < ns.length {
+            out += escape(ns.substring(with: NSRange(location: cursor, length: ns.length - cursor)))
+        }
+        return out
     }
 
     mutating func visitThematicBreak(_ thematicBreak: ThematicBreak) -> String { "<hr>" }
@@ -208,16 +256,42 @@ struct HTMLRenderer: MarkupVisitor {
     mutating func visitSoftBreak(_ softBreak: SoftBreak) -> String { "\n" }
 
     mutating func visitLink(_ link: Link) -> String {
-        let href = Self.attr(link.destination ?? "")
-        return "<a href=\"\(href)\">\(renderChildren(of: link))</a>"
+        let dest = link.destination ?? ""
+        let inner = renderChildren(of: link)
+        // In-page `#fragment` anchors and external links (http/https/mailto, or
+        // any explicit scheme) keep their real href — the nav policy lets the
+        // anchor scroll and hands external schemes to the browser. A relative /
+        // internal destination is wrapped in the private link scheme so it routes
+        // through the app's document graph reliably (independent of how WebKit
+        // rewrites relative hrefs under `baseURL: nil`).
+        if dest.hasPrefix("#") || Self.hasExternalScheme(dest) {
+            return "<a href=\"\(Self.attr(dest))\">\(inner)</a>"
+        }
+        let encoded = dest.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? dest
+        return "<a href=\"\(Self.linkScheme):\(encoded)\">\(inner)</a>"
+    }
+
+    /// Whether a link destination carries an explicit URL scheme (`http:`,
+    /// `mailto:`, `file:`, …) and so should be treated as external/absolute
+    /// rather than a relative path into the document's directory.
+    private static func hasExternalScheme(_ dest: String) -> Bool {
+        guard let colon = dest.firstIndex(of: ":") else { return false }
+        let scheme = dest[dest.startIndex..<colon]
+        // A scheme is letters/digits/+/-/. and can't contain a slash; a path like
+        // "a/b:c" has its first colon after a slash, so it's not a scheme.
+        guard !scheme.isEmpty, scheme.first!.isLetter else { return false }
+        return scheme.allSatisfy { $0.isLetter || $0.isNumber || $0 == "+" || $0 == "-" || $0 == "." }
+            && !scheme.contains("/")
     }
 
     mutating func visitImage(_ image: Image) -> String {
-        // Local image inlining is a deferred follow-up; for now emit a plain
-        // <img> with the alt text so the structure is present (no src ⇒ the
-        // browser shows the alt). The alt is the image's child text.
+        // Emit a placeholder carrying the raw source; `DocumentHTML` resolves and
+        // inlines it in a second pass (it needs the document directory + the
+        // remote-image policy, which the pure renderer doesn't have). No `src`
+        // here ⇒ if the asset pass can't resolve it, the alt text shows.
         let alt = Self.attr(Self.plainText(of: image))
-        return "<img alt=\"\(alt)\">"
+        let src = Self.attr(image.source ?? "")
+        return "<img class=\"md-image\" data-src=\"\(src)\" alt=\"\(alt)\">"
     }
 
     // Never pass raw author HTML through — escape it so a document can't inject
@@ -308,9 +382,14 @@ struct HTMLRenderer: MarkupVisitor {
             case .math(false):
                 let tex = ns.substring(with: span.contentRange)
                 out += "<span class=\"math-inline\" data-tex=\"\(attr(tex))\"></span>"
-            case .wikilink:
-                // Routing deferred — render the visible display text as plain text.
-                out += escape(ns.substring(with: span.contentRange))
+            case .wikilink(let target):
+                // Emit a link in a private scheme so the read view's nav policy
+                // can intercept it and route through the app's document graph
+                // (rather than navigating the webview). The target is fully
+                // percent-encoded so a `#heading` isn't parsed as a URL fragment.
+                let encoded = target.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? target
+                let display = escape(ns.substring(with: span.contentRange))
+                out += "<a class=\"wikilink\" href=\"\(wikiScheme):\(encoded)\">\(display)</a>"
             case .comment:
                 break   // hidden in reading, like the editor
             default:

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -133,7 +133,9 @@ enum HTMLTheme {
     a { color: var(--accent); text-decoration: underline; }
     code { font-family: var(--mono-font); font-size: 0.92em; color: var(--code);
            background: var(--code-bg); padding: 0.1em 0.35em; border-radius: 4px; }
-    pre { background: var(--code-bg); padding: 12px 14px; border-radius: 8px; overflow-x: auto; }
+    pre { background: var(--code-bg); padding: 12px 14px; border-radius: 8px; overflow-x: auto;
+          /* tab-size: browsers default to 8; match the common editor convention of 4. */
+          tab-size: 4; -moz-tab-size: 4; }
     pre code { color: var(--fg); background: none; padding: 0; font-size: var(--mono-size); }
     blockquote { margin: 1em 0; padding: 0.5em 1em; border-left: 3px solid var(--rule); color: var(--faint); }
     /* Without this, the 1em bottom margin on the last <p> inside a blockquote
@@ -201,6 +203,10 @@ enum HTMLTheme {
     th, td { border: 1px solid var(--rule); padding: 6px 10px; }
     thead th { background: var(--code-bg); }
     img { max-width: 100%; }
+    /* Block-display for document images: eliminates the inline baseline gap (the
+       descender space between an inline image's bottom and its line box bottom)
+       that otherwise shows as blank space below tall images. */
+    img.md-image { display: block; max-width: 100%; }
     img.math { vertical-align: middle; }
     .math-display { text-align: center; margin: 1em 0; }
 

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -47,7 +47,29 @@ enum HTMLTheme {
         }
         \(calloutVars(callouts, dark: dark))
         \(staticRules)
+        \(codeTokenRules(dark: dark))
         """
+    }
+
+    // MARK: Code syntax colors
+
+    /// `.tok-*` color rules for fenced code blocks, from the shared
+    /// `CodeSyntaxPalette` so Read mode matches the editor token-for-token. The
+    /// `pre code` rule overrides the static `var(--fg)` so plain (un-tokenized)
+    /// code uses the palette's plain color too, like the editor.
+    private static func codeTokenRules(dark: Bool) -> String {
+        func rule(_ selector: String, _ type: CodeHighlighter.TokenType?) -> String {
+            "\(selector) { color: \(CodeSyntaxPalette.hex(type, dark: dark)); }"
+        }
+        return [
+            rule("pre code", nil),
+            rule("pre code .tok-keyword", .keyword),
+            rule("pre code .tok-type", .type),
+            rule("pre code .tok-string", .string),
+            rule("pre code .tok-number", .number),
+            rule("pre code .tok-comment", .comment),
+            rule("pre code .tok-function", .function),
+        ].joined(separator: "\n")
     }
 
     // MARK: Callout custom properties

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -203,10 +203,6 @@ enum HTMLTheme {
     th, td { border: 1px solid var(--rule); padding: 6px 10px; }
     thead th { background: var(--code-bg); }
     img { max-width: 100%; }
-    /* Block-display for document images: eliminates the inline baseline gap (the
-       descender space between an inline image's bottom and its line box bottom)
-       that otherwise shows as blank space below tall images. */
-    img.md-image { display: block; max-width: 100%; }
     img.math { vertical-align: middle; }
     .math-display { text-align: center; margin: 1em 0; }
 

--- a/Sources/EdmundCore/Export/MarkdownPrinter.swift
+++ b/Sources/EdmundCore/Export/MarkdownPrinter.swift
@@ -21,6 +21,7 @@ public enum MarkdownPrinter {
     public static func exportPDF(markdown: String,
                                  theme: EditorTheme,
                                  callouts: [String: CalloutStyle],
+                                 baseURL: URL? = nil,
                                  options: ReadRenderOptions = .default,
                                  suggestedName: String,
                                  window: NSWindow?) {
@@ -29,7 +30,8 @@ public enum MarkdownPrinter {
         panel.nameFieldStringValue = suggestedName + ".pdf"
 
         let html = DocumentHTML.full(markdown: markdown, theme: theme,
-                                     callouts: callouts, dark: false, options: options)
+                                     callouts: callouts, dark: false,
+                                     baseURL: baseURL, options: options)
         let begin: (URL) -> Void = { url in
             let info = makePrintInfo()
             info.jobDisposition = .save
@@ -48,10 +50,12 @@ public enum MarkdownPrinter {
     public static func print(markdown: String,
                              theme: EditorTheme,
                              callouts: [String: CalloutStyle],
+                             baseURL: URL? = nil,
                              options: ReadRenderOptions = .default,
                              window: NSWindow?) {
         let html = DocumentHTML.full(markdown: markdown, theme: theme,
-                                     callouts: callouts, dark: false, options: options)
+                                     callouts: callouts, dark: false,
+                                     baseURL: baseURL, options: options)
         PrintJob.start(html: html, parentWindow: window, printInfo: makePrintInfo(), showsPanel: true)
     }
 

--- a/Sources/EdmundCore/Export/ReadModeWebView.swift
+++ b/Sources/EdmundCore/Export/ReadModeWebView.swift
@@ -36,18 +36,29 @@ public final class ReadModeWebView: WKWebView {
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
+    /// Called when the user activates a `[[wikilink]]` — the (decoded) target is
+    /// routed through the app's document graph rather than navigating the webview.
+    public var onOpenWikiLink: ((String) -> Void)?
+
+    /// Called when the user activates a relative/internal markdown link
+    /// destination (e.g. `[text](other.md)`), routed the same way.
+    public var onOpenInternalLink: ((String) -> Void)?
+
     /// The most recent render inputs, so the view can re-render itself when the
     /// system appearance flips (light ↔ dark) without the document re-driving it.
     private var pending: (markdown: String, theme: EditorTheme,
-                          callouts: [String: CalloutStyle], options: ReadRenderOptions)?
+                          callouts: [String: CalloutStyle], baseURL: URL?,
+                          options: ReadRenderOptions)?
 
     /// Renders `markdown` with the given theme; appearance is resolved from the
-    /// view itself.
+    /// view itself. `baseURL` is the document's directory (for resolving relative
+    /// image paths to inline).
     public func render(markdown: String,
                        theme: EditorTheme,
                        callouts: [String: CalloutStyle],
+                       baseURL: URL? = nil,
                        options: ReadRenderOptions = .default) {
-        pending = (markdown, theme, callouts, options)
+        pending = (markdown, theme, callouts, baseURL, options)
         reloadHTML()
     }
 
@@ -55,7 +66,8 @@ public final class ReadModeWebView: WKWebView {
         guard let p = pending else { return }
         let dark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         let html = DocumentHTML.full(markdown: p.markdown, theme: p.theme,
-                                     callouts: p.callouts, dark: dark, options: p.options)
+                                     callouts: p.callouts, dark: dark,
+                                     baseURL: p.baseURL, options: p.options)
         loadHTMLString(html, baseURL: nil)
     }
 
@@ -97,16 +109,37 @@ private final class ReadModeNavigationCoordinator: NSObject, WKNavigationDelegat
             owner?.reloadHTML()
             return .cancel
         }
+        guard let url = navigationAction.request.url else { return .allow }
+        let scheme = url.scheme?.lowercased()
+
+        // `[[wikilink]]`s and relative/internal markdown links carry their target
+        // in a private scheme (the renderer classifies them), so routing doesn't
+        // depend on how WebKit rewrites relative hrefs under `baseURL: nil`.
+        // Decode the target and route it through the app's document graph.
+        if scheme == HTMLRenderer.wikiScheme || scheme == HTMLRenderer.linkScheme {
+            let target = decodeTarget(url, scheme: scheme!)
+            if scheme == HTMLRenderer.wikiScheme {
+                owner?.onOpenWikiLink?(target)
+            } else {
+                owner?.onOpenInternalLink?(target)
+            }
+            return .cancel
+        }
         // Decide by URL scheme, not navigation type: with `baseURL: nil` a click
-        // does not reliably report `.linkActivated`. Any real web scheme is an
+        // does not reliably report `.linkActivated`. A real web scheme is an
         // external link to hand off to the browser; everything else (the
-        // about:blank initial load, fragment scrolls, data:) loads in place.
-        if let url = navigationAction.request.url,
-           let scheme = url.scheme?.lowercased(),
-           scheme == "http" || scheme == "https" || scheme == "mailto" {
+        // about:blank initial load, in-page `#fragment` scrolls, data:) loads in place.
+        if scheme == "http" || scheme == "https" || scheme == "mailto" {
             NSWorkspace.shared.open(url)
             return .cancel
         }
         return .allow
+    }
+
+    /// Recovers the percent-decoded target from a private-scheme URL
+    /// (`scheme:encoded`), which has no `//` authority.
+    private func decodeTarget(_ url: URL, scheme: String) -> String {
+        let raw = String(url.absoluteString.dropFirst(scheme.count + 1))
+        return raw.removingPercentEncoding ?? raw
     }
 }

--- a/Sources/EdmundCore/Export/ReadRenderOptions.swift
+++ b/Sources/EdmundCore/Export/ReadRenderOptions.swift
@@ -11,8 +11,14 @@ public struct ReadRenderOptions: Sendable, Equatable {
     /// way Markdown normally does.
     public var preserveBlankLines: Bool
 
-    public init(preserveBlankLines: Bool = true) {
+    /// When true, remote (`http`/`https`) image URLs are loaded in the rendered
+    /// document. Off by default so Read mode makes no surprise network requests;
+    /// local images are always inlined regardless of this flag.
+    public var allowRemoteImages: Bool
+
+    public init(preserveBlankLines: Bool = true, allowRemoteImages: Bool = false) {
         self.preserveBlankLines = preserveBlankLines
+        self.allowRemoteImages = allowRemoteImages
     }
 
     public static let `default` = ReadRenderOptions()

--- a/Sources/EdmundCore/Parsing/CodeSyntaxPalette.swift
+++ b/Sources/EdmundCore/Parsing/CodeSyntaxPalette.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+// MARK: - Code Syntax Palette
+//
+// The single source of truth for fenced-code-block colors: the Tomorrow palette
+// (light) and One Dark (dark), as plain hex strings with no AppKit dependency.
+// Both consumers derive from these:
+//   - the editor (`EditorTextView+CodeHighlighting`) builds `NSColor`s for the
+//     TextKit attribute run,
+//   - Read mode / PDF export (`HTMLTheme`) emits CSS `color` rules,
+// so Edit mode and Read mode color identical tokens identically.
+
+enum CodeSyntaxPalette {
+
+    /// The hex color for a token kind (`nil` = plain, un-tokenized code text) in
+    /// the given appearance. Only foregrounds are themed; the block keeps its
+    /// background, so each palette is paired with the appearance it's legible on.
+    static func hex(_ type: CodeHighlighter.TokenType?, dark: Bool) -> String {
+        dark ? oneDark(type) : tomorrow(type)
+    }
+
+    /// Tomorrow (light).
+    private static func tomorrow(_ type: CodeHighlighter.TokenType?) -> String {
+        switch type {
+        case nil:        return "#4d4d4c"
+        case .keyword:   return "#8959a8"
+        case .type:      return "#c18401"
+        case .string:    return "#718c00"
+        case .number:    return "#f5871f"
+        case .comment:   return "#8e908c"
+        case .function:  return "#4271ae"
+        }
+    }
+
+    /// One Dark.
+    private static func oneDark(_ type: CodeHighlighter.TokenType?) -> String {
+        switch type {
+        case nil:        return "#abb2bf"
+        case .keyword:   return "#c678dd"
+        case .type:      return "#e5c07b"
+        case .string:    return "#98c379"
+        case .number:    return "#d19a66"
+        case .comment:   return "#5c6370"
+        case .function:  return "#61afef"
+        }
+    }
+}

--- a/Sources/EdmundCore/Rendering/EditorTextView+CodeHighlighting.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+CodeHighlighting.swift
@@ -7,63 +7,33 @@ import AppKit
 // are themed — the block keeps the editor's background — so each palette is
 // paired with the appearance whose background it's legible on.
 
-/// Foreground colors for the six highlighted token kinds plus plain code.
-private struct CodePalette {
-    let plain, keyword, type, string, number, comment, function: NSColor
-
-    func color(for type: CodeHighlighter.TokenType) -> NSColor {
-        switch type {
-        case .keyword:  return keyword
-        case .type:     return self.type
-        case .string:   return string
-        case .number:   return number
-        case .comment:  return comment
-        case .function: return function
-        }
-    }
-
-    /// Tomorrow (light).
-    static let tomorrow = CodePalette(
-        plain:    NSColor(hex: "#4d4d4c") ?? .textColor,
-        keyword:  NSColor(hex: "#8959a8") ?? .systemPurple,
-        type:     NSColor(hex: "#c18401") ?? .systemYellow,
-        string:   NSColor(hex: "#718c00") ?? .systemGreen,
-        number:   NSColor(hex: "#f5871f") ?? .systemOrange,
-        comment:  NSColor(hex: "#8e908c") ?? .secondaryLabelColor,
-        function: NSColor(hex: "#4271ae") ?? .systemBlue)
-
-    /// One Dark.
-    static let oneDark = CodePalette(
-        plain:    NSColor(hex: "#abb2bf") ?? .textColor,
-        keyword:  NSColor(hex: "#c678dd") ?? .systemPurple,
-        type:     NSColor(hex: "#e5c07b") ?? .systemYellow,
-        string:   NSColor(hex: "#98c379") ?? .systemGreen,
-        number:   NSColor(hex: "#d19a66") ?? .systemOrange,
-        comment:  NSColor(hex: "#5c6370") ?? .secondaryLabelColor,
-        function: NSColor(hex: "#61afef") ?? .systemBlue)
-}
-
 extension EditorTextView {
 
     private var prefersDarkCodeTheme: Bool {
         effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
     }
 
+    /// The `NSColor` for a token kind (`nil` = plain code) in the current
+    /// appearance, derived from the shared `CodeSyntaxPalette` hexes so the
+    /// editor and Read mode / PDF export color tokens identically.
+    private func codeColor(_ type: CodeHighlighter.TokenType?) -> NSColor {
+        NSColor(hex: CodeSyntaxPalette.hex(type, dark: prefersDarkCodeTheme)) ?? .textColor
+    }
+
     /// Applies syntax colors to a code block's content range in place.
     func highlightCodeBlock(_ result: NSMutableAttributedString,
                             contentRange: NSRange, language: String?) {
         guard contentRange.length > 0, contentRange.upperBound <= result.length else { return }
-        let palette = prefersDarkCodeTheme ? CodePalette.oneDark : CodePalette.tomorrow
 
         // Plain code text first; token colors paint over it.
-        result.addAttribute(.foregroundColor, value: palette.plain, range: contentRange)
+        result.addAttribute(.foregroundColor, value: codeColor(nil), range: contentRange)
 
         let code = (result.string as NSString).substring(with: contentRange)
         for token in CodeHighlighter.tokenize(code, language: language) {
             let abs = NSRange(location: contentRange.location + token.range.location,
                               length: token.range.length)
             guard abs.upperBound <= result.length else { continue }
-            result.addAttribute(.foregroundColor, value: palette.color(for: token.type), range: abs)
+            result.addAttribute(.foregroundColor, value: codeColor(token.type), range: abs)
         }
     }
 }

--- a/Sources/EdmundCore/Rendering/EditorTextView+WikiLinks.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+WikiLinks.swift
@@ -32,7 +32,7 @@ extension EditorTextView {
     // MARK: Following
 
     /// Follows a `[[wikilink]]` target (`path#heading`, no scheme, `.md` implied).
-    func followWikiLink(_ target: String) {
+    public func followWikiLink(_ target: String) {
         let (path, heading) = Self.splitHeading(target)
         if path.isEmpty {
             if let heading { scrollToHeading(heading) } else { NSSound.beep() }
@@ -44,7 +44,7 @@ extension EditorTextView {
     /// Follows a regular markdown link destination: an external URL opens in the
     /// default app; `#heading` scrolls in-document; a local `path#heading`
     /// resolves a file and opens it (scrolling to the heading if named).
-    func followLinkDestination(_ destination: String) {
+    public func followLinkDestination(_ destination: String) {
         let dest = destination.trimmingCharacters(in: .whitespaces)
         if let url = URL(string: dest), let scheme = url.scheme, scheme != "file" {
             NSWorkspace.shared.open(url)

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -167,6 +167,8 @@ class Document: NSDocument, HeadingNavigable {
 
     @objc private func editorDidChange(_ notification: Notification) {
         updateStatusBar()
+        // Keep an open Read view in sync with edits (it renders a snapshot).
+        refreshReadView()
     }
 
     @objc private func editorSelectionDidChange(_ notification: Notification) {
@@ -327,12 +329,18 @@ class Document: NSDocument, HeadingNavigable {
                 v.autoresizingMask = [.width, .height]
                 // Below the floating status bar so counts stay visible.
                 containerView.addSubview(v, positioned: .below, relativeTo: statusBar)
+                // Route internal navigation through the editor's link resolver
+                // (which resolves against this document's directory and opens via
+                // NSDocumentController) instead of navigating the webview.
+                v.onOpenWikiLink = { [weak self] in self?.editor.followWikiLink($0) }
+                v.onOpenInternalLink = { [weak self] in self?.editor.followLinkDestination($0) }
                 readView = v
                 return v
             }()
             read.render(markdown: editor.rawSource,
                         theme: editor.theme,
                         callouts: mergedCallouts,
+                        baseURL: documentDirectory,
                         options: renderOptions)
             read.isHidden = false
             scrollView.isHidden = true
@@ -342,6 +350,24 @@ class Document: NSDocument, HeadingNavigable {
             scrollView.isHidden = false
             editor.window?.makeFirstResponder(editor)
         }
+    }
+
+    /// Re-renders an open Read view from the editor's current source + theme.
+    /// No-op unless Read mode is the active, visible view — so settings/edit
+    /// broadcasts stay cheap when the user is in Edit or Source mode.
+    func refreshReadView() {
+        guard let read = readView, !read.isHidden, editor?.viewMode == .reading else { return }
+        read.render(markdown: editor.rawSource,
+                    theme: editor.theme,
+                    callouts: mergedCallouts,
+                    baseURL: documentDirectory,
+                    options: renderOptions)
+    }
+
+    /// The opened file's directory, used to resolve relative image paths for
+    /// inlining (nil for an unsaved document).
+    private var documentDirectory: URL? {
+        fileURL?.deletingLastPathComponent()
     }
 
     /// Built-in callout styles merged with the editor's user overrides, so Read
@@ -364,6 +390,7 @@ class Document: NSDocument, HeadingNavigable {
         MarkdownPrinter.exportPDF(markdown: editor.rawSource,
                                   theme: editor.theme,
                                   callouts: mergedCallouts,
+                                  baseURL: documentDirectory,
                                   options: renderOptions,
                                   suggestedName: name.isEmpty ? "Untitled" : name,
                                   window: windowControllers.first?.window)
@@ -373,6 +400,7 @@ class Document: NSDocument, HeadingNavigable {
         MarkdownPrinter.print(markdown: editor.rawSource,
                               theme: editor.theme,
                               callouts: mergedCallouts,
+                              baseURL: documentDirectory,
                               options: renderOptions,
                               window: windowControllers.first?.window)
     }

--- a/Sources/edmd/Settings/FontSettings.swift
+++ b/Sources/edmd/Settings/FontSettings.swift
@@ -117,6 +117,8 @@ final class FontSettings: NSObject, ObservableObject {
     private func applyToDocuments(_ theme: EditorTheme) {
         for case let document as Document in NSDocumentController.shared.documents {
             document.editor?.applyTheme(theme)
+            // Reflect the theme change live in an open Read view too.
+            document.refreshReadView()
         }
     }
 

--- a/Tests/EdmundTests/DocumentHTMLTests.swift
+++ b/Tests/EdmundTests/DocumentHTMLTests.swift
@@ -47,4 +47,46 @@ struct DocumentHTMLTests {
         let out = doc("bad $\\frac{$ math")
         #expect(out.contains("<code>\\frac{</code>"))
     }
+
+    // MARK: Images
+
+    @Test("Local image is read and inlined as a data URI")
+    func localImageInlined() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("edmund-img-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        // The file's bytes are irrelevant to the inlining path; an 8-byte PNG
+        // signature is enough to exercise read + base64 + MIME-by-extension.
+        let png = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+        try png.write(to: dir.appendingPathComponent("pic.png"))
+
+        let out = DocumentHTML.full(markdown: "![cat](pic.png)", theme: .default,
+                                    callouts: Callout.defaultStyles, dark: false,
+                                    baseURL: dir)
+        #expect(!out.contains("data-src"))   // placeholder consumed
+        #expect(out.contains("<img class=\"md-image\" src=\"data:image/png;base64,"))
+        #expect(out.contains("alt=\"cat\""))
+    }
+
+    @Test("Unresolvable local image falls back to alt only (no src)")
+    func missingImage() {
+        let out = doc("![gone](nope.png)")   // no baseURL → can't resolve
+        #expect(out.contains("<img class=\"md-image\" alt=\"gone\">"))
+        #expect(!out.contains("src="))
+    }
+
+    @Test("Remote image is suppressed by default, emitted when opted in")
+    func remoteImagePolicy() {
+        let md = "![r](https://example.com/x.png)"
+        let off = DocumentHTML.full(markdown: md, theme: .default,
+                                    callouts: Callout.defaultStyles, dark: false)
+        #expect(off.contains("<img class=\"md-image\" alt=\"r\">"))
+        #expect(!off.contains("https://example.com/x.png"))
+
+        let on = DocumentHTML.full(markdown: md, theme: .default,
+                                   callouts: Callout.defaultStyles, dark: false,
+                                   options: ReadRenderOptions(allowRemoteImages: true))
+        #expect(on.contains("src=\"https://example.com/x.png\""))
+    }
 }

--- a/Tests/EdmundTests/HTMLRendererTests.swift
+++ b/Tests/EdmundTests/HTMLRendererTests.swift
@@ -63,9 +63,58 @@ struct HTMLRendererCoreTests {
         #expect(html("---").contains("<hr>"))
     }
 
-    @Test("Links render as <a href>")
+    @Test("External links keep their real href")
     func links() {
         #expect(html("[text](https://example.com)") == "<p><a href=\"https://example.com\">text</a></p>")
+        #expect(html("[m](mailto:a@b.com)").contains("<a href=\"mailto:a@b.com\">"))
+    }
+
+    @Test("In-page anchor links keep their fragment href")
+    func anchorLink() {
+        #expect(html("[go](#section)").contains("<a href=\"#section\">go</a>"))
+    }
+
+    @Test("Relative/internal links route through the private link scheme")
+    func internalLink() {
+        let out = html("[other](notes/other.md)")
+        #expect(out.contains("<a href=\"x-edmund-link:"))
+        #expect(!out.contains("href=\"notes/other.md\""))
+    }
+
+    @Test("Code block wraps tokens in colored spans, escaping content")
+    func codeTokens() {
+        let out = html("```swift\nlet x = 1 // hi\n```")
+        #expect(out.contains("<span class=\"tok-keyword\">let</span>"))
+        #expect(out.contains("<span class=\"tok-number\">1</span>"))
+        #expect(out.contains("<span class=\"tok-comment\">// hi</span>"))
+    }
+
+    @Test("Code token spans still escape special characters")
+    func codeTokensEscape() {
+        let out = html("```\na < b && c\n```")
+        #expect(out.contains("a &lt; b &amp;&amp; c"))
+        #expect(!out.contains("a < b"))
+    }
+
+    @Test("Image emits a placeholder carrying the raw source for the asset pass")
+    func image() {
+        let out = html("![alt text](pic.png)")
+        #expect(out.contains("<img class=\"md-image\" data-src=\"pic.png\" alt=\"alt text\">"))
+    }
+
+    @Test("Wikilink renders as a private-scheme anchor with encoded target")
+    func wikilink() {
+        let out = html("see [[My Note#Heading]] here")
+        #expect(out.contains("<a class=\"wikilink\" href=\"x-edmund-wiki:"))
+        // `#` is percent-encoded so it isn't parsed as a URL fragment.
+        #expect(!out.contains("x-edmund-wiki:My Note#Heading"))
+        #expect(out.contains(">My Note#Heading</a>"))
+    }
+
+    @Test("Wikilink alias shows the alias as display text")
+    func wikilinkAlias() {
+        let out = html("[[Target|shown]]")
+        #expect(out.contains(">shown</a>"))
     }
 
     @Test("Plain block quote stays a blockquote")
@@ -118,10 +167,12 @@ struct HTMLRendererInlineTests {
         #expect(out.contains("\\int_0^1"))
     }
 
-    @Test("Wikilink renders display text (routing deferred)")
+    @Test("Wikilink renders display text inside a routing anchor")
     func wikilink() {
-        #expect(html("see [[Note|the note]]").contains("the note"))
-        #expect(!html("see [[Note|the note]]").contains("[["))
+        let out = html("see [[Note|the note]]")
+        #expect(out.contains(">the note</a>"))
+        #expect(out.contains("href=\"x-edmund-wiki:Note\""))
+        #expect(!out.contains("[["))
     }
 
     @Test("Comment is hidden")

--- a/Tests/EdmundTests/HTMLThemeTests.swift
+++ b/Tests/EdmundTests/HTMLThemeTests.swift
@@ -41,4 +41,15 @@ struct HTMLThemeTests {
         #expect(css(dark: false).contains("--c-accent: #CF222E;"))
         #expect(css(dark: true).contains("--bg: #1e1e1e;"))
     }
+
+    @Test("Emits code token colors from the shared palette, per appearance")
+    func codeTokenColors() {
+        let light = css(dark: false)
+        #expect(light.contains("pre code .tok-keyword { color: \(CodeSyntaxPalette.hex(.keyword, dark: false)); }"))
+        #expect(light.contains("pre code { color: \(CodeSyntaxPalette.hex(nil, dark: false)); }"))
+        let dark = css(dark: true)
+        #expect(dark.contains("pre code .tok-string { color: \(CodeSyntaxPalette.hex(.string, dark: true)); }"))
+        // The palettes differ between appearances.
+        #expect(CodeSyntaxPalette.hex(.keyword, dark: false) != CodeSyntaxPalette.hex(.keyword, dark: true))
+    }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -132,10 +132,10 @@ rawSource ──BlockParser──▶ [Block]  ──styleBlock per block──�
 | Area | Files |
 | --- | --- |
 | Editor core / state | `TextView/EditorTextView.swift` (+ many extensions) |
-| Parsing | `Parsing/BlockParser.swift`, `SyntaxHighlighter*.swift`, `CodeHighlighter.swift` |
+| Parsing | `Parsing/BlockParser.swift`, `SyntaxHighlighter*.swift`, `CodeHighlighter.swift`, `CodeSyntaxPalette.swift` (shared Tomorrow/One-Dark hex table — read by both the editor's `NSColor` palette and the HTML CSS generator) |
 | Block model | `Model/Block.swift`, `Callout.swift`, `EditorTheme.swift`, `ListIndentState.swift` |
 | Rendering | `Rendering/EditorTextView+*Rendering.swift` (Callout, Code, Image, List, Math, Table, WikiLinks) |
-| Read mode / Export | `Export/` — `HTMLRenderer` (MarkupVisitor → HTML), `HTMLTheme` (EditorTheme → CSS), `DocumentHTML` (assembly + SF-Symbol/math data-URI inlining), `ReadModeWebView`, `MarkdownPrinter` (PDF/Print) |
+| Read mode / Export | `Export/` — `HTMLRenderer` (MarkupVisitor → HTML), `HTMLTheme` (EditorTheme → CSS), `DocumentHTML` (assembly + asset inlining: SF-Symbol icons, math, local images → data URIs), `ReadModeWebView`, `MarkdownPrinter` (PDF/Print). `Document.refreshReadView()` keeps an open Read view in sync with edits and theme changes. |
 | Edit behaviors | `Editing/EditorTextView+{List,Blockquote}Continuation.swift`, `+Indentation.swift` |
 | Formatting commands | `Editing/EditorTextView+Formatting{Core,Commands}.swift` (Format-menu actions: bold/lists/links/callouts/…); menu built from `edmd/App/FormatMenu.swift` |
 | Lazy/compose/undo/scroll | `TextView/EditorTextView+{Composition,LazyStyling,Undo,TypewriterScroll,SelectionTracking,ContentWidth,EditFlow}.swift` |
@@ -172,8 +172,14 @@ every asset (math/icons as data URIs) so it needs no file/network reach; externa
 links open in the default browser. **File ▸ Export as PDF… / Print… (⌘P)** run
 the same HTML through `WKWebView.printOperation` for real vector (selectable)
 text — `MarkdownPrinter`. Math glyphs are high-DPI PNG (SwiftMath has no SVG
-path yet); everything else is vector. Deferred: code syntax-color spans, local
-image inlining, wikilink routing.
+path yet); everything else is vector. Code blocks are syntax-colored by
+`CodeHighlighter` (same tokenizer and `CodeSyntaxPalette` as Edit mode). Local
+images are inlined as data URIs via a `baseURL` (document directory) threaded
+through `DocumentHTML`/`ReadModeWebView`/`MarkdownPrinter`; remote images are
+off by default (`ReadRenderOptions.allowRemoteImages`). `[[Wikilinks]]` and
+relative markdown links use private URL schemes (`x-edmund-wiki:`,
+`x-edmund-link:`) in the rendered HTML so the nav coordinator can intercept
+them and route through the app's document graph without JavaScript.
 
 ---
 


### PR DESCRIPTION
## What

Stage 2 of the Read-mode / PDF-export feature, building on the merged Stage 1 (`feat/read-mode-html`).

### Code syntax highlighting
Reuses `CodeHighlighter.tokenize()` to emit `<span class="tok-*">` inside `<pre><code>`. Colors come from a new AppKit-free `CodeSyntaxPalette` — the single source of Tomorrow / One Dark hex values used by both the editor's `NSColor` palette and `HTMLTheme`'s CSS rules. `tab-size: 4` on `pre` matches Edit-mode width for tab-indented code.

### Local image inlining
`HTMLRenderer.visitImage` emits a placeholder; `DocumentHTML.fillImages` resolves local/relative paths against the document directory (`baseURL` threaded through `DocumentHTML.full` / `ReadModeWebView.render` / `MarkdownPrinter`) and inlines them as data URIs (self-contained PDF). Remote images suppressed by default (`ReadRenderOptions.allowRemoteImages = false`).

### Wikilink + internal-link routing
`[[Note]]` → `<a href="x-edmund-wiki:…">`, relative links → `<a href="x-edmund-link:…">`. The nav coordinator intercepts these private schemes and routes them to `followWikiLink` / `followLinkDestination` on the editor — no new resolution logic. External links and `#fragment` anchors keep their real hrefs.

### Live settings reflection
`Document.refreshReadView()` re-renders an open Read view on font/size/line-height changes (`FontSettings.applyToDocuments`) and on edits (`editorDidChange`).

## Tests
12 new string-assertion tests; 739 total pass.

## Out of scope
SVG math, footnotes, Settings UI for new flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)