### PR TITLE
Release DMGs instead of zipped .app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,18 +31,40 @@ jobs:
       - name: Build app bundle
         run: ./scripts/build-app.sh
 
-      - name: Archive
+      # create-dmg 8.x requires Node >= 20; pin it so the runner's default node
+      # version can't break the release.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install create-dmg
+        # sindresorhus/create-dmg is the npm package (NOT the homebrew
+        # create-dmg/create-dmg tool, which has an incompatible CLI).
+        run: npm install --global create-dmg
+
+      - name: Create DMG
         run: |
           VERSION="$(/usr/libexec/PlistBuddy -c 'Print CFBundleShortVersionString' Info.plist)"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
-          ditto -c -k --keepParent build/Edmund.app "build/Edmund-${VERSION}.zip"
+          # create-dmg exits 2 when it can't Developer-ID-sign / notarize the
+          # image (we ship ad-hoc only) but still produces the .dmg — so don't
+          # let that non-zero status fail the job.
+          create-dmg build/Edmund.app build/ || true
+          # It names the output "Edmund <version>.dmg"; normalize to a
+          # hyphenated, URL-friendly name and fail loudly if none was produced.
+          DMG_SRC="$(ls build/Edmund*.dmg 2>/dev/null | head -1)"
+          if [ -z "$DMG_SRC" ]; then
+            echo "create-dmg produced no .dmg" >&2
+            exit 1
+          fi
+          mv "$DMG_SRC" "build/Edmund-${VERSION}.dmg"
 
       - name: Sign archive (EdDSA)
         env:
           SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
         run: |
           SIGN_UPDATE="$(find .build -name sign_update -type f | head -1)"
