### PR TITLE
Toolbar: Edit↔Read toggle button, Source mode, Customize Toolbar

### DIFF
--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -78,7 +78,7 @@ class Document: NSDocument, HeadingNavigable {
         let windowWidth: CGFloat = 400
         let windowHeight: CGFloat = 500
 
-        let window = NSWindow(
+        let window = DocumentWindow(
             contentRect: NSRect(x: 0, y: 0, width: windowWidth, height: windowHeight),
             styleMask: [.titled, .closable, .resizable, .miniaturizable],
             backing: .buffered,
@@ -125,6 +125,11 @@ class Document: NSDocument, HeadingNavigable {
         window.toolbar = toolbar
         window.toolbarStyle = .unified
         window.titlebarSeparatorStyle = .line
+
+        // Wire the window's secondary-click interception now that the toolbar has
+        // synchronously vended the view-mode button (see DocumentWindow).
+        window.viewModeButton = viewModeButton
+        window.makeViewModeMenu = { [weak self] in self?.viewModeMenu() ?? NSMenu() }
 
         let statusBarHeight: CGFloat = 22
         let contentBounds = window.contentView!.bounds
@@ -311,8 +316,11 @@ class Document: NSDocument, HeadingNavigable {
     /// Shows the active mode's icon on the button and keeps the tooltip in sync.
     private func refreshViewModeButton() {
         guard let editor else { return }
+        // The `</>` source glyph reads wider/larger than pencil and book at the
+        // same point size, so render it a touch smaller to match visually.
+        let pointSize: CGFloat = editor.viewMode == .source ? 11 : 13
         viewModeButton?.image = icon(for: editor.viewMode)?
-            .withSymbolConfiguration(.init(pointSize: 13, weight: .regular))
+            .withSymbolConfiguration(.init(pointSize: pointSize, weight: .regular))
         viewModeButton?.toolTip = "View mode: \(label(for: editor.viewMode))"
     }
 
@@ -426,13 +434,6 @@ class Document: NSDocument, HeadingNavigable {
         if editor.viewMode != .reading { setViewMode(editingMode) }
     }
 
-    /// Pops the right-click mode menu under the toolbar button.
-    @objc private func showViewModeMenu(_ sender: NSGestureRecognizer) {
-        guard let view = sender.view else { return }
-        viewModeMenu().popUp(positioning: nil,
-                             at: NSPoint(x: 0, y: view.bounds.maxY + 4), in: view)
-    }
-
     /// Keeps the View-menu "Source Mode" checkmark in sync with the setting.
     override func validateMenuItem(_ item: NSMenuItem) -> Bool {
         if item.action == #selector(toggleSourceMode(_:)) {
@@ -513,21 +514,46 @@ extension Document: NSToolbarDelegate {
         item.label = "View Mode"
         item.visibilityPriority = .high
 
-        // Left-click toggles the editing view ↔ Read. Right-click shows the
-        // full mode menu — via a gesture recognizer, which claims the secondary
-        // click before the toolbar's own "Customize Toolbar…" context menu does
-        // (overriding rightMouseDown on the view loses that race).
+        // Left-click toggles the editing view ↔ Read. The right-click mode menu
+        // is handled upstream in DocumentWindow.sendEvent — every view-level
+        // approach (the view's `menu`, rightMouseDown, a gesture recognizer)
+        // loses the secondary click to the toolbar's "Customize Toolbar…" menu.
         let button = NSButton(image: NSImage(), target: self,
                               action: #selector(toggleViewMode(_:)))
         button.bezelStyle = .texturedRounded
         button.imagePosition = .imageOnly
-        let secondaryClick = NSClickGestureRecognizer(
-            target: self, action: #selector(showViewModeMenu(_:)))
-        secondaryClick.buttonMask = 0x2   // right / secondary button
-        button.addGestureRecognizer(secondaryClick)
         viewModeButton = button
         item.view = button
         refreshViewModeButton()
         return item
+    }
+}
+
+/// Document window that intercepts a secondary (right / control) click on the
+/// view-mode toolbar button and shows the mode menu itself. `sendEvent` is the
+/// single funnel all window events pass through *before* the toolbar/titlebar
+/// can turn the click into its own "Customize Toolbar…" context menu, so this is
+/// the one place the interception reliably wins.
+final class DocumentWindow: NSWindow {
+    weak var viewModeButton: NSView?
+    var makeViewModeMenu: (() -> NSMenu)?
+
+    override func sendEvent(_ event: NSEvent) {
+        if isSecondaryClick(event), let button = viewModeButton,
+           button.bounds.contains(button.convert(event.locationInWindow, from: nil)),
+           let menu = makeViewModeMenu?() {
+            menu.popUp(positioning: nil,
+                       at: NSPoint(x: 0, y: button.bounds.maxY + 4), in: button)
+            return
+        }
+        super.sendEvent(event)
+    }
+
+    private func isSecondaryClick(_ event: NSEvent) -> Bool {
+        switch event.type {
+        case .rightMouseDown: return true
+        case .leftMouseDown:  return event.modifierFlags.contains(.control)
+        default:              return false
+        }
     }
 }

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -120,6 +120,8 @@ class Document: NSDocument, HeadingNavigable {
         let toolbar = NSToolbar(identifier: "MainToolbar")
         toolbar.delegate = self
         toolbar.displayMode = .iconOnly
+        toolbar.allowsUserCustomization = true
+        toolbar.autosavesConfiguration = true   // persists layout per "MainToolbar"
         window.toolbar = toolbar
         window.toolbarStyle = .unified
         window.titlebarSeparatorStyle = .line
@@ -304,11 +306,11 @@ class Document: NSDocument, HeadingNavigable {
         }
     }
 
-    /// Shows the active mode's icon on the button (with the menu chevrons), and
-    /// keeps the tooltip in sync.
+    /// Shows the active mode's icon on the button and keeps the tooltip in sync.
     private func refreshViewModeButton() {
         guard let editor else { return }
-        viewModeButton?.image = viewModeButtonImage(for: editor.viewMode)
+        viewModeButton?.image = icon(for: editor.viewMode)?
+            .withSymbolConfiguration(.init(pointSize: 16, weight: .regular))
         viewModeButton?.toolTip = "View mode: \(label(for: editor.viewMode))"
     }
 
@@ -409,42 +411,21 @@ class Document: NSDocument, HeadingNavigable {
     @objc private func selectReadingMode(_ sender: Any?) { setViewMode(.reading) }
     @objc private func selectSourceMode(_ sender: Any?)  { setViewMode(.source) }
 
-    /// Cycle Edit → Read → Source → Edit (the View-menu ⌘E item). Keeps the
-    /// toolbar button in sync via `setViewMode`.
-    @objc func cycleViewMode(_ sender: Any?) {
-        let next: EditorTextView.ViewMode
-        switch editor.viewMode {
-        case .edit:    next = .reading
-        case .reading: next = .source
-        case .source:  next = .edit
-        }
-        setViewMode(next)
+    /// Toggle Edit ↔ Read (the View-menu ⌘E item and the toolbar button).
+    /// Read → Edit; anything else (Edit or Source) → Read. Keeps the toolbar
+    /// button in sync via `setViewMode`.
+    @objc func toggleViewMode(_ sender: Any?) {
+        setViewMode(editor.viewMode == .reading ? .edit : .reading)
     }
 
-    /// Drops the mode menu down from the chevron button.
-    @objc private func showViewModeMenu(_ sender: NSButton) {
-        let menu = viewModeMenu()
-        menu.popUp(positioning: nil,
-                   at: NSPoint(x: 0, y: sender.bounds.height + 4), in: sender)
-    }
-
-    /// A checklist menu: each mode with its icon, the current one checked.
-    private func viewModeMenu() -> NSMenu {
-        let menu = NSMenu()
-        menu.autoenablesItems = false   // actions always fire on selection
-        let entries: [(EditorTextView.ViewMode, Selector)] = [
-            (.edit,    #selector(selectEditMode(_:))),
-            (.reading, #selector(selectReadingMode(_:))),
-            (.source,  #selector(selectSourceMode(_:))),
-        ]
-        for (mode, action) in entries {
-            let item = NSMenuItem(title: label(for: mode), action: action, keyEquivalent: "")
-            item.target = self
-            item.image = icon(for: mode)
-            item.state = (editor?.viewMode == mode) ? .on : .off
-            menu.addItem(item)
-        }
-        return menu
+    /// One checklist item: the mode's icon + title, checked when it's active.
+    private func viewModeMenuItem(_ mode: EditorTextView.ViewMode,
+                                  _ action: Selector) -> NSMenuItem {
+        let item = NSMenuItem(title: label(for: mode), action: action, keyEquivalent: "")
+        item.target = self
+        item.image = icon(for: mode)
+        item.state = (editor?.viewMode == mode) ? .on : .off
+        return item
     }
 
     // MARK: - Writing
@@ -475,7 +456,7 @@ extension Document: NSToolbarDelegate {
     }
 
     func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        [.flexibleSpace, Self.viewModeItemID]
+        [.flexibleSpace, .space, Self.viewModeItemID]
     }
 
     func toolbar(_ toolbar: NSToolbar,
@@ -486,39 +467,33 @@ extension Document: NSToolbarDelegate {
         item.label = "View Mode"
         item.visibilityPriority = .high
 
-        // A single button — "<active-mode icon> ⌄⌃" — that drops the menu.
-        let button = NSButton(image: viewModeButtonImage(for: editor.viewMode),
-                              target: self, action: #selector(showViewModeMenu(_:)))
+        // Left-click toggles Edit↔Read; right-click drops the full mode menu
+        // (built on demand via menuNeedsUpdate so the checkmark stays current).
+        let button = NSButton(image: NSImage(), target: self,
+                              action: #selector(toggleViewMode(_:)))
         button.bezelStyle = .texturedRounded
         button.imagePosition = .imageOnly
+        let menu = NSMenu()
+        menu.delegate = self
+        button.menu = menu
         viewModeButton = button
         item.view = button
         refreshViewModeButton()
         return item
     }
+}
 
-    /// Composes the toolbar button face: the active mode's icon at full toolbar
-    /// size with a small `chevron.up.chevron.down` to its right (menu affordance).
-    private func viewModeButtonImage(for mode: EditorTextView.ViewMode) -> NSImage {
-        // Proportions match Finder's view-mode control: a prominent mode icon
-        // with a smaller `chevron.up.chevron.down` tucked close to its right.
-        let modeIcon = (icon(for: mode)?.withSymbolConfiguration(
-            .init(pointSize: 16, weight: .regular))) ?? NSImage()
-        let chevrons = (NSImage(systemSymbolName: "chevron.up.chevron.down",
-                                accessibilityDescription: nil)?
-            .withSymbolConfiguration(.init(pointSize: 10, weight: .medium))) ?? NSImage()
-        let gap: CGFloat = 2
-        let size = NSSize(width: modeIcon.size.width + gap + chevrons.size.width,
-                          height: max(modeIcon.size.height, chevrons.size.height))
-        let image = NSImage(size: size)
-        image.lockFocus()
-        modeIcon.draw(at: NSPoint(x: 0, y: (size.height - modeIcon.size.height) / 2),
-                      from: .zero, operation: .sourceOver, fraction: 1)
-        chevrons.draw(at: NSPoint(x: modeIcon.size.width + gap,
-                                  y: (size.height - chevrons.size.height) / 2),
-                      from: .zero, operation: .sourceOver, fraction: 1)
-        image.unlockFocus()
-        image.isTemplate = true   // tint with the toolbar's light/dark color
-        return image
+// MARK: - View-mode context menu
+
+extension Document: NSMenuDelegate {
+    /// Rebuilds the right-click mode menu — Edit / Read / ─── / Source, with the
+    /// active mode checked — each time it opens.
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        menu.autoenablesItems = false   // actions always fire on selection
+        menu.removeAllItems()
+        menu.addItem(viewModeMenuItem(.edit, #selector(selectEditMode(_:))))
+        menu.addItem(viewModeMenuItem(.reading, #selector(selectReadingMode(_:))))
+        menu.addItem(.separator())
+        menu.addItem(viewModeMenuItem(.source, #selector(selectSourceMode(_:))))
     }
 }

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -164,6 +164,8 @@ class Document: NSDocument, HeadingNavigable {
         let wc = NSWindowController(window: window)
         addWindowController(wc)
         window.makeFirstResponder(editor)
+        // Honor the persisted source-mode preference for the editing view.
+        if AppSettings.sourceMode { setViewMode(.source) }
         updateStatusBar()
     }
 
@@ -310,7 +312,7 @@ class Document: NSDocument, HeadingNavigable {
     private func refreshViewModeButton() {
         guard let editor else { return }
         viewModeButton?.image = icon(for: editor.viewMode)?
-            .withSymbolConfiguration(.init(pointSize: 16, weight: .regular))
+            .withSymbolConfiguration(.init(pointSize: 13, weight: .regular))
         viewModeButton?.toolTip = "View mode: \(label(for: editor.viewMode))"
     }
 
@@ -407,25 +409,53 @@ class Document: NSDocument, HeadingNavigable {
                               window: windowControllers.first?.window)
     }
 
-    @objc private func selectEditMode(_ sender: Any?)    { setViewMode(.edit) }
-    @objc private func selectReadingMode(_ sender: Any?) { setViewMode(.reading) }
-    @objc private func selectSourceMode(_ sender: Any?)  { setViewMode(.source) }
-
-    /// Toggle Edit ↔ Read (the View-menu ⌘E item and the toolbar button).
-    /// Read → Edit; anything else (Edit or Source) → Read. Keeps the toolbar
-    /// button in sync via `setViewMode`.
-    @objc func toggleViewMode(_ sender: Any?) {
-        setViewMode(editor.viewMode == .reading ? .edit : .reading)
+    /// The editing-side view: Source when source mode is on, otherwise Edit.
+    /// Read is the other half of the toggle.
+    private var editingMode: EditorTextView.ViewMode {
+        AppSettings.sourceMode ? .source : .edit
     }
 
-    /// One checklist item: the mode's icon + title, checked when it's active.
-    private func viewModeMenuItem(_ mode: EditorTextView.ViewMode,
-                                  _ action: Selector) -> NSMenuItem {
-        let item = NSMenuItem(title: label(for: mode), action: action, keyEquivalent: "")
+    @objc private func selectEditMode(_ sender: Any?)    { setViewMode(editingMode) }
+    @objc private func selectReadingMode(_ sender: Any?) { setViewMode(.reading) }
+
+    /// The "Source mode" checkbox. Persists the setting and, if we're in the
+    /// editing view, swaps it to the new editing mode right away.
+    @objc private func toggleSourceMode(_ sender: Any?) {
+        AppSettings.sourceMode.toggle()
+        if editor.viewMode != .reading { setViewMode(editingMode) }
+    }
+
+    /// Toggle the editing view ↔ Read (the View-menu ⌘E item and the toolbar
+    /// button). With source mode on the editing view is Source, so this flips
+    /// Source ↔ Read; otherwise Edit ↔ Read.
+    @objc func toggleViewMode(_ sender: Any?) {
+        setViewMode(editor.viewMode == .reading ? editingMode : .reading)
+    }
+
+    /// One mode menu item: icon + title, checked when `on`.
+    private func menuItem(_ title: String, _ image: NSImage?,
+                          _ action: Selector, on: Bool) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
         item.target = self
-        item.image = icon(for: mode)
-        item.state = (editor?.viewMode == mode) ? .on : .off
+        item.image = image
+        item.state = on ? .on : .off
         return item
+    }
+
+    /// The right-click menu: Edit / Read selection, a divider, then the
+    /// "Source mode" checkbox. Built fresh each time so state stays current.
+    fileprivate func viewModeMenu() -> NSMenu {
+        let menu = NSMenu()
+        menu.autoenablesItems = false   // actions always fire on selection
+        let inEditing = editor?.viewMode != .reading
+        menu.addItem(menuItem("Edit", icon(for: .edit),
+                              #selector(selectEditMode(_:)), on: inEditing))
+        menu.addItem(menuItem("Read", icon(for: .reading),
+                              #selector(selectReadingMode(_:)), on: !inEditing))
+        menu.addItem(.separator())
+        menu.addItem(menuItem("Source mode", icon(for: .source),
+                              #selector(toggleSourceMode(_:)), on: AppSettings.sourceMode))
+        return menu
     }
 
     // MARK: - Writing
@@ -467,15 +497,14 @@ extension Document: NSToolbarDelegate {
         item.label = "View Mode"
         item.visibilityPriority = .high
 
-        // Left-click toggles Edit↔Read; right-click drops the full mode menu
-        // (built on demand via menuNeedsUpdate so the checkmark stays current).
-        let button = NSButton(image: NSImage(), target: self,
-                              action: #selector(toggleViewMode(_:)))
+        // Left-click toggles the editing view ↔ Read; right-click drops the
+        // full mode menu (the button pops it itself so it isn't shadowed by the
+        // toolbar's own "Customize Toolbar…" context menu).
+        let button = ViewModeButton(image: NSImage(), target: self,
+                                    action: #selector(toggleViewMode(_:)))
         button.bezelStyle = .texturedRounded
         button.imagePosition = .imageOnly
-        let menu = NSMenu()
-        menu.delegate = self
-        button.menu = menu
+        button.menuProvider = { [weak self] in self?.viewModeMenu() }
         viewModeButton = button
         item.view = button
         refreshViewModeButton()
@@ -483,17 +512,16 @@ extension Document: NSToolbarDelegate {
     }
 }
 
-// MARK: - View-mode context menu
+/// Toolbar button whose right-click shows the view-mode menu directly, rather
+/// than letting the event bubble up to the toolbar's "Customize Toolbar…" menu.
+private final class ViewModeButton: NSButton {
+    var menuProvider: (() -> NSMenu?)?
 
-extension Document: NSMenuDelegate {
-    /// Rebuilds the right-click mode menu — Edit / Read / ─── / Source, with the
-    /// active mode checked — each time it opens.
-    func menuNeedsUpdate(_ menu: NSMenu) {
-        menu.autoenablesItems = false   // actions always fire on selection
-        menu.removeAllItems()
-        menu.addItem(viewModeMenuItem(.edit, #selector(selectEditMode(_:))))
-        menu.addItem(viewModeMenuItem(.reading, #selector(selectReadingMode(_:))))
-        menu.addItem(.separator())
-        menu.addItem(viewModeMenuItem(.source, #selector(selectSourceMode(_:))))
+    override func rightMouseDown(with event: NSEvent) {
+        guard let menu = menuProvider?() else {
+            super.rightMouseDown(with: event)
+            return
+        }
+        NSMenu.popUpContextMenu(menu, with: event, for: self)
     }
 }

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -418,11 +418,27 @@ class Document: NSDocument, HeadingNavigable {
     @objc private func selectEditMode(_ sender: Any?)    { setViewMode(editingMode) }
     @objc private func selectReadingMode(_ sender: Any?) { setViewMode(.reading) }
 
-    /// The "Source mode" checkbox. Persists the setting and, if we're in the
-    /// editing view, swaps it to the new editing mode right away.
-    @objc private func toggleSourceMode(_ sender: Any?) {
+    /// The "Source mode" checkbox (button menu and View menu). Persists the
+    /// setting and, if we're in the editing view, swaps it to the new editing
+    /// mode right away.
+    @objc func toggleSourceMode(_ sender: Any?) {
         AppSettings.sourceMode.toggle()
         if editor.viewMode != .reading { setViewMode(editingMode) }
+    }
+
+    /// Pops the right-click mode menu under the toolbar button.
+    @objc private func showViewModeMenu(_ sender: NSGestureRecognizer) {
+        guard let view = sender.view else { return }
+        viewModeMenu().popUp(positioning: nil,
+                             at: NSPoint(x: 0, y: view.bounds.maxY + 4), in: view)
+    }
+
+    /// Keeps the View-menu "Source Mode" checkmark in sync with the setting.
+    override func validateMenuItem(_ item: NSMenuItem) -> Bool {
+        if item.action == #selector(toggleSourceMode(_:)) {
+            item.state = AppSettings.sourceMode ? .on : .off
+        }
+        return super.validateMenuItem(item)
     }
 
     /// Toggle the editing view ↔ Read (the View-menu ⌘E item and the toolbar
@@ -497,31 +513,21 @@ extension Document: NSToolbarDelegate {
         item.label = "View Mode"
         item.visibilityPriority = .high
 
-        // Left-click toggles the editing view ↔ Read; right-click drops the
-        // full mode menu (the button pops it itself so it isn't shadowed by the
-        // toolbar's own "Customize Toolbar…" context menu).
-        let button = ViewModeButton(image: NSImage(), target: self,
-                                    action: #selector(toggleViewMode(_:)))
+        // Left-click toggles the editing view ↔ Read. Right-click shows the
+        // full mode menu — via a gesture recognizer, which claims the secondary
+        // click before the toolbar's own "Customize Toolbar…" context menu does
+        // (overriding rightMouseDown on the view loses that race).
+        let button = NSButton(image: NSImage(), target: self,
+                              action: #selector(toggleViewMode(_:)))
         button.bezelStyle = .texturedRounded
         button.imagePosition = .imageOnly
-        button.menuProvider = { [weak self] in self?.viewModeMenu() }
+        let secondaryClick = NSClickGestureRecognizer(
+            target: self, action: #selector(showViewModeMenu(_:)))
+        secondaryClick.buttonMask = 0x2   // right / secondary button
+        button.addGestureRecognizer(secondaryClick)
         viewModeButton = button
         item.view = button
         refreshViewModeButton()
         return item
-    }
-}
-
-/// Toolbar button whose right-click shows the view-mode menu directly, rather
-/// than letting the event bubble up to the toolbar's "Customize Toolbar…" menu.
-private final class ViewModeButton: NSButton {
-    var menuProvider: (() -> NSMenu?)?
-
-    override func rightMouseDown(with event: NSEvent) {
-        guard let menu = menuProvider?() else {
-            super.rightMouseDown(with: event)
-            return
-        }
-        NSMenu.popUpContextMenu(menu, with: event, for: self)
     }
 }

--- a/Sources/edmd/App/FormatMenu.swift
+++ b/Sources/edmd/App/FormatMenu.swift
@@ -70,11 +70,11 @@ enum FormatMenu {
         return formatItem
     }
 
-    /// The "Cycle View Mode" item (⌘E) for the View menu — bracketed by
+    /// The "Toggle View Mode" item (⌘E) for the View menu — bracketed by
     /// dividers by the caller.
-    static func viewModeCycleItem() -> NSMenuItem {
-        MenuCommand(id: "view.cycleMode", title: "Cycle View Mode",
-                    action: #selector(Document.cycleViewMode(_:)),
+    static func viewModeToggleItem() -> NSMenuItem {
+        MenuCommand(id: "view.toggleMode", title: "Toggle View Mode",
+                    action: #selector(Document.toggleViewMode(_:)),
                     shortcut: .cmd("e")).makeItem()
     }
 

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -267,9 +267,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
             keyEquivalent: "")
         typewriterItem.state = AppDelegate.typewriterModeEnabled() ? .on : .off
 
-        // View-mode toggle (Edit ↔ Read), bracketed by dividers.
+        // View-mode toggle (Edit ↔ Read) + the Source-mode checkbox.
         viewMenu.addItem(.separator())
         viewMenu.addItem(FormatMenu.viewModeToggleItem())
+        viewMenu.addItem(withTitle: "Source Mode",
+                         action: #selector(Document.toggleSourceMode(_:)),
+                         keyEquivalent: "")
         viewMenu.addItem(.separator())
 
         // Routes through the responder chain to the key window's toolbar.

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -267,10 +267,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
             keyEquivalent: "")
         typewriterItem.state = AppDelegate.typewriterModeEnabled() ? .on : .off
 
-        // View-mode cycle (Edit → Read → Source), bracketed by dividers.
+        // View-mode toggle (Edit ↔ Read), bracketed by dividers.
         viewMenu.addItem(.separator())
-        viewMenu.addItem(FormatMenu.viewModeCycleItem())
+        viewMenu.addItem(FormatMenu.viewModeToggleItem())
         viewMenu.addItem(.separator())
+
+        // Routes through the responder chain to the key window's toolbar.
+        viewMenu.addItem(withTitle: "Customize Toolbar…",
+                         action: #selector(NSWindow.runToolbarCustomizationPalette(_:)),
+                         keyEquivalent: "")
 
         viewMenuItem.submenu = viewMenu
         mainMenu.addItem(viewMenuItem)

--- a/Sources/edmd/Settings/AppSettings.swift
+++ b/Sources/edmd/Settings/AppSettings.swift
@@ -102,6 +102,7 @@ enum AppSettings {
         static let diagnosticLogging = "settings.general.diagnosticLogging"
         static let logRetention = "settings.general.logRetention"
         static let renderBlankLinesAsBreaks = "settings.reading.renderBlankLinesAsBreaks"
+        static let sourceMode = "settings.view.sourceMode"
     }
 
     /// Text-column width as a fraction of the available width (`0...1`). `1`
@@ -121,6 +122,14 @@ enum AppSettings {
     static var reopenWindows: Bool {
         get { UserDefaults.standard.bool(forKey: Key.reopenWindows) }
         set { UserDefaults.standard.set(newValue, forKey: Key.reopenWindows) }
+    }
+
+    /// Source mode: an alternate form of Edit mode that shows the raw markdown.
+    /// When on, the editing half of the view-mode toggle is Source instead of
+    /// Edit (so the toggle flips Source ↔ Read). Defaults off.
+    static var sourceMode: Bool {
+        get { UserDefaults.standard.bool(forKey: Key.sourceMode) }
+        set { UserDefaults.standard.set(newValue, forKey: Key.sourceMode) }
     }
 
     /// Read mode: render runs of blank lines as proportional vertical space

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -161,7 +161,16 @@ use a nil target and route through the responder chain to the focused
 actions funnel through two primitives in `+FormattingCore.swift`
 (`applyFormattingEdit` for a single contiguous edit, modeled on the Tab-indent
 path; `applyWholeDocumentEdit` for non-contiguous edits like footnotes). The
-View-menu ⌘E item cycles Edit→Read→Source via `Document.cycleViewMode`.
+View-menu ⌘E item (and the toolbar button) *toggles* the editing view ↔ Read
+via `Document.toggleViewMode`. **Source is not a third toggle stop** — it's a
+persisted preference (`AppSettings.sourceMode`, a "Source Mode" checkbox in the
+View menu and the toolbar button's right-click menu): when on, the editing half
+of the toggle is Source instead of Edit (so ⌘E flips Source ↔ Read), and a
+freshly opened document honors it. The toolbar's view-mode button left-clicks to
+toggle and right-clicks for the full mode menu (see the §8 gotcha on why that
+right-click is intercepted in `DocumentWindow.sendEvent`). The toolbar enables
+`allowsUserCustomization` (Customize Toolbar… is an AppKit `NSToolbar` feature,
+not a SwiftUI one).
 
 **Read mode is a separate WKWebView**, not an editor styling mode. Entering
 `.reading` swaps the editor's scroll view for a `ReadModeWebView` that renders
@@ -259,6 +268,18 @@ them and route through the app's document graph without JavaScript.
   `+SelectionTracking`). `becomeFirstResponder` resyncs from storage as a
   catch-all if a composition is ever left stranded. Full write-up:
   `docs/delete-drift-investigation.md`.
+- **A custom toolbar item can't win a right-click from a view-level handler.**
+  With `NSToolbar.allowsUserCustomization = true`, the toolbar turns any
+  secondary (right / control) click over the toolbar — *including* a custom item
+  view — into its own "Customize Toolbar…" context menu. Setting the view's
+  `menu`, overriding `rightMouseDown`, and a secondary-button
+  `NSClickGestureRecognizer` **all lose**, because the toolbar claims the click
+  downstream of them. The fix (view-mode button): intercept in
+  `DocumentWindow.sendEvent(_:)` — the documented funnel every window event
+  passes through *before* the toolbar acts — and when the click falls inside the
+  button's bounds, pop the menu and `return` (swallow it). Other right-clicks
+  fall through to `super`. (Caveat: in true fullscreen the toolbar moves to a
+  separate window, so this main-window hook wouldn't cover that case.)
 
 ---
 


### PR DESCRIPTION
## What

Reworks the window toolbar's view-mode control and enables toolbar customization.

- **Toggle button, not a dropdown.** The toolbar button left-clicks to toggle the editing view ↔ Read; the up/down chevron affordance is gone. Right-clicking the button shows the full mode menu (**Edit / Read / ─── / Source Mode**).
- **"Toggle View Mode"** replaces "Cycle View Mode" (⌘E) — it flips the editing view ↔ Read rather than cycling through three stops.
- **Source is now a persisted preference** (`AppSettings.sourceMode`), surfaced as a **"Source Mode" checkbox** in both the View menu and the button's right-click menu. When on, the editing half of the toggle is Source (so ⌘E flips Source ↔ Read), and a freshly opened document honors the saved setting.
- **Customize Toolbar… enabled** via `NSToolbar.allowsUserCustomization` (it's an AppKit feature — no SwiftUI rewrite needed) plus a View-menu item, with `autosavesConfiguration` to persist layout.
- **Smaller icons** — mode glyphs render at 13pt (book was oversized at 16pt); the wider `</>` source glyph at 11pt to match.

## Why the right-click needed a window-level hook

With `allowsUserCustomization` on, the toolbar turns any secondary click over the toolbar — including a custom item view — into its own "Customize Toolbar…" menu. A view's `menu`, a `rightMouseDown` override, and a secondary-button gesture recognizer all lose that race. The fix intercepts in `DocumentWindow.sendEvent(_:)` — the documented funnel every window event passes through *before* the toolbar acts — popping the mode menu and swallowing the click only when it lands inside the button. Documented as a gotcha in `docs/ARCHITECTURE.md`.

## Testing

- `swift test` — 749 pass.
- Verified visually: icon sizes, source-mode-on-open, and the right-click menu (confirmed working with a real mouse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)