### PR TITLE
Disable text completion / inline predictions to close delete-drift source

### DIFF
--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -222,6 +222,16 @@ public class EditorTextView: NSTextView {
         isAutomaticDashSubstitutionEnabled = false
         isAutomaticTextReplacementEnabled = false
         isAutomaticSpellingCorrectionEnabled = false
+        // Completion and inline predictions inject provisional MARKED text as you
+        // type (not just CJK/accent/emoji input). If such a composition is
+        // interrupted — a caret move, a focus change — it can be left stranded
+        // (`hasMarkedText()` stuck true), which permanently breaks the
+        // storage==rawSource sync in `didChangeText` and drifts the caret on every
+        // edit (see docs/delete-drift-investigation.md). A live-preview markdown
+        // editor needs neither, and we already disable the other auto-substitutions
+        // above — so close this marked-text source too.
+        isAutomaticTextCompletionEnabled = false
+        if #available(macOS 14.0, *) { inlinePredictionType = .no }
         allowsUndo = false
 
         textAntialias = theme.antialias
@@ -367,6 +377,14 @@ public class EditorTextView: NSTextView {
 
     func recoverFromStrandedCompositionIfNeeded() {
         guard let ts = textStorage, ts.string != rawSource else { return }
+        // Rare and high-signal: this only fires when focus returns to a desynced
+        // editor. The flag snapshot tells us *why* the sync was stranded the next
+        // time the bug appears (marked text vs a leaked isUpdating/isUndoRedoing).
+        Log.info("""
+            recovered stranded desync on focus regain: hasMarked=\(hasMarkedText()) \
+            isUpdating=\(isUpdating) isUndoRedoing=\(isUndoRedoing) \
+            storageΔ=\((ts.string as NSString).length - (rawSource as NSString).length)
+            """, category: .compose)
         if hasMarkedText() { unmarkText() }
         rawSource = ts.string
         rebuildListIndentState()

--- a/docs/delete-drift-investigation.md
+++ b/docs/delete-drift-investigation.md
@@ -136,6 +136,34 @@ it would false-fire on every IME keystroke.
 3. The `becomeFirstResponder` recovery should still unstick it on focus regain;
    if it doesn't, confirm the override is being called and that
    `recoverFromStrandedCompositionIfNeeded` isn't guarded out.
-4. To get live signal, temporarily log `hasMarkedText()` and
-   `textStorage.string == rawSource` in `didChangeText` (category `.compose`),
-   reproduce, and read `~/.edmund/logs`.
+4. To get live signal, read `~/.edmund/logs` for the
+   `recovered stranded desync on focus regain: …` line — it's emitted (release
+   too, `Log.info`) whenever focus-regain recovers a desync and snapshots
+   `hasMarked` / `isUpdating` / `isUndoRedoing`, which tells you the cause.
+
+## Follow-up: recurred without deliberate IME (round 2)
+
+It came back — reportedly **without** CJK IME / accents / emoji — and clicking
+away and back still fixed it. That second clue narrows the cause by elimination:
+
+- The recovery hook only acts when `storage != rawSource`, and it *did* fix it,
+  so the edit **reached storage** → `shouldChangeText` returned `true` →
+  `isUpdating` was **false** at edit time (it's the only flag that makes
+  `shouldChangeText` return `false`). So `isUpdating` stuck-true is **excluded**
+  (it would make edits do nothing, not drift).
+- That leaves `didChangeText` bailing on `isUndoRedoing` or `hasMarkedText`. A
+  stuck `isUndoRedoing` is **excluded** too: the recovery doesn't reset it, so it
+  would re-break on the very next keystroke rather than be durably fixed by a
+  focus switch.
+- By elimination it is **still stranded marked text** — `unmarkText()` in the
+  recovery is what durably clears it. The composition just came from a source the
+  user doesn't think of as "IME": most likely **automatic text completion /
+  inline predictions**, which inject provisional marked text as you type and were
+  still enabled (every *other* auto-substitution was already off).
+
+**Fix (round 2):** disable the remaining marked-text sources in `commonInit`
+(`EditorTextView.swift`) — `isAutomaticTextCompletionEnabled = false` and, on
+macOS 14+, `inlinePredictionType = .no` — matching the four auto-substitutions
+already disabled there. Kept a permanent `Log.info` in
+`recoverFromStrandedCompositionIfNeeded` so any *future* recurrence records which
+guard stranded the sync (the first thing to grep for if it happens again).


### PR DESCRIPTION
Follow-up to #123. The delete-drift bug recurred **without** any deliberate CJK IME / accent / emoji input, and clicking away and back still fixed it.

## Why it's still marked text (by elimination)

- The focus-regain recovery only acts when `storage != rawSource`, and it *did* fix it → the edit reached storage → `shouldChangeText` returned `true` → `isUpdating` was **false** (it's the only flag that makes `shouldChangeText` return false). So a stuck `isUpdating` is excluded (it would make edits do nothing, not drift).
- That leaves `didChangeText` bailing on `isUndoRedoing` or `hasMarkedText`. A stuck `isUndoRedoing` isn't reset by the recovery, so it would re-break on the next keystroke instead of being durably fixed by a focus switch — excluded.
- So it's **stranded marked text from a non-obvious source**. Automatic text completion and inline predictions inject provisional marked text as you type and were still enabled, while every other auto-substitution was already disabled in `commonInit`.

## Change

- `EditorTextView.commonInit`: `isAutomaticTextCompletionEnabled = false` and, on macOS 14+, `inlinePredictionType = .no` — matching the four auto-substitutions already disabled there, closing the remaining marked-text source.
- `recoverFromStrandedCompositionIfNeeded`: keep a permanent `Log.info` snapshotting `hasMarked`/`isUpdating`/`isUndoRedoing` so any future recurrence records which guard stranded the sync (first thing to grep in `~/.edmund/logs`).
- `docs/delete-drift-investigation.md`: documented the round-2 elimination reasoning and fix.

## Tests

All 749 pass. The actual stranding can't be reproduced headlessly (no live `NSTextInputContext`), so this is verified by reasoning + the existing recovery regression test from #123; the permanent log is there to confirm on any recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)