### PR TITLE
fix(editor): re-assert caret around heal — TextKit 2's queued selection fixup was the drift (round 6)

### DIFF
--- a/Sources/EdmundCore/TextView/EditorTextView+Diagnostics.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+Diagnostics.swift
@@ -40,6 +40,22 @@ extension EditorTextView {
         Log.trace("\(event()) | \(diagnosticState)", category: .edit)
     }
 
+    /// Under verbose tracing, logs a condensed call stack for a suspicious
+    /// selection change — one arriving mid-recompose (up=Y) or while a
+    /// pendingEdit is unconsumed. Those are exactly the changes behind the
+    /// issue-#156 caret drifts, and the stack names the AppKit path that
+    /// moved the caret.
+    func traceSelectionOrigin() {
+        guard Log.shouldTrace else { return }
+        let frames = Thread.callStackSymbols.dropFirst(2).prefix(14).map { frame in
+            // "3  AppKit  0x00: -[NSTextView foo] + 12" → drop index/module/addr.
+            let parts = frame.split(separator: " ", omittingEmptySubsequences: true)
+            return parts.count > 3 ? parts[3...].joined(separator: " ") : frame
+        }
+        Log.trace("selection origin:\n    " + frames.joined(separator: "\n    "),
+                  category: .edit)
+    }
+
     /// A short, newline-escaped, length-capped rendering of edit text for traces.
     func logSnippet(_ s: String?) -> String {
         guard let s else { return "nil" }

--- a/Sources/EdmundCore/TextView/EditorTextView+EditFlow.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+EditFlow.swift
@@ -76,17 +76,29 @@ extension EditorTextView {
                 Log.info("healing storage edit that bypassed didChangeText: " +
                          "storLen=\(storage.length) rawLen=\((self.rawSource as NSString).length)",
                          category: .edit)
-                // The bypassing path also skips AppKit's usual pre-didChangeText
-                // selection fix, so the selection can still span text that no
-                // longer exists. Left alone, the restyle's layout invalidation
-                // makes AppKit clamp it to the end of the document — the caret
-                // visibly leaps. Collapse it to the edit point ourselves first.
-                let sel = self.selectedRange()
-                if NSMaxRange(sel) > storage.length {
-                    self.setSelectedRange(NSRange(location: min(sel.location, storage.length),
-                                                  length: 0))
+                // The bypassing path also skips TextKit 2's selection fixup —
+                // it stays queued and fires at the NEXT endEditing (our restyle),
+                // via _fixSelectionAfterChangeInCharacterRange, mapping the
+                // stale selection against post-edit coordinates. That's the
+                // issue-#156 caret leap: the fixer lands the caret a couple of
+                // lines away. Collapse the selection to the edit's end point
+                // ourselves before syncing; the late fixer then has a valid
+                // caret to map and leaves it in place.
+                var caretAfterEdit: Int?
+                if let pending = storage.pendingEdit {
+                    let newLength = max(0, pending.oldRange.length + pending.delta)
+                    caretAfterEdit = min(pending.oldRange.location + newLength, storage.length)
+                    self.setSelectedRange(NSRange(location: caretAfterEdit!, length: 0))
                 }
                 self.syncRawSourceFromDisplay()
+                // The queued fixer fires during the sync's endEditing and moves
+                // the caret even when it was just set to a valid spot — so
+                // re-assert after the sync; by the next edit the fixer state is
+                // clean (verified: follow-up deletes behave).
+                if let caret = caretAfterEdit {
+                    self.setSelectedRange(NSRange(location: min(caret, storage.length),
+                                                  length: 0))
+                }
                 self.document?.updateChangeCount(.changeDone)
             }
         }

--- a/Sources/EdmundCore/TextView/EditorTextView+SelectionTracking.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+SelectionTracking.swift
@@ -7,6 +7,9 @@ extension EditorTextView {
 
     @objc func selectionDidChange(_ notification: Notification) {
         traceEdit("selectionDidChange")
+        // A selection change landing mid-recompose is the drift signature
+        // (issue #156); the stack names the AppKit path that moved the caret.
+        if isUpdating { traceSelectionOrigin() }
         guard !isUpdating else { return }
         // NSTextView moves the selection DURING an edit, before didChangeText
         // runs the sync — at that moment `blocks` still has pre-edit ranges.

--- a/Sources/edmd/App/ReproScript.swift
+++ b/Sources/edmd/App/ReproScript.swift
@@ -1,0 +1,111 @@
+#if DEBUG
+import AppKit
+import EdmundCore
+
+/// In-process repro driver: `-debug.reproScript <path>` replays a keystroke
+/// script against the front document through the real AppKit key-event path
+/// (window.sendEvent → keyDown → interpretKeyEvents → insertText /
+/// deleteBackward). Exists because TCC-denied automation sessions cannot post
+/// CGEvents at the app; this keeps live-app bug repros scriptable without
+/// Accessibility permission. Commands, one per line:
+///   sleep <ms>        wait before the next command
+///   caret <needle>    place the caret before the first occurrence of <needle>
+///   type <text>       type text, one key event per character
+///   backspace <n>     press delete n times (300ms apart)
+///   logsel            log the current selection
+@MainActor
+enum ReproScript {
+
+    static func runIfRequested() {
+        guard let path = UserDefaults.standard.string(forKey: "debug.reproScript"),
+              let script = try? String(contentsOfFile: path, encoding: .utf8) else { return }
+        Log.info("repro script: \(path)", category: .app)
+        var delay: TimeInterval = 1.5   // let the document finish opening
+        for line in script.split(separator: "\n") {
+            let parts = line.split(separator: " ", maxSplits: 1).map(String.init)
+            guard let cmd = parts.first, !cmd.hasPrefix("#") else { continue }
+            let arg = parts.count > 1 ? parts[1] : ""
+            switch cmd {
+            case "sleep":
+                delay += (Double(arg) ?? 0) / 1000
+            case "caret":
+                schedule(after: delay) { editor in
+                    let r = (editor.rawSource as NSString).range(of: arg)
+                    guard r.location != NSNotFound else {
+                        Log.info("repro caret: needle not found: \(arg)", category: .app)
+                        return
+                    }
+                    editor.setSelectedRange(NSRange(location: r.location, length: 0))
+                }
+            case "type":
+                for ch in arg {
+                    schedule(after: delay) { press(String(ch), keyCode: 0, in: $0) }
+                    delay += 0.08
+                }
+            case "backspace":
+                for _ in 0 ..< (Int(arg) ?? 1) {
+                    schedule(after: delay) { press("\u{7F}", keyCode: 51, in: $0) }
+                    delay += 0.3
+                }
+            case "bypassdelete":
+                // Mimics AppKit's drag-move source deletion (the issue-#156
+                // trigger): select the range, run shouldChangeText and the
+                // storage mutation, and never call didChangeText — the
+                // bypassed-edit heal then fires on the next run-loop pass.
+                schedule(after: delay) { editor in
+                    let r = (editor.rawSource as NSString).range(of: arg)
+                    guard r.location != NSNotFound else {
+                        Log.info("repro bypassdelete: needle not found: \(arg)", category: .app)
+                        return
+                    }
+                    editor.setSelectedRange(r)
+                    guard editor.shouldChangeText(in: r, replacementString: "") else { return }
+                    editor.textStorage?.replaceCharacters(in: r, with: "")
+                }
+            case "assertcaret":
+                // PASS iff the caret sits exactly before the first occurrence
+                // of <needle> — position-independent drift check for soaks.
+                schedule(after: delay) { editor in
+                    let want = (editor.rawSource as NSString).range(of: arg).location
+                    let sel = editor.selectedRange()
+                    let ok = sel.location == want && sel.length == 0
+                    Log.info("repro assertcaret \(ok ? "PASS" : "FAIL") " +
+                             "sel=\(sel) want=\(want) needle=\(arg)", category: .app)
+                }
+            case "logsel":
+                schedule(after: delay) { editor in
+                    Log.info("repro logsel sel=\(editor.selectedRange()) " +
+                             "rawLen=\((editor.rawSource as NSString).length) " +
+                             "docs=\(NSDocumentController.shared.documents.count)",
+                             category: .app)
+                }
+            default:
+                break
+            }
+            delay += 0.02
+        }
+    }
+
+    private static func schedule(after: TimeInterval,
+                                 _ body: @escaping @MainActor (EditorTextView) -> Void) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + after) {
+            guard let doc = NSDocumentController.shared.documents.first as? Document,
+                  let editor = doc.editor else { return }
+            body(editor)
+        }
+    }
+
+    /// Sends a key event through the window so it takes the full AppKit
+    /// keyDown route, exactly like a physical keystroke.
+    private static func press(_ chars: String, keyCode: UInt16, in editor: EditorTextView) {
+        guard let window = editor.window,
+              let event = NSEvent.keyEvent(with: .keyDown, location: .zero, modifierFlags: [],
+                                           timestamp: ProcessInfo.processInfo.systemUptime,
+                                           windowNumber: window.windowNumber, context: nil,
+                                           characters: chars, charactersIgnoringModifiers: chars,
+                                           isARepeat: false, keyCode: keyCode) else { return }
+        window.makeFirstResponder(editor)
+        window.sendEvent(event)
+    }
+}
+#endif

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -53,6 +53,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
             Log.info("Opening file from launch argument: \(url.path)", category: .document)
             NSDocumentController.shared.openDocument(withContentsOf: url, display: true) { _, _, _ in }
         }
