### PR TITLE
Set initial version to 0.1 beta; document create-dmg gotchas

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -17,9 +17,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleVersion</key>
-    <string>1.0</string>
+    <string>0.1</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.0</string>
+    <string>0.1</string>
     <key>LSMinimumSystemVersion</key>
     <string>13.0</string>
     <key>NSHighResolutionCapable</key>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -218,6 +218,14 @@ them and route through the app's document graph without JavaScript.
 - **Sparkle keypair (one-time setup)**: the EdDSA public key in `Info.plist`
   `SUPublicEDKey` is a placeholder. See §8 for the exact commands to generate
   and install the real key before shipping an update.
+- **`create-dmg` — npm only, three quirks**:
+  - Install via **npm** (`npm install --global create-dmg`), not Homebrew — they
+    are different tools with incompatible CLIs. Requires Node ≥20 (`node --version`).
+  - Exits **2** (not 0) when it can't Developer-ID-sign the image (we ship
+    ad-hoc). It still produces the `.dmg`; `release.sh` and the CI step both
+    use `|| true` and then verify the file exists.
+  - Names the output `"Edmund <version>.dmg"` (space, not hyphen). Both scripts
+    rename it to `Edmund-<version>.dmg` before signing and uploading.
 - **Stale release builds**: `swift build -c release` / `build-app.sh` sometimes
   reuses stale object files (you'll run an old binary and be baffled). If a
   visual change "doesn't take," `rm -rf .build` and rebuild. `shasum` the binary


### PR DESCRIPTION
## Changes

**`Info.plist`**: `CFBundleVersion` and `CFBundleShortVersionString` changed from `1.0` → `0.1`. The release scripts read the version dynamically from `Info.plist` via `PlistBuddy`, so no other files needed updating.

**`docs/ARCHITECTURE.md` §8**: adds a `create-dmg` gotchas bullet covering:
- npm install only (not Homebrew — different tools, incompatible CLIs), Node ≥20 required
- Exit code 2 quirk when unsigned and the `|| true` pattern used to handle it
- Filename normalisation (`"Edmund x.y.dmg"` → `Edmund-x.y.dmg`)

These details are also in the script inline comments, but §8 is the first place agents and contributors look when hitting a snag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)