### PR TITLE
release: bump version to 0.1.1 (build 2)

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -17,9 +17,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleVersion</key>
-    <string>1</string>
+    <string>2</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
+    <string>0.1.1</string>
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
     <key>NSHighResolutionCapable</key>


### PR DESCRIPTION
Fix failed v0.1.1 release: VERSION is derived from Info.plist's CFBundleShortVersionString, not the git tag. Bump both CFBundleVersion and CFBundleShortVersionString so the re-tagged v0.1.1 publishes 0.1.1 artifacts.