+
+        #if DEBUG
+        ReproScript.runIfRequested()
+        #endif
     }
 
     // Auto-open a blank document on launch only when no file was passed on the

--- a/Tests/EdmundTests/WrappedParagraphCaretTests.swift
+++ b/Tests/EdmundTests/WrappedParagraphCaretTests.swift
@@ -1,0 +1,77 @@
+import Testing
+import AppKit
+@testable import EdmundCore
+
+/// Delete drift round 6 (issue #156, 2026-07-03 22:13 log): a bypassed
+/// deletion (drag-move whose drop lands nowhere) skips TextKit 2's selection
+/// fixup along with didChangeText. The queued fixup then fires at the next
+/// `endEditing` — the heal's attribute-only restyle — via
+/// `_fixSelectionAfterChangeInCharacterRange`, mapping the stale selection
+/// against post-edit coordinates and leaping the caret (~two wrapped lines
+/// forward in the field report). The heal must both collapse the selection to
+/// the edit point before syncing and re-assert it after, because the late
+/// fixer moves even a freshly set valid caret.
+@Suite("Bypassed-edit caret repair (delete drift round 6)")
+struct WrappedParagraphCaretTests {
+
+    @MainActor private func windowedEditor() -> EditorTextView {
+        let editor = makeEditor()
+        let win = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 500, height: 300),
+                           styleMask: [.titled], backing: .buffered, defer: false)
+        let scroll = NSScrollView(frame: win.contentLayoutRect)
+        scroll.documentView = editor
+        win.contentView = scroll
+        win.makeFirstResponder(editor)
+        editor.typewriterModeEnabled = false
+        editor.isVerticallyResizable = true
+        editor.minSize = .zero
+        editor.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude,
+                                height: CGFloat.greatestFiniteMagnitude)
+        editor.autoresizingMask = [.width]
+        return editor
+    }
+
+    private static let hodgePoster = """
+    # Hodgerank
+
+    ## Introduction
+    Everyone has heard about Calculus. However, not nearly as much people \
+    will have its counterpart - discrete calculus, also known as graph theory.
+
+    Nowadays, discrete calculus is widely used in various applied sciences. \
+    One of its potential uses is ranking. See Sizemore, Strang et al., and Xu et al.
+
+    Here, we apply Hodgerank to college admissions data
+    """
+
+    /// Bypassed deletion mid wrapped paragraph: after the heal, the caret must
+    /// sit at the deletion point — not wherever TextKit 2's late selection
+    /// fixup drops it (321 for 290 in the live repro).
+    @Test @MainActor func healPlacesCaretAtBypassedDeletionPoint() {
+        let editor = windowedEditor()
+        editor.loadContent(Self.hodgePoster)
+        let dragged = (editor.rawSource as NSString).range(of: "Sizemore, ")
+        editor.setSelectedRange(dragged)
+
+        // The drag-move bypass: shouldChangeText + mutation, no didChangeText.
+        #expect(editor.shouldChangeText(in: dragged, replacementString: ""))
+        editor.textStorage!.replaceCharacters(in: dragged, with: "")
+
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+        #expect(editor.textStorage!.string == editor.rawSource)
+        #expect(editor.selectedRange() == NSRange(location: dragged.location, length: 0),
+                "caret must be at the deletion point after the heal")
+
+        // Follow-up edits stay put: backspace deletes exactly one char at the
+        // caret, then typing inserts at the caret.
+        editor.deleteBackward(nil)
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        #expect(editor.selectedRange() == NSRange(location: dragged.location - 1, length: 0),
+                "caret leaped on the first post-heal backspace")
+        editor.deleteBackward(nil)
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        #expect(editor.selectedRange() == NSRange(location: dragged.location - 2, length: 0),
+                "caret leaped on the second post-heal backspace")
+        #expect(editor.textStorage!.string == editor.rawSource)
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -286,7 +286,15 @@ them and route through the app's document graph without JavaScript.
   - Names the output `"Edmund <version>.dmg"` (space, not hyphen). Both scripts
     rename it to `Edmund-<version>.dmg` before signing and uploading.
 - **Stale release builds**: `swift build -c release` / `build-app.sh` sometimes
