### PR TITLE
Fix viewport glitches: diff-based undo/redo, drag-scroll oscillation, TextKit 2 estimate mitigations

### DIFF
--- a/Sources/EdmundCore/TextView/EditorTextView+Composition.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+Composition.swift
@@ -165,7 +165,15 @@ extension EditorTextView {
 
         isUpdating = false
 
-        if !deferred.isEmpty { scheduleProgressiveStyling() }
+        if !deferred.isEmpty {
+            scheduleProgressiveStyling()
+        } else {
+            // Small documents stay fully laid out (no TextKit 2 height
+            // estimates): re-lay the blocks this flush invalidated once this
+            // interaction settles. Cheap on the per-keystroke path — only the
+            // invalidated fragments are re-laid.
+            scheduleFullLayoutSettle()
+        }
     }
 
     /// Maps a block's raw NSRange to an `NSTextRange` for layout invalidation.

--- a/Sources/EdmundCore/TextView/EditorTextView+LazyStyling.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+LazyStyling.swift
@@ -96,7 +96,47 @@ extension EditorTextView {
         }
         isUpdating = false
 
-        if remaining { scheduleProgressiveStyling() }
+        if remaining {
+            scheduleProgressiveStyling()
+        } else {
+            scheduleFullLayoutSettle()
+        }
+    }
+
+    /// TextKit 2 only gives a fragment a real frame once it's laid out;
+    /// everything else is a height *estimate*, and estimate corrections are
+    /// what make the scroller jump, drag-selection autoscroll oscillate, and
+    /// scroll targets land wrong. For small documents we can afford to lay
+    /// everything out once styling has converged, so no estimates remain.
+    /// `ensureLayout` is incremental — already-laid-out fragments are skipped
+    /// — so repeated settles after edits only re-lay the invalidated blocks.
+    /// (Large documents keep viewport-based layout: a full layout there is
+    /// the process-killing path that motivated `scrollRangeToVisible`'s
+    /// override.)
+    ///
+    /// Runs on the next run-loop pass, wrapped in `preservingViewportAnchor`:
+    /// correcting estimates *above* the viewport shifts every laid-out
+    /// position below them, so doing it synchronously inside a caller's own
+    /// anchored restyle would poison that caller's before/after measurement.
+    func scheduleFullLayoutSettle() {
+        guard !fullLayoutSettleScheduled,
+              (textStorage?.length ?? 0) <= Self.fullLayoutMaxLength else { return }
+        fullLayoutSettleScheduled = true
+        // RunLoop.perform, not DispatchQueue.main.async, so tests can drain it
+        // with `RunLoop.main.run(until:)`.
+        RunLoop.main.perform { [weak self] in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.fullLayoutSettleScheduled = false
+                guard !self.isUpdating, !self.hasMarkedText(),
+                      let tlm = self.textLayoutManager,
+                      (self.textStorage?.length ?? 0) <= Self.fullLayoutMaxLength,
+                      self.blocks.allSatisfy({ $0.isStyled }) else { return }
+                self.preservingViewportAnchor {
+                    tlm.ensureLayout(for: tlm.documentRange)
+                }
+            }
+        }
     }
 
     /// Styles any unstyled blocks inside the current viewport window. Forces a

--- a/Sources/EdmundCore/TextView/EditorTextView+LazyStyling.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+LazyStyling.swift
@@ -119,8 +119,7 @@ extension EditorTextView {
     /// position below them, so doing it synchronously inside a caller's own
     /// anchored restyle would poison that caller's before/after measurement.
     func scheduleFullLayoutSettle() {
-        guard !fullLayoutSettleScheduled,
-              (textStorage?.length ?? 0) <= Self.fullLayoutMaxLength else { return }
+        guard !fullLayoutSettleScheduled else { return }
         fullLayoutSettleScheduled = true
         // RunLoop.perform, not DispatchQueue.main.async, so tests can drain it
         // with `RunLoop.main.run(until:)`.
@@ -129,13 +128,50 @@ extension EditorTextView {
                 guard let self else { return }
                 self.fullLayoutSettleScheduled = false
                 guard !self.isUpdating, !self.hasMarkedText(),
-                      let tlm = self.textLayoutManager,
-                      (self.textStorage?.length ?? 0) <= Self.fullLayoutMaxLength,
+                      let tlm = self.textLayoutManager else { return }
+                self.repairContentAboveOrigin()
+                guard (self.textStorage?.length ?? 0) <= Self.fullLayoutMaxLength,
                       self.blocks.allSatisfy({ $0.isStyled }) else { return }
                 self.preservingViewportAnchor {
                     tlm.ensureLayout(for: tlm.documentRange)
                 }
             }
+        }
+    }
+
+    /// TextKit 2 can leave the document's first fragment at a *negative* y
+    /// after edits near the top: layout proceeding upward from a viewport
+    /// anchor with a wrong height estimate assigns origins above 0, and
+    /// nothing renormalizes them. The symptom is the first line sitting above
+    /// the visible area with the scroller already at the top — unreachable.
+    /// Repair: re-lay from the document start (anchoring the first fragment
+    /// back at y 0) inside `preservingViewportAnchor`, which compensates the
+    /// clip origin so what the user is looking at doesn't move — and the
+    /// content above becomes scrollable again.
+    func repairContentAboveOrigin() {
+        guard let tlm = textLayoutManager else { return }
+        var firstMinY: CGFloat?
+        tlm.enumerateTextLayoutFragments(from: tlm.documentRange.location, options: []) {
+            firstMinY = $0.layoutFragmentFrame.minY
+            return false
+        }
+        guard let firstMinY, firstMinY < -0.5 else { return }
+
+        // Bound the re-lay to start→viewport-end (the bug only manifests with
+        // the viewport near the top, so this is small); bail on huge spans
+        // rather than risk the full-document layout cost on a large file.
+        var end = tlm.documentRange.endLocation
+        if let vp = tlm.textViewportLayoutController.viewportRange {
+            end = vp.endLocation
+        }
+        guard tlm.offset(from: tlm.documentRange.location, to: end) <= 60_000,
+              let range = NSTextRange(location: tlm.documentRange.location, end: end)
+        else { return }
+        Log.info("repairing content above origin: firstMinY=\(firstMinY)",
+                 category: .compose)
+        preservingViewportAnchor {
+            tlm.invalidateLayout(for: range)
+            tlm.ensureLayout(for: range)
         }
     }
 

