### PR TITLE
ui: Thematic Break in Format menu

### DIFF
--- a/Sources/EdmundCore/Editing/EditorTextView+FormattingCommands.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+FormattingCommands.swift
@@ -85,6 +85,7 @@ extension EditorTextView {
     @objc public func formatNumberedList(_ sender: Any?)  { toggleNumberedList() }
     @objc public func formatChecklist(_ sender: Any?)     { toggleChecklist() }
     @objc public func formatBlockQuote(_ sender: Any?)    { toggleLinePrefix("> ") }
+    @objc public func formatThematicBreak(_ sender: Any?) { insertThematicBreak() }
     @objc public func formatCodeBlock(_ sender: Any?)     { insertCodeBlock() }
     @objc public func formatMathBlock(_ sender: Any?)     { insertMathBlock() }
     @objc public func formatTable(_ sender: Any?)         { insertTable() }
@@ -119,9 +120,9 @@ extension EditorTextView {
         #selector(formatInlineMath(_:)), #selector(formatKeyboard(_:)), #selector(formatComment(_:)),
         #selector(formatWikilink(_:)), #selector(formatLink(_:)), #selector(formatImage(_:)),
         #selector(formatFootnote(_:)), #selector(formatBulletedList(_:)), #selector(formatNumberedList(_:)),
-        #selector(formatChecklist(_:)), #selector(formatBlockQuote(_:)), #selector(formatCodeBlock(_:)),
-        #selector(formatMathBlock(_:)), #selector(formatTable(_:)), #selector(formatHeading(_:)),
-        #selector(formatCallout(_:)),
+        #selector(formatChecklist(_:)), #selector(formatBlockQuote(_:)), #selector(formatThematicBreak(_:)),
+        #selector(formatCodeBlock(_:)), #selector(formatMathBlock(_:)), #selector(formatTable(_:)),
+        #selector(formatHeading(_:)), #selector(formatCallout(_:)),
     ]
 
     // MARK: - Heading
@@ -424,6 +425,39 @@ extension EditorTextView {
         applyFormattingEdit(rawRange: NSRange(location: insertPos, length: 0),
                             replacement: replacement,
                             select: NSRange(location: caret, length: 0))
+    }
+
+    // MARK: - Thematic break
+
+    /// Thematic break (horizontal rule): inserts `---` on its own line after the
+    /// current line, preceded by a blank separator so it isn't parsed as a setext
+    /// heading underline. Toggle-off: if the selected line is exactly `---`, removes it.
+    ///
+    /// Caret lands after the `---\n` so the next paragraph can be typed immediately.
+    private func insertThematicBreak() {
+        let ns = rawSource as NSString
+        let ctx = selectedLineContext()
+
+        if ctx.lines == ["---"] {
+            // Toggle-off: remove the "---" line (ctx.range includes the trailing \n if any).
+            applyFormattingEdit(rawRange: ctx.range, replacement: "",
+                                select: NSRange(location: ctx.range.location, length: 0))
+            return
+        }
+
+        // Insert "\n---\n" after the current line end. If the current line has no
+        // trailing newline (last line, no EOF newline), prepend an extra \n so the
+        // "---" is separated from the previous content and not parsed as a setext heading.
+        let sel = selectedRange()
+        let line = ns.lineRange(for: NSRange(location: min(sel.location, ns.length), length: 0))
+        let hasTrailingNewline = line.upperBound > line.location
+            && ns.character(at: line.upperBound - 1) == 0x0A
+        let text = hasTrailingNewline ? "\n---\n" : "\n\n---\n"
+        let insertAt = line.upperBound
+        let caret = insertAt + (text as NSString).length
+        applyFormattingEdit(rawRange: NSRange(location: insertAt, length: 0),
+                            replacement: text,
+                            select: NSRange(location: min(caret, (rawSource as NSString).length), length: 0))
     }
 
     // MARK: - Callout / alert

--- a/Sources/EdmundCore/Editing/EditorTextView+FormattingCommands.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+FormattingCommands.swift
@@ -429,27 +429,39 @@ extension EditorTextView {
 
     // MARK: - Thematic break
 
-    /// Thematic break (horizontal rule): inserts `---` on its own line after the
-    /// current line, preceded by a blank separator so it isn't parsed as a setext
-    /// heading underline. Toggle-off: if the selected line is exactly `---`, removes it.
+    /// Thematic break (horizontal rule): inserts `---` on its own line.
+    /// Toggle-off: if the selected line is exactly `---`, removes it.
     ///
-    /// Caret lands after the `---\n` so the next paragraph can be typed immediately.
+    /// Insertion rules:
+    ///   • Empty line — replace the line with `---\n` (the caret is already on
+    ///     an isolated line, so no separator is needed).
+    ///   • Non-empty line — insert `\n---\n` after the line end; prepend an
+    ///     extra `\n` when the line has no trailing newline (last line, no EOF
+    ///     newline) so the `---` isn't parsed as a setext heading underline.
+    ///
+    /// Caret lands after `---\n` so the next paragraph can be typed immediately.
     private func insertThematicBreak() {
         let ns = rawSource as NSString
         let ctx = selectedLineContext()
 
         if ctx.lines == ["---"] {
-            // Toggle-off: remove the "---" line (ctx.range includes the trailing \n if any).
             applyFormattingEdit(rawRange: ctx.range, replacement: "",
                                 select: NSRange(location: ctx.range.location, length: 0))
             return
         }
 
-        // Insert "\n---\n" after the current line end. If the current line has no
-        // trailing newline (last line, no EOF newline), prepend an extra \n so the
-        // "---" is separated from the previous content and not parsed as a setext heading.
         let sel = selectedRange()
         let line = ns.lineRange(for: NSRange(location: min(sel.location, ns.length), length: 0))
+
+        // Empty line: replace just the line content with "---\n".
+        if ctx.lines == [""] {
+            let replacement = "---\n"
+            applyFormattingEdit(rawRange: ctx.range, replacement: replacement,
+                                select: NSRange(location: ctx.range.location + 3, length: 0))
+            return
+        }
+
+        // Non-empty line: insert after the line end.
         let hasTrailingNewline = line.upperBound > line.location
             && ns.character(at: line.upperBound - 1) == 0x0A
         let text = hasTrailingNewline ? "\n---\n" : "\n\n---\n"

--- a/Sources/edmd/App/FormatMenu.swift
+++ b/Sources/edmd/App/FormatMenu.swift
@@ -51,6 +51,7 @@ enum FormatMenu {
         let menu = NSMenu(title: "Format")
 
         menu.addItem(headingSubmenuItem())
+        menu.addItem(thematicBreakCommand.makeItem())
         menu.addItem(.separator())
 
         for cmd in listCommands { menu.addItem(cmd.makeItem()) }
@@ -61,7 +62,6 @@ enum FormatMenu {
 
         for cmd in blockCommands { menu.addItem(cmd.makeItem()) }
         menu.addItem(calloutSubmenuItem())
-        menu.addItem(thematicBreakCommand.makeItem())
         menu.addItem(footnoteCommand.makeItem())
         menu.addItem(.separator())
 

--- a/Sources/edmd/App/FormatMenu.swift
+++ b/Sources/edmd/App/FormatMenu.swift
@@ -61,6 +61,7 @@ enum FormatMenu {
 
         for cmd in blockCommands { menu.addItem(cmd.makeItem()) }
         menu.addItem(calloutSubmenuItem())
+        menu.addItem(thematicBreakCommand.makeItem())
         menu.addItem(footnoteCommand.makeItem())
         menu.addItem(.separator())
 
@@ -97,6 +98,9 @@ enum FormatMenu {
         MenuCommand(id: "format.image", title: "Image",
                     action: #selector(EditorTextView.formatImage(_:))),
     ]
+
+    private static let thematicBreakCommand = MenuCommand(id: "format.thematicBreak", title: "Thematic Break",
+                    action: #selector(EditorTextView.formatThematicBreak(_:)))
 
     private static let footnoteCommand = MenuCommand(id: "format.footnote", title: "Footnote",
                     action: #selector(EditorTextView.formatFootnote(_:)))

--- a/Tests/EdmundTests/FormattingTests.swift
+++ b/Tests/EdmundTests/FormattingTests.swift
@@ -509,18 +509,30 @@ private func mk(_ content: String, _ sel: NSRange) -> EditorTextView {
 
 @MainActor @Suite struct FormatThematicBreakTests {
 
-    @Test func insertsAfterCurrentLine() {
+    @Test func insertsAfterNonEmptyLineNoNewline() {
         let e = mk("Hello", NSRange(location: 2, length: 0))
         e.formatThematicBreak(nil)
-        // No trailing newline on "Hello" → prepend \n\n to avoid setext heading.
         #expect(e.rawSource == "Hello\n\n---\n")
     }
 
     @Test func insertsBlankLineSeparatorWhenLineHasNewline() {
         let e = mk("Hello\nWorld", NSRange(location: 2, length: 0))
         e.formatThematicBreak(nil)
-        // "Hello\n" ends with newline → insert \n---\n after it, giving a blank before ---.
         #expect(e.rawSource == "Hello\n\n---\nWorld")
+    }
+
+    @Test func replacesEmptyLineWithDashes() {
+        // Empty line in the middle: replace with "---\n" directly (no extra separator).
+        let e = mk("Before\n\nAfter", NSRange(location: 7, length: 0))
+        e.formatThematicBreak(nil)
+        #expect(e.rawSource == "Before\n---\nAfter")
+    }
+
+    @Test func replacesEmptyLineAtEOF() {
+        // Caret on an empty-ish document: replace the empty content with "---\n".
+        let e = mk("", NSRange(location: 0, length: 0))
+        e.formatThematicBreak(nil)
+        #expect(e.rawSource == "---\n")
     }
 
     @Test func toggleOffRemovesDashLine() {
@@ -535,8 +547,7 @@ private func mk(_ content: String, _ sel: NSRange) -> EditorTextView {
         #expect(e.rawSource == "")
     }
 
-    @Test func caretInsideLineAlsoInserts() {
-        // Caret anywhere on the line triggers insert, not toggle-off.
+    @Test func caretInsideNonEmptyLineInserts() {
         let e = mk("Line\n", NSRange(location: 2, length: 0))
         e.formatThematicBreak(nil)
         #expect(e.rawSource.contains("---"))

--- a/Tests/EdmundTests/FormattingTests.swift
+++ b/Tests/EdmundTests/FormattingTests.swift
@@ -504,3 +504,42 @@ private func mk(_ content: String, _ sel: NSRange) -> EditorTextView {
         #expect(e.rawSource == "**word**")
     }
 }
+
+// MARK: - Thematic break
+
+@MainActor @Suite struct FormatThematicBreakTests {
+
+    @Test func insertsAfterCurrentLine() {
+        let e = mk("Hello", NSRange(location: 2, length: 0))
+        e.formatThematicBreak(nil)
+        // No trailing newline on "Hello" → prepend \n\n to avoid setext heading.
+        #expect(e.rawSource == "Hello\n\n---\n")
+    }
+
+    @Test func insertsBlankLineSeparatorWhenLineHasNewline() {
+        let e = mk("Hello\nWorld", NSRange(location: 2, length: 0))
+        e.formatThematicBreak(nil)
+        // "Hello\n" ends with newline → insert \n---\n after it, giving a blank before ---.
+        #expect(e.rawSource == "Hello\n\n---\nWorld")
+    }
+
+    @Test func toggleOffRemovesDashLine() {
+        let e = mk("---", NSRange(location: 0, length: 3))
+        e.formatThematicBreak(nil)
+        #expect(e.rawSource == "")
+    }
+
+    @Test func toggleOffWithTrailingNewline() {
+        let e = mk("---\n", NSRange(location: 0, length: 3))
+        e.formatThematicBreak(nil)
+        #expect(e.rawSource == "")
+    }
+
+    @Test func caretInsideLineAlsoInserts() {
+        // Caret anywhere on the line triggers insert, not toggle-off.
+        let e = mk("Line\n", NSRange(location: 2, length: 0))
+        e.formatThematicBreak(nil)
+        #expect(e.rawSource.contains("---"))
+        #expect(e.rawSource.contains("Line"))
+    }
+}


### PR DESCRIPTION
Adds a **Thematic Break** command to the Format menu (after Heading), inserting a `---` rule.

- Empty line → replaces the line with `---\n`.
- Non-empty line → inserts `\n---\n` after it (extra leading `\n` when the line has no trailing newline, to avoid setext-heading parsing).
- Toggle-off: a line whose only content is `---` is removed.

Tests in `FormattingTests.swift` (FormatThematicBreakTests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)