-  reuses stale object files (you'll run an old binary and be baffled). If a
+  reuses stale object files (you'll run an old binary and be baffled). Debug
+  builds have the same disease: `swift build` can print `Build complete!`
+  after compiling a changed file **without relinking `edmd`** — the app then
+  runs old code. Detect it by grepping
+  `strings .build/arm64-apple-macosx/debug/edmd` for a long string literal
+  unique to the new code (literals ≤15 bytes are stored inline on arm64 and
+  never appear); cure with `swift package clean`. Never delete
+  `.build/…/edmd.build/` by hand — that corrupts the output-file-map and
+  wedges the target until a full clean. If a
   visual change "doesn't take," `rm -rf .build` and rebuild. `shasum` the binary
   to confirm it changed.
 - **`open Edmund.app` foregrounds a *running* instance instead of relaunching.**
@@ -351,6 +359,23 @@ them and route through the app's document graph without JavaScript.
   (`+EditFlow`, `scheduleBypassedEditSyncCheck`; `healing storage edit that
   bypassed didChangeText` in `~/.edmund/logs` is its breadcrumb). Never build
   a sync path on the assumption that `didChangeText` follows every edit.
+- **A bypassed edit also leaves TextKit 2's selection fixup queued** (delete-
+  drift round 6). The skipped
+  `-[NSTextLayoutManager _fixSelectionAfterChangeInCharacterRange:]` fires at
+  the **next** `endEditing` — even an attribute-only restyle — where it maps
+  the stale selection against post-edit coordinates and leaps the caret blocks
+  away. It moves even a freshly set, valid caret, so the heal must set the
+  caret (derived from the pendingEdit hull) *before* the sync **and re-assert
+  it after** (`+EditFlow`). Corollary: any suspicious selection change arrives
+  mid-recompose (`up=Y` in traces); under verbose diagnostics
+  `traceSelectionOrigin` logs the call stack of whoever moved it — start there.
+  This class of bug does not reproduce headless (the test harness runs the
+  fixup synchronously): use the in-process repro driver — DEBUG builds accept
+  `-debug.reproScript <path>` (`Sources/edmd/App/ReproScript.swift`) and replay
+  keystroke scripts (`caret` / `type` / `backspace` / `bypassdelete` /
+  `assertcaret` / `logsel`) through the real `window.sendEvent` key path — no
+  Accessibility/TCC needed, works with the window on an invisible Space. Full
+  chronicle: `docs/delete-drift-investigation.md` round 6.
 - **A custom toolbar item can't win a right-click from a view-level handler.**
   With `NSToolbar.allowsUserCustomization = true`, the toolbar turns any
   secondary (right / control) click over the toolbar — *including* a custom item

--- a/docs/delete-drift-investigation.md
+++ b/docs/delete-drift-investigation.md
@@ -322,3 +322,58 @@ selection to the edit point (`min(location, length)`, zero length). Covered
 by `healRepairsSelectionSpanningDeletedText()` — though note headless
 NSTextView clamps the selection itself, so the test documents intent; the
 leap only reproduces under live layout.
+
+## Round 6: TextKit 2's queued selection fixup — the drift mechanism itself
+
+Recurred 2026-07-03 ~22:13 (hodge-poster.md) on the round-5 build: typing
+"While go" mid wrapped paragraph, then backspace → caret leaped +43 to the
+end of the block ("always starts two viewport-lines down" — user), next
+backspace leaped to end of document. New user observation: the drift is no
+longer continuous — one delete drifts, the next doesn't.
+
+**Reproduced deterministically** (first time ever headless-ish): simulate the
+drag-move bypass (shouldChangeText + replaceCharacters, no didChangeText) via
+the new in-process repro driver, let the heal fire, and the caret lands at
+321 instead of 290 — every run.
+
+The new `traceSelectionOrigin` (verbose call-stack log for selection changes
+arriving mid-recompose) named the culprit:
+
+```
+-[NSTextLayoutManager _fixSelectionAfterChangeInCharacterRange:changeInLength:]
+-[NSTextContentStorage synchronizeTextLayoutManagers:]
+-[NSTextStorage endEditing]
+recomposeDirty ← syncRawSourceFromDisplay ← the heal
+```
+
+A didChangeText-bypassing mutation also skips TextKit 2's selection fixup for
+that edit. The fixup stays queued and fires at the **next** `endEditing` —
+the heal's attribute-only restyle — where it maps the stale selection against
+post-edit coordinates and drops the caret blocks away. That's why drift is
+intermittent: the fixer fires once, state is synced, deletes behave again
+until the next silent bypass. Round 5's out-of-bounds clamp only caught the
+case where the stale selection ran past the document end.
+
+**Fix** (in the heal, `EditorTextView+EditFlow.swift`): derive the correct
+caret from the pendingEdit hull (`oldRange.location + max(0, oldRange.length
++ delta)`), set it before the sync (so cursorRaw/active-block styling are
+right), and **re-assert it after** — the queued fixer moves even a freshly
+set valid caret during the sync's endEditing, so the pre-set alone is not
+enough (verified: pre-set only still landed at 321).
+
+**Tooling built for this round** (both DEBUG-only):
+- `Sources/edmd/App/ReproScript.swift` — `-debug.reproScript <path>` replays
+  keystroke scripts (`caret/type/backspace/bypassdelete/assertcaret/logsel`)
+  through the real AppKit key-event path in-process; works when TCC blocks
+  CGEvent injection.
+- `traceSelectionOrigin` — call stack for mid-recompose selection changes.
+
+Soak-verified: 4 bypass+heal cycles with typing/backspaces/block merges
+between, all `assertcaret PASS`. Note the unit test
+(`WrappedParagraphCaretTests`) cannot reproduce the queued fixer headlessly —
+the live scripted repro is the regression proof.
+
+Build gotcha hit twice this round: SwiftPM kept "Build complete!" while
+linking a stale `edmd` binary (compile ran, relink skipped). When a repro
+behaves like old code, check `strings .build/.../edmd` for a new literal;
+`swift package clean` fixes it.

--- a/docs/delete-drift-investigation.md
+++ b/docs/delete-drift-investigation.md
@@ -325,55 +325,132 @@ leap only reproduces under live layout.
 
 ## Round 6: TextKit 2's queued selection fixup — the drift mechanism itself
 
-Recurred 2026-07-03 ~22:13 (hodge-poster.md) on the round-5 build: typing
-"While go" mid wrapped paragraph, then backspace → caret leaped +43 to the
-end of the block ("always starts two viewport-lines down" — user), next
-backspace leaped to end of document. New user observation: the drift is no
-longer continuous — one delete drifts, the next doesn't.
+Recurred 2026-07-03 ~22:13 (hodge-poster.md) on the round-5 build: the user
+typed "While go" mid wrapped paragraph, backspaced the "o" → the caret leaped
++43 to the end of the block (sel 294 → 337); the next backspace deleted the
+block separator and leaped to the end of the document (337 → 388). Two new
+field observations shaped the investigation:
 
-**Reproduced deterministically** (first time ever headless-ish): simulate the
-drag-move bypass (shouldChangeText + replaceCharacters, no didChangeText) via
-the new in-process repro driver, let the heal fire, and the caret lands at
-321 instead of 290 — every run.
+- the first drift is always "two viewport-lines down";
+- the drift is no longer continuous — a delete that drifts is followed by
+  deletes that don't (unlike rounds 4/5).
 
-The new `traceSelectionOrigin` (verbose call-stack log for selection changes
-arriving mid-recompose) named the culprit:
+No heal breadcrumb at the drift moment, no LEN-MISMATCH persisting, `synced`
+lines present — the *model* was fine. The drifting deletes' signature was a
+`selectionDidChange` arriving **mid-recompose** (up=Y) at a wrong position,
+with no pre-sync up=N notification. And 80 seconds *earlier* the log showed a
+heal (a drag-move bypass at 22:11:57) followed immediately by three backspaces
+with a *stuck* caret — the same up=Y signature. That temporal link (bypass →
+later delete drifts) became the working hypothesis.
+
+### How it was finally reproduced (the first deterministic repro in 6 rounds)
+
+Everything before round 6 relied on reading traces from the user's live
+sessions; every scripted attempt had failed to drift. What failed, and why,
+matters as much as what worked:
+
+1. **Windowed unit test, real `deleteBackward`** (`WrappedParagraphCaretTests`
+   first version): reconstruct the exact document, caret mid wrapped
+   paragraph, type "While go" via `insertText`, then `deleteBackward(nil)`
+   with run-loop drains. **Passed** — under the test harness NSTextView
+   updates the selection synchronously; the deferred-fixup state never forms.
+   Lesson: this bug class is invisible headless, full stop.
+
+2. **CGEvent injection** (the round-4 approach: drive the real app with
+   synthetic clicks/keys): this session's TCC context silently dropped the
+   events — clicks and keys posted fine but never arrived. Also the app's
+   windows launch on an inactive Space (`kCGWindowIsOnscreen == false`), and
+   `osascript`/System Events activation was denied assistive access.
+   Lesson (already in memory, reconfirmed): CGEvent-based repro depends on
+   per-session TCC grants you can't count on.
+
+3. **In-process replay — the breakthrough.** If events can't be injected from
+   outside, have the app inject them itself: `ReproScript.swift` (DEBUG-only,
+   `-debug.reproScript <path>`) replays a command script against the front
+   document by synthesizing `NSEvent` key events and pushing them through
+   `window.sendEvent(_:)` — the full, authentic AppKit route (keyDown →
+   interpretKeyEvents → insertText:/deleteBackward:), no TCC involved, and it
+   works with the window on an invisible Space. Commands: `sleep <ms>`,
+   `caret <needle>` (place caret before first occurrence), `type <text>`,
+   `backspace <n>`, `logsel`, and the two that cracked the case:
+   - `bypassdelete <needle>` — simulates the drag-move source deletion
+     exactly as AppKit performs it: select the range, call
+     `shouldChangeText`, mutate the storage, **never call `didChangeText`**;
+   - `assertcaret <needle>` — PASS/FAIL log line iff the caret sits exactly
+     before `<needle>` (position-independent, so soak scripts survive
+     upstream edits).
+
+4. **First scripted run reproduced the leap immediately and deterministically**:
+   `bypassdelete "Sizemore,"` → heal fires → caret lands at **321** instead
+   of 290, every run, window not even visible. Typing and backspacing alone
+   (step 1's recipe) never drifts; one bypassed edit beforehand always does.
+   The trigger was never the typing — it was the silent drag-move bypass
+   minutes earlier.
+
+### Naming the culprit: `traceSelectionOrigin`
+
+New verbose diagnostic (`+Diagnostics`): any `selectionDidChange` arriving
+while `isUpdating` (the drift signature) logs a condensed call stack. One run
+later the mover had a name:
 
 ```
+-[NSTextView(NSSharing) setSelectedRanges:affinity:stillSelecting:]
 -[NSTextLayoutManager _fixSelectionAfterChangeInCharacterRange:changeInLength:]
 -[NSTextContentStorage synchronizeTextLayoutManagers:]
 -[NSTextStorage endEditing]
 recomposeDirty ← syncRawSourceFromDisplay ← the heal
 ```
 
-A didChangeText-bypassing mutation also skips TextKit 2's selection fixup for
-that edit. The fixup stays queued and fires at the **next** `endEditing` —
-the heal's attribute-only restyle — where it maps the stale selection against
-post-edit coordinates and drops the caret blocks away. That's why drift is
-intermittent: the fixer fires once, state is synced, deletes behave again
-until the next silent bypass. Round 5's out-of-bounds clamp only caught the
-case where the stale selection ran past the document end.
+The mechanism: a normal edit runs TextKit 2's selection fixup synchronously
+inside its own editing transaction (the same stack appears under
+`deleteBackward` → `_NSDoUserReplaceForCharRange` on healthy deletes). A
+didChangeText-bypassing mutation skips that too — the fixup **stays queued**
+and fires at the *next* `endEditing`, which is the heal's attribute-only
+restyle. There it maps the by-then-stale selection against post-edit
+coordinates and drops the caret blocks away. This also explains both field
+observations: the landing offset (+31 chars here) spans about two wrapped
+lines in the user's window, and the fixer fires exactly once — after it the
+TextKit state is synchronized and deletes behave until the *next* silent
+bypass (hence "drifts once, then fine").
 
-**Fix** (in the heal, `EditorTextView+EditFlow.swift`): derive the correct
-caret from the pendingEdit hull (`oldRange.location + max(0, oldRange.length
-+ delta)`), set it before the sync (so cursorRaw/active-block styling are
-right), and **re-assert it after** — the queued fixer moves even a freshly
-set valid caret during the sync's endEditing, so the pre-set alone is not
-enough (verified: pre-set only still landed at 321).
+Round 5's fix was a special case of this: when the stale selection happened
+to run past the shrunk document end, the late fixer clamped it to the
+document end. The out-of-bounds clamp caught that variant and no other.
 
-**Tooling built for this round** (both DEBUG-only):
-- `Sources/edmd/App/ReproScript.swift` — `-debug.reproScript <path>` replays
-  keystroke scripts (`caret/type/backspace/bypassdelete/assertcaret/logsel`)
-  through the real AppKit key-event path in-process; works when TCC blocks
-  CGEvent injection.
-- `traceSelectionOrigin` — call stack for mid-recompose selection changes.
+### The fix — and the iteration that proved its shape
 
-Soak-verified: 4 bypass+heal cycles with typing/backspaces/block merges
-between, all `assertcaret PASS`. Note the unit test
-(`WrappedParagraphCaretTests`) cannot reproduce the queued fixer headlessly —
-the live scripted repro is the regression proof.
+In the heal (`+EditFlow`): derive the correct caret from the pendingEdit hull
+(`oldRange.location + max(0, oldRange.length + delta)` — the edit's end
+point), then:
 
-Build gotcha hit twice this round: SwiftPM kept "Build complete!" while
-linking a stale `edmd` binary (compile ran, relink skipped). When a repro
-behaves like old code, check `strings .build/.../edmd` for a new literal;
-`swift package clean` fixes it.
+1. `setSelectedRange` **before** `syncRawSourceFromDisplay()` — first attempt.
+   **Still leaped to 321**: the queued fixer runs during the sync's
+   `endEditing` and moves even a freshly set, fully valid caret.
+2. Re-assert the same caret **after** the sync as well — the fixer has fired
+   by then and its state is clean (verified: all follow-up edits healthy).
+   The pre-set is still kept so the sync computes `cursorRaw`/active-block
+   styling from the right position.
+
+### Verification
+
+- Deterministic repro flips: logsel 321 → **290** with the fix.
+- Soak (per the "accumulate a session" suggestion): one script, one app run,
+  four bypass+heal cycles at different document positions with typing,
+  backspaces, and block-merge deletes between them — **all five `assertcaret`
+  PASS**, final state byte-identical across runs.
+- Full suite green (810). The unit test survives as a contract spec but
+  cannot catch a regression (see step 1); the scripted live repro is the
+  regression harness — script preserved in the test bundle's sibling docs and
+  reproducible in one command.
+
+### Build-system trap hit twice this round
+
+`swift build` twice reported `Build complete!` while linking a **stale**
+`edmd` binary — the compile step ran (`Compiling edmd ReproScript.swift`
+visible in the log) but the relink silently didn't, so the app kept executing
+old code and two "failed" fix iterations were phantoms. Detection: check
+`strings .build/arm64-apple-macosx/debug/edmd` for a string literal unique to
+the new code (beware: literals ≤15 bytes are stored inline on arm64 and never
+show up — grep for a *long* one). Cure: `swift package clean`. Never delete
+`edmd.build/` by hand — that corrupts the output-file-map and wedges the
+target until a clean.


### PR DESCRIPTION
## What

When the didChangeText-bypass heal fires, derive the correct caret from the pendingEdit hull, set it before the sync, and **re-assert it after** — plus the diagnostics and repro tooling that found the root cause.

## Why

Delete drift (#156) recurred on the round-5 build (2026-07-03 ~22:13): backspace mid wrapped paragraph leaped the caret to the block end, then to the document end. New field data: the first drift is ~two viewport-lines down, and drifts are intermittent (one delete drifts, the next doesn't).

**Root cause, finally named.** A didChangeText-bypassing mutation (the drag-move source deletion) also skips TextKit 2's selection fixup. The fixup stays **queued** and fires at the next `endEditing` — the heal's attribute-only restyle — via:

```
-[NSTextLayoutManager _fixSelectionAfterChangeInCharacterRange:changeInLength:]
-[NSTextContentStorage synchronizeTextLayoutManagers:]
-[NSTextStorage endEditing]
recomposeDirty ← syncRawSourceFromDisplay ← the heal
```

There it maps the stale selection against post-edit coordinates and drops the caret blocks away (321 for 290 in the deterministic repro). It fires exactly once — hence the intermittency — and it moves even a freshly set valid caret, hence the post-sync re-assert (a pre-set alone was tested and still leaped). Round 5's out-of-bounds clamp was a special case of this and caught no other variant.

## Repro & verification

- First deterministic repro in six rounds: new DEBUG-only in-process driver (`-debug.reproScript`) replays keystroke scripts through the real `window.sendEvent` key path (no TCC needed; headless harnesses cannot form the queued-fixup state, and CGEvent injection is TCC-gated). `bypassdelete` simulates the drag-move bypass; `assertcaret` gives PASS/FAIL soak checks.
- `traceSelectionOrigin`: verbose call-stack log for selection changes arriving mid-recompose — named the culprit in one run.
- Soak: four bypass+heal cycles with typing, backspaces, and block merges between — all five `assertcaret` PASS; fix flips the repro from 321 to 290.
- Full suite: 810 tests green.
- Docs: full round-6 chronicle in `docs/delete-drift-investigation.md`; new §8 gotchas (queued selection fixup, ReproScript, SwiftPM stale-link trap) in `docs/ARCHITECTURE.md`.

Refs #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)