### PR TITLE
ux: rename Typewriter Mode → Typewriter Scroll; center only on typing

### DIFF
--- a/Sources/EdmundCore/TextView/EditorTextView+SelectionTracking.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+SelectionTracking.swift
@@ -25,7 +25,10 @@ extension EditorTextView {
 
         if newActiveIndex != activeBlockIndex && !pendingRecompose {
             pendingRecompose = true
-            DispatchQueue.main.async { [weak self] in
+            // Capture the flag now — it's reset synchronously after mouseDown
+            // returns, before this async block runs.
+            let fromMouse = suppressTypewriterCentering
+            DispatchQueue.main.async { [weak self, fromMouse] in
                 guard let self = self else { return }
                 // Always clear the flag first. If we bail out below (a recompose is
                 // mid-flight and will set the active block itself), leaving it set
@@ -70,7 +73,7 @@ extension EditorTextView {
                 // Only the new (visible) active block changes height now, so the
                 // caret anchor's delta is small and reliable. Typewriter mode
                 // centers on the post-restyle layout instead.
-                if self.typewriterModeEnabled {
+                if self.typewriterModeEnabled && !fromMouse {
                     self.recomposeDirty(dirty, cursorInRaw: loc)
                     self.scrollCursorToCenter()
                 } else {
@@ -85,6 +88,6 @@ extension EditorTextView {
             // Same block — update active token (re-style to show/hide delimiters)
             applyBlockStyle()
         }
-        scrollCursorToCenter()
+        if !suppressTypewriterCentering { scrollCursorToCenter() }
     }
 }

--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -133,6 +133,12 @@ public class EditorTextView: NSTextView {
     /// scrolling logic lives in EditorTextView+TypewriterScroll.
     public var typewriterModeEnabled: Bool = true
 
+    /// Set to true for the duration of a mouse-down event so that the
+    /// resulting selection change does not trigger typewriter centering.
+    /// Clicks position the caret where the user clicked — centering there
+    /// would be jarring and is the root cause of the "glitchy" feeling.
+    var suppressTypewriterCentering = false
+
     /// Fraction of the available width the text column occupies, in `0...1`.
     /// `1` fills the width (the base inset only — today's look); lower values
     /// give a narrower, centered column with symmetric margins that grow on
@@ -313,6 +319,9 @@ public class EditorTextView: NSTextView {
 
     /// Cmd+click on a link's text follows it: a `[[wikilink]]` resolves to a
     /// file / heading, a regular link opens its URL. Any other click edits.
+    /// Sets `suppressTypewriterCentering` for the duration of the super call so
+    /// that the resulting selection change does not re-center the viewport —
+    /// centering when the user merely clicks somewhere feels glitchy.
     public override func mouseDown(with event: NSEvent) {
         if event.modifierFlags.contains(.command) {
             if let target = wikiTarget(at: event) {
@@ -324,7 +333,9 @@ public class EditorTextView: NSTextView {
                 return
             }
         }
+        suppressTypewriterCentering = true
         super.mouseDown(with: event)
+        suppressTypewriterCentering = false
     }
 
     /// The storage character index directly under a mouse event, or nil if the

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -270,7 +270,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         let viewMenu = NSMenu(title: "View")
 
         let typewriterItem = viewMenu.addItem(
-            withTitle: "Typewriter Mode",
+            withTitle: "Typewriter Scroll",
             action: #selector(AppDelegate.toggleTypewriterMode(_:)),
             keyEquivalent: "")
         typewriterItem.state = AppDelegate.typewriterModeEnabled() ? .on : .off


### PR DESCRIPTION
- Renames the View-menu item to **Typewriter Scroll**.
- Fixes the click-centering glitch: a click moves the caret, which used to re-center the viewport. Now `suppressTypewriterCentering` is set for the duration of `mouseDown` so the resulting selection change skips centering; typing is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)