### PR TITLE
Fix release signing: feed EdDSA key via --ed-key-file - (stdin)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,9 @@ jobs:
           SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
         run: |
           SIGN_UPDATE="$(find .build -name sign_update -type f | head -1)"
-          SIG_OUTPUT="$("$SIGN_UPDATE" -s "$SPARKLE_ED_PRIVATE_KEY" "build/Edmund-${VERSION}.dmg")"
+          # Pass the key on stdin via --ed-key-file -. The deprecated `-s <key>`
+          # is fatal for newly generated keys ("no longer supported").
+          SIG_OUTPUT="$(echo "$SPARKLE_ED_PRIVATE_KEY" | "$SIGN_UPDATE" --ed-key-file - "build/Edmund-${VERSION}.dmg")"
           echo "ED_SIG=$(echo "$SIG_OUTPUT" | grep -o 'sparkle:edSignature="[^"]*"')" >> "$GITHUB_ENV"
           echo "LENGTH=$(echo "$SIG_OUTPUT" | grep -o 'length="[^"]*"' | head -1)" >> "$GITHUB_ENV"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -56,8 +56,9 @@ fi
 
 # ── EdDSA signature ───────────────────────────────────────────────────────────
 if [ -n "${SPARKLE_ED_PRIVATE_KEY:-}" ]; then
-    # CI path: private key passed via env (base64 string, no keychain)
-    SIG_OUTPUT="$("$SIGN_UPDATE" -s "$SPARKLE_ED_PRIVATE_KEY" "$DMG")"
+    # CI path: private key from env, fed on stdin via --ed-key-file -.
+    # The deprecated `-s <key>` is fatal for newly generated keys.
+    SIG_OUTPUT="$(echo "$SPARKLE_ED_PRIVATE_KEY" | "$SIGN_UPDATE" --ed-key-file - "$DMG")"
 else
     # Local path: key lives in the login keychain (placed there by generate_keys)
     SIG_OUTPUT="$("$SIGN_UPDATE" "$DMG")"


### PR DESCRIPTION
The v0.1.0 release failed at the EdDSA signing step.

## Cause
`sign_update -s <key>` is now fatal for newly generated keys ("no longer
supported" per its own help) — it prints the deprecation warning and exits 1.

## Fix
Both the CI workflow and `scripts/release.sh` now pass the key on stdin via the
supported form:

```
echo "$SPARKLE_ED_PRIVATE_KEY" | sign_update --ed-key-file - <dmg>
```

Verified locally that this invocation is accepted (the flag parses; a real
64/96-byte key signs).

After merge, `v0.1.0` will be re-pointed at the fixed commit to re-trigger the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)