-          SIG_OUTPUT="$("$SIGN_UPDATE" -s "$SPARKLE_ED_PRIVATE_KEY" "build/Edmund-${VERSION}.zip")"
+          SIG_OUTPUT="$("$SIGN_UPDATE" -s "$SPARKLE_ED_PRIVATE_KEY" "build/Edmund-${VERSION}.dmg")"
           echo "ED_SIG=$(echo "$SIG_OUTPUT" | grep -o 'sparkle:edSignature="[^"]*"')" >> "$GITHUB_ENV"
           echo "LENGTH=$(echo "$SIG_OUTPUT" | grep -o 'length="[^"]*"' | head -1)" >> "$GITHUB_ENV"
 
@@ -51,7 +73,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "v${VERSION}" "build/Edmund-${VERSION}.zip" \
+          gh release create "v${VERSION}" "build/Edmund-${VERSION}.dmg" \
             --title "Edmund ${VERSION}" \
             --notes "See CHANGELOG for details." \
             --latest
@@ -61,7 +83,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           REPO="${{ github.repository }}"
-          ASSET_URL="https://github.com/${REPO}/releases/download/v${VERSION}/Edmund-${VERSION}.zip"
+          ASSET_URL="https://github.com/${REPO}/releases/download/v${VERSION}/Edmund-${VERSION}.dmg"
           PUB_DATE="$(date -u '+%a, %d %b %Y %H:%M:%S +0000')"
           BUILD="$(/usr/libexec/PlistBuddy -c 'Print CFBundleVersion' Info.plist)"
 
@@ -73,7 +95,7 @@ jobs:
                          sparkle:shortVersionString=\"${VERSION}\"
                          ${ED_SIG}
                          ${LENGTH}
-                         type=\"application/octet-stream\"/>
+                         type=\"application/x-apple-diskimage\"/>
           </item>"
 
           python3 - "$NEW_ITEM" <<'PYEOF'

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -142,7 +142,7 @@ rawSource ──BlockParser──▶ [Block]  ──styleBlock per block──�
 | Lazy/compose/undo/scroll | `TextView/EditorTextView+{Composition,LazyStyling,Undo,TypewriterScroll,SelectionTracking,ContentWidth,EditFlow}.swift` |
 | App shell | `edmd/App/{main,Document,DocumentController}.swift`; menu bar in `main.swift` `setupMenuBar()` + `FormatMenu.swift`; Sparkle `SPUStandardUpdaterController` in `AppDelegate` |
 | Settings (SwiftUI) | `edmd/Settings/*` (AppSettings = UserDefaults keys; FontSettings; Appearance/General/Advanced views) |
-| Auto-update | Sparkle 2.x. `Info.plist`: `SUFeedURL` (raw GitHub URL to `appcast.xml`), `SUPublicEDKey` (ed25519 public key). `scripts/release.sh`: build → zip → EdDSA sign → update appcast → `gh release create`. CI: `.github/workflows/release.yml` (tag-triggered). One-time setup: generate the EdDSA keypair with `generate_keys` (§8). |
+| Auto-update | Sparkle 2.x. `Info.plist`: `SUFeedURL` (raw GitHub URL to `appcast.xml`), `SUPublicEDKey` (ed25519 public key). `scripts/release.sh`: build → DMG (sindresorhus `create-dmg`, **npm** — not the homebrew tool) → EdDSA sign → update appcast → `gh release create`. The DMG is the Sparkle enclosure (it mounts the image and installs the `.app` inside). CI: `.github/workflows/release.yml` (tag-triggered). One-time setup: generate the EdDSA keypair with `generate_keys` (§8). |
 | Status bar | `edmd/Views/StatusBarView.swift` |
 | Build/packaging | `scripts/build-app.sh` (release build + Sparkle.framework embedding + signing), `Package.swift`, `Info.plist`, `Resources/` |
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -9,11 +9,14 @@
 #      `generate_keys`) OR exported as SPARKLE_ED_PRIVATE_KEY in the environment
 #      (used in CI). The script auto-detects which path to take.
 #   3. `gh` CLI must be installed and authenticated (for the GitHub Release step).
+#   4. create-dmg installed via npm: `npm install --global create-dmg`
+#      (this is sindresorhus/create-dmg, NOT the homebrew create-dmg/create-dmg
+#      tool — they have incompatible CLIs).
 #
 # Output:
-#   - build/Edmund-<version>.zip  (signed archive)
+#   - build/Edmund-<version>.dmg  (signed archive)
 #   - appcast.xml updated with the new <item> (commit + push it yourself)
-#   - GitHub Release created with the zip as an asset
+#   - GitHub Release created with the DMG as an asset
 
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -21,17 +24,28 @@ cd "$(dirname "$0")/.."
 # ── Version from Info.plist ──────────────────────────────────────────────────
 VERSION="$(/usr/libexec/PlistBuddy -c 'Print CFBundleShortVersionString' Info.plist)"
 BUILD="$(/usr/libexec/PlistBuddy -c 'Print CFBundleVersion' Info.plist)"
-ZIP="build/Edmund-${VERSION}.zip"
+DMG="build/Edmund-${VERSION}.dmg"
 
 echo "Releasing Edmund ${VERSION} (build ${BUILD})"
 
 # ── Build ────────────────────────────────────────────────────────────────────
 ./scripts/build-app.sh
 
-# ── Archive ──────────────────────────────────────────────────────────────────
-rm -f "$ZIP"
-ditto -c -k --keepParent build/Edmund.app "$ZIP"
-echo "Archive: $ZIP ($(du -sh "$ZIP" | cut -f1))"
+# ── Disk image ────────────────────────────────────────────────────────────────
+# create-dmg exits 2 when it can't Developer-ID-sign / notarize the image (we
+# ship ad-hoc only) but still produces the .dmg, so tolerate that status and
+# verify the file exists instead. It names the output "Edmund <version>.dmg";
+# normalize to the hyphenated name the appcast URL expects.
+rm -f "$DMG" "build/Edmund ${VERSION}.dmg"
+create-dmg build/Edmund.app build/ || true
+DMG_SRC="$(ls build/Edmund*.dmg 2>/dev/null | grep -v "Edmund-${VERSION}.dmg" | head -1)"
+if [ -z "$DMG_SRC" ]; then
+    echo "Error: create-dmg produced no .dmg." >&2
+    echo "Install it with: npm install --global create-dmg" >&2
+    exit 1
+fi
+mv "$DMG_SRC" "$DMG"
+echo "Archive: $DMG ($(du -sh "$DMG" | cut -f1))"
 
 # ── Locate sign_update ────────────────────────────────────────────────────────
 SIGN_UPDATE="$(find .build -name sign_update -type f | head -1)"
@@ -43,10 +57,10 @@ fi
 # ── EdDSA signature ───────────────────────────────────────────────────────────
 if [ -n "${SPARKLE_ED_PRIVATE_KEY:-}" ]; then
     # CI path: private key passed via env (base64 string, no keychain)
-    SIG_OUTPUT="$("$SIGN_UPDATE" -s "$SPARKLE_ED_PRIVATE_KEY" "$ZIP")"
+    SIG_OUTPUT="$("$SIGN_UPDATE" -s "$SPARKLE_ED_PRIVATE_KEY" "$DMG")"
 else
     # Local path: key lives in the login keychain (placed there by generate_keys)
-    SIG_OUTPUT="$("$SIGN_UPDATE" "$ZIP")"
+    SIG_OUTPUT="$("$SIGN_UPDATE" "$DMG")"
 fi
 
 # sign_update prints:  sparkle:edSignature="<sig>" length="<n>"
@@ -57,7 +71,7 @@ echo "Signature: $ED_SIG"
 
 # ── Build the GitHub Release asset URL ────────────────────────────────────────
 REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
-ASSET_URL="https://github.com/${REPO}/releases/download/v${VERSION}/Edmund-${VERSION}.zip"
+ASSET_URL="https://github.com/${REPO}/releases/download/v${VERSION}/Edmund-${VERSION}.dmg"
 
 # ── Prepend item to appcast.xml ───────────────────────────────────────────────
 PUB_DATE="$(date -u '+%a, %d %b %Y %H:%M:%S +0000')"
@@ -69,7 +83,7 @@ NEW_ITEM="        <item>
                        sparkle:shortVersionString=\"${VERSION}\"
                        ${ED_SIG}
                        ${LENGTH}
-                       type=\"application/octet-stream\"/>
+                       type=\"application/x-apple-diskimage\"/>
         </item>"
 
 # Insert the new item right after <channel>...<language>en</language>
@@ -88,7 +102,7 @@ echo "appcast.xml updated."
 
 # ── GitHub Release ────────────────────────────────────────────────────────────
 echo "Creating GitHub Release v${VERSION}..."
-gh release create "v${VERSION}" "$ZIP" \
+gh release create "v${VERSION}" "$DMG" \
     --title "Edmund ${VERSION}" \
     --notes "See [CHANGELOG](https://github.com/${REPO}/blob/main/CHANGELOG.md) for details." \
     --latest


### PR DESCRIPTION
## What

Switches the Sparkle release artifact from a `ditto` zip to a proper `.dmg` built with [sindresorhus/create-dmg](https://github.com/sindresorhus/create-dmg).

- **`release.yml`**: pin Node 20 (create-dmg 8.x requires `node >=20`), `npm install --global create-dmg`, build the DMG, tolerate its exit-2-when-it-can't-Developer-ID-sign quirk, normalize the `Edmund <ver>.dmg` filename, then sign + release + appcast off the `.dmg`.
- **`release.sh`**: same flow for local publishing; documents the npm-vs-homebrew `create-dmg` distinction (they're different tools with incompatible CLIs).
- Appcast enclosure `type` → `application/x-apple-diskimage`.
- ARCHITECTURE §6 updated.

## Why

A DMG with a styled background, volume icon, and `/Applications` symlink is the native macOS install experience. Sparkle consumes the DMG directly as the appcast enclosure — it mounts the image and installs the `Edmund.app` inside, so no separate zip is needed.

## Verification

Tested locally against a built `Edmund.app`:
- `create-dmg` produced a valid mountable DMG containing `Edmund.app` + an `Applications` symlink, custom volume icon, and background.
- `sign_update` produced a usable `sparkle:edSignature` + `length` for the DMG.
- Confirmed create-dmg 8.1.0 no longer needs graphicsmagick/imagemagick.

First tagged release should be eyeballed to confirm create-dmg runs cleanly on the headless runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)