### PR TITLE
Fix Edit-mode delete-drift from stranded IME composition

### DIFF
--- a/Sources/EdmundCore/TextView/EditorTextView+SelectionTracking.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+SelectionTracking.swift
@@ -33,6 +33,17 @@ extension EditorTextView {
                 // with un-editable zero-width marker characters.
                 self.pendingRecompose = false
                 guard !self.isUpdating else { return }
+                // Never restyle (mutate storage / invalidate layout) while an
+                // input method is composing. This async block was scheduled
+                // before composition began, so — unlike the synchronous guard
+                // above — `hasMarkedText()` can have flipped true in between.
+                // Running `recomposeDirty` over storage that holds a live
+                // composition can strand the marked text in the input context,
+                // after which `didChangeText` keeps bailing on its own
+                // marked-text guard and the storage/`rawSource` invariant breaks
+                // — the "delete drift" bug. The active-block restyle is applied
+                // anyway when composition commits (didChangeText → recomposeDirty).
+                guard !self.hasMarkedText() else { return }
 
                 // Restyle the new active block now. DEFER the old active block
                 // if it's off screen: deactivating it (rendered ↔ raw — callout

--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -347,6 +347,33 @@ public class EditorTextView: NSTextView {
         return storage.attribute(.editorLinkURL, at: charIndex, effectiveRange: nil) as? String
     }
 
+    // MARK: - Stranded-Composition Recovery
+
+    /// Regaining first-responder status: recover from any stranded input-method
+    /// composition. If a marked-text (IME / accent / emoji) composition is ever
+    /// left uncommitted, `didChangeText` keeps bailing on its `hasMarkedText()`
+    /// guard, so the text storage drifts away from `rawSource` and every edit
+    /// then does offset math against a frozen block model — the "delete drift"
+    /// bug. Returning focus is a reliable "composition is over" signal (the view
+    /// can't become first responder while it already holds an active
+    /// composition), so when the invariant is broken here we commit any stranded
+    /// marked text and resync the model from the storage the user actually sees.
+    /// This formalizes the focus-switch recovery users already stumble into.
+    public override func becomeFirstResponder() -> Bool {
+        let became = super.becomeFirstResponder()
+        if became { recoverFromStrandedCompositionIfNeeded() }
+        return became
+    }
+
+    func recoverFromStrandedCompositionIfNeeded() {
+        guard let ts = textStorage, ts.string != rawSource else { return }
+        if hasMarkedText() { unmarkText() }
+        rawSource = ts.string
+        rebuildListIndentState()
+        blocks = BlockParser.parse(rawSource, previous: blocks)
+        recompose(cursorInRaw: min(selectedRange().location, (rawSource as NSString).length))
+    }
+
     // MARK: - Helpers
 
     func currentCursorInRaw() -> Int {

--- a/Tests/EdmundTests/MarkedTextDesyncTests.swift
+++ b/Tests/EdmundTests/MarkedTextDesyncTests.swift
@@ -1,0 +1,68 @@
+import Testing
+import AppKit
+@testable import EdmundCore
+
+/// Regression tests for the "delete drift" bug. A stranded marked-text (IME /
+/// accent / emoji) composition makes `didChangeText` bail before
+/// `syncRawSourceFromDisplay()`, so the text storage mutates while
+/// `rawSource`/`blocks` freeze — breaking the storage==rawSource invariant.
+/// From then on every edit does offset math against a stale model and the caret
+/// drifts. Two defenses:
+///   1. The async active-block restyle never recomposes during composition
+///      (so it can't strand the marked text in the first place).
+///   2. Regaining first responder resyncs if the invariant is broken
+///      (a catch-all recovery for any other stranding path).
+@Suite("Marked-text desync (delete drift)") @MainActor
+struct MarkedTextDesyncTests {
+
+    /// Sanity: setting marked text breaks the invariant (this is the transient
+    /// state during composition); it is *stranding* that turns it into a bug.
+    @Test func markedTextBreaksInvariantTransiently() {
+        let editor = makeEditor()
+        editor.loadContent("alpha\nbravo\ncharlie")
+        editor.setSelectedRange(NSRange(location: 5, length: 0))
+        #expect(editor.textStorage!.string == editor.rawSource)
+
+        editor.setMarkedText("´", selectedRange: NSRange(location: 0, length: 1),
+                             replacementRange: NSRange(location: NSNotFound, length: 0))
+        #expect(editor.hasMarkedText())
+        #expect(editor.textStorage!.string != editor.rawSource)   // storage ahead
+    }
+
+    /// Recovery: once a composition is stranded (storage drifted from
+    /// rawSource), regaining first responder must restore the invariant and a
+    /// styled, parseable model. Without the recovery hook the editor stays
+    /// desynced and every delete drifts.
+    @Test func regainingFocusRecoversStrandedComposition() {
+        let editor = makeEditor()
+        let win = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+                           styleMask: [.titled], backing: .buffered, defer: false)
+        win.contentView = editor
+        win.makeFirstResponder(editor)
+
+        editor.loadContent("alpha\nbravo\ncharlie")
+        editor.setSelectedRange(NSRange(location: 5, length: 0))
+
+        // Strand a composition: storage gains "´", rawSource frozen.
+        editor.setMarkedText("´", selectedRange: NSRange(location: 0, length: 1),
+                             replacementRange: NSRange(location: NSNotFound, length: 0))
+        #expect(editor.textStorage!.string != editor.rawSource)
+
+        // Leave the editor and come back (what the user does to unstick it).
+        win.makeFirstResponder(nil)
+        win.makeFirstResponder(editor)
+
+        // Invariant restored, no stranded marked text, model reflects storage.
+        #expect(!editor.hasMarkedText())
+        #expect(editor.textStorage!.string == editor.rawSource)
+        let joined = editor.blocks.map(\.content).joined(separator: "\n")
+        #expect(joined == editor.rawSource)
+
+        // A normal backspace now deletes exactly one character (no drift).
+        let before = (editor.rawSource as NSString).length
+        editor.setSelectedRange(NSRange(location: before, length: 0))
+        pressBackspace(in: editor)
+        #expect((editor.rawSource as NSString).length == before - 1)
+        #expect(editor.textStorage!.string == editor.rawSource)
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -228,6 +228,17 @@ them and route through the app's document graph without JavaScript.
   block whose height/indent changed, you must `invalidateLayout(for:)` its range
   or the fragment keeps a stale frame (empty bands / clipped lines). `recompose
   Dirty` and the idle drain already do this; new paths must too.
+- **Never mutate storage while an IME is composing (`hasMarkedText()`)**: during
+  composition the storage holds the provisional marked text, so `storage ==
+  rawSource` is transiently false and `didChangeText` defers syncing until
+  commit. Any styling that runs `beginEditing`/`setAttributes`/`invalidateLayout`
+  mid-composition can strand the marked text in the input context — after which
+  `didChangeText` keeps bailing on its own guard and the invariant stays broken,
+  so every later edit drifts the caret (the old "delete-drift" bug). Every
+  storage-touching styling path must guard `!hasMarkedText()` — including async
+  ones scheduled *before* composition began (the caret-move restyle in
+  `+SelectionTracking`). `becomeFirstResponder` resyncs from storage as a
+  catch-all if a composition is ever left stranded.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -238,7 +238,8 @@ them and route through the app's document graph without JavaScript.
   storage-touching styling path must guard `!hasMarkedText()` — including async
   ones scheduled *before* composition began (the caret-move restyle in
   `+SelectionTracking`). `becomeFirstResponder` resyncs from storage as a
-  catch-all if a composition is ever left stranded.
+  catch-all if a composition is ever left stranded. Full write-up:
+  `docs/delete-drift-investigation.md`.
 
 ---
 

--- a/docs/delete-drift-investigation.md
+++ b/docs/delete-drift-investigation.md
@@ -1,0 +1,141 @@
+# Edit-mode "delete drift" — investigation notes
+
+Context for anyone who sees the bug again. It was intermittent, state-dependent,
+and looked nothing like its actual cause, so this records the trail end to end.
+
+Fixed in commits `386604b` (fix + test) and `ef3d87e` (ARCHITECTURE gotcha) on
+branch `fix/delete-caret-drift-marked-text`.
+
+## Symptom
+
+In Edit mode the editor would sometimes enter a **bad mode where pressing Delete
+(backspace) moved the caret to a different line instead of deleting a
+character**. Key properties (all from the reporter):
+
+- **Caret/selection desync, not content corruption** — the underlying text
+  stayed correct; the delete was effectively dropped while the caret jumped.
+- **Persistent once it started** — *every* delete drifted, not just one. Not
+  tied to any particular preceding keystroke.
+- **Never right after launch** — only after the window had been used a while.
+- **Sometimes cleared by switching to another app and back.**
+- **Not list-specific** — reproduced in a plain-paragraph `undo_test.md`.
+
+Evidence: `~/Desktop/delete-jump-2.mov` and `~/Desktop/delete-jump.mp4` (the
+latter with a keystroke overlay). A diagnostic log
+(`~/Desktop/edmund-2026-06-25.log`) showed only routine I/O — no clue on its own.
+
+## How it was diagnosed
+
+1. **Frame extraction.** Pulling frames from the recordings showed the caret
+   teleporting between lines on single Delete presses while the document text
+   was stable. That ruled out "wrong text deleted" and pointed at a
+   selection/model desync.
+2. **Reporter clarifications were decisive** and overturned two earlier wrong
+   theories (a viewport-scroll jump, then an Enter-then-Delete interaction):
+   - it's caret-only (text fine),
+   - every delete drifts once it starts,
+   - it's state-dependent (never at launch),
+   - **focus-switch clears it**.
+3. **The focus-switch clue cracked it.** There is no
+   `becomeFirstResponder`/`resignFirstResponder`/window-key handling anywhere in
+   the editor (verified in `EditorTextView.swift`), so the *only* state an
+   app-focus switch resets that also gates the editor's behavior is AppKit's
+   **input-context marked text** (`hasMarkedText()`).
+
+## Root cause
+
+The editor's hard invariant is **text storage always equals `rawSource`**
+(ARCHITECTURE §2). It's maintained in `didChangeText` →
+`syncRawSourceFromDisplay()`. But that sync — and every other styling entry
+point — is gated on `!hasMarkedText()`:
+
+- `EditorTextView+EditFlow.swift` — `didChangeText` (bails **before** syncing)
+- `EditorTextView+SelectionTracking.swift` — `selectionDidChange`
+- `EditorTextView+LazyStyling.swift` — the idle drain
+
+This guard is correct *during* a live IME / accent / emoji composition: the
+storage transiently holds the provisional marked text, so `storage == rawSource`
+is briefly false and we must not restyle the marked range (it aborts the
+composition).
+
+The bug is when a composition gets **stranded** (`hasMarkedText()` stuck true
+with no live composition). Then `didChangeText` keeps bailing forever: the
+storage mutates on every keystroke but `rawSource`/`blocks` freeze. From that
+point on, every edit does offset / active-block math against a **frozen, stale
+block model**, so the caret drifts. Nothing re-syncs until marked text clears —
+and the only thing that reliably clears it is the text view resigning first
+responder (switching apps), which commits/discards the composition. That is
+exactly why **switching apps and back fixed it**, and why it never happened at
+launch (you need to accumulate a stranded composition first).
+
+### What stranded the composition
+
+The prime suspect is the **async active-block restyle** scheduled from
+`selectionDidChange` (`EditorTextView+SelectionTracking.swift`). The deferred
+`DispatchQueue.main.async` block re-checked `isUpdating` but **not**
+`hasMarkedText()`. Because it's scheduled on a caret move and runs a turn later,
+a composition can begin in between; the block then runs `recomposeDirty`
+(`beginEditing`/`setAttributes`/`endEditing` + `invalidateLayout`) over storage
+that holds a live composition, which can strand the marked text in the input
+context. Timing/usage dependent → "after a while," never at launch.
+
+## The fix (two defenses)
+
+1. **Prevention** (`EditorTextView+SelectionTracking.swift`): add
+   `guard !self.hasMarkedText() else { return }` to the async restyle block, so
+   it matches the guard every other storage-touching styling path already has.
+   The active-block restyle still happens — `didChangeText`'s
+   `recomposeDirty` covers the active block when the composition commits.
+
+2. **Recovery** (`EditorTextView.swift`,
+   `recoverFromStrandedCompositionIfNeeded` + a `becomeFirstResponder`
+   override): regaining first-responder status is a reliable "composition is
+   over" signal (the view can't become first responder while it already holds an
+   active composition). If the invariant is broken at that moment, commit any
+   stranded marked text (`unmarkText()`) and resync the model from storage. This
+   makes the focus-switch recovery the user already relied on **deterministic**
+   instead of occasional, and is a catch-all for *any* future stranding path.
+
+The new gotcha bullet in ARCHITECTURE §8 states the general rule: **never mutate
+storage while `hasMarkedText()`**, including async paths scheduled before
+composition began.
+
+## Testing — and its limit
+
+`Tests/EdmundTests/MarkedTextDesyncTests.swift`:
+
+- `markedTextBreaksInvariantTransiently` — documents that `setMarkedText` makes
+  `storage != rawSource` (the normal, transient state).
+- `regainingFocusRecoversStrandedComposition` — strands a composition, simulates
+  leave-and-return focus, and asserts the invariant is restored and a delete
+  then removes exactly one character. **This fails without the recovery hook**,
+  so it's the real regression guard.
+
+**Limit:** the *actual* stranding can't be reproduced headlessly. A unit-test
+`NSTextView` has no live `NSTextInputContext`, so `recomposeDirty` running during
+marked text does **not** corrupt/strand it the way the real input context does
+(verified by probing: `activeBlockIndex` was unchanged with or without the
+prevention guard). So:
+
+- Fix 1 (prevention) is justified by **consistency** with the codebase's own
+  established pattern, not by a failing test.
+- Fix 2 (recovery) is the test-backed safety net.
+
+A DEBUG assertion in `didChangeText`'s marked-text guard was considered and
+**rejected**: during normal composition the invariant is legitimately broken, so
+it would false-fire on every IME keystroke.
+
+## If it ever recurs
+
+1. Check the invariant first: is `textStorage.string == rawSource`? If not, the
+   model has desynced.
+2. Check `hasMarkedText()`. If it's stuck true outside an active composition,
+   a styling path mutated storage mid-composition again — audit every
+   storage-touching path for the `!hasMarkedText()` guard (especially any new
+   async/deferred styling, like new scroll/idle/promotion paths).
+3. The `becomeFirstResponder` recovery should still unstick it on focus regain;
+   if it doesn't, confirm the override is being called and that
+   `recoverFromStrandedCompositionIfNeeded` isn't guarded out.
+4. To get live signal, temporarily log `hasMarkedText()` and
+   `textStorage.string == rawSource` in `didChangeText` (category `.compose`),
+   reproduce, and read `~/.edmund/logs`.


### PR DESCRIPTION
## What

When a marked-text composition (CJK IME, press-and-hold accent, emoji picker) got stranded — `hasMarkedText()` stuck true with no live composition — `didChangeText` kept bailing before `syncRawSourceFromDisplay()`. The text storage would mutate on every keystroke while `rawSource`/`blocks` froze, breaking the `storage == rawSource` invariant. From then on, every delete did offset math against a stale block model and the caret drifted to a different line instead of deleting a character.

The symptom was persistent (every delete drifted), never appeared right after launch, and was sometimes cleared by switching to another app and back — because resigning first responder is the only thing that reliably clears the input context's marked text.

## Root cause

The async active-block restyle scheduled from `selectionDidChange` re-checked `isUpdating` but not `hasMarkedText()`. Because it fires a run-loop turn after the caret move that scheduled it, a composition can begin in between; it then ran `recomposeDirty` over storage holding a live composition, which could strand the marked text in the input context.

## Fix

Two defenses:

1. **Prevention** (`EditorTextView+SelectionTracking.swift`): guard the async restyle block on `!hasMarkedText()`, matching the pattern every other storage-touching path already uses. The active-block restyle still happens — `didChangeText`'s recompose covers it when the composition commits.

2. **Recovery** (`EditorTextView.swift`): a `becomeFirstResponder` override calls `recoverFromStrandedCompositionIfNeeded()`, which resyncs the model from storage whenever the invariant is broken on focus regain. This makes the focus-switch recovery the user relied on deterministic rather than occasional, and is a catch-all for any future stranding path.

## Tests

`MarkedTextDesyncTests.swift` — strands a composition via `setMarkedText`, simulates leave-and-return focus, and asserts the invariant is restored and a delete removes exactly one character. Confirmed it fails on `main` without the recovery hook.

## Docs

- `docs/delete-drift-investigation.md` — full investigation write-up (symptom, diagnosis trail, root cause, fix, testing limits, recurrence checklist).
- `docs/ARCHITECTURE.md` §8 — new gotcha bullet documenting the marked-text styling rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)