### PR TITLE
ux: remember last window size

### DIFF
--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -180,8 +180,11 @@ class Document: NSDocument, HeadingNavigable {
     }
 
     @objc private func windowDidResize(_ notification: Notification) {
-        guard let window = notification.object as? NSWindow else { return }
-        AppSettings.lastWindowSize = window.frame.size
+        guard let window = notification.object as? NSWindow,
+              let contentSize = window.contentView?.bounds.size else { return }
+        // Save content-view size, not frame: frame includes title bar + toolbar
+        // and is larger than the contentRect the window is initialized with.
+        AppSettings.lastWindowSize = contentSize
     }
 
     @objc private func editorDidChange(_ notification: Notification) {

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -75,8 +75,9 @@ class Document: NSDocument, HeadingNavigable {
     // MARK: - Window Setup
 
     override func makeWindowControllers() {
-        let windowWidth: CGFloat = 400
-        let windowHeight: CGFloat = 500
+        let lastSize = AppSettings.lastWindowSize
+        let windowWidth: CGFloat  = lastSize?.width  ?? 800
+        let windowHeight: CGFloat = lastSize?.height ?? 560
 
         let window = DocumentWindow(
             contentRect: NSRect(x: 0, y: 0, width: windowWidth, height: windowHeight),
@@ -165,6 +166,10 @@ class Document: NSDocument, HeadingNavigable {
             self, selector: #selector(editorSelectionDidChange(_:)),
             name: NSTextView.didChangeSelectionNotification, object: editor
         )
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(windowDidResize(_:)),
+            name: NSWindow.didResizeNotification, object: window
+        )
 
         let wc = NSWindowController(window: window)
         addWindowController(wc)
@@ -172,6 +177,11 @@ class Document: NSDocument, HeadingNavigable {
         // Honor the persisted source-mode preference for the editing view.
         if AppSettings.sourceMode { setViewMode(.source) }
         updateStatusBar()
+    }
+
+    @objc private func windowDidResize(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow else { return }
+        AppSettings.lastWindowSize = window.frame.size
     }
 
     @objc private func editorDidChange(_ notification: Notification) {

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -75,9 +75,12 @@ class Document: NSDocument, HeadingNavigable {
     // MARK: - Window Setup
 
     override func makeWindowControllers() {
-        let lastSize = AppSettings.lastWindowSize
-        let windowWidth: CGFloat  = lastSize?.width  ?? 800
-        let windowHeight: CGFloat = lastSize?.height ?? 560
+        // Default content size for first launch. Any saved size is applied as a
+        // full window frame at the end of setup (below), once the toolbar is in
+        // place — so the frame round-trips exactly and doesn't drift by the
+        // title bar + toolbar height each time.
+        let windowWidth: CGFloat = 800
+        let windowHeight: CGFloat = 560
 
         let window = DocumentWindow(
             contentRect: NSRect(x: 0, y: 0, width: windowWidth, height: windowHeight),
@@ -92,7 +95,6 @@ class Document: NSDocument, HeadingNavigable {
         // otherwise reopens the last-edited file on the next launch, so a fresh
         // start (or File ▸ New) shows that document instead of a blank Untitled.
         window.isRestorable = AppSettings.reopenWindows
-        window.center()
         window.minSize = NSSize(width: 320, height: 400)
         window.backgroundColor = NSColor.textBackgroundColor
 
@@ -171,6 +173,14 @@ class Document: NSDocument, HeadingNavigable {
             name: NSWindow.didResizeNotification, object: window
         )
 
+        // Restore the last window's frame size (the toolbar is now installed, so
+        // the frame is final). Applied as a frame, not a contentRect, so it
+        // round-trips exactly with what windowDidResize saves. Then center.
+        if let savedSize = AppSettings.lastWindowSize {
+            window.setFrame(NSRect(origin: window.frame.origin, size: savedSize), display: false)
+        }
+        window.center()
+
         let wc = NSWindowController(window: window)
         addWindowController(wc)
         window.makeFirstResponder(editor)
@@ -180,11 +190,10 @@ class Document: NSDocument, HeadingNavigable {
     }
 
     @objc private func windowDidResize(_ notification: Notification) {
-        guard let window = notification.object as? NSWindow,
-              let contentSize = window.contentView?.bounds.size else { return }
-        // Save content-view size, not frame: frame includes title bar + toolbar
-        // and is larger than the contentRect the window is initialized with.
-        AppSettings.lastWindowSize = contentSize
+        guard let window = notification.object as? NSWindow else { return }
+        // Save the full frame size; it's restored verbatim via setFrame on the
+        // next window, so the size round-trips exactly (no title-bar/toolbar drift).
+        AppSettings.lastWindowSize = window.frame.size
     }
 
     @objc private func editorDidChange(_ notification: Notification) {

--- a/Sources/edmd/Settings/AppSettings.swift
+++ b/Sources/edmd/Settings/AppSettings.swift
@@ -106,6 +106,8 @@ enum AppSettings {
         static let sourceMode = "settings.view.sourceMode"
         static let sendCrashLogs = "settings.advanced.sendCrashLogs"
         static let sentCrashReports = "settings.advanced.sentCrashReports"
+        static let lastWindowWidth  = "settings.window.lastWidth"
+        static let lastWindowHeight = "settings.window.lastHeight"
     }
 
     /// Text-column width as a fraction of the available width (`0...1`). `1`
@@ -120,6 +122,22 @@ enum AppSettings {
             return UserDefaults.standard.double(forKey: Key.contentWidthFraction)
         }
         set { UserDefaults.standard.set(newValue, forKey: Key.contentWidthFraction) }
+    }
+
+    /// Size of the last document window, to reopen new windows at the same dimensions.
+    /// Returns nil when no size has been saved yet.
+    static var lastWindowSize: NSSize? {
+        get {
+            let w = UserDefaults.standard.double(forKey: Key.lastWindowWidth)
+            let h = UserDefaults.standard.double(forKey: Key.lastWindowHeight)
+            guard w >= 320, h >= 400 else { return nil }
+            return NSSize(width: w, height: h)
+        }
+        set {
+            guard let s = newValue else { return }
+            UserDefaults.standard.set(Double(s.width),  forKey: Key.lastWindowWidth)
+            UserDefaults.standard.set(Double(s.height), forKey: Key.lastWindowHeight)
+        }
     }
 
     static var reopenWindows: Bool {

--- a/Sources/edmd/Settings/AppSettings.swift
+++ b/Sources/edmd/Settings/AppSettings.swift
@@ -124,13 +124,15 @@ enum AppSettings {
         set { UserDefaults.standard.set(newValue, forKey: Key.contentWidthFraction) }
     }
 
-    /// Size of the last document window, to reopen new windows at the same dimensions.
-    /// Returns nil when no size has been saved yet.
+    /// Full frame size of the last document window, to reopen new windows at the
+    /// same dimensions (applied via setFrame). Returns nil when nothing is saved.
+    /// The floor only rejects garbage/zero values — every real window size,
+    /// including ones smaller than the default, is remembered.
     static var lastWindowSize: NSSize? {
         get {
             let w = UserDefaults.standard.double(forKey: Key.lastWindowWidth)
             let h = UserDefaults.standard.double(forKey: Key.lastWindowHeight)
-            guard w >= 320, h >= 400 else { return nil }
+            guard w >= 100, h >= 100 else { return nil }
             return NSSize(width: w, height: h)
         }
         set {


### PR DESCRIPTION
New document windows reopen at the size of the last resized window (default 800×560 on first launch).

- Stores the full window **frame** size and restores it via `setFrame` after the toolbar is installed, so the size round-trips exactly (no title-bar/toolbar drift on reopen).
- Remembers all sizes, including ones smaller than the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)