### PR TITLE
Apply max content width to Read mode

### DIFF
--- a/Sources/EdmundCore/Export/DocumentHTML.swift
+++ b/Sources/EdmundCore/Export/DocumentHTML.swift
@@ -23,7 +23,8 @@ enum DocumentHTML {
         var body = HTMLRenderer.render(markdown: markdown, options: options)
         body = fillMath(body, theme: theme, dark: dark)
         body = fillImages(body, baseURL: baseURL, options: options)
-        let css = HTMLTheme.css(theme, callouts: callouts, dark: dark)
+        let css = HTMLTheme.css(theme, callouts: callouts, dark: dark,
+                                maxContentWidthPoints: options.maxContentWidthPoints)
         return """
         <!DOCTYPE html>
         <html><head><meta charset="utf-8">

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -16,7 +16,8 @@ enum HTMLTheme {
     @MainActor
     static func css(_ theme: EditorTheme,
                     callouts: [String: CalloutStyle],
-                    dark: Bool) -> String {
+                    dark: Bool,
+                    maxContentWidthPoints: Double = .greatestFiniteMagnitude) -> String {
         let bg = dark ? "#1e1e1e" : "#ffffff"
         let fg = dark ? "#e6e6e6" : "#1a1a1a"
         let faint = dark ? "#9a9a9a" : "#6a6a6a"
@@ -27,6 +28,13 @@ enum HTMLTheme {
         // *between* lines on top of the font's natural leading (~1.2×). The CSS
         // equivalent is 1.2 + (lineSpacing / fontSize).
         let lineHeight = 1.2 + theme.lineSpacing / theme.fontSize
+
+        // CSS px and AppKit points are both device-independent, so the editor's
+        // physical cap (EditorTextView.maxContentWidthPoints) carries over as-is.
+        // A huge/infinite value means "uncapped" in the editor too; `none` skips
+        // the constraint instead of emitting an unusable giant number.
+        let pageMaxWidth = maxContentWidthPoints < 100_000
+            ? "\(trim(CGFloat(maxContentWidthPoints)))px" : "none"
 
         return """
         :root {
@@ -45,6 +53,7 @@ enum HTMLTheme {
           --check-fill: \(resolvedRGBA(.controlAccentColor, dark: dark));
           --line-height: \(trim(lineHeight));
           --para-space: \(trim(max(theme.paragraphSpacingBefore, 0)))px;
+          --page-max-width: \(pageMaxWidth);
         }
         \(calloutVars(callouts, dark: dark))
         \(staticRules)
@@ -122,7 +131,7 @@ enum HTMLTheme {
       margin: 0;
       padding: 48px 24px;
     }
-    .page { max-width: 46em; margin: 0 auto; }
+    .page { max-width: var(--page-max-width); margin: 0 auto; }
     /* Styled-source spacing: paragraphs and blocks get a full line's breathing
        room, so the cadence feels like a clean, readable version of Edit mode
        rather than a collapsed publication layout. */

--- a/Sources/EdmundCore/Export/ReadRenderOptions.swift
+++ b/Sources/EdmundCore/Export/ReadRenderOptions.swift
@@ -16,9 +16,18 @@ public struct ReadRenderOptions: Sendable, Equatable {
     /// local images are always inlined regardless of this flag.
     public var allowRemoteImages: Bool
 
-    public init(preserveBlankLines: Bool = true, allowRemoteImages: Bool = false) {
+    /// The centered reading column's max width in points, matching the editor's
+    /// `EditorTextView.maxContentWidthPoints` (§EditorTextView+ContentWidth). CSS
+    /// px and AppKit points are both device-independent, so the same number caps
+    /// the column to the same physical width in Read mode as in Edit mode.
+    /// `.greatestFiniteMagnitude` → uncapped (fills the page).
+    public var maxContentWidthPoints: Double
+
+    public init(preserveBlankLines: Bool = true, allowRemoteImages: Bool = false,
+                maxContentWidthPoints: Double = .greatestFiniteMagnitude) {
         self.preserveBlankLines = preserveBlankLines
         self.allowRemoteImages = allowRemoteImages
+        self.maxContentWidthPoints = maxContentWidthPoints
     }
 
     public static let `default` = ReadRenderOptions()

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -427,9 +427,12 @@ class Document: NSDocument, HeadingNavigable {
         return m
     }
 
-    /// Read-mode/export render options derived from user settings.
+    /// Read-mode/export render options derived from user settings. Reuses the
+    /// editor's own `maxContentWidthPoints` (already the cm setting converted via
+    /// the window's screen PPI) so Read mode's column matches Edit mode's.
     private var renderOptions: ReadRenderOptions {
-        ReadRenderOptions(preserveBlankLines: AppSettings.renderBlankLinesAsBreaks)
+        ReadRenderOptions(preserveBlankLines: AppSettings.renderBlankLinesAsBreaks,
+                         maxContentWidthPoints: Double(editor.maxContentWidthPoints))
     }
 
     // MARK: - Export / Print

--- a/Sources/edmd/Settings/AppearanceSettingsView.swift
+++ b/Sources/edmd/Settings/AppearanceSettingsView.swift
@@ -157,6 +157,7 @@ struct AppearanceSettingsView: View {
             let screen = document.editor?.window?.screen ?? NSScreen.main
             guard let screen else { continue }
             document.editor?.maxContentWidthPoints = screen.cmToPoints(maxContentWidthCm)
+            document.refreshReadView()
         }
     }
 

--- a/Tests/EdmundTests/HTMLThemeTests.swift
+++ b/Tests/EdmundTests/HTMLThemeTests.swift
@@ -25,6 +25,19 @@ struct HTMLThemeTests {
         #expect(out.contains("\"Iowan Old Style\""))
     }
 
+    @Test("Reading column max-width matches the editor's physical cap; uncapped by default")
+    func pageMaxWidth() {
+        let theme = EditorTheme(fontName: "Iowan Old Style", fontSize: 16,
+                                linkBlueHex: "#3366E6", codeHex: "#8A2425",
+                                lineSpacing: 4, paragraphSpacingBefore: 2)
+        let capped = HTMLTheme.css(theme, callouts: Callout.defaultStyles, dark: false,
+                                   maxContentWidthPoints: 340)
+        #expect(capped.contains("--page-max-width: 340px;"))
+
+        let uncapped = HTMLTheme.css(theme, callouts: Callout.defaultStyles, dark: false)
+        #expect(uncapped.contains("--page-max-width: none;"))
+    }
+
     @Test("Emits per-callout-type colors with derived rgba background")
     func calloutVars() {
         let out = css(dark: false)


### PR DESCRIPTION
## Summary
- Read mode's `.page` column was hardcoded to `max-width: 46em`, ignoring the "Max content width" setting that already caps Edit mode's column (`EditorTextView.maxContentWidthPoints`).
- Threads that physical points value through `ReadRenderOptions` → `HTMLTheme.css` → CSS `--page-max-width`, shared by Read mode, PDF export, and print (they already share `ReadRenderOptions`/`DocumentHTML.full`).
- Live-updates open Read views when the width slider changes (`refreshReadView()`), matching Edit mode's live update.
- Uncapped (`.greatestFiniteMagnitude`, the pre-existing default for other `ReadRenderOptions` callers) now emits `max-width: none` instead of a giant unusable number.

## Test plan
- [x] `swift test` — all 809 tests green, including a new `HTMLThemeTests` case asserting `--page-max-width` for both a capped and uncapped value.
- [ ] Visual check (screencapture) — attempted but this background job's screencapture lacks the Screen Recording grant the interactive session has; the CSS output is deterministic and covered by the new unit test instead. Worth a manual eyeball check on a wide window before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)