### PR TITLE
Architecture review: References section, doc updates, dead-code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If Edmund's not your thing, some of the following might be:
   - [MarkEdit](https://github.com/MarkEdit-app/MarkEdit) - TextEdit for Markdown
     - I *love* this. If only I wasn't so dependent on rendered math...
   - [editxr](https://github.com/pixdeo/editxr) - TUI
-  - More feature-rich: [Zettlr](https://www.zettlr.com), [Joplin](https://joplinapp.org), [Tangent](https://www.tangentnotes.com)
+  - More feature-rich: [FSNotes](https://fsnot.es), [Zettlr](https://www.zettlr.com), [Joplin](https://joplinapp.org), [Tangent](https://www.tangentnotes.com)
 
 The list is by no means exhaustive, and neither was it meant to be. I just wanted to give credit to the makers of these apps, esp. IMO the aesthetic open sourced ones. A comprehensive list may be found [here](https://github.com/mundimark/awesome-markdown-editors). 
 
@@ -97,7 +97,7 @@ The following have greatly influenced the architecture and/or helped with design
 - [MarkEdit](https://github.com/MarkEdit-app/MarkEdit) for the readme organization
 - [screenshot-studio](screenshot-studio.com) for the amazing screenshots editing experience
 - [shields](shields.io) for the beautiful badges in this readme
-- Claude for the engineering. 
+- Claude, [caveman](https://github.com/JuliusBrussee/caveman), and [ponytail](https://github.com/DietrichGebert/ponytail) for the engineering. 
 
 
 ## License

--- a/Sources/EdmundCore/Diagnostics/Log.swift
+++ b/Sources/EdmundCore/Diagnostics/Log.swift
@@ -52,10 +52,6 @@ public enum Log {
         LogStore.shared.configure(enabled: enabled, directory: directory, retention: retention)
     }
 
-    public static func setEnabled(_ enabled: Bool) {
-        LogStore.shared.setEnabled(enabled)
-    }
-
     /// Verbose editor tracing: a separate opt-in (off by default) gating the
     /// high-volume per-edit / per-caret-move `trace` lines. Kept distinct from the
     /// on/off of the whole logger so a normal user's logs aren't flooded with
@@ -180,10 +176,6 @@ private final class LogStore: @unchecked Sendable {
             self?.closeHandle()   // directory may have changed
             if enabled, let retention { self?.prune(retention: retention) }
         }
-    }
-
-    func setEnabled(_ enabled: Bool) {
-        lock.withLock { _enabled = enabled }
     }
 
     func setVerbose(_ verbose: Bool) {

--- a/Sources/EdmundCore/Editing/EditorTextView+Indentation.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+Indentation.swift
@@ -42,8 +42,8 @@ extension EditorTextView {
     /// selection, but only if every covered block is a list line.
     private func affectedListBlockRange() -> (Int, Int)? {
         let sel = selectedRange()
-        let rawStart = displayOffsetToRawOffset(sel.location)
-        let rawEnd = displayOffsetToRawOffset(sel.location + sel.length)
+        let rawStart = sel.location
+        let rawEnd = sel.location + sel.length
 
         guard let startIdx = blockIndexForRawOffset(rawStart),
               var endIdx = blockIndexForRawOffset(rawEnd) else {
@@ -70,8 +70,8 @@ extension EditorTextView {
 
     private func indentListBlocks(from startBlock: Int, to endBlock: Int) {
         let sel = selectedRange()
-        let rawStart = displayOffsetToRawOffset(sel.location)
-        let rawEnd = displayOffsetToRawOffset(sel.location + sel.length)
+        let rawStart = sel.location
+        let rawEnd = sel.location + sel.length
         let indentLen = (Self.indentUnit as NSString).length
 
         // The pre-edit storage span covering exactly the affected blocks; only
@@ -136,8 +136,8 @@ extension EditorTextView {
 
     private func dedentListBlocks(from startBlock: Int, to endBlock: Int) {
         let sel = selectedRange()
-        let rawStart = displayOffsetToRawOffset(sel.location)
-        let rawEnd = displayOffsetToRawOffset(sel.location + sel.length)
+        let rawStart = sel.location
+        let rawEnd = sel.location + sel.length
         let maxRemove = (Self.indentUnit as NSString).length
 
         // Compute how many leading whitespace characters to strip from each block.

--- a/Sources/EdmundCore/TextView/EditorTextView+Composition.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+Composition.swift
@@ -6,8 +6,8 @@ import AppKit
 // joining them; `recomposeIncremental` re-styles only the block(s) the cursor
 // moved between, which is what runs on most edits. Because the text storage
 // always equals the raw source (word-level rendering, no string stripping),
-// the display↔raw coordinate mapping is the identity — the conversion helpers
-// exist so call sites read clearly and stay correct if that ever changes.
+// the display↔raw coordinate mapping is the identity — display offsets are
+// used as raw offsets directly.
 
 extension EditorTextView {
 
@@ -145,8 +145,6 @@ extension EditorTextView {
             blocks[idx].isStyled = false
         }
 
-        displayRanges = blocks.map { $0.range }
-
         if settingSelection {
             if let rawSel = selectionInRaw, rawSel.length > 0 {
                 let len = ts.length
@@ -231,12 +229,6 @@ extension EditorTextView {
         return max(0, anchor - 200) ... min(blocks.count - 1, anchor + 200)
     }
 
-    /// Recalculates displayRanges from current blocks.
-    /// With word-level rendering, display ranges = raw block ranges.
-    func recalcDisplayRanges() {
-        displayRanges = blocks.map { $0.range }
-    }
-
     // MARK: - Coordinate Mapping
     //
     // With text storage = rawSource, display offset = raw offset (identity).
@@ -258,17 +250,5 @@ extension EditorTextView {
             }
         }
         return lo
-    }
-
-    func displayOffsetToRawOffset(_ displayOffset: Int) -> Int {
-        return displayOffset
-    }
-
-    func rawOffsetToDisplayOffset(_ rawOffset: Int) -> Int {
-        return rawOffset
-    }
-
-    func displayRangeToRawRange(_ displayRange: NSRange) -> NSRange {
-        return displayRange
     }
 }

--- a/Sources/EdmundCore/TextView/EditorTextView+ContentWidth.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+ContentWidth.swift
@@ -33,12 +33,6 @@ extension EditorTextView {
         }
     }
 
-    /// Sets the max-column width (in points) and applies it immediately.
-    /// Called from the Settings broadcast and the screen-change observer.
-    public func applyContentWidth(_ points: CGFloat) {
-        maxContentWidthPoints = points
-    }
-
     /// Recompute the centered inset as the view width changes (window resize).
     public override func setFrameSize(_ newSize: NSSize) {
         super.setFrameSize(newSize)

--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -57,7 +57,6 @@ public class EditorTextView: NSTextView {
     var blocks: [Block] = []
     var activeBlockIndex: Int? = nil
     var isUpdating = false
-    var displayRanges: [NSRange] = []
     /// Coalesces the async active-block restyle scheduled from a caret move
     /// (internal so EditorTextView+SelectionTracking can clear it).
     var pendingRecompose = false

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -208,7 +208,7 @@ class Document: NSDocument, HeadingNavigable {
     @objc private func windowDidChangeScreen(_ notification: Notification) {
         guard let window = notification.object as? NSWindow,
               let screen = window.screen else { return }
-        editor?.applyContentWidth(screen.cmToPoints(AppSettings.maxContentWidthCm))
+        editor?.maxContentWidthPoints = screen.cmToPoints(AppSettings.maxContentWidthCm)
     }
 
     @objc private func editorDidChange(_ notification: Notification) {

--- a/Sources/edmd/Settings/AppearanceSettingsView.swift
+++ b/Sources/edmd/Settings/AppearanceSettingsView.swift
@@ -156,7 +156,7 @@ struct AppearanceSettingsView: View {
         for case let document as Document in NSDocumentController.shared.documents {
             let screen = document.editor?.window?.screen ?? NSScreen.main
             guard let screen else { continue }
-            document.editor?.applyContentWidth(screen.cmToPoints(maxContentWidthCm))
+            document.editor?.maxContentWidthPoints = screen.cmToPoints(maxContentWidthCm)
         }
     }
 

--- a/Tests/EdmundTests/BlockStylingTests.swift
+++ b/Tests/EdmundTests/BlockStylingTests.swift
@@ -414,7 +414,7 @@ struct TableNonActiveTests {
         editor.loadContent("| A | B |\n| --- | --- |\n| 1 | 2 |\nother")
         activateBlock(1, in: editor)
 
-        let base = editor.displayRanges[0].location
+        let base = editor.blocks[0].range.location
         // "A" at base+2 should be bold
         let f = font(at: base + 2, in: editor)!
         let traits = NSFontManager.shared.traits(of: f)
@@ -427,7 +427,7 @@ struct TableNonActiveTests {
         editor.loadContent("| A | B |\n| --- | --- |\n| 1 | 2 |\nother")
         activateBlock(1, in: editor)
 
-        let base = editor.displayRanges[0].location
+        let base = editor.blocks[0].range.location
         // All pipes are hidden (vertical borders drawn by the .tableRow decoration)
         let outerF = font(at: base, in: editor)!
         #expect(outerF.pointSize < 1.0)

--- a/Tests/EdmundTests/EditorDiagnosticsTests.swift
+++ b/Tests/EdmundTests/EditorDiagnosticsTests.swift
@@ -16,7 +16,7 @@ struct EditorDiagnosticsTests {
         Log.configure(enabled: true, directory: dir, retention: nil)
         Log.setVerbose(verbose)
         defer {
-            Log.setEnabled(false)
+            Log.configure(enabled: false, directory: dir, retention: nil)
             Log.setVerbose(false)
             try? FileManager.default.removeItem(at: dir)
         }

--- a/Tests/EdmundTests/EditorDocumentTests.swift
+++ b/Tests/EdmundTests/EditorDocumentTests.swift
@@ -102,7 +102,7 @@ struct EditorDocumentLoadingTests {
 
         // Non-active block's delimiters are hidden via attributes, not stripped.
         // "*" at block 1 start should have hidden font.
-        let b1Start = editor.displayRanges[1].location
+        let b1Start = editor.blocks[1].range.location
         let delimFont = font(at: b1Start, in: editor)!
         #expect(delimFont.pointSize < 1.0)
         #expect(fgColor(at: b1Start, in: editor) == NSColor.clear)

--- a/Tests/EdmundTests/EditorFeatureTests.swift
+++ b/Tests/EdmundTests/EditorFeatureTests.swift
@@ -243,7 +243,7 @@ struct FontIntegrationTests {
 
         // In word-level rendering, offset 0 is a delimiter (hidden font).
         // Content "bold" starts at offset 2.
-        let base = editor.displayRanges[0].location
+        let base = editor.blocks[0].range.location
         let f = font(at: base + 2, in: editor)!
         #expect(NSFontManager.shared.traits(of: f).contains(.boldFontMask))
         #expect(f.pointSize == 18)
@@ -370,7 +370,7 @@ struct AppearanceIntegrationTests {
         // Switch to block 1, making block 0 non-active.
         // Offset 0 is backtick (hidden), content "active" starts at offset 1.
         activateBlock(1, in: editor)
-        let nonActiveColor = fgColor(at: editor.displayRanges[0].location + 1, in: editor)
+        let nonActiveColor = fgColor(at: editor.blocks[0].range.location + 1, in: editor)
         #expect(nonActiveColor == editor.foregroundColor)
     }
 
@@ -409,7 +409,7 @@ struct FullDocumentIntegrationTests {
         let h = displayText(for: 0, in: editor)
         #expect(h == "# Title")
         // Heading marker "#" at offset 0 is hidden. Content has bold font.
-        let hBase = editor.displayRanges[0].location
+        let hBase = editor.blocks[0].range.location
         #expect(fgColor(at: hBase, in: editor) == NSColor.clear)
         let hf = font(at: hBase + 2, in: editor)!
         #expect(NSFontManager.shared.traits(of: hf).contains(.boldFontMask))
@@ -425,7 +425,7 @@ struct FullDocumentIntegrationTests {
         // Block 3 (quote, non-active): raw text preserved, ">" hidden
         let q = displayText(for: 3, in: editor)
         #expect(q == "> quote")
-        let qBase = editor.displayRanges[3].location
+        let qBase = editor.blocks[3].range.location
         #expect(fgColor(at: qBase, in: editor) == NSColor.clear)
     }
 
@@ -456,13 +456,13 @@ struct FullDocumentIntegrationTests {
 
         // Block 0 non-active: raw text preserved, delimiters hidden, content bold
         #expect(displayText(for: 0, in: editor) == "**Bold title**")
-        let b0 = editor.displayRanges[0].location
+        let b0 = editor.blocks[0].range.location
         let bf = font(at: b0 + 2, in: editor)!  // content starts after **
         #expect(NSFontManager.shared.traits(of: bf).contains(.boldFontMask))
 
         // Block 1 non-active: raw text preserved, delimiters hidden, content italic
         #expect(displayText(for: 1, in: editor) == "*Italic subtitle*")
-        let b1 = editor.displayRanges[1].location
+        let b1 = editor.blocks[1].range.location
         let itf = font(at: b1 + 1, in: editor)!  // content starts after *
         #expect(NSFontManager.shared.traits(of: itf).contains(.italicFontMask))
 
@@ -471,13 +471,13 @@ struct FullDocumentIntegrationTests {
 
         // Block 3 non-active: raw text preserved, delimiters hidden, content has strikethrough
         #expect(displayText(for: 3, in: editor) == "~~deleted~~")
-        let b3 = editor.displayRanges[3].location
+        let b3 = editor.blocks[3].range.location
         let a3 = attrs(at: b3 + 2, in: editor)  // content starts after ~~
         #expect(a3[.strikethroughStyle] as? Int == NSUnderlineStyle.single.rawValue)
 
         // Block 4 non-active: raw text preserved, delimiters hidden, content has background
         #expect(displayText(for: 4, in: editor) == "==highlight==")
-        let b4 = editor.displayRanges[4].location
+        let b4 = editor.blocks[4].range.location
         let a4 = attrs(at: b4 + 2, in: editor)  // content starts after ==
         #expect(a4[.backgroundColor] != nil)
     }

--- a/Tests/EdmundTests/EditorIndentationTests.swift
+++ b/Tests/EdmundTests/EditorIndentationTests.swift
@@ -339,12 +339,12 @@ struct EditorListIndentIntegrationTests {
         // Block 0 is "- first" (inactive rendered). Block 1 should become active.
         // In the display, block 0 is rendered (shorter due to bullet), block 1 raw.
         // Let's set cursor into block 1's display region.
-        let block1DisplayStart = editor.displayRanges[1].location
+        let block1DisplayStart = editor.blocks[1].range.location
         editor.setSelectedRange(NSRange(location: block1DisplayStart, length: 0))
 
         // Trigger recompose so block 1 becomes active
         // (Selection change notification fires async, so drive it manually)
-        let rawOffset = editor.displayOffsetToRawOffset(block1DisplayStart)
+        let rawOffset = block1DisplayStart
         editor.recompose(cursorInRaw: rawOffset)
 
         #expect(editor.activeBlockIndex == 1)

--- a/Tests/EdmundTests/EditorRenderingTests.swift
+++ b/Tests/EdmundTests/EditorRenderingTests.swift
@@ -7,20 +7,6 @@ import AppKit
 @Suite("EditorTextView — Coordinate Mapping")
 struct EditorCoordinateTests {
 
-    @Test("Display offset equals raw offset (identity mapping)")
-    @MainActor func identityMapping() {
-        let editor = makeEditor()
-        type("hello", into: editor)
-
-        #expect(editor.displayOffsetToRawOffset(0) == 0)
-        #expect(editor.displayOffsetToRawOffset(3) == 3)
-        #expect(editor.displayOffsetToRawOffset(5) == 5)
-
-        #expect(editor.rawOffsetToDisplayOffset(0) == 0)
-        #expect(editor.rawOffsetToDisplayOffset(3) == 3)
-        #expect(editor.rawOffsetToDisplayOffset(5) == 5)
-    }
-
     @Test("blockIndexForRawOffset returns correct index")
     @MainActor func blockIndexMapping() {
         let editor = makeEditor()
@@ -779,18 +765,6 @@ struct EditorRecomposeTests {
         // Cursor in block 1
         editor.recompose(cursorInRaw: 9)
         #expect(editor.textStorage!.string == "**bold**\nplain")
-    }
-
-    @Test("Display ranges equal block ranges (identity)")
-    @MainActor func displayRangesAreBlockRanges() {
-        let editor = makeEditor()
-        editor.rawSource = "**bold**\nplain"
-        editor.blocks = BlockParser.parse(editor.rawSource)
-        editor.recompose(cursorInRaw: 0)
-
-        #expect(editor.displayRanges.count == 2)
-        #expect(editor.displayRanges[0].length == 8)  // "**bold**"
-        #expect(editor.displayRanges[1].length == 5)  // "plain"
     }
 
     @Test("activeBlockIndex is set correctly")

--- a/Tests/EdmundTests/InlineStylingTests.swift
+++ b/Tests/EdmundTests/InlineStylingTests.swift
@@ -230,7 +230,7 @@ struct InlineStylingInactiveTests {
         let text = displayText(for: 0, in: editor)
         #expect(text == "**bold**")
 
-        let base = editor.displayRanges[0].location
+        let base = editor.blocks[0].range.location
         // Delimiters hidden
         #expect(font(at: base, in: editor)!.pointSize < 1.0)
         #expect(fgColor(at: base, in: editor) == NSColor.clear)
@@ -248,7 +248,7 @@ struct InlineStylingInactiveTests {
         let text = displayText(for: 0, in: editor)
         #expect(text == "__bold__")
 
-        let base = editor.displayRanges[0].location
+        let base = editor.blocks[0].range.location
         #expect(font(at: base, in: editor)!.pointSize < 1.0)
         let f = font(at: base + 2, in: editor)!
         #expect(NSFontManager.shared.traits(of: f).contains(.boldFontMask))
@@ -263,7 +263,7 @@ struct InlineStylingInactiveTests {
         let text = displayText(for: 0, in: editor)
         #expect(text == "*italic*")
 
-        let base = editor.displayRanges[0].location
+        let base = editor.blocks[0].range.location
         #expect(font(at: base, in: editor)!.pointSize < 1.0)
         let f = font(at: base + 1, in: editor)!
         #expect(NSFontManager.shared.traits(of: f).contains(.italicFontMask))
@@ -278,7 +278,7 @@ struct InlineStylingInactiveTests {
         let text = displayText(for: 0, in: editor)
         #expect(text == "_italic_")
 
-        let base = editor.displayRanges[0].location
+        let base = editor.blocks[0].range.location
         #expect(font(at: base, in: editor)!.pointSize < 1.0)
         let f = font(at: base + 1, in: editor)!
         #expect(NSFontManager.shared.traits(of: f).contains(.italicFontMask))
@@ -293,7 +293,7 @@ struct InlineStylingInactiveTests {
         let text = displayText(for: 0, in: editor)
         #expect(text == "***both***")
 
-        let base = editor.displayRanges[0].location
+        let base = editor.blocks[0].range.location
         #expect(font(at: base, in: editor)!.pointSize < 1.0)
         let f = font(at: base + 3, in: editor)!
         let traits = NSFontManager.shared.traits(of: f)
@@ -310,7 +310,7 @@ struct InlineStylingInactiveTests {
         let text = displayText(for: 0, in: editor)
         #expect(text == "`code`")
 
-        let base = editor.displayRanges[0].location
+        let base = editor.blocks[0].range.location
         #expect(font(at: base, in: editor)!.pointSize < 1.0)
         let color = fgColor(at: base + 1, in: editor)
         #expect(color == editor.foregroundColor)
@@ -325,7 +325,7 @@ struct InlineStylingInactiveTests {
         let text = displayText(for: 0, in: editor)
         #expect(text == "~~struck~~")
 
-        let base = editor.displayRanges[0].location
+        let base = editor.blocks[0].range.location
         #expect(font(at: base, in: editor)!.pointSize < 1.0)
         let a = attrs(at: base + 2, in: editor)
         #expect(a[.strikethroughStyle] as? Int == NSUnderlineStyle.single.rawValue)
@@ -340,7 +340,7 @@ struct InlineStylingInactiveTests {
         let text = displayText(for: 0, in: editor)
         #expect(text == "==marked==")
 
-        let base = editor.displayRanges[0].location
+        let base = editor.blocks[0].range.location
         #expect(font(at: base, in: editor)!.pointSize < 1.0)
         let a = attrs(at: base + 2, in: editor)
         #expect(a[.backgroundColor] != nil)
@@ -355,7 +355,7 @@ struct InlineStylingInactiveTests {
         let text = displayText(for: 0, in: editor)
         #expect(text == "[click](https://example.com)")
 
-        let base = editor.displayRanges[0].location
+        let base = editor.blocks[0].range.location
         // "[" delimiter hidden
         #expect(font(at: base, in: editor)!.pointSize < 1.0)
         // "click" content has link color and underline
@@ -376,7 +376,7 @@ struct InlineStylingInactiveTests {
         let text = displayText(for: 0, in: editor)
         #expect(text == "**bold** *italic* `code`")
 
-        let base = editor.displayRanges[0].location
+        let base = editor.blocks[0].range.location
         // ** delimiters hidden
         #expect(font(at: base, in: editor)!.pointSize < 1.0)
         // "bold" at base+2 has bold font

--- a/Tests/EdmundTests/TestHelpers.swift
+++ b/Tests/EdmundTests/TestHelpers.swift
@@ -85,8 +85,8 @@ func pressBackspace(in editor: EditorTextView) {
 /// Returns the text storage string for a specific block's display range.
 @MainActor
 func displayText(for blockIndex: Int, in editor: EditorTextView) -> String {
-    guard blockIndex < editor.displayRanges.count else { return "" }
-    let range = editor.displayRanges[blockIndex]
+    guard blockIndex < editor.blocks.count else { return "" }
+    let range = editor.blocks[blockIndex].range
     let ts = editor.textStorage!
     guard range.upperBound <= ts.length else { return "" }
     return (ts.string as NSString).substring(with: range)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -221,7 +221,10 @@ them and route through the app's document graph without JavaScript.
   `bodyFont`, colors, paragraph styles.
 - **Max content width** persists as **centimetres** (`maxContentWidthCm`); the
   cm/in shown in Settings is a display unit (`contentWidthUnit`), the column
-  itself is always physical (see §6 content width). Default is 12 cm / 5 in.
+  itself is always physical (see §6 content width). The default is locale-aware
+  — 5 in (US) / 12 cm (elsewhere) — and doubles as the slider's magnetic snap
+  point; the slider runs from a 3 in floor to the current screen's physical
+  width (`NSScreen.physicalWidthCm`).
 - **Window size** persists as the last document window's full **frame** size
   (`lastWindowSize`) — see the §8 gotcha on why it's the frame, not the content
   size.
@@ -484,3 +487,24 @@ releases fail at the appcast push.
 hit Gatekeeper on first launch; the README documents the
 `xattr -dr com.apple.quarantine` / right-click-Open workarounds. A Developer ID
 cert + notarization (see §8) would remove the prompt entirely.
+
+---
+
+## 14. References
+
+Dependencies and prior art worth consulting before designing something new here:
+
+- [apple/swift-markdown](https://github.com/apple/swift-markdown) — the
+  CommonMark/GFM parser both back-ends walk (§3, §6 Read mode).
+- [SwiftMath](https://github.com/mgriebling/SwiftMath) — LaTeX rendering
+  (raster only; no SVG output yet — why exported math is PNG, §6).
+- [Sparkle](https://sparkle-project.org) — auto-update (§8, §13 for the
+  signing/appcast quirks).
+- [Lucide](https://lucide.dev) — vendored icon SVGs (ISC), `Model/LucideIcons.swift`.
+- [nodes-app/swift-markdown-engine](https://github.com/nodes-app/swift-markdown-engine)
+  — an independent AppKit + TextKit 2 live-preview markdown engine (Apache 2.0,
+  macOS 14+). Solves the same problems (viewport virtualization, live styling,
+  wiki links, reading column, LaTeX) with different trade-offs — useful
+  comparison point before inventing a new mechanism for an editing-experience
+  problem, and a candidate source of techniques (e.g. drag-select autoscroll,
+  overscroll) if we hit the same walls.


### PR DESCRIPTION
## What

- **ARCHITECTURE.md**: new §14 References (swift-markdown, SwiftMath, Sparkle, Lucide, and nodes-app/swift-markdown-engine as TextKit 2 prior art); §7 content-width entry now records the locale-aware default (5 in US / 12 cm elsewhere = slider snap point) and the slider's 3 in floor / screen-width cap.
- **README**: updated alternatives and acknowledgements.
- **Cleanup from the review** (net −61 lines, behavior unchanged):
  - `displayRanges` — a mirror of `blocks[].range` read only by tests — deleted; tests read block ranges directly.
  - Identity display↔raw conversion helpers deleted (storage == rawSource is invariant, so they returned their argument).
  - `applyContentWidth(_:)` wrapper deleted; callers assign `maxContentWidthPoints` (didSet applies it).
  - `Log.setEnabled` deleted; `configure` covers it.

## Why

Project-wide over-engineering review: keep the architecture doc current and remove flexibility nothing uses. All 809 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)