### PR TITLE
Move Diagnostics and Dialog warnings to Advanced settings pane

### DIFF
--- a/Sources/edmd/Settings/AdvancedSettingsView.swift
+++ b/Sources/edmd/Settings/AdvancedSettingsView.swift
@@ -1,8 +1,12 @@
 import SwiftUI
+import AppKit
 
 struct AdvancedSettingsView: View {
     @AppStorage(AppSettings.Key.automaticallyChecksForUpdates)
     private var autoCheckUpdates = true
+    @AppStorage(AppSettings.Key.diagnosticLogging) private var diagnosticLogging = true
+    @AppStorage(AppSettings.Key.logRetention) private var logRetention = AppSettings.LogRetention.twoWeeks
+    @State private var showingWarnings = false
 
     var body: some View {
         Grid(alignment: .leadingFirstTextBaseline, verticalSpacing: 18) {
@@ -11,7 +15,67 @@ struct AdvancedSettingsView: View {
                     .gridColumnAlignment(.trailing)
                 Toggle("Automatically check for updates", isOn: $autoCheckUpdates)
             }
+
+            GridRow {
+                Divider().gridCellColumns(2)
+            }
+
+            GridRow {
+                Text("Diagnostics:")
+                    .gridColumnAlignment(.trailing)
+                VStack(alignment: .leading, spacing: 6) {
+                    Toggle("Save diagnostic logs", isOn: $diagnosticLogging)
+                        .onChange(of: diagnosticLogging) { AppSettings.applyLogging() }
+                    HStack(spacing: 6) {
+                        Text("Clear logs after:")
+                        Picker("", selection: $logRetention) {
+                            ForEach(AppSettings.LogRetention.allCases) { Text($0.label).tag($0) }
+                        }
+                        .labelsHidden()
+                        .fixedSize()
+                        .onChange(of: logRetention) { AppSettings.applyLogging() }
+                    }
+                    .disabled(!diagnosticLogging)
+                    .padding(.leading, 20)
+                    Text("Logs are kept locally at ~/.edmund/logs and they are useful only if you would like to help the dev by submitting context-rich bug reports and make her life happier. Otherwise, the logs will never leave their folder.")
+                        .foregroundStyle(.secondary)
+                        .controlSize(.small)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(width: 380, alignment: .leading)
+                        .padding(.leading, 20)
+                }
+            }
+
+            GridRow {
+                Text("Dialog warnings:")
+                    .gridColumnAlignment(.trailing)
+                Button("Manage Warnings…") { showingWarnings = true }
+            }
         }
         .settingsPanePadding()
+        .sheet(isPresented: $showingWarnings) {
+            ManageWarningsView()
+        }
+    }
+}
+
+/// The Manage Warnings sheet: per-warning suppression toggles.
+private struct ManageWarningsView: View {
+    @AppStorage(AppSettings.Key.suppressInconsistentLineEndingWarning)
+    private var suppressLineEnding = false
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Suppress the following warnings:")
+            Toggle("Inconsistent line endings", isOn: $suppressLineEnding)
+            HStack {
+                Spacer()
+                Button("Done") { dismiss() }
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .scenePadding()
+        .frame(width: 360)
     }
 }

--- a/Sources/edmd/Settings/GeneralSettingsView.swift
+++ b/Sources/edmd/Settings/GeneralSettingsView.swift
@@ -1,5 +1,4 @@
-// The General settings pane (startup, document saving, conflict resolution,
-// dialog warnings) and its Manage Warnings sheet.
+// The General settings pane (startup, document saving, conflict resolution).
 
 import SwiftUI
 import AppKit
@@ -11,9 +10,6 @@ struct GeneralSettingsView: View {
     @AppStorage(AppSettings.Key.startupAction) private var startupAction = AppSettings.StartupAction.createNewDocument
     @AppStorage(AppSettings.Key.autoSaveWithVersions) private var autoSave = true
     @AppStorage(AppSettings.Key.conflictResolution) private var conflict = AppSettings.ConflictResolution.ask
-    @AppStorage(AppSettings.Key.diagnosticLogging) private var diagnosticLogging = true
-    @AppStorage(AppSettings.Key.logRetention) private var logRetention = AppSettings.LogRetention.twoWeeks
-    @State private var showingWarnings = false
 
     var body: some View {
         Grid(alignment: .leadingFirstTextBaseline, verticalSpacing: 18) {
@@ -61,66 +57,7 @@ struct GeneralSettingsView: View {
                 .labelsHidden()
             }
 
-            GridRow {
-                Divider().gridCellColumns(2)
-            }
-
-            GridRow {
-                Text("Diagnostics:")
-                    .gridColumnAlignment(.trailing)
-                VStack(alignment: .leading, spacing: 6) {
-                    Toggle("Save diagnostic logs", isOn: $diagnosticLogging)
-                        .onChange(of: diagnosticLogging) { AppSettings.applyLogging() }
-                    HStack(spacing: 6) {
-                        Text("Clear logs after:")
-                        Picker("", selection: $logRetention) {
-                            ForEach(AppSettings.LogRetention.allCases) { Text($0.label).tag($0) }
-                        }
-                        .labelsHidden()
-                        .fixedSize()
-                        .onChange(of: logRetention) { AppSettings.applyLogging() }
-                    }
-                    .disabled(!diagnosticLogging)
-                    .padding(.leading, 20)
-                    Text("Logs are kept locally at ~/.edmund/logs and they are useful only if you would like to help the dev by submitting context-rich bug reports and make her life happier. Otherwise, the logs will never leave their folder.")
-                        .foregroundStyle(.secondary)
-                        .controlSize(.small)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(width: 380, alignment: .leading)
-                        .padding(.leading, 20)
-                }
-            }
-
-            GridRow {
-                Text("Dialog warnings:")
-                    .gridColumnAlignment(.trailing)
-                Button("Manage Warnings…") { showingWarnings = true }
-            }
         }
         .settingsPanePadding()
-        .sheet(isPresented: $showingWarnings) {
-            ManageWarningsView()
-        }
-    }
-}
-
-/// The Manage Warnings sheet: per-warning suppression toggles.
-private struct ManageWarningsView: View {
-    @AppStorage(AppSettings.Key.suppressInconsistentLineEndingWarning)
-    private var suppressLineEnding = false
-    @Environment(\.dismiss) private var dismiss
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text("Suppress the following warnings:")
-            Toggle("Inconsistent line endings", isOn: $suppressLineEnding)
-            HStack {
-                Spacer()
-                Button("Done") { dismiss() }
-                    .keyboardShortcut(.defaultAction)
-            }
-        }
-        .scenePadding()
-        .frame(width: 360)
     }
 }


### PR DESCRIPTION
The divider and everything below it in **Settings › General** (Diagnostics toggle, log retention picker, Manage Warnings button and sheet) moves to **Settings › Advanced**, appended after the Software update row with the same divider separating them.

General is now startup / document save / conflict resolution only.

No logic changes — same `@AppStorage` keys, same `AppSettings.applyLogging()` call sites, same `ManageWarningsView` sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)