### PR TITLE
fix(editor): collapse stale selection when healing bypassed edits (delete drift round 5)

### DIFF
--- a/Sources/EdmundCore/TextView/EditorTextView+EditFlow.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+EditFlow.swift
@@ -76,6 +76,16 @@ extension EditorTextView {
                 Log.info("healing storage edit that bypassed didChangeText: " +
                          "storLen=\(storage.length) rawLen=\((self.rawSource as NSString).length)",
                          category: .edit)
+                // The bypassing path also skips AppKit's usual pre-didChangeText
+                // selection fix, so the selection can still span text that no
+                // longer exists. Left alone, the restyle's layout invalidation
+                // makes AppKit clamp it to the end of the document — the caret
+                // visibly leaps. Collapse it to the edit point ourselves first.
+                let sel = self.selectedRange()
+                if NSMaxRange(sel) > storage.length {
+                    self.setSelectedRange(NSRange(location: min(sel.location, storage.length),
+                                                  length: 0))
+                }
                 self.syncRawSourceFromDisplay()
                 self.document?.updateChangeCount(.changeDone)
             }

--- a/Tests/EdmundTests/BypassedEditSyncTests.swift
+++ b/Tests/EdmundTests/BypassedEditSyncTests.swift
@@ -43,6 +43,30 @@ struct BypassedEditSyncTests {
         #expect(editor.textStorage!.string == editor.rawSource)
     }
 
+    /// When the bypassed deletion removes the selected text itself (the log's
+    /// {951,37} case), the stale selection spans past the new document end.
+    /// The heal must collapse it to the edit point — otherwise the restyle's
+    /// layout invalidation makes AppKit clamp the caret to the end of the
+    /// document (the round-5 leap).
+    @Test func healRepairsSelectionSpanningDeletedText() {
+        let editor = makeEditor()
+        editor.loadContent("alpha\nbravo\ncharlie")
+        let dragged = NSRange(location: 12, length: 7)   // "charlie"
+        editor.setSelectedRange(dragged)
+
+        #expect(editor.shouldChangeText(in: dragged, replacementString: ""))
+        editor.textStorage!.replaceCharacters(in: dragged, with: "")
+
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+        #expect(editor.textStorage!.string == editor.rawSource)
+        #expect(editor.selectedRange() == NSRange(location: 12, length: 0))
+
+        // Backspace deletes exactly the character before the edit point.
+        pressBackspace(in: editor)
+        #expect(editor.rawSource == "alpha\nbravo")
+        #expect(editor.selectedRange() == NSRange(location: 11, length: 0))
+    }
+
     /// The check must NOT fire during a live IME composition: there the
     /// unconsumed pendingEdit is legitimate and didChangeText syncs on commit.
     @Test func healSkipsLiveComposition() {

--- a/docs/delete-drift-investigation.md
+++ b/docs/delete-drift-investigation.md
@@ -296,3 +296,29 @@ against invalidated layout and landed the caret at the following block
 boundary. Healing on the run-loop pass right after the rogue edit (before any
 further keystroke) removes both ingredients; no explicit selection repair was
 needed.
+
+## Round 5: the heal itself leaped the caret (stale selection)
+
+Recurred 2026-07-03 (~11:25, editing ROADMAP.md) on the round-4 build. The
+heal worked — invariant restored, autosave wrote correct bytes — but the
+caret leaped to the **end of the document** at the heal moment:
+
+```
+11:25:14.834 selectionDidChange sel={951,37}              drag-select
+11:25:15.172 shouldChangeText OK range={951, 37} repl=""  drag-move deletion, no didChangeText
+11:25:15.207 healing storage edit ... storLen=973 rawLen=1010
+11:25:15.208 selectionDidChange sel={973,0} up=Y          caret at doc end
+```
+
+Round 4's "no explicit selection repair needed" was wrong for one case: when
+the bypassed deletion removes the *selected* text itself, the bypassing path
+also skips AppKit's usual pre-`didChangeText` selection fix, so at heal time
+the selection still spans text that no longer exists ({951,37} in a 973-char
+doc). The heal's restyle invalidates layout, AppKit re-resolves the invalid
+selection, and clamps it to the document end.
+
+Fix: before `syncRawSourceFromDisplay`, the heal collapses an out-of-bounds
+selection to the edit point (`min(location, length)`, zero length). Covered
+by `healRepairsSelectionSpanningDeletedText()` — though note headless
+NSTextView clamps the selection itself, so the test documents intent; the
+leap only reproduces under live layout.


### PR DESCRIPTION
## What

When the didChangeText-bypass heal (round 4, #163) fires, it now collapses an out-of-bounds selection to the edit point before syncing.

## Why

The drift recurred on 2026-07-03 (~11:25, editing ROADMAP.md) on the round-4 build. The heal itself worked — rawSource/blocks restored, autosave wrote correct bytes — but the caret leaped to the end of the document at the heal moment:

```
11:25:14.834 selectionDidChange sel={951,37}              drag-select
11:25:15.172 shouldChangeText OK range={951, 37} repl=""  drag-move deletion, no didChangeText
11:25:15.207 healing storage edit ... storLen=973 rawLen=1010
11:25:15.208 selectionDidChange sel={973,0} up=Y          caret at doc end
```

The bypassing path (drag-move whose drop lands nowhere) also skips AppKit's usual pre-didChangeText selection fix. When the bypassed deletion removes the selected text itself, the selection at heal time still spans text that no longer exists ({951,37} in a 973-char doc). The heal's restyle invalidates layout, AppKit re-resolves the invalid selection, and clamps it to the document end — the visible leap.

## How

In the heal (`EditorTextView+EditFlow.swift`), before `syncRawSourceFromDisplay()`: if `NSMaxRange(selectedRange()) > storage.length`, collapse the selection to `{min(location, length), 0}` — the edit point.

## Tests

- New `healRepairsSelectionSpanningDeletedText()` in `BypassedEditSyncTests`. Note: headless NSTextView clamps the stale selection itself, so the test documents intended behavior; the leap only reproduces under live layout.
- Full suite: 811 tests green.
- Investigation write-up appended as round 5 in `docs/delete-drift-investigation.md`.

Refs #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)