### PR TITLE
ci: push appcast to main via RELEASE_TOKEN PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ jobs:
         with:
           # Fetch full history so we can push the appcast commit back.
           fetch-depth: 0
+          # Admin PAT so the appcast commit can be pushed to the protected
+          # `main` branch. The default GITHUB_TOKEN/bot is not an admin and is
+          # blocked by the required `test` status check.
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:


### PR DESCRIPTION
## Problem
The release workflow publishes the signed DMG fine, but its final step — committing the updated `appcast.xml` back to `main` — fails:

```
GH006: Protected branch update failed for refs/heads/main.
Required status check "test" is expected.
```

The push runs as `github-actions[bot]` (default `GITHUB_TOKEN`), which isn't a repo admin, so `main`'s required `test` check blocks it. (The 0.1.0 feed was patched by hand; this fixes it for all future releases.)

## Fix
`main` has `enforce_admins: false`, so an admin's push bypasses the required check. Give the `checkout` step an admin fine-grained PAT (`secrets.RELEASE_TOKEN`); the existing `git push origin HEAD:main` then inherits those credentials and is allowed through.

Setting the **checkout token** (not rewriting the push URL) is deliberate: `actions/checkout` persists an `http.<host>.extraheader` credential that would otherwise override inline-URL creds and keep using the bot token.

## Required before next release
Repo owner must create a fine-grained PAT (Contents: read/write on `I7T5/Edmund`) and add it as the `RELEASE_TOKEN` repo secret. Only affects releases tagged after this merges; 0.1.0 is already out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)