### PR TITLE
fix(release-workflow): repair invalid YAML in appcast update step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,25 +100,21 @@ jobs:
 
           # Release notes for Sparkle's update dialog (scrollable pane), built
           # from this version's CHANGELOG section. Omitted if the section is missing.
+          # Built with printf (not a literal multi-line string) so this step's
+          # `run: |` block scalar doesn't contain an unindented line, which
+          # breaks YAML parsing of the whole workflow file.
+          # $(...) strips trailing newlines, so DESC_BLOCK can't carry its own
+          # trailing separator — NEW_ITEM's printf adds it explicitly instead.
           DESC_HTML="$(python3 scripts/changelog-to-html.py "$VERSION")"
           DESC_BLOCK=""
           if [ -n "$DESC_HTML" ]; then
-            DESC_BLOCK="            <description><![CDATA[
-${DESC_HTML}
-]]></description>
-"
+            DESC_BLOCK="$(printf '            <description><![CDATA[\n%s\n]]></description>' "$DESC_HTML")"
           fi
 
-          NEW_ITEM="        <item>
-              <title>Edmund ${VERSION}</title>
-              <pubDate>${PUB_DATE}</pubDate>
-${DESC_BLOCK}              <enclosure url=\"${ASSET_URL}\"
-                         sparkle:version=\"${BUILD}\"
-                         sparkle:shortVersionString=\"${VERSION}\"
-                         ${ED_SIG}
-                         ${LENGTH}
-                         type=\"application/x-apple-diskimage\"/>
-          </item>"
+          # Built with printf (one logical YAML line) rather than a literal
+          # multi-line string: an unindented line inside this value would
+          # break this run block's YAML indentation (as DESC_BLOCK did above).
+          NEW_ITEM="$(printf '        <item>\n            <title>Edmund %s</title>\n            <pubDate>%s</pubDate>\n%s\n            <enclosure url="%s"\n                       sparkle:version="%s"\n                       sparkle:shortVersionString="%s"\n                       %s\n                       %s\n                       type="application/x-apple-diskimage"/>\n        </item>' "$VERSION" "$PUB_DATE" "$DESC_BLOCK" "$ASSET_URL" "$BUILD" "$VERSION" "$ED_SIG" "$LENGTH")"
 
           python3 - "$NEW_ITEM" <<'PYEOF'
           import sys


### PR DESCRIPTION
## Summary
- Follow-up to #161. That PR's "Update appcast.xml" step embedded multi-line bash strings directly in the workflow's `run: |` block, and two of those literal lines had no leading whitespace — invalid inside a YAML block scalar. This broke parsing of the entire `release.yml` file, which is why the [failed run](https://github.com/I7T5/Edmund/actions/runs/28578347403) showed "likely failed because of a workflow file issue" — it fired on every push (not just tags) because GitHub couldn't determine the real trigger from the broken file, and failed immediately.
- It didn't block #161's merge because `release.yml` isn't a required status check (only `test` is) — but `main` has shipped with a broken release workflow since that merge, which would fail the next real release.
- Fix: rebuild `DESC_BLOCK` and `NEW_ITEM` with `printf` so every literal line in the workflow file stays properly indented (newlines are produced at runtime via `\n`, not written raw into the file). Also fixes a second bug this surfaced: `$(...)` command substitution strips trailing newlines, so `DESC_BLOCK`'s separator has to live in `NEW_ITEM`'s format string, not in `DESC_BLOCK` itself, or `</description>` and the following `<enclosure>` tag collide on one line.

## Verification
- `.github/workflows/release.yml` now parses as valid YAML (confirmed broken on current `main` before this fix, OK after).
- `bash -n` passes on the extracted step script.
- Simulated the step's shell logic locally, both with and without a matching CHANGELOG section, and confirmed well-formed XML with correct line breaks in both cases.
- `swift test`: 791/791 passed.

## Test plan
- [x] `release.yml` parses as YAML
- [x] `bash -n` on the extracted step
- [x] Local simulation produces well-formed appcast XML (with and without release notes)
- [x] `swift test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)