### PR TITLE
fix(editor): heal storage edits that bypass didChangeText (delete drift round 4)

### DIFF
--- a/Sources/EdmundCore/TextView/EditorTextView+EditFlow.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+EditFlow.swift
@@ -37,7 +37,49 @@ extension EditorTextView {
             }
         }
         traceEdit("shouldChangeText OK range=\(affectedCharRange) repl=\(logSnippet(replacementString))")
+        scheduleBypassedEditSyncCheck()
         return true
+    }
+
+    /// AppKit does not pair every storage mutation with `didChangeText()`.
+    /// Known case: after a drag of the selected text whose drop falls through
+    /// to no valid target (e.g. released past the end of the document), the
+    /// drag-move's source deletion runs shouldChangeText → replaceCharacters
+    /// and never calls didChangeText. rawSource/blocks then silently freeze:
+    /// every later edit does its offset math against the stale model (the
+    /// issue-#156 caret leap) and autosave writes the stale rawSource.
+    /// didChangeText consumes the storage's pendingEdit synchronously within
+    /// the same event turn, so a pendingEdit still unconsumed on the next
+    /// run-loop pass is exactly the "didChangeText was bypassed" signal —
+    /// heal by running the sync it would have run.
+    private func scheduleBypassedEditSyncCheck() {
+        guard !bypassedEditCheckScheduled else { return }
+        bypassedEditCheckScheduled = true
+        // RunLoop.perform, not DispatchQueue.main.async: identical "next
+        // run-loop pass" timing in the app, but also drainable by
+        // `RunLoop.main.run(until:)` in tests.
+        RunLoop.main.perform { [weak self] in
+            // The main run loop only ever performs on the main thread; the
+            // closure just isn't statically annotated as such.
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.bypassedEditCheckScheduled = false
+                guard let storage = self.textStorage as? EditorTextStorage,
+                      storage.pendingEdit != nil,
+                      !self.isUpdating, !self.isUndoRedoing,
+                      // During IME composition the unconsumed pendingEdit is
+                      // legitimate — didChangeText defers the sync until commit.
+                      !self.hasMarkedText() else { return }
+                // Permanent breadcrumb (release builds too): if a desync recurs,
+                // grep ~/.edmund/logs for this line to see which path bypassed
+                // didChangeText.
+                Log.info("healing storage edit that bypassed didChangeText: " +
+                         "storLen=\(storage.length) rawLen=\((self.rawSource as NSString).length)",
+                         category: .edit)
+                self.syncRawSourceFromDisplay()
+                self.document?.updateChangeCount(.changeDone)
+            }
+        }
     }
 
     public override func didChangeText() {

--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -66,6 +66,9 @@ public class EditorTextView: NSTextView {
     /// Coalesces scroll-driven promotion onto the next run-loop turn, off the
     /// scroll notification (see EditorTextView+LazyStyling).
     var pendingPromotion = false
+    /// Coalesces the didChangeText-bypass check scheduled from
+    /// shouldChangeText (see EditorTextView+EditFlow).
+    var bypassedEditCheckScheduled = false
     /// Where the idle drain resumes scanning for unstyled blocks (a hint;
     /// it wraps around and self-corrects after edits shift indices).
     var drainCursor = 0

--- a/Tests/EdmundTests/BypassedEditSyncTests.swift
+++ b/Tests/EdmundTests/BypassedEditSyncTests.swift
@@ -1,0 +1,64 @@
+import Testing
+import AppKit
+@testable import EdmundCore
+
+/// Regression tests for the round-4 "delete drift" (issue #156): AppKit's
+/// drag-move source deletion runs shouldChangeText → replaceCharacters but
+/// never calls didChangeText, so rawSource/blocks silently freeze. Every later
+/// edit then does offset math against the stale model (the caret leap) and
+/// autosave writes the stale rawSource. The fix schedules a check from
+/// shouldChangeText: a pendingEdit still unconsumed on the next run-loop pass
+/// means didChangeText was bypassed, and the editor heals by running the sync
+/// didChangeText would have run.
+@Suite("didChangeText-bypass heal (delete drift round 4)") @MainActor
+struct BypassedEditSyncTests {
+
+    /// An edit that goes through shouldChangeText but never didChangeText —
+    /// the drag-move source deletion — must be healed on the next run-loop
+    /// pass, restoring storage == rawSource and a parseable model.
+    @Test func editBypassingDidChangeTextHeals() {
+        let editor = makeEditor()
+        editor.loadContent("alpha\nbravo\ncharlie")
+        editor.setSelectedRange(NSRange(location: 11, length: 0))
+
+        // Simulate AppKit's bypass: shouldChangeText, storage mutation, and
+        // no closing didChangeText.
+        let dragged = NSRange(location: 6, length: 5)   // "bravo"
+        #expect(editor.shouldChangeText(in: dragged, replacementString: ""))
+        editor.textStorage!.replaceCharacters(in: dragged, with: "")
+
+        // Desync is live: storage moved, model frozen.
+        #expect(editor.textStorage!.string != editor.rawSource)
+
+        // The scheduled check fires on the next main-run-loop pass and heals.
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+        #expect(editor.textStorage!.string == editor.rawSource)
+        let joined = editor.blocks.map(\.content).joined(separator: "\n")
+        #expect(joined == editor.rawSource)
+
+        // A normal backspace now deletes exactly one character — no drift.
+        editor.setSelectedRange(NSRange(location: 5, length: 0))
+        pressBackspace(in: editor)
+        #expect(editor.rawSource == "alph\n\ncharlie")
+        #expect(editor.textStorage!.string == editor.rawSource)
+    }
+
+    /// The check must NOT fire during a live IME composition: there the
+    /// unconsumed pendingEdit is legitimate and didChangeText syncs on commit.
+    @Test func healSkipsLiveComposition() {
+        let editor = makeEditor()
+        editor.loadContent("alpha\nbravo\ncharlie")
+        editor.setSelectedRange(NSRange(location: 5, length: 0))
+
+        editor.setMarkedText("´", selectedRange: NSRange(location: 0, length: 1),
+                             replacementRange: NSRange(location: NSNotFound, length: 0))
+        #expect(editor.hasMarkedText())
+        #expect(editor.textStorage!.string != editor.rawSource)   // transient
+
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+        // Still composing: the heal must not have recomposed the marked text
+        // away or force-synced mid-composition.
+        #expect(editor.hasMarkedText())
+        #expect(editor.textStorage!.string != editor.rawSource)
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -306,6 +306,18 @@ them and route through the app's document graph without JavaScript.
   `+SelectionTracking`). `becomeFirstResponder` resyncs from storage as a
   catch-all if a composition is ever left stranded. Full write-up:
   `docs/delete-drift-investigation.md`.
+- **AppKit does not pair every storage mutation with `didChangeText`.** A
+  drag-move of the selected text whose drop lands on no valid target (e.g.
+  released past the end of the document) deletes the dragged range via
+  `shouldChangeText` → `replaceCharacters` and **never calls `didChangeText`**
+  — silently freezing `rawSource`/`blocks`, after which every edit drifts the
+  caret and autosave writes the stale `rawSource` (delete-drift round 4).
+  `shouldChangeText` therefore schedules a next-run-loop bypass check: a
+  storage `pendingEdit` still unconsumed by then means the closing
+  `didChangeText` never came, and the editor heals by running the same sync
+  (`+EditFlow`, `scheduleBypassedEditSyncCheck`; `healing storage edit that
+  bypassed didChangeText` in `~/.edmund/logs` is its breadcrumb). Never build
+  a sync path on the assumption that `didChangeText` follows every edit.
 - **A custom toolbar item can't win a right-click from a view-level handler.**
   With `NSToolbar.allowsUserCustomization = true`, the toolbar turns any
   secondary (right / control) click over the toolbar — *including* a custom item

--- a/docs/delete-drift-investigation.md
+++ b/docs/delete-drift-investigation.md
@@ -212,3 +212,87 @@ reproduce, and send `~/.edmund/logs`. The trace shows exactly when the caret
 diverges from the edit and what the marked-text / flag / length state was at that
 instant — which should finally localize the live-layer cause (still-sneaking
 marked text vs. a TextKit 2 selection-after-edit quirk).
+
+## Round 4: the round-3 diagnostics caught it — a drag-move deletes without `didChangeText`
+
+The verbose trace (`misc/bug-repros/edmund-2026-06-30_delete-caret-drift-4.log`)
+paid off. Reporter's extra clue: drifts start **right after drag-selecting text
+and doing something with it**. Fixed on branch
+`fix/delete-caret-drift-round-4`.
+
+### What the trace showed
+
+Every drifting delete had one signature, distinct from healthy deletes:
+
+- **Healthy**: `shouldChangeText` → `selectionDidChange` (up=N, transient
+  LEN-MISMATCH, caret already adjusted) → `synced` with correct `cursorRaw`.
+- **Drifting**: `shouldChangeText` → *nothing* → `selectionDidChange` **up=Y**
+  (fires mid-recompose, storage and rawSource both already synced, caret
+  already leaped) → `synced` logged with a **stale** `cursorRaw`.
+
+Walking back to the first bad event found the origin (11:06:17–19):
+
+```
+selectionDidChange sel={329,17}                 ← drag-select
+shouldChangeText OK range={329,17} repl=""      ← 1s gap = drag gesture
+selectionDidChange sel={329,0} storLen=329 rawLen=346 ⚠︎LEN-MISMATCH
+                                                ← storage shrank; NO synced /
+                                                  SKIPPED / DEFERRED line ever
+```
+
+`didChangeText` **was never called** for that deletion. Every path through our
+override logs *something*, so the call itself was absent — an AppKit path that
+runs `shouldChangeText` → `replaceCharacters` and skips the closing
+`didChangeText`.
+
+### Live reproduction (deterministic)
+
+Scripted CGEvent automation against the real app found the exact gesture:
+
+1. Drag-select some text.
+2. **Drag the selection and drop it past the end of the document** (below the
+   last line — a drop that falls through to no valid insertion target, or
+   toward another window). The move's insert half syncs fine; the **source
+   deletion** then runs `shouldChangeText` → `replaceCharacters` with **no
+   `didChangeText`**.
+3. `rawSource`/`blocks` silently freeze (LEN-MISMATCH on every following trace
+   line). The desync also reaches disk: **autosave writes the stale
+   `rawSource`** — this was a data-corruption bug, not just a caret bug.
+4. Click into another block and press Delete: the heal-on-next-edit sync runs
+   *inside* that keystroke, NSTextView's own selection adjustment arrives late
+   and resolves against the mid-restyle layout, and the caret leaps (in the
+   repro: 210 → 371, then snapping toward doc end on each delete) — exactly
+   the round-1/2/3 symptom.
+
+Consistent with rounds 1–3: focus-switch "fixed" it (any recovery resync), it
+needed accumulated state (a prior fumbled drag), and it never reproduced
+headlessly (drag sessions are live-app-only).
+
+### The fix
+
+`EditorTextView+EditFlow.swift` — `shouldChangeText` schedules a **bypass
+check on the next run-loop pass** (`RunLoop.main.perform`, coalesced by
+`bypassedEditCheckScheduled`): `didChangeText` consumes the storage's
+`pendingEdit` synchronously within the same event turn, so a `pendingEdit`
+still unconsumed one pass later is exactly the "didChangeText was bypassed"
+signal. The check then runs the same sync `didChangeText` would have
+(`syncRawSourceFromDisplay` + dirty-change count), and logs a permanent
+`healing storage edit that bypassed didChangeText` breadcrumb (release too).
+Guards: skipped while `isUpdating` / `isUndoRedoing` / `hasMarkedText()` (an
+unconsumed `pendingEdit` during IME composition is legitimate — the commit's
+`didChangeText` syncs it).
+
+Verified live with the scripted repro: the heal fires ~60ms after the rogue
+deletion, and the previously-drifting delete sequence runs with healthy
+ordering and a correct caret. `Tests/EdmundTests/BypassedEditSyncTests.swift`
+covers the heal and the IME-composition exemption headlessly.
+
+### Why the caret leaped during the *heal* sync (round-4 mechanics)
+
+When the heal ran lazily (inside the next delete's `didChangeText`, as before
+the fix), that keystroke's model math used the stale blocks and NSTextView's
+own post-edit selection fix was deferred past our recompose — it then resolved
+against invalidated layout and landed the caret at the following block
+boundary. Healing on the run-loop pass right after the rogue edit (before any
+further keystroke) removes both ingredients; no explicit selection repair was
+needed.


### PR DESCRIPTION
Fixes the round-4 recurrence of #156 (edit-mode delete caret drift).

## Root cause

A drag-move of the selected text whose drop lands on no valid target (e.g. released past the end of the document) deletes the dragged range via `shouldChangeText` → `replaceCharacters` and **never calls `didChangeText`** — the single hook the editor's model sync hangs on. `rawSource`/`blocks` silently freeze; every later edit does its offset math against the stale model (the caret leap in the issue's recordings) and **autosave writes the stale `rawSource`** — so this was also a silent save-corruption bug, not just a caret bug.

Found via the round-3 verbose trace (`misc/bug-repros/edmund-2026-06-30_delete-caret-drift-4.log`): the first drifting event is a selection deletion with a `shouldChangeText` line and no `synced`/`SKIPPED`/`DEFERRED` line — `didChangeText` was never invoked. Reproduced deterministically against the live app with scripted drag events.

## Fix

`didChangeText` consumes the storage's `pendingEdit` synchronously within the same event turn, so `shouldChangeText` now schedules a next-run-loop check: a still-unconsumed `pendingEdit` means the closing `didChangeText` never came, and the editor heals by running the sync it would have run. Skipped while `isUpdating`/`isUndoRedoing`/`hasMarkedText()` (an unconsumed `pendingEdit` during IME composition is legitimate — the commit's `didChangeText` syncs it). Logs a permanent breadcrumb (`healing storage edit that bypassed didChangeText`) so any future bypass path is greppable in `~/.edmund/logs`.

## Verification

- 793 tests green; 2 new regression tests (`BypassedEditSyncTests`): the bypass heals on the next run-loop pass, and the check exempts live IME composition.
- Live replay of the repro gesture: heal fires ~60ms after the rogue deletion; the previously-drifting delete sequence keeps a correct caret (230→229→228→227, no leap).
- Docs: round-4 write-up in `docs/delete-drift-investigation.md`, new gotcha in ARCHITECTURE §8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)