### PR TITLE
Add opt-in crash-log uploading (UI dormant pending server)

### DIFF
--- a/Sources/EdmundCore/Diagnostics/CrashReporter.swift
+++ b/Sources/EdmundCore/Diagnostics/CrashReporter.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+// MARK: - Crash report uploading
+//
+// Opt-in (default off), best-effort uploading of the crash reports macOS writes
+// for Edmund. On launch — when the user has enabled it — we read the per-user
+// `.ips` reports the OS dropped in ~/Library/Logs/DiagnosticReports/ and POST any
+// we haven't sent before.
+//
+// Why read `.ips` files rather than MetricKit's `MXCrashDiagnostic`? It's the
+// simplest path that yields the *full* report (not just a call-stack payload),
+// is available immediately on the next launch, and needs no framework wiring.
+// The tradeoff: it relies on direct filesystem access, which only works because
+// Edmund is **not sandboxed** (no entitlements file). If App Sandbox is ever
+// adopted, this directory becomes unreadable and we'd switch to MetricKit.
+//
+// PII note: `.ips` reports embed the user's home path (and so their account
+// name), the device model, and the OS version. We send them as-is — acceptable
+// for crash-fix use, which the Settings note states plainly. Revisit if scope
+// changes.
+
+public enum CrashReporter {
+
+    /// Placeholder ingestion endpoint. Nothing is ever sent against this in the
+    /// shipped build (the feature toggle is off and its UI is commented out);
+    /// replace this with the real server before exposing the toggle.
+    static let reportingEndpoint = URL(string: "https://REPLACE-ME.invalid/crash")!  // TODO: real server
+
+    /// macOS crash reports are named `<executable>-<timestamp>.ips`. Our Mach-O
+    /// executable is `edmd` (see `main.swift`), so that's the filename prefix.
+    public static let processPrefix = "edmd"
+
+    /// Where macOS writes this user's crash reports.
+    public static var diagnosticReportsDirectory: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Logs/DiagnosticReports", isDirectory: true)
+    }
+
+    /// Pure and testable: the `.ips` crash reports in `directory` that belong to
+    /// our process and haven't been sent yet, sorted by name (oldest-ish first)
+    /// for deterministic order.
+    public static func pendingReports(in directory: URL,
+                                      processPrefix: String = processPrefix,
+                                      alreadySent: Set<String>) -> [URL] {
+        let fm = FileManager.default
+        guard let urls = try? fm.contentsOfDirectory(
+            at: directory, includingPropertiesForKeys: nil) else { return [] }
+        return urls.filter { url in
+            url.pathExtension == "ips"
+                && url.lastPathComponent.hasPrefix(processPrefix)
+                && !alreadySent.contains(url.lastPathComponent)
+        }.sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
+    /// Scan the real DiagnosticReports directory and POST any crash reports not in
+    /// `alreadySent`. Fire-and-forget — returns immediately and never blocks the
+    /// caller. `onSent` is invoked on the main actor with each filename that
+    /// uploaded successfully, so the caller can record it and avoid resending.
+    public static func uploadPendingReports(alreadySent: Set<String>,
+                                            onSent: @escaping @MainActor (String) -> Void) {
+        let pending = pendingReports(in: diagnosticReportsDirectory, alreadySent: alreadySent)
+        guard !pending.isEmpty else { return }
+        for url in pending { upload(url, onSent: onSent) }
+    }
+
+    private static func upload(_ url: URL,
+                               onSent: @escaping @MainActor (String) -> Void) {
+        guard let data = try? Data(contentsOf: url) else { return }
+        let name = url.lastPathComponent
+        var request = URLRequest(url: reportingEndpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        request.setValue(name, forHTTPHeaderField: "X-Crash-Report-Name")
+        let task = URLSession.shared.uploadTask(with: request, from: data) { _, response, error in
+            guard error == nil,
+                  let http = response as? HTTPURLResponse,
+                  (200..<300).contains(http.statusCode) else { return }
+            Task { @MainActor in onSent(name) }
+        }
+        task.resume()
+    }
+}

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -36,6 +36,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         AppSettings.applyAppearance()
         setupMenuBar()
 
+        // Opt-in (default off): upload any crash reports macOS wrote for us since
+        // last launch. Fire-and-forget; never blocks startup.
+        if AppSettings.sendCrashLogs {
+            CrashReporter.uploadPendingReports(
+                alreadySent: AppSettings.sentCrashReports,
+                onSent: { AppSettings.sentCrashReports.insert($0) })
+        }
+
         // Open file from command-line argument. When a file is given,
         // `applicationShouldOpenUntitledFile` suppresses the otherwise-automatic
         // blank document, so we don't end up with two windows.

--- a/Sources/edmd/Settings/AdvancedSettingsView.swift
+++ b/Sources/edmd/Settings/AdvancedSettingsView.swift
@@ -6,6 +6,10 @@ struct AdvancedSettingsView: View {
     private var autoCheckUpdates = true
     @AppStorage(AppSettings.Key.diagnosticLogging) private var diagnosticLogging = true
     @AppStorage(AppSettings.Key.logRetention) private var logRetention = AppSettings.LogRetention.twoWeeks
+    // Crash-log sending is dormant until the receiving server exists — the toggle
+    // is hidden (commented out below) so it isn't offered with nowhere to send to.
+    // Uncomment this and the "Crash reports:" GridRow once the server is live.
+    // @AppStorage(AppSettings.Key.sendCrashLogs) private var sendCrashLogs = false
     @State private var showingWarnings = false
 
     var body: some View {
@@ -45,6 +49,23 @@ struct AdvancedSettingsView: View {
                         .padding(.leading, 20)
                 }
             }
+
+            // Dormant until the crash-report server exists (see note above and
+            // CrashReporter). The launch-time upload path and the `sendCrashLogs`
+            // setting stay in place but inert (default off); only this UI is hidden.
+            // GridRow {
+            //     Text("Crash reports:")
+            //         .gridColumnAlignment(.trailing)
+            //     VStack(alignment: .leading, spacing: 6) {
+            //         Toggle("Automatically send crash logs", isOn: $sendCrashLogs)
+            //         Text("Crash logs are sent only to us and will be used and stored for crash fix purposes only.")
+            //             .foregroundStyle(.secondary)
+            //             .controlSize(.small)
+            //             .fixedSize(horizontal: false, vertical: true)
+            //             .frame(width: 380, alignment: .leading)
+            //             .padding(.leading, 20)
+            //     }
+            // }
 
             GridRow {
                 Text("Dialog warnings:")

--- a/Sources/edmd/Settings/AppSettings.swift
+++ b/Sources/edmd/Settings/AppSettings.swift
@@ -103,6 +103,8 @@ enum AppSettings {
         static let logRetention = "settings.general.logRetention"
         static let renderBlankLinesAsBreaks = "settings.reading.renderBlankLinesAsBreaks"
         static let sourceMode = "settings.view.sourceMode"
+        static let sendCrashLogs = "settings.advanced.sendCrashLogs"
+        static let sentCrashReports = "settings.advanced.sentCrashReports"
     }
 
     /// Text-column width as a fraction of the available width (`0...1`). `1`
@@ -202,6 +204,26 @@ enum AppSettings {
             return UserDefaults.standard.bool(forKey: Key.diagnosticLogging)
         }
         set { UserDefaults.standard.set(newValue, forKey: Key.diagnosticLogging) }
+    }
+
+    /// Whether to auto-send crash reports on launch. Opt-in: defaults off, since
+    /// it sends data off-device. (UI currently commented out — see
+    /// AdvancedSettingsView — until the receiving server exists.)
+    static var sendCrashLogs: Bool {
+        get { UserDefaults.standard.bool(forKey: Key.sendCrashLogs) }
+        set { UserDefaults.standard.set(newValue, forKey: Key.sendCrashLogs) }
+    }
+
+    /// Filenames of crash reports already uploaded, so we don't resend them.
+    /// Bounded on write by dropping entries whose `.ips` file no longer exists.
+    static var sentCrashReports: Set<String> {
+        get { Set(UserDefaults.standard.stringArray(forKey: Key.sentCrashReports) ?? []) }
+        set {
+            let onDisk = (try? FileManager.default.contentsOfDirectory(
+                atPath: CrashReporter.diagnosticReportsDirectory.path)).map(Set.init) ?? []
+            let pruned = onDisk.isEmpty ? newValue : newValue.intersection(onDisk)
+            UserDefaults.standard.set(Array(pruned), forKey: Key.sentCrashReports)
+        }
     }
 
     static var logRetention: LogRetention {

--- a/Tests/EdmundTests/CrashReporterTests.swift
+++ b/Tests/EdmundTests/CrashReporterTests.swift
@@ -1,0 +1,59 @@
+import Testing
+import Foundation
+@testable import EdmundCore
+
+/// Crash-report discovery: picks up our process's `.ips` files, ignores everything
+/// else, and skips ones already uploaded. (The upload path itself is network I/O
+/// and isn't exercised here.)
+@Suite("Crash report discovery")
+struct CrashReporterTests {
+
+    /// A fresh temp directory seeded with the given filenames (empty files).
+    private func tempDir(files: [String]) -> URL {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory
+            .appendingPathComponent("edmund-crashtest-\(UUID().uuidString)", isDirectory: true)
+        try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        for name in files {
+            fm.createFile(atPath: dir.appendingPathComponent(name).path, contents: Data())
+        }
+        return dir
+    }
+
+    @Test("Selects edmd .ips reports, ignores other processes and non-.ips files")
+    func selectsOurReports() {
+        let dir = tempDir(files: [
+            "edmd-2026-06-27-120000.ips",     // ours
+            "edmd-2026-06-26-090000.ips",     // ours
+            "Safari-2026-06-27-120000.ips",   // other process
+            "edmd-2026-06-27.log",            // not a crash report
+            "edmd-notes.txt",                 // not .ips
+        ])
+
+        let names = CrashReporter.pendingReports(in: dir, alreadySent: [])
+            .map(\.lastPathComponent)
+
+        #expect(names == ["edmd-2026-06-26-090000.ips", "edmd-2026-06-27-120000.ips"])
+    }
+
+    @Test("Skips reports already sent")
+    func skipsAlreadySent() {
+        let dir = tempDir(files: [
+            "edmd-2026-06-27-120000.ips",
+            "edmd-2026-06-26-090000.ips",
+        ])
+
+        let names = CrashReporter.pendingReports(
+            in: dir, alreadySent: ["edmd-2026-06-26-090000.ips"]
+        ).map(\.lastPathComponent)
+
+        #expect(names == ["edmd-2026-06-27-120000.ips"])
+    }
+
+    @Test("Missing directory yields no reports")
+    func missingDirectory() {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("edmund-crashtest-missing-\(UUID().uuidString)")
+        #expect(CrashReporter.pendingReports(in: dir, alreadySent: []).isEmpty)
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,7 +11,7 @@ or change an invariant, edit this file in the same PR.
 
 ```bash
 swift build                 # debug build of both targets
-swift test                  # full suite (≈630+ tests, ~10s)
+swift test                  # full suite (≈750+ tests, ~10s)
 swift test --filter Callout # one suite
 ./scripts/build-app.sh      # builds build/Edmund.app (release + bundles + icon + codesign)
 ```
@@ -142,6 +142,7 @@ rawSource ──BlockParser──▶ [Block]  ──styleBlock per block──�
 | Lazy/compose/undo/scroll | `TextView/EditorTextView+{Composition,LazyStyling,Undo,TypewriterScroll,SelectionTracking,ContentWidth,EditFlow}.swift` |
 | App shell | `edmd/App/{main,Document,DocumentController}.swift`; menu bar in `main.swift` `setupMenuBar()` + `FormatMenu.swift`; Sparkle `SPUStandardUpdaterController` in `AppDelegate` |
 | Settings (SwiftUI) | `edmd/Settings/*` (AppSettings = UserDefaults keys; FontSettings; Appearance/General/Advanced views) |
+| Crash-log uploading | `EdmundCore/Diagnostics/CrashReporter.swift` (see §7) |
 | Auto-update | Sparkle 2.x. `Info.plist`: `SUFeedURL` (raw GitHub URL to `appcast.xml`), `SUPublicEDKey` (ed25519 public key). `scripts/release.sh`: build → DMG (sindresorhus `create-dmg`, **npm** — not the homebrew tool) → EdDSA sign → update appcast → `gh release create`. The DMG is the Sparkle enclosure (it mounts the image and installs the `.app` inside). CI: `.github/workflows/release.yml` (tag-triggered). One-time setup: generate the EdDSA keypair with `generate_keys` (§8). |
 | Status bar | `edmd/Views/StatusBarView.swift` |
 | Build/packaging | `scripts/build-app.sh` (release build + Sparkle.framework embedding + signing), `Package.swift`, `Info.plist`, `Resources/` |
@@ -210,6 +211,18 @@ them and route through the app's document graph without JavaScript.
   user only toggles it on/off and picks a retention window (Settings ▸ General ▸
   Diagnostics). `AppSettings.applyLogging()` pushes the toggle/retention into
   `Log.configure` at launch and on change; retention is pruned there.
+- **Crash-log uploading** (`EdmundCore/Diagnostics/CrashReporter.swift`): opt-in
+  (default off), fire-and-forget upload of the `.ips` crash reports macOS writes
+  to `~/Library/Logs/DiagnosticReports/`. On launch, if `AppSettings.sendCrashLogs`
+  is true, we POST any `edmd-*.ips` files not in `AppSettings.sentCrashReports`
+  (dedup) to `CrashReporter.reportingEndpoint`. Note: `edmd` is the Mach-O
+  executable name (not "Edmund") — that's the prefix in crash-report filenames.
+  **The Settings ▸ Advanced toggle is currently commented out** (the `// Crash
+  reports:` GridRow in `AdvancedSettingsView.swift`); uncomment it and replace the
+  placeholder `reportingEndpoint` URL once the receiving server exists. The upload
+  path reads `~/Library/Logs/DiagnosticReports/` directly, which only works
+  because the app is not sandboxed; if App Sandbox is ever adopted, switch to
+  MetricKit's `MXCrashDiagnostic` API instead.
 
 ---
 


### PR DESCRIPTION
## What

Adds infrastructure for automatically sending crash logs to the developer, gated behind an opt-in setting that defaults **off**.

**Apple's free offerings don't cover this fully:** macOS writes `.ips` crash reports for free (readable in Xcode Organizer), but there's no free private ingestion endpoint — Organizer routes through Apple and is gated by a system-wide user setting the in-app checkbox can't control. So capture is free; the destination has to be our own server.

## How

- **`EdmundCore/Diagnostics/CrashReporter.swift`** — reads `edmd-*.ips` from `~/Library/Logs/DiagnosticReports/` on launch and POSTs new ones to a placeholder endpoint. Pure, testable discovery/dedup separated from the upload side effect. Works because the app is not sandboxed; a comment flags the MetricKit fallback path if App Sandbox is ever adopted.
- **`AppSettings`** — `sendCrashLogs` key (default **off**) + `sentCrashReports` dedup record.
- **`applicationDidFinishLaunching`** — gated, fire-and-forget upload call; never blocks startup.
- **Settings ▸ Advanced** — "Automatically send crash logs" toggle + "Crash logs are sent only to us and will be used and stored for crash fix purposes only." note, built and visually verified, then **commented out** so the feature ships dormant until the receiving server exists.
- **3 new tests** in `CrashReporterTests` covering discovery, filtering, and dedup.
- **`docs/ARCHITECTURE.md`** updated: §1 test count, §6 feature map, §7 crash-log entry.

## To activate later

1. Stand up a receiving endpoint.
2. Replace `CrashReporter.reportingEndpoint` (marked `// TODO: real server`).
3. Uncomment the `@AppStorage` line and `// Crash reports:` `GridRow` in `AdvancedSettingsView.swift`.

## Test plan

- [x] `swift test` — 752/752 pass (includes 3 new `CrashReporterTests`)
- [x] Visual: screencaptured the Advanced pane with the toggle visible (unchecked/off), layout matching the Diagnostics row
- [x] Dormancy: re-screencaptured after commenting out UI — row gone, pane resizes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)