--- a/Sources/EdmundCore/TextView/EditorTextView+TypewriterScroll.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+TypewriterScroll.swift
@@ -85,6 +85,23 @@ extension EditorTextView {
 
         scrollView.contentView.scroll(to: NSPoint(x: 0, y: clampedY))
         scrollView.reflectScrolledClipView(scrollView.contentView)
+
+        // Settle passes: the target Y was computed from geometry that can
+        // still contain TextKit 2 height *estimates* above the caret. After
+        // the scroll, the viewport's own layout is real — re-measure and
+        // correct any residual error (typically converges in one pass;
+        // bounded for safety).
+        guard let tlm = textLayoutManager else { return }
+        for _ in 0..<3 {
+            tlm.textViewportLayoutController.layoutViewport()
+            guard let settled = caretLineRect() else { return }
+            let settledTarget = settled.midY + textContainerOrigin.y - visibleHeight / 2
+            let settledMaxY = max(0, frame.height - visibleHeight)
+            let settledY = min(max(0, settledTarget), settledMaxY)
+            guard abs(settledY - scrollView.contentView.bounds.origin.y) > 1 else { return }
+            scrollView.contentView.scroll(to: NSPoint(x: 0, y: settledY))
+            scrollView.reflectScrolledClipView(scrollView.contentView)
+        }
     }
 
     /// Lays out the span between the current viewport and the caret so the
@@ -128,6 +145,22 @@ extension EditorTextView {
                                  y: lineRect.minY + textContainerOrigin.y,
                                  width: 1, height: lineRect.height)
         return visible.intersects(caretInView)
+    }
+
+    /// Whether any part of `range`'s vertical span (start line through end
+    /// line) lies within the viewport defined by `origin`. Used by undo/redo
+    /// to decide hold-vs-center for the restored change.
+    func rangeIsVisible(_ range: NSRange, forViewportOrigin origin: CGPoint) -> Bool {
+        guard let scrollView = enclosingScrollView,
+              let startRect = lineRect(forCharacterAt: range.location) else { return false }
+        let endRect = range.length > 0
+            ? (lineRect(forCharacterAt: range.upperBound) ?? startRect) : startRect
+        let visible = CGRect(origin: origin, size: scrollView.contentView.bounds.size)
+        let span = CGRect(x: visible.minX,
+                          y: min(startRect.minY, endRect.minY) + textContainerOrigin.y,
+                          width: 1,
+                          height: max(startRect.maxY, endRect.maxY) - min(startRect.minY, endRect.minY))
+        return visible.intersects(span)
     }
 
     /// The caret line's rect in text-container coordinates (TextKit 2: lays
