### PR TITLE
Show the type icon on custom-title callouts (stroked path, not image)

### DIFF
--- a/Sources/EdmundCore/Model/LucideIcons.swift
+++ b/Sources/EdmundCore/Model/LucideIcons.swift
@@ -65,6 +65,17 @@ enum LucideIcons {
         return image
     }
 
+    /// The icon's stroke geometry as a CGPath in Lucide's canonical 24×24,
+    /// y-down viewBox space (stroke it with width 2, round caps/joins, to
+    /// match the rendered SVG). Used where the icon must be drawn as a
+    /// *shape*, not an image — an image on a wrapping TextKit 2 fragment
+    /// wedges its layout to one line (see FragmentOverlay). `nil` for an
+    /// unknown id.
+    static func path(_ name: String) -> CGPath? {
+        guard let g = geometry[name] else { return nil }
+        return SVGPath.path(fromGeometry: g)
+    }
+
     /// Read-mode checkbox markup mirroring the editor's look. Unchecked: a
     /// stroked `circle`. Checked: a disc filled in `currentColor` (CSS supplies
     /// the accent) with a white check on top. The themeable part uses

--- a/Sources/EdmundCore/Model/SVGPath.swift
+++ b/Sources/EdmundCore/Model/SVGPath.swift
@@ -1,0 +1,278 @@
+import CoreGraphics
+import Foundation
+
+// MARK: - SVGPath
+//
+// Minimal SVG → CGPath converter for the vendored Lucide icon geometry
+// (`LucideIcons.geometry`). Exists so the editor can draw a callout icon as a
+// *stroked vector path* instead of an NSImage: drawing an image on a wrapping,
+// multi-line TextKit 2 layout fragment wedges that fragment's layout to a
+// single line, while shape drawing does not (see
+// docs/callout-title-wrap-investigation.md). Supports exactly what the
+// vendored geometry uses: `<path>`, `<circle>`, and `<rect>` elements, and the
+// full SVG path-data command set. Coordinates stay in the icons' 24×24,
+// y-down viewBox space; callers scale to the target size.
+enum SVGPath {
+
+    /// Parses a fragment of SVG markup (one or more `<path>`/`<circle>`/
+    /// `<rect>` elements) into a single CGPath in viewBox coordinates.
+    /// Returns `nil` if nothing parseable is found.
+    static func path(fromGeometry svg: String) -> CGPath? {
+        let result = CGMutablePath()
+        let elementRegex = try! NSRegularExpression(pattern: #"<(path|circle|rect)\b([^>]*?)/?>"#)
+        let attrRegex = try! NSRegularExpression(pattern: #"([\w-]+)="([^"]*)""#)
+        let ns = svg as NSString
+
+        for m in elementRegex.matches(in: svg, range: NSRange(location: 0, length: ns.length)) {
+            let tag = ns.substring(with: m.range(at: 1))
+            let attrString = ns.substring(with: m.range(at: 2))
+            var attrs: [String: String] = [:]
+            let ans = attrString as NSString
+            for am in attrRegex.matches(in: attrString,
+                                        range: NSRange(location: 0, length: ans.length)) {
+                attrs[ans.substring(with: am.range(at: 1))] = ans.substring(with: am.range(at: 2))
+            }
+            func num(_ key: String) -> CGFloat? { attrs[key].flatMap { Double($0) }.map { CGFloat($0) } }
+
+            switch tag {
+            case "path":
+                if let d = attrs["d"], let p = path(fromData: d) { result.addPath(p) }
+            case "circle":
+                if let cx = num("cx"), let cy = num("cy"), let r = num("r") {
+                    result.addEllipse(in: CGRect(x: cx - r, y: cy - r, width: 2 * r, height: 2 * r))
+                }
+            case "rect":
+                if let w = num("width"), let h = num("height") {
+                    let rect = CGRect(x: num("x") ?? 0, y: num("y") ?? 0, width: w, height: h)
+                    let rx = num("rx") ?? num("ry") ?? 0
+                    let ry = num("ry") ?? rx
+                    if rx > 0 || ry > 0 {
+                        result.addRoundedRect(in: rect, cornerWidth: rx, cornerHeight: ry)
+                    } else {
+                        result.addRect(rect)
+                    }
+                }
+            default:
+                break
+            }
+        }
+        return result.isEmpty ? nil : result
+    }
+
+    /// Parses an SVG path-data string (the `d` attribute) into a CGPath.
+    static func path(fromData d: String) -> CGPath? {
+        var scanner = NumberScanner(d)
+        let path = CGMutablePath()
+        var current = CGPoint.zero
+        var subpathStart = CGPoint.zero
+        // Reflection anchors for S/T smooth curves.
+        var lastCubicControl: CGPoint?
+        var lastQuadControl: CGPoint?
+        var lastCommand: Character = " "
+
+        while let command = scanner.nextCommand() {
+            let relative = command.isLowercase
+            let cmd = Character(command.uppercased())
+            // Each iteration of the repeat loop consumes one parameter set;
+            // SVG allows implicit command repetition until a new letter.
+            repeat {
+                func point() -> CGPoint? {
+                    guard let x = scanner.nextNumber(), let y = scanner.nextNumber() else { return nil }
+                    return relative ? CGPoint(x: current.x + x, y: current.y + y) : CGPoint(x: x, y: y)
+                }
+                switch cmd {
+                case "M":
+                    guard let p = point() else { return nil }
+                    path.move(to: p); current = p; subpathStart = p
+                    // Subsequent implicit pairs are LineTos.
+                    while scanner.peekNumber() {
+                        guard let q = point() else { return nil }
+                        path.addLine(to: q); current = q
+                    }
+                case "L":
+                    guard let p = point() else { return nil }
+                    path.addLine(to: p); current = p
+                case "H":
+                    guard let x = scanner.nextNumber() else { return nil }
+                    current.x = relative ? current.x + x : x
+                    path.addLine(to: current)
+                case "V":
+                    guard let y = scanner.nextNumber() else { return nil }
+                    current.y = relative ? current.y + y : y
+                    path.addLine(to: current)
+                case "C":
+                    guard let c1 = point(), let c2 = point(), let p = point() else { return nil }
+                    path.addCurve(to: p, control1: c1, control2: c2)
+                    current = p; lastCubicControl = c2
+                case "S":
+                    // First control point reflects the previous cubic's second
+                    // control about the current point (or is the current point).
+                    let c1: CGPoint
+                    if "CS".contains(lastCommand), let prev = lastCubicControl {
+                        c1 = CGPoint(x: 2 * current.x - prev.x, y: 2 * current.y - prev.y)
+                    } else {
+                        c1 = current
+                    }
+                    guard let c2 = point(), let p = point() else { return nil }
+                    path.addCurve(to: p, control1: c1, control2: c2)
+                    current = p; lastCubicControl = c2
+                case "Q":
+                    guard let c = point(), let p = point() else { return nil }
+                    path.addQuadCurve(to: p, control: c)
+                    current = p; lastQuadControl = c
+                case "T":
+                    let c: CGPoint
+                    if "QT".contains(lastCommand), let prev = lastQuadControl {
+                        c = CGPoint(x: 2 * current.x - prev.x, y: 2 * current.y - prev.y)
+                    } else {
+                        c = current
+                    }
+                    guard let p = point() else { return nil }
+                    path.addQuadCurve(to: p, control: c)
+                    current = p; lastQuadControl = c
+                case "A":
+                    guard let rx = scanner.nextNumber(), let ry = scanner.nextNumber(),
+                          let rot = scanner.nextNumber(),
+                          let largeArc = scanner.nextNumber(), let sweep = scanner.nextNumber(),
+                          let end = point() else { return nil }
+                    addArc(to: path, from: current, rx: rx, ry: ry,
+                           xAxisRotationDegrees: rot,
+                           largeArc: largeArc != 0, sweep: sweep != 0, end: end)
+                    current = end
+                case "Z":
+                    path.closeSubpath()
+                    current = subpathStart
+                default:
+                    return nil
+                }
+                if !"CS".contains(cmd) { lastCubicControl = nil }
+                if !"QT".contains(cmd) { lastQuadControl = nil }
+                lastCommand = cmd
+            } while cmd != "Z" && scanner.peekNumber()
+        }
+        return path.isEmpty ? nil : path
+    }
+
+    /// SVG elliptical arc → cubic Béziers, via the endpoint-to-center
+    /// conversion in SVG spec appendix B.2.4, splitting into ≤90° segments.
+    private static func addArc(to path: CGMutablePath, from start: CGPoint,
+                               rx: CGFloat, ry: CGFloat, xAxisRotationDegrees: CGFloat,
+                               largeArc: Bool, sweep: Bool, end: CGPoint) {
+        if start == end { return }
+        var rx = abs(rx), ry = abs(ry)
+        if rx == 0 || ry == 0 { path.addLine(to: end); return }
+
+        let phi = xAxisRotationDegrees * .pi / 180
+        let cosPhi = cos(phi), sinPhi = sin(phi)
+
+        // (x1', y1'): midpoint vector rotated into the ellipse frame.
+        let dx = (start.x - end.x) / 2, dy = (start.y - end.y) / 2
+        let x1p = cosPhi * dx + sinPhi * dy
+        let y1p = -sinPhi * dx + cosPhi * dy
+
+        // Scale radii up if the endpoints can't be spanned (spec F.6.6).
+        let lambda = (x1p * x1p) / (rx * rx) + (y1p * y1p) / (ry * ry)
+        if lambda > 1 {
+            let s = sqrt(lambda)
+            rx *= s; ry *= s
+        }
+
+        // Center in the ellipse frame (spec F.6.5.2).
+        let rx2 = rx * rx, ry2 = ry * ry, x1p2 = x1p * x1p, y1p2 = y1p * y1p
+        var radicand = (rx2 * ry2 - rx2 * y1p2 - ry2 * x1p2) / (rx2 * y1p2 + ry2 * x1p2)
+        radicand = max(0, radicand)
+        let coef = (largeArc != sweep ? 1 : -1) * sqrt(radicand)
+        let cxp = coef * (rx * y1p / ry)
+        let cyp = coef * -(ry * x1p / rx)
+
+        // Center in user space.
+        let cx = cosPhi * cxp - sinPhi * cyp + (start.x + end.x) / 2
+        let cy = sinPhi * cxp + cosPhi * cyp + (start.y + end.y) / 2
+
+        func angle(_ ux: CGFloat, _ uy: CGFloat, _ vx: CGFloat, _ vy: CGFloat) -> CGFloat {
+            let dot = ux * vx + uy * vy
+            let len = sqrt((ux * ux + uy * uy) * (vx * vx + vy * vy))
+            var a = acos(min(1, max(-1, dot / len)))
+            if ux * vy - uy * vx < 0 { a = -a }
+            return a
+        }
+        let theta1 = angle(1, 0, (x1p - cxp) / rx, (y1p - cyp) / ry)
+        var delta = angle((x1p - cxp) / rx, (y1p - cyp) / ry,
+                          (-x1p - cxp) / rx, (-y1p - cyp) / ry)
+        if !sweep && delta > 0 { delta -= 2 * .pi }
+        if sweep && delta < 0 { delta += 2 * .pi }
+
+        // Approximate each ≤90° slice with one cubic.
+        let segments = max(1, Int(ceil(abs(delta) / (.pi / 2))))
+        let segmentDelta = delta / CGFloat(segments)
+        // Control-point distance for a cubic approximating a unit arc.
+        let t = 4 / 3 * tan(segmentDelta / 4)
+
+        var theta = theta1
+        for _ in 0..<segments {
+            let thetaNext = theta + segmentDelta
+            func onEllipse(_ a: CGFloat) -> CGPoint {
+                CGPoint(x: cx + rx * cos(a) * cosPhi - ry * sin(a) * sinPhi,
+                        y: cy + rx * cos(a) * sinPhi + ry * sin(a) * cosPhi)
+            }
+            // Derivative (tangent) at the segment endpoints.
+            func tangent(_ a: CGFloat) -> CGPoint {
+                CGPoint(x: -rx * sin(a) * cosPhi - ry * cos(a) * sinPhi,
+                        y: -rx * sin(a) * sinPhi + ry * cos(a) * cosPhi)
+            }
+            let p0 = onEllipse(theta), p1 = onEllipse(thetaNext)
+            let t0 = tangent(theta), t1 = tangent(thetaNext)
+            path.addCurve(to: p1,
+                          control1: CGPoint(x: p0.x + t * t0.x, y: p0.y + t * t0.y),
+                          control2: CGPoint(x: p1.x - t * t1.x, y: p1.y - t * t1.y))
+            theta = thetaNext
+        }
+    }
+
+    /// Lexer for SVG path data: commands are single letters; numbers may be
+    /// packed together (`-.5.83` is −0.5 then 0.83 — a second `.` starts a new
+    /// number), separated by whitespace or commas.
+    private struct NumberScanner {
+        private let chars: [Character]
+        private var index = 0
+
+        init(_ s: String) { chars = Array(s) }
+
+        private mutating func skipSeparators() {
+            while index < chars.count, chars[index] == " " || chars[index] == "," ||
+                chars[index] == "\n" || chars[index] == "\t" || chars[index] == "\r" {
+                index += 1
+            }
+        }
+
+        mutating func nextCommand() -> Character? {
+            skipSeparators()
+            guard index < chars.count, chars[index].isLetter else { return nil }
+            defer { index += 1 }
+            return chars[index]
+        }
+
+        /// True if a number (not a command letter) comes next.
+        mutating func peekNumber() -> Bool {
+            skipSeparators()
+            guard index < chars.count else { return false }
+            let c = chars[index]
+            return c.isNumber || c == "-" || c == "+" || c == "."
+        }
+
+        mutating func nextNumber() -> CGFloat? {
+            skipSeparators()
+            var s = ""
+            guard index < chars.count else { return nil }
+            if chars[index] == "-" || chars[index] == "+" { s.append(chars[index]); index += 1 }
+            var seenDot = false
+            while index < chars.count {
+                let c = chars[index]
+                if c.isNumber { s.append(c); index += 1 }
+                else if c == ".", !seenDot { seenDot = true; s.append(c); index += 1 }
+                else { break }
+            }
+            return Double(s).map { CGFloat($0) }
+        }
+    }
+}

--- a/Sources/EdmundCore/Rendering/EditorTextView+CalloutRendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+CalloutRendering.swift
@@ -123,14 +123,15 @@ extension EditorTextView {
                 // Custom title: hide the `[!type]` marker and render the title as
                 // real bold + tinted text so a long title WRAPS inside the box.
                 //
-                // NOTE: custom-title callouts deliberately have NO type icon.
-                // The icon is an image, and drawing an image on this (potentially
-                // multi-line, wrapping) header line wedges TextKit 2's layout to a
-                // single line — clipping the title. Every way of drawing it was
-                // tried and hit the same wall; see
+                // NOTE: the type icon here is a stroked vector *path* overlay,
+                // never an image: drawing an image on this (potentially
+                // multi-line, wrapping) header line wedges TextKit 2's layout to
+                // a single line — clipping the title — by every image-drawing
+                // mechanism tried, while shape drawing is unaffected. See
                 // docs/callout-title-wrap-investigation.md. Default callouts (the
-                // `else` below) keep their icon: their synthesized type name is
-                // short and never wraps, so it stays a single-line image overlay.
+                // `else` below) keep their icon+name image: their synthesized
+                // type name is short and never wraps, so the single-line image
+                // overlay never hits the wedge.
                 let markerHide = NSRange(location: header.location,
                                          length: titleRange.location - header.location)
                 if markerHide.length > 0 {
@@ -141,16 +142,30 @@ extension EditorTextView {
                 result.addAttribute(.font, value: titleFont, range: titleRange)
                 result.addAttribute(.foregroundColor, value: c.accent, range: titleRange)
 
+                // Icon before the title: anchored on the hidden `[`, with the
+                // kern reserving the icon's advance plus a gap so the title
+                // starts clear of it (applyOverlay's own kern is only the icon
+                // width — overwrite it).
+                var iconAdvance: CGFloat = 0
+                if let icon = calloutIconPathOverlay(iconName: info.style.iconName,
+                                                     color: c.accent, titleFont: titleFont,
+                                                     iconNudge: info.style.iconBaselineNudge) {
+                    let anchor = NSRange(location: header.location, length: 1)
+                    applyOverlay(icon, anchor: anchor, in: result)
+                    iconAdvance = icon.bounds.width + bodyFont.pointSize * 0.3
+                    result.addAttribute(.kern, value: iconAdvance, range: anchor)
+                }
+
                 // The title sits at the callout's left padding. The first line
                 // carries the width-preserved `> ` marker before the (hidden)
-                // `[!type]`, so its text starts `quoteMarkerWidth` past the inset;
-                // headIndent adds that width so wrapped lines align under the
-                // title. Top breathing room is above the first line only (the box
-                // covers it).
+                // `[!type]`, so its text starts `quoteMarkerWidth` past the
+                // inset, plus the icon's kerned advance; headIndent adds both so
+                // wrapped lines align under the title. Top breathing room is
+                // above the first line only (the box covers it).
                 let ps = NSMutableParagraphStyle()
                 ps.lineSpacing = bodyParagraphStyle.lineSpacing
                 ps.firstLineHeadIndent = 2
-                ps.headIndent = 2 + quoteMarkerWidth
+                ps.headIndent = 2 + quoteMarkerWidth + iconAdvance
                 ps.tailIndent = -10
                 ps.paragraphSpacingBefore = calloutTopPad
                 result.addAttribute(.paragraphStyle, value: ps, range: headerLine)
@@ -385,6 +400,31 @@ extension EditorTextView {
         ps.tailIndent = -10
         ps.minimumLineHeight = minimumLineHeight
         return ps
+    }
+
+    // MARK: Header icon (custom title — stroked path, never an image)
+
+    /// The type icon for a custom-title header, as a stroked-path overlay
+    /// sized to a `pointSize` square and vertically centered on the bold
+    /// title's optical middle (same optics as the header image below). A path
+    /// — not an image — because the custom-title line wraps, and an image
+    /// drawn on a multi-line fragment wedges its layout to one line (see
+    /// docs/callout-title-wrap-investigation.md). `nil` for an unknown icon.
+    private func calloutIconPathOverlay(iconName: String, color: NSColor,
+                                        titleFont: NSFont, iconNudge: CGFloat) -> FragmentOverlay? {
+        let pointSize = bodyFont.pointSize
+        guard let svgPath = LucideIcons.path(iconName) else { return nil }
+        let scale = pointSize / 24   // Lucide viewBox → icon square
+        var transform = CGAffineTransform(scaleX: scale, y: scale)
+        guard let scaled = svgPath.copy(using: &transform) else { return nil }
+        // bounds.minY is the icon's *bottom* relative to the baseline: center
+        // the square on the title's optical middle (midpoint of x-height and
+        // cap-height centers — matches the header image's icon placement).
+        let opticalCenter = (titleFont.xHeight + titleFont.capHeight) / 4
+        return FragmentOverlay(path: scaled, color: color, lineWidth: 2 * scale,
+                               bounds: CGRect(x: 0,
+                                              y: opticalCenter - pointSize / 2 + iconNudge,
+                                              width: pointSize, height: pointSize))
     }
 
     // MARK: Header image (icon + title)

--- a/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
@@ -109,22 +109,47 @@ public final class BlockDecorationList: NSObject, @unchecked Sendable {
     public override var hash: Int { decorations.count }
 }
 
-/// An image drawn at a character's laid-out position, with attachment-style
-/// bounds: `bounds.origin.y` is the image bottom relative to the text baseline
-/// (negative descends below it).
+/// An image or stroked vector path drawn at a character's laid-out position,
+/// with attachment-style bounds: `bounds.origin.y` is the drawing's bottom
+/// relative to the text baseline (negative descends below it).
+///
+/// The path form exists because of a TextKit 2 wedge: drawing an *image* on a
+/// wrapping, multi-line layout fragment collapses that fragment's layout to a
+/// single line, while drawing a *shape* does not (see
+/// docs/callout-title-wrap-investigation.md). Overlays that can share a line
+/// with wrapping text (the custom-callout-title icon) must use the path form.
 public final class FragmentOverlay: NSObject, @unchecked Sendable {
-    public let image: NSImage
+    public let image: NSImage?
+    /// Stroked path in bounds-local coordinates (y-down, origin at the
+    /// bounds' top-left), pre-scaled to the bounds size.
+    public let path: CGPath?
+    public let pathColor: NSColor?
+    public let pathLineWidth: CGFloat
     public let bounds: CGRect
 
     public init(image: NSImage, bounds: CGRect) {
         self.image = image
+        self.path = nil
+        self.pathColor = nil
+        self.pathLineWidth = 0
+        self.bounds = bounds
+        super.init()
+    }
+
+    public init(path: CGPath, color: NSColor, lineWidth: CGFloat, bounds: CGRect) {
+        self.image = nil
+        self.path = path
+        self.pathColor = color
+        self.pathLineWidth = lineWidth
         self.bounds = bounds
         super.init()
     }
 
     public override func isEqual(_ object: Any?) -> Bool {
         guard let other = object as? FragmentOverlay else { return false }
-        return other.image === image && other.bounds == bounds
+        return other.image === image && other.path == path
+            && other.pathColor == pathColor && other.pathLineWidth == pathLineWidth
+            && other.bounds == bounds
     }
 
     public override var hash: Int { Int(bounds.width) ^ Int(bounds.height) }
@@ -225,18 +250,35 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
         for (offset, overlay) in overlays {
             guard let rect = overlayRect(anchorOffset: offset, overlay: overlay) else { continue }
             let drawRect = rect.offsetBy(dx: point.x, dy: point.y)
-            // Draw the (resolution-independent) NSImage into the flipped context,
-            // so it rasterizes at the screen's backing scale — crisp on Retina,
-            // and positioned precisely. (Converting to a CGImage first would bake
-            // it at 1×, then upscale: soft, and quantized a pixel low.) The math
-            // image carries a small transparent inset, so the flipped draw can't
-            // clip a descender at the image edge.
-            let nsContext = NSGraphicsContext(cgContext: context, flipped: true)
-            NSGraphicsContext.saveGraphicsState()
-            NSGraphicsContext.current = nsContext
-            overlay.image.draw(in: drawRect, from: .zero, operation: .sourceOver,
-                               fraction: 1, respectFlipped: true, hints: nil)
-            NSGraphicsContext.restoreGraphicsState()
+            if let image = overlay.image {
+                // Draw the (resolution-independent) NSImage into the flipped context,
+                // so it rasterizes at the screen's backing scale — crisp on Retina,
+                // and positioned precisely. (Converting to a CGImage first would bake
+                // it at 1×, then upscale: soft, and quantized a pixel low.) The math
+                // image carries a small transparent inset, so the flipped draw can't
+                // clip a descender at the image edge.
+                let nsContext = NSGraphicsContext(cgContext: context, flipped: true)
+                NSGraphicsContext.saveGraphicsState()
+                NSGraphicsContext.current = nsContext
+                image.draw(in: drawRect, from: .zero, operation: .sourceOver,
+                           fraction: 1, respectFlipped: true, hints: nil)
+                NSGraphicsContext.restoreGraphicsState()
+            } else if let path = overlay.path, let color = overlay.pathColor {
+                // Stroke the vector path directly in CG — never rasterize it to
+                // an image first: an image drawn on a multi-line fragment wedges
+                // its layout to one line (see the FragmentOverlay note). Path
+                // coords are bounds-local and y-down, matching this flipped
+                // context, so a translate places them.
+                context.saveGState()
+                context.translateBy(x: drawRect.minX, y: drawRect.minY)
+                context.addPath(path)
+                context.setStrokeColor(color.cgColor)
+                context.setLineWidth(overlay.pathLineWidth)
+                context.setLineCap(.round)
+                context.setLineJoin(.round)
+                context.strokePath()
+                context.restoreGState()
+            }
         }
     }
 

--- a/Tests/EdmundTests/CalloutRenderingTests.swift
+++ b/Tests/EdmundTests/CalloutRenderingTests.swift
@@ -108,6 +108,28 @@ struct CalloutRenderingTests {
         #expect(isHidden(at: marker.location, in: styled))
     }
 
+    @Test("Custom title shows the type icon as a stroked path (never an image)")
+    @MainActor func customTitleIcon() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("> [!note] My Title\n> body")
+        // The icon overlay anchors on "[" — as a vector path, NOT an image:
+        // an image drawn on this wrapping header line wedges TextKit 2's
+        // layout to a single line (docs/callout-title-wrap-investigation.md).
+        let att = styled.attribute(.fragmentOverlay, at: 2, effectiveRange: nil) as? FragmentOverlay
+        #expect(att != nil)
+        #expect(att?.path != nil)
+        #expect(att?.image == nil)
+        // The anchor's kern reserves the icon advance plus a gap before the title.
+        let kern = styled.attribute(.kern, at: 2, effectiveRange: nil) as? CGFloat
+        #expect((kern ?? 0) > (att?.bounds.width ?? .infinity))
+        // Wrapped title lines hang past the icon so they align under the title.
+        let ns = styled.string as NSString
+        let title = ns.range(of: "My Title")
+        let ps = styled.attribute(.paragraphStyle, at: title.location,
+                                  effectiveRange: nil) as? NSParagraphStyle
+        #expect((ps?.headIndent ?? 0) > (kern ?? .infinity))
+    }
+
     @Test("A long custom title wraps to multiple lines instead of clipping")
     @MainActor func longCustomTitleWraps() {
         let editor = makeEditor()   // ~500pt container

--- a/Tests/EdmundTests/LucideIconsTests.swift
+++ b/Tests/EdmundTests/LucideIconsTests.swift
@@ -43,6 +43,70 @@ struct LucideIconsTests {
         #expect(opaque > 0, "SVG decoded to a blank image — NSImage(data:) didn't render strokes")
     }
 
+    /// Every vendored icon must parse into a stroked CGPath (the custom-title
+    /// callout icon is drawn as a path, not an image), staying within the
+    /// 24×24 viewBox (small slack for stroke geometry that touches the edge).
+    @Test func everyIconParsesToPath() {
+        for name in LucideIcons.geometry.keys {
+            guard let path = LucideIcons.path(name) else {
+                Issue.record("no path for \(name)"); continue
+            }
+            let box = path.boundingBoxOfPath
+            #expect(box.minX >= -1 && box.minY >= -1 && box.maxX <= 25 && box.maxY <= 25,
+                    "\(name) path escapes the viewBox: \(box)")
+        }
+        #expect(LucideIcons.path("not-an-icon") == nil)
+    }
+
+    /// Parser fidelity: for every icon, the stroked CGPath must rasterize to
+    /// (nearly) the same pixels as the platform SVG decoder's rendering.
+    /// Catches path-data parsing bugs — especially arc conversion — that a
+    /// bounding-box check would miss. Compared by intersection-over-union of
+    /// covered pixels; rasterizer/antialiasing differences keep it below 1.
+    @MainActor @Test func pathMatchesSVGRendering() throws {
+        let side = 48
+        func coverage(_ draw: (CGContext) -> Void) -> [Bool] {
+            let ctx = CGContext(data: nil, width: side, height: side,
+                                bitsPerComponent: 8, bytesPerRow: side * 4,
+                                space: CGColorSpaceCreateDeviceRGB(),
+                                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)!
+            draw(ctx)
+            let data = ctx.data!.assumingMemoryBound(to: UInt8.self)
+            return (0..<(side * side)).map { data[$0 * 4 + 3] > 127 }
+        }
+        for name in LucideIcons.geometry.keys {
+            let path = try #require(LucideIcons.path(name))
+            let scale = CGFloat(side) / 24
+            let pathPixels = coverage { ctx in
+                // The path is in SVG's y-down space; the bitmap context is y-up.
+                ctx.translateBy(x: 0, y: CGFloat(side))
+                ctx.scaleBy(x: scale, y: -scale)
+                ctx.addPath(path)
+                ctx.setStrokeColor(NSColor.black.cgColor)
+                ctx.setLineWidth(2)
+                ctx.setLineCap(.round)
+                ctx.setLineJoin(.round)
+                ctx.strokePath()
+            }
+            let image = try #require(LucideIcons.image(name, color: .black,
+                                                       pointSize: CGFloat(side)))
+            let svgPixels = coverage { ctx in
+                NSGraphicsContext.saveGraphicsState()
+                NSGraphicsContext.current = NSGraphicsContext(cgContext: ctx, flipped: false)
+                image.draw(in: NSRect(x: 0, y: 0, width: side, height: side))
+                NSGraphicsContext.restoreGraphicsState()
+            }
+            var intersection = 0, union = 0
+            for i in 0..<(side * side) {
+                if pathPixels[i] && svgPixels[i] { intersection += 1 }
+                if pathPixels[i] || svgPixels[i] { union += 1 }
+            }
+            #expect(union > 0, "\(name): nothing rendered")
+            let iou = union == 0 ? 0 : Double(intersection) / Double(union)
+            #expect(iou > 0.6, "\(name): path raster diverges from SVG (IoU \(iou))")
+        }
+    }
+
     @Test func checkboxSVGShapes() {
         #expect(LucideIcons.checkboxSVG(checked: true).contains("fill=\"currentColor\""))
         #expect(LucideIcons.checkboxSVG(checked: true).contains("stroke=\"#fff\""))

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -120,17 +120,20 @@ rawSource ──BlockParser──▶ [Block]  ──styleBlock per block──�
     `bottomPad` grows the *last* fragment's frame (TextKit 2 omits trailing
     paragraph spacing from the fragment, so padding done that way would be dead
     space).
-  - **`.fragmentOverlay`** (character-level): an image drawn at a character's
-    laid-out position — rendered math, list bullets/checkboxes, the callout
-    header icon+name image. The anchor glyph is hidden and `.kern` reserves the
-    image's advance width (the same trick the table renderer uses).
+  - **`.fragmentOverlay`** (character-level): an image *or stroked vector
+    path* drawn at a character's laid-out position — rendered math, list
+    bullets/checkboxes, the callout header icon+name image, the custom-title
+    callout icon (path). The anchor glyph is hidden and `.kern` reserves the
+    drawing's advance width (the same trick the table renderer uses).
 - **Hiding** text = `hiddenFont` (≈0.01pt) + clear `foregroundColor`. This is
   how delimiters and synthesized-but-in-source markers vanish without changing
   the string.
-- **Overlays only work on single-line fragments.** Drawing an image on a
-  *multi-line* (wrapping) fragment re-triggers a layout pass that wedges it to
-  one line. This is why a wrapping callout *custom title* has no icon — see
-  `docs/callout-title-wrap-investigation.md` for the full saga.
+- **Image overlays only work on single-line fragments.** Drawing an *image* on
+  a *multi-line* (wrapping) fragment re-triggers a layout pass that wedges it
+  to one line; drawing a *shape* does not. So the wrapping callout custom
+  title's icon is a stroked `CGPath` (`SVGPath` parses the vendored Lucide
+  geometry), never an image — see `docs/callout-title-wrap-investigation.md`
+  for the full saga.
 
 ---
 
@@ -369,19 +372,17 @@ them and route through the app's document graph without JavaScript.
 
 ## 9. Known issues / lurking problems
 
-- **Callout custom title can't show the type icon** (TextKit 2 multi-line +
-  image wedge). Shipped workaround: custom titles wrap as real text *without*
-  an icon; default callouts keep theirs. Full investigation + a preserved
-  (non-working) image-based alternative on branch `fix/callout-title-image`:
+- **Images can't be drawn on multi-line (wrapping) fragments** (TextKit 2
+  image wedge — collapses the fragment's layout to one line). Resolved for the
+  callout custom-title icon by drawing it as a stroked `CGPath` instead
+  (shapes don't trigger the wedge); the constraint still holds for any *new*
+  overlay that could share a line with wrapping text. Full investigation:
   `docs/callout-title-wrap-investigation.md`.
 - *(Add new ones here as you find them — with a one-line repro and a pointer to
   any deeper write-up in `docs/`.)*
 
 ## 10. Still to address
 
-- Revisit the callout icon limitation if a newer macOS/TextKit 2 fixes the
-  reentrancy (reproduce first; would require bumping the deployment target off
-  macOS 14).
 - **Inline HTML renders in both modes for a fixed whitelist** —
   `SyntaxHighlighter.htmlFormatTags` (`u`/`kbd`/`mark`/`sub`/`sup`), the single
   source of truth. Edit: `parseHTMLTags` colors any tag (name red, brackets

--- a/docs/callout-title-wrap-investigation.md
+++ b/docs/callout-title-wrap-investigation.md
@@ -64,13 +64,33 @@ including the dev machine this was found on — so it wouldn't help without an O
 upgrade. If revisiting: reproduce on the newest macOS first (a long custom-title
 callout in a narrow window — does it still clip on initial display?).
 
-## What shipped
+## What shipped originally
 
 **Drop the icon for custom-title callouts.** A custom title is real, literal,
 bold + tinted text that wraps inside the box (wrapped lines hang under the
-title); it has **no** type icon. Default callouts keep their icon+name image
-(short, single-line, never wraps). This is the only option that works reliably.
-See `styleCalloutContent` in `EditorTextView+CalloutRendering.swift`.
+title); it had **no** type icon. Default callouts keep their icon+name image
+(short, single-line, never wraps).
+
+## Resolution (2026-07): draw the icon as a shape, not an image
+
+The control matrix above was the key: *shape* drawing on the multi-line
+fragment never triggered the wedge — only *image* drawing did. Lucide icons
+are pure stroke geometry, so the icon doesn't have to be an image at all.
+
+Custom-title callouts now get their icon back as a **stroked `CGPath`
+overlay**: `SVGPath` converts the vendored Lucide geometry (paths incl. arcs,
+circles, rects) to a CGPath, `FragmentOverlay` gained a path form, and
+`DecoratedTextLayoutFragment` strokes it directly in CG (round caps/joins,
+width 2 scaled from the 24×24 viewBox) instead of blitting an NSImage. The
+anchor's `.kern` reserves the icon advance plus a gap; wrapped title lines
+hang under the title. Verified live: icon renders, a long title still wraps,
+and re-wraps on window resize, with no clipping.
+
+The wedge itself remains unexplained (no matching known TextKit 2 issue was
+found) and still constrains any *future* overlay that could share a line with
+wrapping text: such overlays must use the path form, never the image form.
+See `styleCalloutContent` / `calloutIconPathOverlay` in
+`EditorTextView+CalloutRendering.swift`.
 
 ## The image alternative (preserved, not shipped)
 


### PR DESCRIPTION
## What

Custom-title callouts (`> [!type] Some title`) get their type icon back. The icon is drawn as a **stroked vector path** overlay instead of an `NSImage`.

## Why

Custom titles render as real, wrapping text, and drawing an *image* on a wrapping, multi-line TextKit 2 layout fragment wedges that fragment's layout to a single line — the reason the icon was dropped in #108. The investigation's own control matrix showed *shape* drawing never triggers the wedge, and Lucide icons are pure stroke geometry, so the icon doesn't need to be an image at all.

## How

- `SVGPath` (new): converts the vendored Lucide SVG geometry to `CGPath` (full path-data command set incl. arc→Bézier conversion, circles, rounded rects).
- `FragmentOverlay` gains a stroked-path form; `DecoratedTextLayoutFragment` strokes it directly in CG (round caps/joins, width scaled from the 24×24 viewBox) — never blits an image.
- Callout rendering anchors the path overlay on the hidden `[`, with kern reserving the icon advance plus a gap; `headIndent` grows by the same amount so wrapped title lines still hang under the title. Default callouts are untouched.

## Verification

- Parser fidelity is pixel-tested against the platform SVG decoder for every vendored icon (IoU of covered pixels).
- New rendering test asserts the custom-title overlay is path-not-image with the kern reserved; the existing long-title wrap test still passes.
- Verified live via screencapture: icon renders, a long title wraps, and re-wraps on window resize with icons intact — no clipping.

Docs updated: resolution section in `docs/callout-title-wrap-investigation.md`; ARCHITECTURE known-issue rewritten as a constraint on future overlays (path form only when sharing a line with wrapping text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)