### PR TITLE
Add Sparkle auto-update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: Build & publish
+    runs-on: macos-14
+    permissions:
+      contents: write  # create releases and commit appcast
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Fetch full history so we can push the appcast commit back.
+          fetch-depth: 0
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Cache .build
+        uses: actions/cache@v5
+        with:
+          path: .build
+          key: spm-v2-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: spm-v2-${{ runner.os }}-
+
+      - name: Build app bundle
+        run: ./scripts/build-app.sh
+
+      - name: Archive
+        run: |
+          VERSION="$(/usr/libexec/PlistBuddy -c 'Print CFBundleShortVersionString' Info.plist)"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          ditto -c -k --keepParent build/Edmund.app "build/Edmund-${VERSION}.zip"
+
+      - name: Sign archive (EdDSA)
+        env:
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+        run: |
+          SIGN_UPDATE="$(find .build -name sign_update -type f | head -1)"
+          SIG_OUTPUT="$("$SIGN_UPDATE" -s "$SPARKLE_ED_PRIVATE_KEY" "build/Edmund-${VERSION}.zip")"
+          echo "ED_SIG=$(echo "$SIG_OUTPUT" | grep -o 'sparkle:edSignature="[^"]*"')" >> "$GITHUB_ENV"
+          echo "LENGTH=$(echo "$SIG_OUTPUT" | grep -o 'length="[^"]*"' | head -1)" >> "$GITHUB_ENV"
+
+      - name: Create GitHub Release
+        id: create_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${VERSION}" "build/Edmund-${VERSION}.zip" \
+            --title "Edmund ${VERSION}" \
+            --notes "See CHANGELOG for details." \
+            --latest
+
+      - name: Update appcast.xml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO="${{ github.repository }}"
+          ASSET_URL="https://github.com/${REPO}/releases/download/v${VERSION}/Edmund-${VERSION}.zip"
+          PUB_DATE="$(date -u '+%a, %d %b %Y %H:%M:%S +0000')"
+          BUILD="$(/usr/libexec/PlistBuddy -c 'Print CFBundleVersion' Info.plist)"
+
+          NEW_ITEM="        <item>
+              <title>Edmund ${VERSION}</title>
+              <pubDate>${PUB_DATE}</pubDate>
+              <enclosure url=\"${ASSET_URL}\"
+                         sparkle:version=\"${BUILD}\"
+                         sparkle:shortVersionString=\"${VERSION}\"
+                         ${ED_SIG}
+                         ${LENGTH}
+                         type=\"application/octet-stream\"/>
+          </item>"
+
+          python3 - "$NEW_ITEM" <<'PYEOF'
+          import sys
+          new_item = sys.argv[1]
+          with open("appcast.xml", "r") as f:
+              content = f.read()
+          content = content.replace("    </channel>", new_item + "\n    </channel>")
+          with open("appcast.xml", "w") as f:
+              f.write(content)
+          PYEOF
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add appcast.xml
+          git commit -m "appcast: add Edmund ${VERSION}"
+          git push origin HEAD:main

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 
+# Sparkle private key (never commit — store in keychain or CI secret)
+sparkle_private_key.txt
+
 # Misc
 .DS_Store
 CLAUDE.md

--- a/Info.plist
+++ b/Info.plist
@@ -31,7 +31,7 @@
     <key>SUFeedURL</key>
     <string>https://raw.githubusercontent.com/I7T5/Edmund/main/appcast.xml</string>
     <key>SUPublicEDKey</key>
-    <string>PLACEHOLDER_RUN_generate_keys_AND_PASTE_PUBLIC_KEY_HERE</string>
+    <string>0XdLbbuOm0NonqWeDJkQuFF0CGnhKmpAfq+RNKVwEDs=</string>
     <key>SUEnableAutomaticChecks</key>
     <true/>
     <key>CFBundleDocumentTypes</key>

--- a/Info.plist
+++ b/Info.plist
@@ -28,6 +28,12 @@
     <false/>
     <key>NSSupportsSuddenTermination</key>
     <false/>
+    <key>SUFeedURL</key>
+    <string>https://raw.githubusercontent.com/I7T5/Edmund/main/appcast.xml</string>
+    <key>SUPublicEDKey</key>
+    <string>PLACEHOLDER_RUN_generate_keys_AND_PASTE_PUBLIC_KEY_HERE</string>
+    <key>SUEnableAutomaticChecks</key>
+    <true/>
     <key>CFBundleDocumentTypes</key>
     <array>
         <dict>

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "40e40f4c9574618aba68a76f62f318411774fee5f79b7b8b9a18dce6f5c7315f",
+  "originHash" : "a31b21636c19c1fb2661a51b226a2aef490af95e85b9325c822a9c5af1d81190",
   "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
+      }
+    },
     {
       "identity" : "swift-cmark",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/swiftlang/swift-markdown.git", from: "0.5.0"),
         .package(url: "https://github.com/mgriebling/SwiftMath.git", from: "1.7.0"),
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.6.0"),
     ],
     targets: [
         .target(
@@ -21,7 +22,7 @@ let package = Package(
         // peeks inside the bundle or runs `swift run edmd`.
         .executableTarget(
             name: "edmd",
-            dependencies: ["EdmundCore"]),
+            dependencies: ["EdmundCore", .product(name: "Sparkle", package: "Sparkle")]),
         .testTarget(
             name: "EdmundTests",
             dependencies: ["EdmundCore"]),

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Edmund
 
+> [!WARNING] Active development
+
 > [!TIP] Guidelines for Build and Contributing coming soon!
 
 Edmund is a native, lightweight markdown editor with Live Preview made for macOS.  
@@ -22,27 +24,13 @@ Edmund is a native, lightweight markdown editor with Live Preview made for macOS
 
 ## Roadmap
 
-See [ROADMAP](ROADMAP.md). 
-
-Current priorities: 
-
-- Full [GFM spec](https://github.github.com/gfm/#fenced-code-blocks) support. Including but not limited to: 
-  - Table alignment
-  - ATX headings
-- Render icons in custom-titled callouts / alerts
-- Comprehensive math support through [RaTeX](https://github.com/erweixin/RaTeX) integration (extension)
-- Native export to PDF with style
-- Automatic updates via Sparkle
-- Themes
-- Onboarding
-  - Log preference
-  - Advanced Math
-  - Pandoc path for more export options
+See [ROADMAP](docs/ROADMAP.md). 
 
 ## Dependencies
 
 - [swift-markdown](https://github.com/swiftlang/swift-markdown)
 - [SwiftMath](https://github.com/mgriebling/SwiftMath)
+- [Sparkle](https://github.com/sparkle-project/Sparkle)
 
 ## Alternatives
 
@@ -50,7 +38,7 @@ If Edmund's not your thing, some of the following might be:
 
 - Closed source
   - Obsidian, cyberWriter, Notion
-  - Typora, Lettera (currently in [beta](https://lettera.md))
+  - Typora, Lettera ([beta](https://lettera.md))
 - Open source
   - WYSIWYG: [MarkText](https://marktext.me), [Nodes](https://nodes-web.com), [Scratch](https://github.com/erictli/scratch)
   - Split-screen: [MacDown](https://macdown.uranusjr.com), [MiaoYan](https://miaoyan.app)
@@ -59,7 +47,7 @@ If Edmund's not your thing, some of the following might be:
   - [editxr](https://github.com/pixdeo/editxr) - TUI
   - More feature-rich: [Zettlr](https://www.zettlr.com), [Joplin](https://joplinapp.org), [Tangent](https://www.tangentnotes.com)
 
-The list is by no means exhaustive, and neither was it meant to be. I just wanted to give credit to the makers of these apps, esp. the aesthetic open sourced ones. If you want a comprehensive list, [this](https://github.com/mundimark/awesome-markdown-editors) might be more helpful. 
+The list is by no means exhaustive, and neither was it meant to be. I just wanted to give credit to the makers of these apps, esp. the aesthetic open sourced ones. If you want a comprehensive list, see [here](https://github.com/mundimark/awesome-markdown-editors). 
 
 ## Motivation, philosophy, acknowledgements
 

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -1,5 +1,6 @@
 import AppKit
 import EdmundCore
+import Sparkle
 
 // Entry point for the app the user knows as "Edmund" (CFBundleName). The
 // executable target — and so this binary at Edmund.app/Contents/MacOS/edmd — is
@@ -9,9 +10,12 @@ import EdmundCore
 
 // --- App Delegate -----------------------------------------------------------
 
+@MainActor
 class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 
     var settingsWindowController: SettingsWindowController?
+    let updaterController = SPUStandardUpdaterController(
+        startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
 
     // MARK: - Typewriter Mode (persisted)
 
@@ -136,6 +140,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         appMenu.addItem(withTitle: "Settings\u{2026}",
                         action: #selector(AppDelegate.showSettings(_:)),
                         keyEquivalent: ",")
+
+        let updatesItem = appMenu.addItem(
+            withTitle: "Check for Updates\u{2026}",
+            action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)),
+            keyEquivalent: "")
+        updatesItem.target = updaterController
 
         appMenu.addItem(NSMenuItem.separator())
 

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -14,6 +14,8 @@ import Sparkle
 class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 
     var settingsWindowController: SettingsWindowController?
+    // startingUpdater: true kicks off the scheduled background check immediately;
+    // the "Check for Updates…" menu item targets this controller directly.
     let updaterController = SPUStandardUpdaterController(
         startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
 

--- a/Sources/edmd/Settings/AdvancedSettingsView.swift
+++ b/Sources/edmd/Settings/AdvancedSettingsView.swift
@@ -7,7 +7,7 @@ struct AdvancedSettingsView: View {
     var body: some View {
         Grid(alignment: .leadingFirstTextBaseline, verticalSpacing: 18) {
             GridRow {
-                Text("Updates:")
+                Text("Software update:")
                     .gridColumnAlignment(.trailing)
                 Toggle("Automatically check for updates", isOn: $autoCheckUpdates)
             }

--- a/Sources/edmd/Settings/AdvancedSettingsView.swift
+++ b/Sources/edmd/Settings/AdvancedSettingsView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct AdvancedSettingsView: View {
+    @AppStorage(AppSettings.Key.automaticallyChecksForUpdates)
+    private var autoCheckUpdates = true
+
+    var body: some View {
+        Grid(alignment: .leadingFirstTextBaseline, verticalSpacing: 18) {
+            GridRow {
+                Text("Updates:")
+                    .gridColumnAlignment(.trailing)
+                Toggle("Automatically check for updates", isOn: $autoCheckUpdates)
+            }
+        }
+        .settingsPanePadding()
+    }
+}

--- a/Sources/edmd/Settings/AppSettings.swift
+++ b/Sources/edmd/Settings/AppSettings.swift
@@ -91,6 +91,8 @@ enum AppSettings {
 
     enum Key {
         static let reopenWindows = "settings.general.reopenWindows"
+        // Must match Sparkle's own default key exactly — Sparkle reads/writes this string.
+        static let automaticallyChecksForUpdates = "SUAutomaticallyChecksForUpdates"
         static let startupAction = "settings.general.startupAction"
         static let autoSaveWithVersions = "settings.general.autoSaveWithVersions"
         static let conflictResolution = "settings.general.conflictResolution"

--- a/Sources/edmd/Settings/SettingsWindowController.swift
+++ b/Sources/edmd/Settings/SettingsWindowController.swift
@@ -37,6 +37,7 @@ final class SettingsTabViewController: NSTabViewController {
 
         addPane(GeneralSettingsView(), label: "General", symbol: "gearshape")
         addPane(AppearanceSettingsView(fonts: fonts), label: "Appearance", symbol: "eyeglasses")
+        addPane(AdvancedSettingsView(), label: "Advanced", symbol: "gearshape.2")
     }
 
     private func addPane(_ view: some View, label: String, symbol: String) {

--- a/appcast.xml
+++ b/appcast.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"
+     xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <channel>
+        <title>Edmund</title>
+        <link>https://raw.githubusercontent.com/I7T5/Edmund/main/appcast.xml</link>
+        <description>Edmund release feed</description>
+        <language>en</language>
+    </channel>
+</rss>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,7 +27,7 @@ Two SPM targets (see `Package.swift`):
 - **`edmd`** — the executable: `NSDocument` app shell, Settings (SwiftUI),
   menus, window setup. Depends on EdmundCore.
 
-Dependencies: `swift-markdown` (CommonMark/GFM parsing) and `SwiftMath` (LaTeX).
+Dependencies: `swift-markdown` (CommonMark/GFM parsing), `SwiftMath` (LaTeX), and `Sparkle` (auto-update).
 
 ---
 
@@ -140,10 +140,11 @@ rawSource ──BlockParser──▶ [Block]  ──styleBlock per block──�
 | Edit behaviors | `Editing/EditorTextView+{List,Blockquote}Continuation.swift`, `+Indentation.swift` |
 | Formatting commands | `Editing/EditorTextView+Formatting{Core,Commands}.swift` (Format-menu actions: bold/lists/links/callouts/…); menu built from `edmd/App/FormatMenu.swift` |
 | Lazy/compose/undo/scroll | `TextView/EditorTextView+{Composition,LazyStyling,Undo,TypewriterScroll,SelectionTracking,ContentWidth,EditFlow}.swift` |
-| App shell | `edmd/App/{main,Document,DocumentController}.swift`; menu bar in `main.swift` `setupMenuBar()` + `FormatMenu.swift` |
-| Settings (SwiftUI) | `edmd/Settings/*` (AppSettings = UserDefaults keys; FontSettings; Appearance/General views) |
+| App shell | `edmd/App/{main,Document,DocumentController}.swift`; menu bar in `main.swift` `setupMenuBar()` + `FormatMenu.swift`; Sparkle `SPUStandardUpdaterController` in `AppDelegate` |
+| Settings (SwiftUI) | `edmd/Settings/*` (AppSettings = UserDefaults keys; FontSettings; Appearance/General/Advanced views) |
+| Auto-update | Sparkle 2.x. `Info.plist`: `SUFeedURL` (raw GitHub URL to `appcast.xml`), `SUPublicEDKey` (ed25519 public key). `scripts/release.sh`: build → zip → EdDSA sign → update appcast → `gh release create`. CI: `.github/workflows/release.yml` (tag-triggered). One-time setup: generate the EdDSA keypair with `generate_keys` (§8). |
 | Status bar | `edmd/Views/StatusBarView.swift` |
-| Build/packaging | `scripts/build-app.sh`, `Package.swift`, `Info.plist`, `Resources/` |
+| Build/packaging | `scripts/build-app.sh` (release build + Sparkle.framework embedding + signing), `Package.swift`, `Info.plist`, `Resources/` |
 
 Notable subsystems: **typewriter scroll** (keeps caret vertically centered;
 must lay out the viewport↔caret span before measuring or it reads stale TK2
@@ -207,6 +208,16 @@ them and route through the app's document graph without JavaScript.
 
 - **SwiftMath fonts**: `build-app.sh` must copy `*.bundle` into the `.app` root
   (it does). Without it, the app **crashes the instant it renders any LaTeX**.
+- **Sparkle codesign workaround**: `Contents/Frameworks/` triggers codesign's
+  strict bundle-seal mode, which rejects the SwiftMath bundle at the `.app` root
+  (required by its generated `Bundle.module` accessor — it's hardcoded to
+  `Bundle.main.bundleURL`). The build script works around this by signing the
+  main binary as a temporary standalone file rather than sealing the whole bundle.
+  A Developer ID cert + notarization would fix it properly; ad-hoc signing is
+  the current limit.
+- **Sparkle keypair (one-time setup)**: the EdDSA public key in `Info.plist`
+  `SUPublicEDKey` is a placeholder. See §8 for the exact commands to generate
+  and install the real key before shipping an update.
 - **Stale release builds**: `swift build -c release` / `build-app.sh` sometimes
   reuses stale object files (you'll run an old binary and be baffled). If a
   visual change "doesn't take," `rm -rf .build` and rebuild. `shasum` the binary

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -293,9 +293,8 @@ only with reason):
 2. **Visual changes are eyeballed** — build the app and `screencapture` the
    result (§8), or render offscreen to a PNG. Don't trust headless layout alone
    for anything that draws.
-3. **Small, logical commits** — one feature/fix each. End commit messages with
-   the `Co-Authored-By` trailer.
-4. **Don't auto-commit, push, PR, or merge unless asked.** Branch off `main`
+3. **Frequent, small, logical commits** — one feature/fix each. Don't discard uncommited changes. 
+4. **Don't autopush, PR, or merge unless asked.** Branch off `main`
    (don't commit straight to it); each fix on its own branch.
 5. Touch only what the task needs; match surrounding style; don't refactor
    unrelated code.

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -49,8 +49,43 @@ ACTOOL="$(xcrun --find actool 2>/dev/null || echo /Applications/Xcode.app/Conten
     --output-partial-info-plist "$(mktemp)" \
     >/dev/null
 
-# Ad-hoc codesign so macOS doesn't quarantine-block it
-codesign --force --sign - "${BUNDLE}"
+# Embed Sparkle.framework so the installed bundle is self-contained.
+# SwiftPM links Sparkle but doesn't copy the framework (which carries the XPC
+# helpers and Autoupdate.app) into the bundle; without this the updater crashes
+# on the first check because it can't locate its helper processes.
+echo "Embedding Sparkle.framework..."
+mkdir -p "${BUNDLE}/Contents/Frameworks"
+SPARKLE_FW="$(find .build -type d -name 'Sparkle.framework' | grep -v '\.dSYM' | head -1)"
+if [ -z "$SPARKLE_FW" ]; then
+    echo "Error: Sparkle.framework not found in .build. Run 'swift build -c release' first." >&2
+    exit 1
+fi
+cp -R "$SPARKLE_FW" "${BUNDLE}/Contents/Frameworks/"
+
+# Fix the rpath so the binary resolves @rpath/Sparkle.framework at the bundle-
+# relative path above rather than the build-artifacts path that won't exist once
+# the app is installed.
+install_name_tool -add_rpath "@executable_path/../Frameworks" \
+    "${BUNDLE}/Contents/MacOS/${EXECUTABLE}" 2>/dev/null || true
+
+# Sign Sparkle's framework (--deep handles its nested XPC services and helpers,
+# which macOS requires to be signed before it will launch them).
+#
+# Sign the main binary by copying it out of the bundle first. The SwiftMath
+# resource bundle lives at the .app root (outside Contents/) because
+# Bundle.main.bundleURL is where its generated accessor looks — there is no
+# way to move it. That non-standard placement makes codesign's strict bundle-
+# seal mode reject the outer bundle with "unsealed contents present in the
+# bundle root". Signing the binary as a temporary standalone file sidesteps
+# that check; the resulting ad-hoc signature is identical to what bundle-mode
+# signing would produce for the executable itself.
+echo "Code signing..."
+codesign --force --sign - --deep "${BUNDLE}/Contents/Frameworks/Sparkle.framework"
+TMP_BIN="$(mktemp)"
+cp "${BUNDLE}/Contents/MacOS/${EXECUTABLE}" "$TMP_BIN"
+codesign --force --sign - --identifier "com.i7t5.edmd" "$TMP_BIN"
+cp "$TMP_BIN" "${BUNDLE}/Contents/MacOS/${EXECUTABLE}"
+rm "$TMP_BIN"
 
 echo ""
 echo "Done: ${BUNDLE}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Publish a new Edmund release.
+#
+# Usage: ./scripts/release.sh
+#
+# Prerequisites:
+#   1. Run `generate_keys` once and put the public key in Info.plist SUPublicEDKey.
+#   2. The Sparkle private key must be in the login keychain (placed there by
+#      `generate_keys`) OR exported as SPARKLE_ED_PRIVATE_KEY in the environment
+#      (used in CI). The script auto-detects which path to take.
+#   3. `gh` CLI must be installed and authenticated (for the GitHub Release step).
+#
+# Output:
+#   - build/Edmund-<version>.zip  (signed archive)
+#   - appcast.xml updated with the new <item> (commit + push it yourself)
+#   - GitHub Release created with the zip as an asset
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# ── Version from Info.plist ──────────────────────────────────────────────────
+VERSION="$(/usr/libexec/PlistBuddy -c 'Print CFBundleShortVersionString' Info.plist)"
+BUILD="$(/usr/libexec/PlistBuddy -c 'Print CFBundleVersion' Info.plist)"
+ZIP="build/Edmund-${VERSION}.zip"
+
+echo "Releasing Edmund ${VERSION} (build ${BUILD})"
+
+# ── Build ────────────────────────────────────────────────────────────────────
+./scripts/build-app.sh
+
+# ── Archive ──────────────────────────────────────────────────────────────────
+rm -f "$ZIP"
+ditto -c -k --keepParent build/Edmund.app "$ZIP"
+echo "Archive: $ZIP ($(du -sh "$ZIP" | cut -f1))"
+
+# ── Locate sign_update ────────────────────────────────────────────────────────
+SIGN_UPDATE="$(find .build -name sign_update -type f | head -1)"
+if [ -z "$SIGN_UPDATE" ]; then
+    echo "Error: sign_update not found. Run 'swift build' to fetch Sparkle tools." >&2
+    exit 1
+fi
+
+# ── EdDSA signature ───────────────────────────────────────────────────────────
+if [ -n "${SPARKLE_ED_PRIVATE_KEY:-}" ]; then
+    # CI path: private key passed via env (base64 string, no keychain)
+    SIG_OUTPUT="$("$SIGN_UPDATE" -s "$SPARKLE_ED_PRIVATE_KEY" "$ZIP")"
+else
+    # Local path: key lives in the login keychain (placed there by generate_keys)
+    SIG_OUTPUT="$("$SIGN_UPDATE" "$ZIP")"
+fi
+
+# sign_update prints:  sparkle:edSignature="<sig>" length="<n>"
+ED_SIG="$(echo "$SIG_OUTPUT" | grep -o 'sparkle:edSignature="[^"]*"')"
+LENGTH="$(echo "$SIG_OUTPUT" | grep -o 'length="[^"]*"' | head -1)"
+
+echo "Signature: $ED_SIG"
+
+# ── Build the GitHub Release asset URL ────────────────────────────────────────
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+ASSET_URL="https://github.com/${REPO}/releases/download/v${VERSION}/Edmund-${VERSION}.zip"
+
+# ── Prepend item to appcast.xml ───────────────────────────────────────────────
+PUB_DATE="$(date -u '+%a, %d %b %Y %H:%M:%S +0000')"
+NEW_ITEM="        <item>
+            <title>Edmund ${VERSION}</title>
+            <pubDate>${PUB_DATE}</pubDate>
+            <enclosure url=\"${ASSET_URL}\"
+                       sparkle:version=\"${BUILD}\"
+                       sparkle:shortVersionString=\"${VERSION}\"
+                       ${ED_SIG}
+                       ${LENGTH}
+                       type=\"application/octet-stream\"/>
+        </item>"
+
+# Insert the new item right after <channel>...<language>en</language>
+python3 - "$NEW_ITEM" <<'PYEOF'
+import sys, re
+new_item = sys.argv[1]
+with open("appcast.xml", "r") as f:
+    content = f.read()
+# Insert before closing </channel>
+content = content.replace("    </channel>", new_item + "\n    </channel>")
+with open("appcast.xml", "w") as f:
+    f.write(content)
+PYEOF
+
+echo "appcast.xml updated."
+
+# ── GitHub Release ────────────────────────────────────────────────────────────
+echo "Creating GitHub Release v${VERSION}..."
+gh release create "v${VERSION}" "$ZIP" \
+    --title "Edmund ${VERSION}" \
+    --notes "See [CHANGELOG](https://github.com/${REPO}/blob/main/CHANGELOG.md) for details." \
+    --latest
+
+echo ""
+echo "Done. Next steps:"
+echo "  1. git add appcast.xml && git commit -m 'Release ${VERSION}' && git push"
+echo "  2. Verify: open https://github.com/${REPO}/releases/tag/v${VERSION}"


### PR DESCRIPTION
## What

Integrates [Sparkle 2.x](https://github.com/sparkle-project/Sparkle) for automatic in-app updates.

- **"Check for Updates…"** menu item in the Edmund app menu, wired to `SPUStandardUpdaterController`
- **Advanced settings tab** (⚙︎ `gearshape.2`) with an "Automatically check for updates" toggle — persisted via Sparkle's own `SUAutomaticallyChecksForUpdates` key
- `Info.plist`: `SUFeedURL` (raw GitHub URL to `appcast.xml`), `SUPublicEDKey`, `SUEnableAutomaticChecks`
- `build-app.sh`: embeds `Sparkle.framework` in `Contents/Frameworks/`, adds rpath, signs framework with `--deep`, signs binary as standalone (workaround for SwiftMath bundle at `.app` root conflicting with codesign strict bundle-seal mode — documented in ARCHITECTURE §8)
- `appcast.xml`: empty initial feed committed at repo root
- `scripts/release.sh`: build → zip → EdDSA sign → update appcast → `gh release create`
- `.github/workflows/release.yml`: tag-triggered CI pipeline (build, sign with `SPARKLE_ED_PRIVATE_KEY` secret, publish release, commit updated appcast)

## Why

Auto-update was the last item on the v1.0 roadmap. Users can now receive updates without manually downloading a new build.

## Setup required before first release

Add `SPARKLE_ED_PRIVATE_KEY` (the exported ed25519 private key) to GitHub Actions secrets. Then `git tag v<version> && git push origin v<version>` triggers a full release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)