@@ -177,7 +210,18 @@ extension EditorTextView {
         let margin: CGFloat = 8
 
         var targetY = visible.origin.y
-        if top < visible.minY {
+        if top < visible.minY && bottom > visible.maxY {
+            // The range overflows the viewport on both sides (e.g. a drag
+            // selection grown taller than the screen). Follow the end
+            // *nearest* the viewport — that's the end being extended. Always
+            // scrolling to the top here fought the drag's downward autoscroll
+            // and made the viewport oscillate up and down mid-drag.
+            let overflowTop = visible.minY - top
+            let overflowBottom = bottom - visible.maxY
+            targetY = overflowBottom <= overflowTop
+                ? bottom + margin - visible.height
+                : top - margin
+        } else if top < visible.minY {
             targetY = top - margin
         } else if bottom > visible.maxY {
             // Prefer keeping the bottom edge visible; fall back to the top if

--- a/Sources/EdmundCore/TextView/EditorTextView+Undo.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+Undo.swift
@@ -53,37 +53,117 @@ extension EditorTextView {
         restoreSnapshot(snapshot)
     }
 
+    /// The single contiguous span that differs between two strings, as the
+    /// replaced range in `old` (UTF-16) plus its replacement text from `new`.
+    /// nil when the strings are equal. Boundaries never split a surrogate
+    /// pair, so the result is always safe to select or restyle.
+    nonisolated static func textDiff(old: String, new: String) -> (oldRange: NSRange, replacement: String)? {
+        let o = old as NSString
+        let n = new as NSString
+        guard !o.isEqual(to: new) else { return nil }
+
+        var prefix = 0
+        let maxPrefix = min(o.length, n.length)
+        while prefix < maxPrefix && o.character(at: prefix) == n.character(at: prefix) {
+            prefix += 1
+        }
+        var suffix = 0
+        let maxSuffix = min(o.length, n.length) - prefix
+        while suffix < maxSuffix
+            && o.character(at: o.length - 1 - suffix) == n.character(at: n.length - 1 - suffix) {
+            suffix += 1
+        }
+        // Widen rather than split a surrogate pair at either boundary.
+        while prefix > 0 && UTF16.isLeadSurrogate(o.character(at: prefix - 1)) {
+            prefix -= 1
+        }
+        while suffix > 0 && UTF16.isTrailSurrogate(o.character(at: o.length - suffix)) {
+            suffix -= 1
+        }
+
+        let oldRange = NSRange(location: prefix, length: o.length - suffix - prefix)
+        let replacement = n.substring(with: NSRange(location: prefix,
+                                                    length: n.length - suffix - prefix))
+        return (oldRange, replacement)
+    }
+
     private func restoreSnapshot(_ snapshot: UndoSnapshot) {
+        // Diff the current text against the snapshot: the changed span is what
+        // this undo/redo actually touches, so it drives the selection and the
+        // viewport — not the caret stored at snapshot time (which, for redo,
+        // is wherever the caret happened to sit when undo was invoked).
+        guard let diff = Self.textDiff(old: rawSource, new: snapshot.rawSource) else {
+            // Nothing changed textually — just restore the caret.
+            let clamped = min(snapshot.cursorInRaw, (rawSource as NSString).length)
+            setSelectedRange(NSRange(location: clamped, length: 0))
+            return
+        }
+
         isUndoRedoing = true
+        let oldIndentUnit = listIndentUnit
+        let oldActive = activeBlockIndex
+        let oldCount = blocks.count
+
         rawSource = snapshot.rawSource
         rebuildListIndentState()
-        blocks = BlockParser.parse(rawSource, previous: blocks)
+        let (newBlocks, changed) = BlockParser.parseWithDiff(rawSource, previous: blocks)
+        blocks = newBlocks
 
-        // Drive the viewport deliberately so undo/redo doesn't lurch.
+        var dirty = IndexSet(integersIn: changed)
+        // Map the old active block through the diff (same scheme as the edit
+        // path): prefix indices are unchanged, suffix indices shift by the
+        // count delta, anything inside the window is already dirty.
+        if let old = oldActive {
+            let suffixCount = newBlocks.count - changed.upperBound
+            if old < changed.lowerBound {
+                dirty.insert(old)
+            } else if old >= oldCount - suffixCount {
+                dirty.insert(old + (newBlocks.count - oldCount))
+            }
+        }
+        // listIndentUnit is document-global: when it changes, every list
+        // block's rendered indentation changes with it.
+        if listIndentUnit != oldIndentUnit {
+            for (i, block) in blocks.enumerated() where block.kind == .listItem {
+                dirty.insert(i)
+            }
+        }
+
+        // The changed text in restored coordinates: select it so the user sees
+        // exactly what this undo/redo did. A pure deletion has no new text to
+        // select — the caret goes to the deletion point instead.
+        let changedInNew = NSRange(location: diff.oldRange.location,
+                                   length: (diff.replacement as NSString).length)
+        let selection: NSRange? = changedInNew.length > 0 ? changedInNew : nil
+
+        // Range-bounded storage replacement: layout outside the changed span
+        // stays real. (The old full `recompose` reset the whole document to
+        // TextKit 2 height estimates, and centering math done on estimates is
+        // what made the post-undo scroll land too far down.)
+        let apply = {
+            self.recomposeReplacing(oldRange: diff.oldRange, with: diff.replacement,
+                                    dirty: dirty, cursorInRaw: changedInNew.location,
+                                    selectionInRaw: selection)
+        }
+
         if typewriterModeEnabled {
-            // Typewriter: the caret is always centered, so re-center on it.
-            recompose(cursorInRaw: snapshot.cursorInRaw)
+            // Typewriter: always center on the changed text.
+            apply()
             centerViewportOnCaret()
         } else if let scrollView = enclosingScrollView {
-            // Remember exactly where the viewport was, recompose, then: if the
-            // restored caret (the change being undone) is already on screen,
-            // hold the viewport perfectly still — no measured-delta nudge, so no
-            // residual jump. Only when the edit is off-screen do we scroll, and
-            // then we put the caret at the exact vertical center.
+            // If any of the changed text is already on screen, hold the
+            // viewport perfectly still; otherwise center the change.
             let savedOrigin = scrollView.contentView.bounds.origin
-            recompose(cursorInRaw: snapshot.cursorInRaw)
-            // Lay out the caret's real geometry before deciding visible-vs-center,
-            // otherwise an off-screen caret's estimated position can look "visible"
-            // and the viewport wrongly holds instead of centering.
+            apply()
             ensureCaretRegionLaidOut()
-            if caretIsVisible(forViewportOrigin: savedOrigin) {
+            if rangeIsVisible(changedInNew, forViewportOrigin: savedOrigin) {
                 scrollView.contentView.scroll(to: savedOrigin)
                 scrollView.reflectScrolledClipView(scrollView.contentView)
             } else {
                 centerViewportOnCaret()
             }
         } else {
-            recompose(cursorInRaw: snapshot.cursorInRaw)
+            apply()
         }
 
         isUndoRedoing = false

--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -72,6 +72,13 @@ public class EditorTextView: NSTextView {
     /// Where the idle drain resumes scanning for unstyled blocks (a hint;
     /// it wraps around and self-corrects after edits shift indices).
     var drainCursor = 0
+    /// Coalesces the deferred full-document layout settle for small documents
+    /// (see EditorTextView+LazyStyling `scheduleFullLayoutSettle`).
+    var fullLayoutSettleScheduled = false
+    /// Documents at or below this UTF-16 length are laid out in full once
+    /// styling converges, eliminating TextKit 2 height estimates (and the
+    /// scroll jumps they cause). See `scheduleFullLayoutSettle`.
+    static let fullLayoutMaxLength = 100_000
 
     // MARK: - Custom Undo/Redo State
 

--- a/Tests/EdmundTests/UndoRedoViewportTests.swift
+++ b/Tests/EdmundTests/UndoRedoViewportTests.swift
@@ -1,0 +1,253 @@
+import Testing
+import AppKit
+@testable import EdmundCore
+
+// MARK: - textDiff
+
+@Suite("Undo/redo text diff")
+struct TextDiffTests {
+
+    @Test("Equal strings diff to nil")
+    func equalStrings() {
+        #expect(EditorTextView.textDiff(old: "abc", new: "abc") == nil)
+        #expect(EditorTextView.textDiff(old: "", new: "") == nil)
+    }
+
+    @Test("Pure insertion")
+    func insertion() {
+        let d = EditorTextView.textDiff(old: "ac", new: "abc")
+        #expect(d?.oldRange == NSRange(location: 1, length: 0))
+        #expect(d?.replacement == "b")
+    }
+
+    @Test("Pure deletion")
+    func deletion() {
+        let d = EditorTextView.textDiff(old: "abc", new: "ac")
+        #expect(d?.oldRange == NSRange(location: 1, length: 1))
+        #expect(d?.replacement == "")
+    }
+
+    @Test("Replacement")
+    func replacement() {
+        let d = EditorTextView.textDiff(old: "hello world", new: "hello brave world")
+        #expect(d?.oldRange == NSRange(location: 6, length: 0))
+        #expect(d?.replacement == "brave ")
+    }
+
+    @Test("Whole-string replacement")
+    func wholeString() {
+        let d = EditorTextView.textDiff(old: "abc", new: "xyz")
+        #expect(d?.oldRange == NSRange(location: 0, length: 3))
+        #expect(d?.replacement == "xyz")
+    }
+
+    @Test("Repeated character insertion picks a single contiguous span")
+    func repeatedChars() {
+        // "aaa" → "aaaa": prefix eats 3, suffix 0 → insert at 3.
+        let d = EditorTextView.textDiff(old: "aaa", new: "aaaa")
+        #expect(d?.oldRange.length == 0)
+        #expect(d?.replacement == "a")
+    }
+
+    @Test("Surrogate pairs are never split")
+    func surrogates() {
+        // 😀 = D83D DE00, 😅 = D83D DE05 — common lead surrogate would split
+        // the pair if the diff were computed naively per UTF-16 unit.
+        let d = EditorTextView.textDiff(old: "a😀b", new: "a😅b")
+        let old = "a😀b" as NSString
+        let range = d!.oldRange
+        // Boundaries must sit on scalar boundaries: the range covers the
+        // whole emoji, and the replacement is the whole new emoji.
+        #expect(range == NSRange(location: 1, length: 2))
+        #expect(d?.replacement == "😅")
+        #expect(old.substring(with: range) == "😀")
+    }
+}
+
+// MARK: - Undo/redo selection
+
+/// Puts the caret at `offset` through the recompose path so
+/// `activeBlockIndex` is in sync (bare `setSelectedRange` in headless tests
+/// leaves it stale, which splits the next typing run into two undo groups).
+@MainActor
+private func placeCaret(_ editor: EditorTextView, at offset: Int) {
+    editor.setSelectedRange(NSRange(location: offset, length: 0))
+    editor.recomposeIncremental(cursorInRaw: offset)
+}
+
+@Suite("Undo/redo selects the changed text")
+struct UndoRedoSelectionTests {
+
+    @Test("Redo selects the restored text")
+    @MainActor func redoSelectsRestoredText() {
+        let editor = makeEditor()
+        editor.loadContent("aaa\nbbb\nccc")
+        editor.setSelectedRange(NSRange(location: 3, length: 0))
+        type(" X", into: editor)
+        #expect(editor.rawSource == "aaa X\nbbb\nccc")
+
+        editor.undo(nil)
+        #expect(editor.rawSource == "aaa\nbbb\nccc")
+        // Undo of an insertion is a deletion — caret at the deletion point.
+        #expect(editor.selectedRange() == NSRange(location: 3, length: 0))
+
+        editor.redo(nil)
+        #expect(editor.rawSource == "aaa X\nbbb\nccc")
+        // The re-inserted text is selected.
+        #expect(editor.selectedRange() == NSRange(location: 3, length: 2))
+    }
+
+    @Test("Redo targets the changed text, not the caret at undo time")
+    @MainActor func redoIgnoresStaleCaret() {
+        let editor = makeEditor()
+        editor.loadContent("aaa\nbbb\nccc")
+        placeCaret(editor, at: 8)
+        type("ZZ", into: editor)
+        editor.undo(nil)
+        // Move the caret far from the change before redoing.
+        editor.setSelectedRange(NSRange(location: 0, length: 0))
+        editor.redo(nil)
+        #expect(editor.rawSource == "aaa\nbbb\nZZccc")
+        #expect(editor.selectedRange() == NSRange(location: 8, length: 2))
+    }
+
+    @Test("Undo of a deletion selects the restored text")
+    @MainActor func undoDeletionSelectsRestoredText() {
+        let editor = makeEditor()
+        editor.loadContent("aaa\nbbb\nccc")
+        placeCaret(editor, at: 7)
+        pressBackspace(in: editor)
+        pressBackspace(in: editor)
+        #expect(editor.rawSource == "aaa\nb\nccc")
+
+        editor.undo(nil)
+        #expect(editor.rawSource == "aaa\nbbb\nccc")
+        // The two restored characters are selected.
+        #expect(editor.selectedRange() == NSRange(location: 5, length: 2))
+    }
+
+    @Test("Undo/redo round-trip keeps storage == rawSource")
+    @MainActor func invariantHolds() {
+        let editor = makeEditor()
+        editor.loadContent("# Title\n\n- item one\n- item two\n\npara")
+        editor.setSelectedRange(NSRange(location: 12, length: 0))
+        type("hello", into: editor)
+        editor.undo(nil)
+        #expect(editor.textStorage?.string == editor.rawSource)
+        editor.redo(nil)
+        #expect(editor.textStorage?.string == editor.rawSource)
+        assertMatchesFullRecomposeOracle(editor)
+    }
+}
+
+// MARK: - Undo/redo viewport
+
+@Suite("Undo/redo viewport placement")
+struct UndoRedoViewportTests {
+
+    @MainActor
+    private func makeScrollingEditor(_ doc: String) -> (EditorTextView, NSScrollView) {
+        let editor = makeEditor()
+        let win = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 500, height: 300),
+                           styleMask: [.titled], backing: .buffered, defer: false)
+        let scroll = NSScrollView(frame: win.contentLayoutRect)
+        scroll.documentView = editor
+        win.contentView = scroll
+        win.makeFirstResponder(editor)
+        editor.typewriterModeEnabled = false
+        editor.isVerticallyResizable = true
+        editor.minSize = NSSize(width: 0, height: 0)
+        editor.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude,
+                                height: CGFloat.greatestFiniteMagnitude)
+        editor.autoresizingMask = [.width]
+        editor.loadContent(doc)
+        drainAllStyling(editor)
+        ensureFullLayout(editor)
+        editor.sizeToFit()
+        editor.layoutSubtreeIfNeeded()
+        return (editor, scroll)
+    }
+
+    /// The changed line's vertical distance from the viewport's center.
+    @MainActor
+    private func distanceFromViewportCenter(of offset: Int, _ editor: EditorTextView,
+                                            _ scroll: NSScrollView) -> CGFloat? {
+        guard let rect = editor.lineRect(forCharacterAt: offset) else { return nil }
+        let visible = scroll.contentView.bounds
+        return abs(rect.midY + editor.textContainerOrigin.y - visible.midY)
+    }
+
+    @Test("Undo of an off-screen edit centers the changed text")
+    @MainActor func undoCentersOffscreenChange() {
+        var doc = ""
+        for i in 0..<80 { doc += "paragraph number \(i)\n\n" }
+        let (editor, scroll) = makeScrollingEditor(doc)
+
+        // Edit deep in the document…
+        let target = (editor.rawSource as NSString).range(of: "paragraph number 60").location
+        editor.setSelectedRange(NSRange(location: target, length: 0))
+        editor.recomposeIncremental(cursorInRaw: target)
+        type("XYZ", into: editor)
+
+        // …then scroll away to the top and undo.
+        scroll.contentView.scroll(to: .zero)
+        scroll.reflectScrolledClipView(scroll.contentView)
+        editor.undo(nil)
+
+        // The deletion point (the changed text) is vertically centered.
+        let caret = editor.selectedRange().location
+        #expect(caret == target)
+        let dist = distanceFromViewportCenter(of: caret, editor, scroll)
+        #expect(dist != nil && dist! < 30,
+                "changed text is \(dist ?? -1)pt from the viewport center")
+    }
+
+    @Test("Redo centers the changed text, not the pre-undo caret")
+    @MainActor func redoCentersChangedText() {
+        var doc = ""
+        for i in 0..<80 { doc += "paragraph number \(i)\n\n" }
+        let (editor, scroll) = makeScrollingEditor(doc)
+
+        let target = (editor.rawSource as NSString).range(of: "paragraph number 60").location
+        editor.setSelectedRange(NSRange(location: target, length: 0))
+        editor.recomposeIncremental(cursorInRaw: target)
+        type("XYZ", into: editor)
+        editor.undo(nil)
+
+        // Simulate the user moving the caret and viewport far away, then redo.
+        editor.setSelectedRange(NSRange(location: 0, length: 0))
+        scroll.contentView.scroll(to: .zero)
+        scroll.reflectScrolledClipView(scroll.contentView)
+        editor.redo(nil)
+
+        // The restored text is selected and centered.
+        #expect(editor.selectedRange() == NSRange(location: target, length: 3))
+        let dist = distanceFromViewportCenter(of: target, editor, scroll)
+        #expect(dist != nil && dist! < 30,
+                "changed text is \(dist ?? -1)pt from the viewport center")
+    }
+
+    @Test("Undo of a visible edit holds the viewport still")
+    @MainActor func undoHoldsViewportWhenVisible() {
+        var doc = ""
+        for i in 0..<80 { doc += "paragraph number \(i)\n\n" }
+        let (editor, scroll) = makeScrollingEditor(doc)
+
+        let target = (editor.rawSource as NSString).range(of: "paragraph number 40").location
+        editor.setSelectedRange(NSRange(location: target, length: 0))
+        editor.recomposeIncremental(cursorInRaw: target)
+        // Bring the edit on screen the way undo will see it.
+        guard let lineY = editor.lineRect(forCharacterAt: target)?.midY else {
+            Issue.record("no line rect for the target"); return
+        }
+        scroll.contentView.scroll(to: NSPoint(x: 0, y: max(0, lineY - 150)))
+        scroll.reflectScrolledClipView(scroll.contentView)
+        type("XYZ", into: editor)
+
+        let yBefore = scroll.contentView.bounds.origin.y
+        editor.undo(nil)
+        let yAfter = scroll.contentView.bounds.origin.y
+        #expect(abs(yAfter - yBefore) < 2.0,
+                "viewport moved by \(yAfter - yBefore) on a visible undo")
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -97,8 +97,14 @@ rawSource ──BlockParser──▶ [Block]  ──styleBlock per block──�
 - **Incremental parsing**: edits capture a pending edit on `EditorTextStorage`
   and reparse a window, not the whole doc.
 - **Undo/redo** is custom: stacks of `rawSource` snapshots (`+Undo.swift`),
-  bypassing NSTextView's built-in undo. Restoring a snapshot manages the
-  viewport deliberately (hold if on-screen, else center on the caret).
+  bypassing NSTextView's built-in undo. Restoring a snapshot *diffs* the
+  snapshot against the current text (`textDiff`, single contiguous span) and
+  applies it with the range-bounded `recomposeReplacing` — never a full
+  `recompose`, which would reset every fragment to a TextKit 2 height
+  estimate and make the follow-up scroll land wrong. The changed text is
+  selected (caret at the deletion point for pure deletions) and drives the
+  viewport: hold if any of it is on-screen, else center it. The snapshot's
+  stored caret is only a fallback for a no-op diff.
 - **Cursor tracking** (`+SelectionTracking`): moving between blocks restyles
   both; moving within a block updates which token's delimiters are revealed.
 
@@ -294,6 +300,27 @@ them and route through the app's document graph without JavaScript.
   block whose height/indent changed, you must `invalidateLayout(for:)` its range
   or the fragment keeps a stale frame (empty bands / clipped lines). `recompose
   Dirty` and the idle drain already do this; new paths must too.
+- **TextKit 2 height *estimates* are the root of most viewport glitches.** A
+  fragment has a real frame only once laid out; everything else (and the total
+  document height) is an estimate that gets corrected as layout reaches it —
+  which is what makes the scroller jump and scroll-to-target land wrong (a
+  widely documented TK2 limitation; even TextEdit shows it). Mitigations here:
+  documents ≤ `fullLayoutMaxLength` (100k UTF-16) are kept **fully laid out**
+  by a coalesced next-run-loop settle (`scheduleFullLayoutSettle`, wrapped in
+  `preservingViewportAnchor` so corrections never shift what's on screen);
+  `centerViewportOnCaret` re-measures after its first scroll and corrects the
+  residual error; and undo/redo avoids resetting layout at all (see §4). Don't
+  add code that trusts an off-screen fragment's y-coordinate without laying
+  out the span first.
+- **TK2 can strand content above the document origin.** Edits near the top of
+  a tall document sometimes leave the first fragment at negative y: the first
+  line sits above the visible area and the scroller is already at the top, so
+  the user can't reach it. `repairContentAboveOrigin` (run by the layout
+  settle) detects a negative first-fragment origin and re-lays start→viewport
+  inside `preservingViewportAnchor` to renormalize.
+- **A selection taller than the viewport must be revealed at its *nearest*
+  end** (`scrollRangeToVisible` override): always revealing the top fought the
+  drag-selection autoscroll and oscillated the viewport mid-drag.
 - **Never mutate storage while an IME is composing (`hasMarkedText()`)**: during
   composition the storage holds the provisional marked text, so `storage ==
   rawSource` is transiently false and `didChangeText` defers syncing until

--- a/docs/viewport-glitch-investigation.md
+++ b/docs/viewport-glitch-investigation.md
@@ -1,0 +1,222 @@
+# Viewport glitches (undo/redo, top-edit, drag-select) — investigation notes
+
+Context for anyone touching viewport/scroll behavior again. Three separately
+reported symptoms turned out to share one root cause — **TextKit 2 height
+estimates** — reached through three different code paths, so this records the
+trail end to end.
+
+Fixed on branch `fix/viewport-glitches`, commits:
+
+- `5bb2b40` — fix(undo): select + center the changed text; diff-based snapshot restore
+- `340fcbc` — fix(scroll): follow the nearest end of a selection taller than the viewport
+- `217da5f` — fix(layout): keep small documents fully laid out (no TextKit 2 estimates)
+- `8b4ecfe` — fix(layout): repair TextKit 2 content stranded above the document origin
+- `cf10741` — docs: ARCHITECTURE §4/§8 updates
+
+## Symptoms (as reported)
+
+**Bug 1 — undo/redo viewport.** Undo/redo should center the viewport on the
+changed text and select it. Instead:
+
+- undo almost always scrolled **too far down** the document;
+- redo centered on **wherever the caret sat before the undo**, not on the
+  changed text;
+- the changed text was never selected.
+
+**Bug 2 — editing at the top.** Editing the first line of a
+taller-than-viewport file sometimes pushed the first line **above** the
+viewport, with the scroller already at the top — the user **couldn't scroll
+up** to reach it. Intermittent.
+
+**Bug 3 — drag-selection jerks.** Evidence:
+`~/Desktop/viewport-jerks-in-selection.mov`. Two phases:
+
+1. first half: dragging produced **no visible selection** at all;
+2. second half: during a steady downward drag (reporter: "I did not move my
+   hand"), the viewport **oscillated** — autoscrolled down, jumped back up,
+   repeatedly.
+
+## How it was diagnosed
+
+1. **Git history first.** Prior art on every one of these paths:
+   `9aaa11b` (undo/redo viewport hold-or-center), `21cc284`/`2778d6e`
+   (cursor-move lurch → `preservingViewportAnchor`), `84123e4` (pin scroll for
+   height changes above the viewport), `c49cd5c` (lazy viewport-first
+   styling). Each fix was sound but all of them *work around* the same
+   underlying instability without naming it.
+
+2. **Code read of the undo path** (`+Undo.swift`) found two concrete defects
+   before any experiment:
+   - `restoreSnapshot` ran a **full `recompose`** — replacing the entire text
+     storage discards every TextKit 2 layout fragment, so *all* geometry
+     reverts to estimates. The subsequent `caretIsVisible` /
+     `centerViewportOnCaret` math then ran on estimated y-coordinates →
+     scroll landed wrong (usually too far down). Explains Bug 1's undo drift.
+   - `performUndo` recorded the redo snapshot with
+     `currentCursorInRaw()` — the caret **at the moment undo was invoked**
+     (user may have clicked/scrolled anywhere since the edit). Redo then
+     restored and centered on that stale caret. Explains Bug 1's redo
+     behavior exactly.
+
+3. **Frame extraction from the video** (ffmpeg, 4–15 fps + contact sheets)
+   confirmed Bug 3 phase 2: monotonic downward autoscroll interrupted by
+   ~screen-sized upward jumps. Phase 1 showed a drag with the caret parked at
+   the document top and no selection appearing.
+
+4. **Phase-1 explanation came from the diagnostic log**, not the video: the
+   verbose trace from that session (`~/.edmund/logs/edmund-2026-07-02.log`,
+   20:29) shows `selectionDidChange | sel={0,1526}` — a **whole-document
+   selection was already active** when the drag began. Dragging *inside* an
+   existing selection is AppKit's drag-*move* gesture, not a new selection.
+   So "can't select" was standard (if surprising) AppKit behavior, and it's
+   the same gesture family as delete-drift round 4 (`9f99795`), where a
+   failed drag-move bypassed `didChangeText`. No new bug.
+
+5. **The upward jumps had exactly one candidate.** During a drag,
+   typewriter centering is suppressed (`suppressTypewriterCentering` spans
+   `super.mouseDown`), promotion is deferred, and `applyBlockStyle` is
+   attribute-only. The only up-scroller left is the **`scrollRangeToVisible`
+   override** (`+TypewriterScroll.swift`): when the selection overflowed the
+   viewport on *both* edges (a drag selection grown taller than the screen),
+   its first branch always revealed the selection **top** — while the drag's
+   autoscroll pulled toward the bottom. Two scrollers fighting → oscillation.
+
+6. **Known-issues research** (per the task brief: prioritize documented
+   TextKit 2 problems over empirical fiddling) closed the loop on Bugs 1–2.
+   Community consensus (Krzyżanowski / STTextView, Apple dev forums):
+   - a fragment's frame is only real once laid out; everything else, plus
+     `usageBoundsForTextContainer` and total document height, is an
+     **estimate** that changes as layout progresses;
+   - estimate corrections are what make the scroller jump and scroll-to-range
+     land wrong; even TextEdit exhibits it;
+   - the reliable recipe for scrolling to a target: ensure layout for the
+     target range **first**, then align the viewport to real geometry;
+   - the practical mitigation for small documents: keep them **fully laid
+     out** so estimates never exist. (This matches the reporter's own
+     suggestion: "load small files fully".)
+
+   Sources:
+   - https://blog.krzyzanowskim.com/2025/08/14/textkit-2-the-promised-land/
+   - https://developer.apple.com/forums/thread/761364
+   - https://mjtsai.com/blog/2025/08/15/textkit-2-the-promised-land/
+
+7. **Bug 2 was *not* reproduced live** (see "Verification limits" below). The
+   best-supported theory, consistent with the symptom and the research: TK2
+   lays out from a viewport anchor using estimated heights for the content
+   above; when the estimate is wrong, fragments near the top can be assigned
+   **negative y** — content stranded *above the document origin*. The
+   scroller (clamped at 0) can never reach it: "first line above the
+   viewport, can't scroll up". A targeted detector + repair now exists and
+   logs when it fires, so the theory is falsifiable in real use.
+
+## Root cause
+
+**TextKit 2 viewport-based layout only materializes on-screen fragments;
+every off-screen frame is an estimate.** Any code that (a) discards layout
+unnecessarily, (b) trusts an off-screen y-coordinate, or (c) lets two scroll
+policies run concurrently, turns estimate churn into a visible jump:
+
+- Bug 1a: full `recompose` on undo *manufactured* estimates, then measured them.
+- Bug 1b: not estimate-related — a plain stale-caret bug in the redo snapshot.
+- Bug 2: estimate correction above the viewport strands fragments at y < 0.
+- Bug 3: two scroll policies (drag autoscroll vs reveal-selection-top)
+  fighting over a selection whose height exceeded the viewport.
+
+## The fixes
+
+**Diff-based undo/redo restore** (`5bb2b40`, `+Undo.swift`):
+
+- `textDiff(old:new:)` — single contiguous changed span (common prefix/suffix
+  over UTF-16, surrogate-pair-safe boundaries).
+- `restoreSnapshot` applies it with the range-bounded `recomposeReplacing`
+  instead of full `recompose`: layout outside the changed span **stays
+  real**, so the viewport decision runs on real geometry and small-doc
+  documents remain fully laid out through an undo.
+- The **changed text is selected** (pure deletion → caret at the deletion
+  point). The changed range — not the snapshot's stored caret — drives the
+  viewport: hold if any part is on-screen (`rangeIsVisible`), else center it.
+  Redo therefore centers on the changed text by construction; the stale-caret
+  path is gone. Snapshot caret remains only as a fallback for a no-op diff.
+- Typewriter mode: always center the changed text.
+- Dirty-set mapping (changed block window + old active block + list-indent
+  global) mirrors the edit path's scheme in `+EditFlow`.
+
+**Settle passes in `centerViewportOnCaret`** (`340fcbc`,
+`+TypewriterScroll.swift`): after the first scroll the viewport's layout is
+real — re-measure the caret line and correct the residual error (≤3 bounded
+passes, converges in one). Handles the far-jump case where estimates above
+the target can't all be eliminated first.
+
+**Nearest-end reveal** (`340fcbc`, `scrollRangeToVisible` override): when the
+range overflows both viewport edges, follow the end **nearest** the current
+viewport — that's the end being extended during a drag. The drag's autoscroll
+and the reveal now agree on direction; oscillation gone.
+
+**Small documents stay fully laid out** (`217da5f`, `+LazyStyling.swift`):
+`scheduleFullLayoutSettle()` — coalesced, next-run-loop
+(`RunLoop.main.perform` so tests can drain it), runs after the idle drain
+completes and after any dirty flush with nothing deferred. For documents
+≤ `fullLayoutMaxLength` (100k UTF-16) it runs `ensureLayout(documentRange)`
+inside `preservingViewportAnchor`, so the correction never shifts what the
+user is looking at. `ensureLayout` is incremental — per-keystroke settles
+only re-lay the blocks that flush invalidated. Large documents keep
+viewport-based layout: full layout there is the process-killing path that
+motivated the `scrollRangeToVisible` override in the first place.
+
+Why deferred: running the full layout *inside* a caller's own
+`preservingViewportAnchor` body poisons that caller's before/after
+measurement (the tab-indent stability test caught exactly this — a 366pt
+compensation).
+
+**Stranded-content repair** (`8b4ecfe`, `repairContentAboveOrigin`): the
+settle also checks the document's **first fragment**; if its `minY < -0.5`,
+re-lay start→viewport-end (bounded at 60k chars) inside
+`preservingViewportAnchor`. Content above the origin renormalizes to y ≥ 0
+and becomes scrollable again; the visible content holds still. Breadcrumb:
+`repairing content above origin` in `~/.edmund/logs`.
+
+## Verification
+
+- 805 tests green (14 new):
+  - `TextDiffTests` — insertion/deletion/replacement/whole-string/repeated
+    chars/surrogate boundaries;
+  - `UndoRedoSelectionTests` — redo selects restored text; redo ignores the
+    stale caret; undo of a deletion selects the restored span; storage ==
+    rawSource invariant + full-recompose oracle across a round-trip;
+  - `UndoRedoViewportTests` — off-screen undo centers the change (±30pt),
+    redo centers the change after the caret moved away, visible undo holds
+    the viewport (<2pt), using the ScrollStabilityTests scroll-view harness.
+- Existing stability suites (`ScrollStabilityTests`, typewriter centering,
+  lazy rendering, height stability) unchanged and green — they gate the
+  regressions this class of change tends to cause.
+- Live app launched with the fixes; rendering, caret placement and scrolling
+  sane in screenshots.
+
+### Verification limits (honest gaps)
+
+This session's host process could not synthesize keyboard input
+(`osascript is not allowed to send keystrokes.`, CGEvent keyboard events
+dropped) and synthetic drags never armed AppKit's selection even with
+`clickState=1` + 400ms hold. Consequently:
+
+- **Bug 2 was never reproduced live**; the negative-origin diagnosis is
+  theory + targeted repair, not a confirmed kill. If it recurs, grep
+  `~/.edmund/logs` for `repairing content above origin`: present → diagnosis
+  confirmed (and repair maybe raced/undersized); absent → different cause,
+  look at estimate corrections that *don't* strand fragments (scroller-only
+  jumps) or at `textContainerOrigin`.
+- The drag-oscillation fix is verified by reasoning + the reveal logic's
+  geometry, not by a live drag.
+
+## Future work / notes for next time
+
+- If Bug 2 survives: consider running `repairContentAboveOrigin` from the
+  scroll-promotion observer too (currently settle-only), and instrument
+  `usageBoundsForTextContainer` origin.
+- `fullLayoutMaxLength` (100k) is a guess with margin; if large-doc users see
+  the old glitches at 100k–200k, measure `ensureLayout` cost before raising.
+- The undo path still centers the *start* of a multi-screen change; if that
+  ever feels wrong, follow the selection-affinity end instead.
+- Drag-move of a selection (Bug 3 phase 1) is AppKit-standard but surprised
+  the reporter; a UX option (disable drag-move, or require a hold) would be a
+  product decision, not a bug fix.


### PR DESCRIPTION
## What

Fixes three reported viewport glitches, all tracing back to TextKit 2 height estimates (full trail in `docs/viewport-glitch-investigation.md`):

1. **Undo/redo** now select the changed text and center the viewport on it. Restore is diff-based (`textDiff` + range-bounded `recomposeReplacing`) instead of a full `recompose`, so layout outside the change stays real — the old estimate-reset is what made undo land too far down. Redo centers on the changed text, not the caret position at undo time.
2. **Drag-selection oscillation**: `scrollRangeToVisible` always revealed a taller-than-viewport selection's *top*, fighting the drag's downward autoscroll. It now follows the nearest end (the end being extended).
3. **First line pushed above the viewport / can't scroll up**: documents ≤100k UTF-16 are kept fully laid out via a coalesced, viewport-anchored settle (no estimates → no correction jumps), and `repairContentAboveOrigin` renormalizes TextKit 2 fragments stranded at negative y (logs `repairing content above origin` when it fires).

## Why

TextKit 2 gives a fragment a real frame only once laid out; everything else is an estimate that gets corrected as layout reaches it. Estimate churn is what makes the scroller jump and scroll targets land wrong. The fixes avoid manufacturing estimates (undo), stop two scroll policies from fighting (drag), and eliminate estimates entirely for small documents.

## Testing

- 805 tests green, 14 new: `TextDiffTests`, `UndoRedoSelectionTests`, `UndoRedoViewportTests` (off-screen undo centers the change, redo ignores the stale caret, visible undo holds the viewport <2pt).
- Known gap: the negative-origin repair (bug 3 above) was not reproduced live this session — the repair logs a breadcrumb so real use can confirm the diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)