### PR TITLE
ui: absolute content width (cm/in) with slider, snap, screen-width cap

### DIFF
--- a/Sources/EdmundCore/TextView/EditorTextView+ContentWidth.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+ContentWidth.swift
@@ -2,68 +2,41 @@ import AppKit
 
 // MARK: - Content width (centered reading column)
 //
-// The text column can be narrowed to a fraction of the available width and
-// centered, so wide/full-screen windows get readable side margins instead of
-// edge-to-edge lines. The fraction is a symmetric `textContainerInset.width`,
-// recomputed whenever the fraction or the view width changes.
+// The text column has a physical maximum width (set in cm in Settings and
+// converted to points using the display's real PPI). Windows wider than the
+// cap get symmetric side margins that center the column; narrower windows
+// fill edge-to-edge as usual. This is CSS `max-width` semantics: the cap is
+// an absolute physical size, not a fraction of the window or the screen, so
+// the column doesn't widen when you make the window bigger.
 
 extension EditorTextView {
 
-    /// The minimum text-column width (a comfortable mobile-ish reading measure)
-    /// the slider's low end maps to, and the base inset kept at full width.
-    static let contentMinWidth: CGFloat = 380
+    /// Padding applied on each side of the text column at all window sizes.
     static let contentBaseInset: CGFloat = 24
 
-    /// The symmetric horizontal inset for a given view width and fraction.
-    /// `fraction == 1` → just the base inset (fills the width, today's look);
-    /// lower fractions interpolate the column down to `contentMinWidth`, the
-    /// remaining space split into equal left/right margins. Narrow windows
-    /// (where even the minimum column won't fit past the base inset) just fill.
-    static func horizontalInset(viewWidth: CGFloat, fraction: CGFloat) -> CGFloat {
+    /// The symmetric horizontal inset for a given view width and max-column width.
+    /// `maxContentWidth == .greatestFiniteMagnitude` → base inset only (fills the window).
+    /// When the window is too narrow to fit `maxContentWidth`, the column also fills.
+    public static func horizontalInset(viewWidth: CGFloat, maxContentWidth: CGFloat) -> CGFloat {
         let available = viewWidth - 2 * contentBaseInset
-        guard available > contentMinWidth else { return contentBaseInset }
-        let f = min(1, max(0, fraction))
-        let column = min(available, max(contentMinWidth,
-                                        contentMinWidth + f * (available - contentMinWidth)))
-        return contentBaseInset + (available - column) / 2
+        guard available > maxContentWidth else { return contentBaseInset }
+        return contentBaseInset + (available - maxContentWidth) / 2
     }
 
-    /// The fraction of `viewWidth` the text column actually occupies for a given
-    /// `fraction` — i.e. how much of the screen the content covers. The settings
-    /// slider uses this to show a meaningful percentage (the column at its
-    /// narrowest still covers a sizeable share of the screen, never 0%).
-    public static func contentCoverage(viewWidth: CGFloat, fraction: CGFloat) -> CGFloat {
-        guard viewWidth > 0 else { return 1 }
-        let inset = horizontalInset(viewWidth: viewWidth, fraction: fraction)
-        return (viewWidth - 2 * inset) / viewWidth
-    }
-
-    /// The inverse of `contentCoverage`: the `fraction` that makes the column
-    /// cover `coverage` of `viewWidth`. Lets the settings stepper work in whole
-    /// coverage-percent steps. Clamped to `0...1`.
-    public static func fraction(forCoverage coverage: CGFloat, viewWidth: CGFloat) -> CGFloat {
-        let available = viewWidth - 2 * contentBaseInset
-        guard available > contentMinWidth else { return 1 }
-        let column = coverage * viewWidth
-        let f = (column - contentMinWidth) / (available - contentMinWidth)
-        return min(1, max(0, f))
-    }
-
-    /// Recomputes the horizontal text inset from the current width + fraction,
-    /// preserving the vertical inset. Cheap (no recompose) — only the inset and
-    /// the resulting re-layout change.
+    /// Recomputes the horizontal text inset from the current bounds + max-column cap,
+    /// preserving the vertical inset. Cheap (no recompose) — only the inset changes.
     public func updateContentInset() {
         let target = Self.horizontalInset(viewWidth: bounds.width,
-                                          fraction: contentWidthFraction)
+                                          maxContentWidth: maxContentWidthPoints)
         if abs(textContainerInset.width - target) > 0.5 {
             textContainerInset = NSSize(width: target, height: textContainerInset.height)
         }
     }
 
-    /// Sets the column fraction and applies it immediately. Called from the
-    /// Settings broadcast.
-    public func applyContentWidth(_ fraction: CGFloat) {
-        contentWidthFraction = fraction
+    /// Sets the max-column width (in points) and applies it immediately.
+    /// Called from the Settings broadcast and the screen-change observer.
+    public func applyContentWidth(_ points: CGFloat) {
+        maxContentWidthPoints = points
     }
 
     /// Recompute the centered inset as the view width changes (window resize).

--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -133,15 +133,14 @@ public class EditorTextView: NSTextView {
     /// scrolling logic lives in EditorTextView+TypewriterScroll.
     public var typewriterModeEnabled: Bool = true
 
-    /// Fraction of the available width the text column occupies, in `0...1`.
-    /// `1` fills the width (the base inset only — today's look); lower values
-    /// give a narrower, centered column with symmetric margins that grow on
-    /// wide/full-screen windows, down to a mobile-ish minimum. Applied as a
-    /// symmetric `textContainerInset.width`, recomputed on resize. See
+    /// Physical maximum text-column width in points. Windows wider than this
+    /// cap get symmetric side margins; narrower windows fill edge-to-edge.
+    /// `.greatestFiniteMagnitude` means no cap (fill always). Set from the
+    /// persisted cm value converted via the window's screen PPI. See
     /// EditorTextView+ContentWidth.
-    public var contentWidthFraction: CGFloat = 1.0 {
+    public var maxContentWidthPoints: CGFloat = .greatestFiniteMagnitude {
         didSet {
-            guard oldValue != contentWidthFraction else { return }
+            guard oldValue != maxContentWidthPoints else { return }
             updateContentInset()
         }
     }

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -107,9 +107,12 @@ class Document: NSDocument, HeadingNavigable {
         editor.isHorizontallyResizable = false
         editor.autoresizingMask = [.width]
         editor.textContainerInset = NSSize(width: 24, height: 18)
-        // Centered reading column (see EditorTextView+ContentWidth); applies the
-        // persisted fraction now and recomputes the inset on every resize.
-        editor.contentWidthFraction = CGFloat(AppSettings.contentWidthFraction)
+        // Centered reading column (see EditorTextView+ContentWidth). Convert the
+        // persisted cm value to points using the main screen PPI at window-creation
+        // time; recomputed on resize (setFrameSize) and when the window moves to a
+        // different display (windowDidChangeScreen).
+        let initScreen = NSScreen.main
+        editor.maxContentWidthPoints = initScreen?.cmToPoints(AppSettings.maxContentWidthCm) ?? 1000
         editor.updateContentInset()
         editor.typewriterModeEnabled = AppDelegate.typewriterModeEnabled()
         editor.document = self
@@ -165,6 +168,10 @@ class Document: NSDocument, HeadingNavigable {
             self, selector: #selector(editorSelectionDidChange(_:)),
             name: NSTextView.didChangeSelectionNotification, object: editor
         )
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(windowDidChangeScreen(_:)),
+            name: NSWindow.didChangeScreenNotification, object: window
+        )
 
         let wc = NSWindowController(window: window)
         addWindowController(wc)
@@ -172,6 +179,14 @@ class Document: NSDocument, HeadingNavigable {
         // Honor the persisted source-mode preference for the editing view.
         if AppSettings.sourceMode { setViewMode(.source) }
         updateStatusBar()
+    }
+
+    /// Reapply the content-width cap in points when the window moves to a
+    /// display with a different physical PPI (e.g. external monitor).
+    @objc private func windowDidChangeScreen(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow,
+              let screen = window.screen else { return }
+        editor?.applyContentWidth(screen.cmToPoints(AppSettings.maxContentWidthCm))
     }
 
     @objc private func editorDidChange(_ notification: Notification) {

--- a/Sources/edmd/Settings/AppSettings.swift
+++ b/Sources/edmd/Settings/AppSettings.swift
@@ -48,19 +48,6 @@ enum AppSettings {
         static let displayOrder: [AppearanceMode] = [.light, .dark, .matchSystem]
     }
 
-    /// Content-width slider bounds. The stored value is a fraction of the
-    /// available width (see `EditorTextView+ContentWidth`): the slider runs
-    /// continuously from the Mobile minimum to full width, with a magnetic snap
-    /// only at the default (≈ Obsidian) reading width.
-    enum ContentWidth {
-        /// Slider floor — the "Mobile" width (narrowest readable column).
-        static let minFraction = 0.0
-        /// Out-of-the-box default — ≈ Obsidian's default reading width.
-        static let defaultFraction = 0.25
-        /// How close to the default the marker must get to snap onto it.
-        static let snapTolerance = 0.02
-    }
-
     /// How long diagnostic logs are kept before being pruned on launch.
     enum LogRetention: String, CaseIterable, Identifiable {
         case oneDay, twoDays, oneWeek, twoWeeks, thirtyDays, never
@@ -97,7 +84,7 @@ enum AppSettings {
         static let autoSaveWithVersions = "settings.general.autoSaveWithVersions"
         static let conflictResolution = "settings.general.conflictResolution"
         static let appearanceMode = "settings.appearance.mode"
-        static let contentWidthFraction = "settings.appearance.contentWidthFraction"
+        static let maxContentWidthCm = "settings.appearance.maxContentWidthCm"
         static let suppressInconsistentLineEndingWarning = "settings.general.suppressInconsistentLineEndingWarning"
         static let diagnosticLogging = "settings.general.diagnosticLogging"
         static let verboseEditorDiagnostics = "settings.advanced.verboseEditorDiagnostics"
@@ -108,18 +95,25 @@ enum AppSettings {
         static let sentCrashReports = "settings.advanced.sentCrashReports"
     }
 
-    /// Text-column width as a fraction of the available width (`0...1`). `1`
-    /// fills the width; lower narrows toward a mobile-ish minimum, centered.
-    /// Defaults to the Narrower (≈ Obsidian) width so full-screen windows get
-    /// readable margins out of the box.
-    static var contentWidthFraction: Double {
+    /// Maximum text-column width in centimetres. Wider windows center the
+    /// column at this physical width; narrower windows fill edge-to-edge.
+    /// Default: 43 % of the main screen's physical width at first launch.
+    static var maxContentWidthCm: Double {
         get {
-            guard UserDefaults.standard.object(forKey: Key.contentWidthFraction) != nil else {
-                return ContentWidth.defaultFraction
+            guard UserDefaults.standard.object(forKey: Key.maxContentWidthCm) != nil else {
+                return defaultMaxContentWidthCm
             }
-            return UserDefaults.standard.double(forKey: Key.contentWidthFraction)
+            return UserDefaults.standard.double(forKey: Key.maxContentWidthCm)
         }
-        set { UserDefaults.standard.set(newValue, forKey: Key.contentWidthFraction) }
+        set { UserDefaults.standard.set(newValue, forKey: Key.maxContentWidthCm) }
+    }
+
+    /// 43 % of the main screen's physical width in cm — a comfortable reading
+    /// column out of the box that matches the previous fraction-based default.
+    static var defaultMaxContentWidthCm: Double {
+        guard let screen = NSScreen.main else { return 40.0 }
+        let pts = screen.frame.width * 0.43
+        return Double(pts / screen.physicalPPI) * 2.54
     }
 
     static var reopenWindows: Bool {
@@ -266,5 +260,27 @@ enum AppSettings {
         case .dark:
             NSApp.appearance = NSAppearance(named: .darkAqua)
         }
+    }
+}
+
+// MARK: - Screen physical-unit helpers
+
+extension NSScreen {
+    /// Physical pixels-per-inch from the display's actual diagonal/width size
+    /// (via Core Graphics — not the nominal 72 pt/in). Falls back to 109 PPI
+    /// (the typical value for a 27-inch 5K iMac) when the display ID can't be read.
+    var physicalPPI: CGFloat {
+        guard let n = deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber else {
+            return 109
+        }
+        let mm = CGDisplayScreenSize(CGDirectDisplayID(n.uint32Value))
+        guard mm.width > 0 else { return 109 }
+        // frame.width is in points (not pixels); mm.width is physical mm.
+        return frame.width / (mm.width / 25.4)
+    }
+
+    /// Convert a physical centimetre value to AppKit points on this display.
+    func cmToPoints(_ cm: Double) -> CGFloat {
+        CGFloat(cm) / 2.54 * physicalPPI
     }
 }

--- a/Sources/edmd/Settings/AppSettings.swift
+++ b/Sources/edmd/Settings/AppSettings.swift
@@ -99,7 +99,7 @@ enum AppSettings {
 
     /// Maximum text-column width in centimetres. Wider windows center the
     /// column at this physical width; narrower windows fill edge-to-edge.
-    /// Default: 43 % of the main screen's physical width at first launch.
+    /// Default: a comfortable 12 cm / 5 in reading column.
     static var maxContentWidthCm: Double {
         get {
             guard UserDefaults.standard.object(forKey: Key.maxContentWidthCm) != nil else {
@@ -110,12 +110,10 @@ enum AppSettings {
         set { UserDefaults.standard.set(newValue, forKey: Key.maxContentWidthCm) }
     }
 
-    /// 43 % of the main screen's physical width in cm — a comfortable reading
-    /// column out of the box that matches the previous fraction-based default.
+    /// Out-of-the-box reading column: 5 in for US locales, 12 cm elsewhere.
+    /// This is also the slider's magnetic snap point.
     static var defaultMaxContentWidthCm: Double {
-        guard let screen = NSScreen.main else { return 40.0 }
-        let pts = screen.frame.width * 0.43
-        return Double(pts / screen.physicalPPI) * 2.54
+        Locale.current.measurementSystem == .us ? 5.0 * 2.54 : 12.0
     }
 
     static var reopenWindows: Bool {

--- a/Sources/edmd/Settings/AppSettings.swift
+++ b/Sources/edmd/Settings/AppSettings.swift
@@ -85,6 +85,8 @@ enum AppSettings {
         static let conflictResolution = "settings.general.conflictResolution"
         static let appearanceMode = "settings.appearance.mode"
         static let maxContentWidthCm = "settings.appearance.maxContentWidthCm"
+        // "cm" / "in" override the locale default for the content-width control.
+        static let contentWidthUnit = "settings.appearance.contentWidthUnit"
         static let suppressInconsistentLineEndingWarning = "settings.general.suppressInconsistentLineEndingWarning"
         static let diagnosticLogging = "settings.general.diagnosticLogging"
         static let verboseEditorDiagnostics = "settings.advanced.verboseEditorDiagnostics"
@@ -282,5 +284,10 @@ extension NSScreen {
     /// Convert a physical centimetre value to AppKit points on this display.
     func cmToPoints(_ cm: Double) -> CGFloat {
         CGFloat(cm) / 2.54 * physicalPPI
+    }
+
+    /// The display's full physical width in centimetres.
+    var physicalWidthCm: Double {
+        Double(frame.width / physicalPPI) * 2.54
     }
 }

--- a/Sources/edmd/Settings/AppearanceSettingsView.swift
+++ b/Sources/edmd/Settings/AppearanceSettingsView.swift
@@ -10,18 +10,35 @@ struct AppearanceSettingsView: View {
     @ObservedObject var fonts: FontSettings
     @AppStorage(AppSettings.Key.appearanceMode) private var appearanceMode = AppSettings.AppearanceMode.matchSystem
     @AppStorage(AppSettings.Key.maxContentWidthCm) private var maxContentWidthCm = AppSettings.defaultMaxContentWidthCm
+    /// "" follows the locale; "cm"/"in" override it (toggled via the unit button).
+    @AppStorage(AppSettings.Key.contentWidthUnit) private var unitOverride = ""
 
-    // MARK: - Locale helpers
+    // MARK: - Unit helpers
 
-    /// Only US locale uses inches; everywhere else uses cm.
-    private var usesImperial: Bool { Locale.current.measurementSystem == .us }
+    /// Imperial when the user picked "in", metric when "cm", else the locale default.
+    private var usesImperial: Bool {
+        switch unitOverride {
+        case "in": return true
+        case "cm": return false
+        default:   return Locale.current.measurementSystem == .us
+        }
+    }
+    private func toggleUnit() { unitOverride = usesImperial ? "cm" : "in" }
+
     private var unitLabel: String { usesImperial ? "in" : "cm" }
     /// Stepper increment in display units (0.5 cm ≈ 0.25 in).
     private var stepSize: Double { usesImperial ? 0.25 : 0.5 }
-    /// Slider / stepper bounds in display units.
-    private var displayRange: ClosedRange<Double> { usesImperial ? 2.0...20.0 : 5.0...50.0 }
     /// Tick-mark spacing on the slider in display units (~5 cm / 2 in).
     private var tickStep: Double { usesImperial ? 2.0 : 5.0 }
+
+    /// Lower bound ≈ 3 inches (7.62 cm); upper bound is the full physical width
+    /// of the main display, so the column can be capped anywhere up to the
+    /// screen edge.
+    private var minCm: Double { 7.62 }
+    private var maxCm: Double { NSScreen.main?.physicalWidthCm ?? 50 }
+    private var displayRange: ClosedRange<Double> {
+        usesImperial ? (minCm / 2.54)...(maxCm / 2.54) : minCm...maxCm
+    }
 
     /// Two-way binding between stored cm and the display unit.
     private var displayValueBinding: Binding<Double> {
@@ -64,7 +81,11 @@ struct AppearanceSettingsView: View {
                     Stepper("", value: displayValueBinding,
                             in: displayRange, step: stepSize)
                         .labelsHidden()
-                    Text(unitLabel)
+                    // Clickable unit toggle styled exactly like a plain label —
+                    // .plain strips all button chrome so only the text shows.
+                    Button(action: toggleUnit) { Text(unitLabel) }
+                        .buttonStyle(.plain)
+                        .help("Switch between centimetres and inches")
                 }
                 .onChange(of: maxContentWidthCm) { applyContentWidthToOpenDocuments() }
             }
@@ -168,20 +189,28 @@ private struct ContentWidthSlider: NSViewRepresentable {
         max(displayRange.lowerBound, min(displayRange.upperBound, v))
     }
 
+    private var tickCount: Int {
+        let span = displayRange.upperBound - displayRange.lowerBound
+        return max(2, Int((span / tickStep).rounded()) + 1)
+    }
+
     func makeNSView(context: Context) -> NSSlider {
         let slider = NSSlider(value: clamp(cmToDisplay(cmValue)),
                               minValue: displayRange.lowerBound,
                               maxValue: displayRange.upperBound,
                               target: context.coordinator,
                               action: #selector(Coordinator.sliderChanged(_:)))
-        let span = displayRange.upperBound - displayRange.lowerBound
-        slider.numberOfTickMarks = Int((span / tickStep).rounded()) + 1
+        slider.numberOfTickMarks = tickCount
         slider.allowsTickMarkValuesOnly = false
         return slider
     }
 
     func updateNSView(_ slider: NSSlider, context: Context) {
         context.coordinator.parent = self
+        // Range and tick count change when the unit is toggled (cm ↔ in).
+        slider.minValue = displayRange.lowerBound
+        slider.maxValue = displayRange.upperBound
+        slider.numberOfTickMarks = tickCount
         let display = clamp(cmToDisplay(cmValue))
         if abs(slider.doubleValue - display) > 0.001 {
             slider.doubleValue = display

--- a/Sources/edmd/Settings/AppearanceSettingsView.swift
+++ b/Sources/edmd/Settings/AppearanceSettingsView.swift
@@ -11,6 +11,26 @@ struct AppearanceSettingsView: View {
     @AppStorage(AppSettings.Key.appearanceMode) private var appearanceMode = AppSettings.AppearanceMode.matchSystem
     @AppStorage(AppSettings.Key.maxContentWidthCm) private var maxContentWidthCm = AppSettings.defaultMaxContentWidthCm
 
+    // MARK: - Locale helpers
+
+    /// Only US locale uses inches; everywhere else uses cm.
+    private var usesImperial: Bool { Locale.current.measurementSystem == .us }
+    private var unitLabel: String { usesImperial ? "in" : "cm" }
+    /// Stepper increment in display units (0.5 cm ≈ 0.25 in).
+    private var stepSize: Double { usesImperial ? 0.25 : 0.5 }
+    /// Slider / stepper bounds in display units.
+    private var displayRange: ClosedRange<Double> { usesImperial ? 2.0...20.0 : 5.0...50.0 }
+    /// Tick-mark spacing on the slider in display units (~5 cm / 2 in).
+    private var tickStep: Double { usesImperial ? 2.0 : 5.0 }
+
+    /// Two-way binding between stored cm and the display unit.
+    private var displayValueBinding: Binding<Double> {
+        Binding(
+            get: { usesImperial ? maxContentWidthCm / 2.54 : maxContentWidthCm },
+            set: { maxContentWidthCm = usesImperial ? $0 * 2.54 : $0 }
+        )
+    }
+
     var body: some View {
         Grid(alignment: .leadingFirstTextBaseline, verticalSpacing: 12) {
             GridRow {
@@ -29,16 +49,22 @@ struct AppearanceSettingsView: View {
                 Text("Max content width:")
                     .gridColumnAlignment(.trailing)
                 HStack(spacing: 8) {
-                    TextField("", value: $maxContentWidthCm,
+                    ContentWidthSlider(
+                        cmValue: $maxContentWidthCm,
+                        usesImperial: usesImperial,
+                        displayRange: displayRange,
+                        tickStep: tickStep
+                    )
+                    .frame(width: 200, height: 20)
+
+                    TextField("", value: displayValueBinding,
                               format: .number.precision(.fractionLength(1)))
                         .multilineTextAlignment(.trailing)
-                        .frame(width: 56)
-                    Stepper("", value: $maxContentWidthCm, in: 5.0...200.0, step: 0.5)
+                        .frame(width: 44)
+                    Stepper("", value: displayValueBinding,
+                            in: displayRange, step: stepSize)
                         .labelsHidden()
-                    Text("cm")
-                    Text("(wider windows cap the column at this physical width)")
-                        .foregroundStyle(.secondary)
-                        .controlSize(.small)
+                    Text(unitLabel)
                 }
                 .onChange(of: maxContentWidthCm) { applyContentWidthToOpenDocuments() }
             }
@@ -121,6 +147,56 @@ struct AppearanceSettingsView: View {
                 .labelsHidden()
             Button("Select…", action: select)
                 .fixedSize()
+        }
+    }
+}
+
+// MARK: - Continuous NSSlider with visual tick marks
+
+/// Wraps NSSlider to get a continuous slider with visual tick marks.
+/// `allowsTickMarkValuesOnly = false` keeps dragging smooth; ticks are visual only.
+private struct ContentWidthSlider: NSViewRepresentable {
+    @Binding var cmValue: Double
+    let usesImperial: Bool
+    let displayRange: ClosedRange<Double>
+    let tickStep: Double
+
+    func cmToDisplay(_ cm: Double) -> Double { usesImperial ? cm / 2.54 : cm }
+    func displayToCm(_ d: Double) -> Double  { usesImperial ? d * 2.54 : d }
+
+    private func clamp(_ v: Double) -> Double {
+        max(displayRange.lowerBound, min(displayRange.upperBound, v))
+    }
+
+    func makeNSView(context: Context) -> NSSlider {
+        let slider = NSSlider(value: clamp(cmToDisplay(cmValue)),
+                              minValue: displayRange.lowerBound,
+                              maxValue: displayRange.upperBound,
+                              target: context.coordinator,
+                              action: #selector(Coordinator.sliderChanged(_:)))
+        let span = displayRange.upperBound - displayRange.lowerBound
+        slider.numberOfTickMarks = Int((span / tickStep).rounded()) + 1
+        slider.allowsTickMarkValuesOnly = false
+        return slider
+    }
+
+    func updateNSView(_ slider: NSSlider, context: Context) {
+        context.coordinator.parent = self
+        let display = clamp(cmToDisplay(cmValue))
+        if abs(slider.doubleValue - display) > 0.001 {
+            slider.doubleValue = display
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(parent: self) }
+
+    @MainActor
+    final class Coordinator: NSObject {
+        var parent: ContentWidthSlider
+        init(parent: ContentWidthSlider) { self.parent = parent }
+
+        @objc func sliderChanged(_ sender: NSSlider) {
+            parent.cmValue = parent.displayToCm(sender.doubleValue)
         }
     }
 }

--- a/Sources/edmd/Settings/AppearanceSettingsView.swift
+++ b/Sources/edmd/Settings/AppearanceSettingsView.swift
@@ -40,6 +40,9 @@ struct AppearanceSettingsView: View {
         usesImperial ? (minCm / 2.54)...(maxCm / 2.54) : minCm...maxCm
     }
 
+    /// Magnetic snap target in display units: 5 in / 12 cm (the default width).
+    private var snapDisplayValue: Double { usesImperial ? 5.0 : 12.0 }
+
     /// Two-way binding between stored cm and the display unit.
     private var displayValueBinding: Binding<Double> {
         Binding(
@@ -70,14 +73,18 @@ struct AppearanceSettingsView: View {
                         cmValue: $maxContentWidthCm,
                         usesImperial: usesImperial,
                         displayRange: displayRange,
-                        tickStep: tickStep
+                        tickStep: tickStep,
+                        snapDisplayValue: snapDisplayValue
                     )
                     .frame(width: 200, height: 20)
 
+                    // Field width is sized so its stepper's chevrons line up
+                    // vertically with the font rows' steppers (slider 200 + two
+                    // 8-pt gaps + field == 240, the font rows' label width).
                     TextField("", value: displayValueBinding,
                               format: .number.precision(.fractionLength(1)))
                         .multilineTextAlignment(.trailing)
-                        .frame(width: 44)
+                        .frame(width: 32)
                     Stepper("", value: displayValueBinding,
                             in: displayRange, step: stepSize)
                         .labelsHidden()
@@ -181,9 +188,18 @@ private struct ContentWidthSlider: NSViewRepresentable {
     let usesImperial: Bool
     let displayRange: ClosedRange<Double>
     let tickStep: Double
+    /// Magnetic snap target in display units (the default width); dragging
+    /// within `snapTolerance` of it locks onto it exactly.
+    let snapDisplayValue: Double
+    private var snapTolerance: Double { usesImperial ? 0.15 : 0.4 }
 
     func cmToDisplay(_ cm: Double) -> Double { usesImperial ? cm / 2.54 : cm }
     func displayToCm(_ d: Double) -> Double  { usesImperial ? d * 2.54 : d }
+
+    /// Snap `display` onto the default value when it lands close enough.
+    func snapped(_ display: Double) -> Double {
+        abs(display - snapDisplayValue) < snapTolerance ? snapDisplayValue : display
+    }
 
     private func clamp(_ v: Double) -> Double {
         max(displayRange.lowerBound, min(displayRange.upperBound, v))
@@ -225,7 +241,9 @@ private struct ContentWidthSlider: NSViewRepresentable {
         init(parent: ContentWidthSlider) { self.parent = parent }
 
         @objc func sliderChanged(_ sender: NSSlider) {
-            parent.cmValue = parent.displayToCm(sender.doubleValue)
+            let snapped = parent.snapped(sender.doubleValue)
+            if snapped != sender.doubleValue { sender.doubleValue = snapped }
+            parent.cmValue = parent.displayToCm(snapped)
         }
     }
 }

--- a/Sources/edmd/Settings/AppearanceSettingsView.swift
+++ b/Sources/edmd/Settings/AppearanceSettingsView.swift
@@ -9,7 +9,7 @@ import EdmundCore
 struct AppearanceSettingsView: View {
     @ObservedObject var fonts: FontSettings
     @AppStorage(AppSettings.Key.appearanceMode) private var appearanceMode = AppSettings.AppearanceMode.matchSystem
-    @AppStorage(AppSettings.Key.contentWidthFraction) private var contentWidth = AppSettings.ContentWidth.defaultFraction
+    @AppStorage(AppSettings.Key.maxContentWidthCm) private var maxContentWidthCm = AppSettings.defaultMaxContentWidthCm
 
     var body: some View {
         Grid(alignment: .leadingFirstTextBaseline, verticalSpacing: 12) {
@@ -29,27 +29,18 @@ struct AppearanceSettingsView: View {
                 Text("Max content width:")
                     .gridColumnAlignment(.trailing)
                 HStack(spacing: 8) {
-                    // Continuous from the Mobile minimum to full width, with a
-                    // magnetic snap onto the default (≈ Obsidian) width.
-                    let value = Binding(
-                        get: { contentWidth },
-                        set: { newValue in
-                            let d = AppSettings.ContentWidth.defaultFraction
-                            contentWidth = abs(newValue - d) < AppSettings.ContentWidth.snapTolerance
-                                ? d : newValue
-                        }
-                    )
-                    Slider(value: value, in: AppSettings.ContentWidth.minFraction...1.0)
-                        .frame(width: 200)
-                    let percent = contentWidthPercentBinding
-                    TextField("", value: percent, format: .number.precision(.fractionLength(0)))
+                    TextField("", value: $maxContentWidthCm,
+                              format: .number.precision(.fractionLength(1)))
                         .multilineTextAlignment(.trailing)
-                        .frame(width: 32)
-                    Stepper("", value: percent, in: contentWidthPercentRange, step: 1)
+                        .frame(width: 56)
+                    Stepper("", value: $maxContentWidthCm, in: 5.0...200.0, step: 0.5)
                         .labelsHidden()
-                    Text("%")
+                    Text("cm")
+                    Text("(wider windows cap the column at this physical width)")
+                        .foregroundStyle(.secondary)
+                        .controlSize(.small)
                 }
-                .onChange(of: contentWidth) { applyContentWidthToOpenDocuments() }
+                .onChange(of: maxContentWidthCm) { applyContentWidthToOpenDocuments() }
             }
 
             GridRow {
@@ -108,38 +99,13 @@ struct AppearanceSettingsView: View {
         .settingsPanePadding()
     }
 
-    /// The standard screen the coverage percentage is measured against.
-    private var contentWidthScreen: CGFloat { NSScreen.main?.frame.width ?? 1440 }
-
-    /// The percentage shown/edited is how much of the screen the column covers
-    /// (≈25%…97%), not the raw fraction — so the narrowest setting reads as a
-    /// sensible share of the screen, never 0%. The binding maps that percentage
-    /// back to the stored fraction so the slider and stepper share one value.
-    private var contentWidthPercentBinding: Binding<Double> {
-        Binding(
-            get: {
-                (EditorTextView.contentCoverage(viewWidth: contentWidthScreen,
-                                                fraction: CGFloat(contentWidth)) * 100).rounded()
-            },
-            set: { pct in
-                contentWidth = Double(EditorTextView.fraction(forCoverage: CGFloat(pct / 100),
-                                                              viewWidth: contentWidthScreen))
-            }
-        )
-    }
-
-    /// The coverage-percent range the stepper clamps to (Mobile minimum … full).
-    private var contentWidthPercentRange: ClosedRange<Double> {
-        let lo = (EditorTextView.contentCoverage(viewWidth: contentWidthScreen, fraction: 0) * 100).rounded()
-        let hi = (EditorTextView.contentCoverage(viewWidth: contentWidthScreen, fraction: 1) * 100).rounded()
-        return lo...hi
-    }
-
-    /// Pushes a content-width change to every open editor live (mirrors the
-    /// font/line-height broadcast in FontSettings).
+    /// Pushes a content-width change to every open editor live, converting cm
+    /// to points using each editor's window screen PPI (or main screen as fallback).
     private func applyContentWidthToOpenDocuments() {
         for case let document as Document in NSDocumentController.shared.documents {
-            document.editor?.applyContentWidth(CGFloat(contentWidth))
+            let screen = document.editor?.window?.screen ?? NSScreen.main
+            guard let screen else { continue }
+            document.editor?.applyContentWidth(screen.cmToPoints(maxContentWidthCm))
         }
     }
 

--- a/Tests/EdmundTests/ContentWidthTests.swift
+++ b/Tests/EdmundTests/ContentWidthTests.swift
@@ -2,77 +2,75 @@ import Testing
 import AppKit
 @testable import EdmundCore
 
-/// The centered reading-column math: `horizontalInset` turns a width + fraction
-/// into a symmetric text inset. Pins the endpoints and the clamps.
+/// The centered reading-column math: `horizontalInset` turns a view width and
+/// a physical max-column cap into a symmetric text inset.
 @Suite("Content width")
 @MainActor
 struct ContentWidthTests {
 
     let base = EditorTextView.contentBaseInset      // 24
-    let minW = EditorTextView.contentMinWidth       // 380
 
-    @Test("Fraction 1 fills the width (base inset only)")
-    func fullWidth() {
-        let inset = EditorTextView.horizontalInset(viewWidth: 1400, fraction: 1)
-        #expect(abs(inset - base) < 0.01)
-    }
-
-    @Test("Fraction 0 yields the minimum centered column")
-    func minColumn() {
-        let viewWidth: CGFloat = 1400
-        let inset = EditorTextView.horizontalInset(viewWidth: viewWidth, fraction: 0)
-        let available = viewWidth - 2 * base
-        let expected = base + (available - minW) / 2
-        #expect(abs(inset - expected) < 0.01)
-        // The resulting column is exactly the minimum width.
-        let column = viewWidth - 2 * inset
-        #expect(abs(column - minW) < 0.01)
-    }
-
-    @Test("Lower fraction means wider margins")
-    func monotonic() {
-        let w: CGFloat = 1400
-        let i100 = EditorTextView.horizontalInset(viewWidth: w, fraction: 1)
-        let i60 = EditorTextView.horizontalInset(viewWidth: w, fraction: 0.6)
-        let i20 = EditorTextView.horizontalInset(viewWidth: w, fraction: 0.2)
-        #expect(i100 < i60)
-        #expect(i60 < i20)
-    }
-
-    @Test("Margins grow with window width at a fixed fraction")
-    func widerWindowMoreMargin() {
-        let narrow = EditorTextView.horizontalInset(viewWidth: 800, fraction: 0.6)
-        let wide = EditorTextView.horizontalInset(viewWidth: 1600, fraction: 0.6)
-        #expect(wide > narrow)
-    }
-
-    @Test("contentCoverage: fraction 1 ≈ whole screen; fraction 0 is the floor share")
-    func coverage() {
-        let w: CGFloat = 1512
-        let full = EditorTextView.contentCoverage(viewWidth: w, fraction: 1)
-        let mobile = EditorTextView.contentCoverage(viewWidth: w, fraction: 0)
-        // Full = the whole width minus the base inset on each side.
-        #expect(abs(full - (w - 2 * base) / w) < 0.001)
-        // Mobile = the fixed minimum column as a share of the screen (never 0).
-        #expect(abs(mobile - minW / w) < 0.001)
-        #expect(mobile > 0.2 && full < 1.0 && full > mobile)
-    }
-
-    @Test("fraction(forCoverage:) inverts contentCoverage")
-    func coverageRoundTrip() {
-        let w: CGFloat = 1512
-        for tenth in 0...10 {
-            let f = CGFloat(tenth) / 10
-            let cov = EditorTextView.contentCoverage(viewWidth: w, fraction: f)
-            let back = EditorTextView.fraction(forCoverage: cov, viewWidth: w)
-            #expect(abs(back - f) < 0.001)
-        }
-    }
-
-    @Test("Narrow windows just fill (base inset)")
+    @Test("Window narrower than cap fills (base inset only)")
     func narrowFills() {
-        // Available width below the minimum column → no room to center; fill.
-        let inset = EditorTextView.horizontalInset(viewWidth: minW + 2 * base - 10, fraction: 0.3)
+        let inset = EditorTextView.horizontalInset(viewWidth: 500, maxContentWidth: 600)
         #expect(abs(inset - base) < 0.01)
+    }
+
+    @Test("Window exactly at cap fills (available == cap, no room to center)")
+    func exactFills() {
+        let cap: CGFloat = 500
+        let viewWidth = cap + 2 * base   // available == cap
+        let inset = EditorTextView.horizontalInset(viewWidth: viewWidth, maxContentWidth: cap)
+        #expect(abs(inset - base) < 0.01)
+    }
+
+    @Test("Wide window centers the column at the cap")
+    func wideWindowCenters() {
+        let cap: CGFloat = 600
+        let viewWidth: CGFloat = 1200
+        let inset = EditorTextView.horizontalInset(viewWidth: viewWidth, maxContentWidth: cap)
+        let available = viewWidth - 2 * base
+        let expected = base + (available - cap) / 2
+        #expect(abs(inset - expected) < 0.01)
+        // Column equals the cap exactly.
+        #expect(abs((viewWidth - 2 * inset) - cap) < 0.01)
+    }
+
+    @Test("Larger cap means wider column (smaller inset)")
+    func largerCapWiderColumn() {
+        let viewWidth: CGFloat = 1400
+        let insetNarrow = EditorTextView.horizontalInset(viewWidth: viewWidth, maxContentWidth: 400)
+        let insetWide   = EditorTextView.horizontalInset(viewWidth: viewWidth, maxContentWidth: 800)
+        #expect(insetNarrow > insetWide)
+    }
+
+    @Test("Infinite cap fills the window (base inset only)")
+    func infiniteCapFills() {
+        let inset = EditorTextView.horizontalInset(viewWidth: 1400, maxContentWidth: .greatestFiniteMagnitude)
+        #expect(abs(inset - base) < 0.01)
+    }
+
+    @Test("Margins grow as window widens past the cap")
+    func marginsGrowWithWindow() {
+        let cap: CGFloat = 600
+        let inset800  = EditorTextView.horizontalInset(viewWidth: 800,  maxContentWidth: cap)
+        let inset1400 = EditorTextView.horizontalInset(viewWidth: 1400, maxContentWidth: cap)
+        #expect(inset1400 > inset800)
+    }
+
+    @Test("Column stays pinned at cap regardless of window width")
+    func columnPinnedAtCap() {
+        let cap: CGFloat = 700
+        for w: CGFloat in [800, 1000, 1400, 2000] {
+            let inset = EditorTextView.horizontalInset(viewWidth: w, maxContentWidth: cap)
+            let column = w - 2 * inset
+            // Either filling (window too narrow) or exactly capped.
+            let filling = w - 2 * base <= cap
+            if filling {
+                #expect(abs(inset - base) < 0.01)
+            } else {
+                #expect(abs(column - cap) < 0.01)
+            }
+        }
     }
 }


### PR DESCRIPTION
Replaces the fraction-of-window content-width model with an **absolute physical max-column width** (CSS `max-width` semantics).

- Stored in cm; converted to points via the display's real PPI. Windows wider than the cap get centered margins; narrower windows fill.
- Settings: continuous `NSSlider` with tick marks, a 0.5 cm / 0.25 in stepper, a numeric field, and a clickable **cm/in unit toggle** (plain-styled). Range: ~3 in floor → full display width. Default 12 cm / 5 in with a magnetic snap.
- Re-converts on display change (`NSWindow.didChangeScreenNotification`).
- Tests rewritten in `ContentWidthTests.swift`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)