### PR TITLE
Render footnotes in Read mode

### DIFF
--- a/Sources/EdmundCore/Editing/EditorTextView+FormattingCommands.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+FormattingCommands.swift
@@ -337,8 +337,16 @@ extension EditorTextView {
         var newRaw = ns.replacingCharacters(in: NSRange(location: markerPos, length: 0),
                                             with: "[^\(n)]")
         let body = newRaw as NSString
-        let needsNewline = body.length > 0 && body.character(at: body.length - 1) != 0x0A
-        newRaw += (needsNewline ? "\n" : "") + "[^\(n)]: "
+        // A blank line (not just a single \n) before the definition so it parses
+        // as its own paragraph rather than a lazy-continuation line of the
+        // reference's paragraph — CommonMark (and Read mode's HTMLRenderer, which
+        // parses the whole document) needs that separation to recognize it as a
+        // footnote definition rather than fused body text.
+        var trailingNewlines = 0
+        var i = body.length - 1
+        while i >= 0 && body.character(at: i) == 0x0A { trailingNewlines += 1; i -= 1 }
+        let separator = body.length == 0 ? "" : String(repeating: "\n", count: max(0, 2 - trailingNewlines))
+        newRaw += separator + "[^\(n)]: "
         let caret = (newRaw as NSString).length
         applyWholeDocumentEdit(newRawSource: newRaw, select: NSRange(location: caret, length: 0))
     }

--- a/Sources/EdmundCore/Export/HTMLRenderer.swift
+++ b/Sources/EdmundCore/Export/HTMLRenderer.swift
@@ -37,6 +37,11 @@ struct HTMLRenderer: MarkupVisitor {
     private let sourceLines: [String]
     private let options: ReadRenderOptions
 
+    /// Footnote definitions collected while walking the document (see
+    /// `visitParagraph`), rendered as a section at the bottom of the page
+    /// instead of in place. Order is document order of the *definitions*.
+    private var footnotes: [(id: String, bodyHTML: String)] = []
+
     private init(source: String, options: ReadRenderOptions) {
         self.source = source
         self.sourceLines = source.components(separatedBy: "\n")
@@ -48,7 +53,24 @@ struct HTMLRenderer: MarkupVisitor {
     static func render(markdown: String, options: ReadRenderOptions = .default) -> String {
         var r = HTMLRenderer(source: markdown, options: options)
         let doc = Document(parsing: markdown, options: [.disableSmartOpts])
-        return r.visit(doc)
+        let body = r.visit(doc)
+        return body + r.renderFootnotesSection()
+    }
+
+    /// `[^id]: body` definitions render at the bottom of the page as a `<hr>` +
+    /// ordered list, each entry linking back to its in-text reference — the
+    /// Obsidian-style footnote layout (see misc/backlog.md's Markdown Footnotes
+    /// entry). Not rendered at all if the document had no footnote definitions.
+    private func renderFootnotesSection() -> String {
+        guard !footnotes.isEmpty else { return "" }
+        var out = "<hr class=\"footnotes-sep\"><ol class=\"footnotes\">"
+        for (id, bodyHTML) in footnotes {
+            let safeID = Self.attr(id)
+            out += "<li id=\"fn-\(safeID)\">\(bodyHTML) " +
+                   "<a href=\"#fnref-\(safeID)\" class=\"footnote-backref\">↩</a></li>"
+        }
+        out += "</ol>"
+        return out
     }
 
     /// Top-level block iteration. When `preserveBlankLines` is on, a *run* of
@@ -122,6 +144,18 @@ struct HTMLRenderer: MarkupVisitor {
         if let span = dm.first(where: { if case .math(true) = $0.kind { return true }; return false }) {
             let tex = (raw as NSString).substring(with: span.contentRange)
             return "<div class=\"math-display\" data-tex=\"\(Self.attr(tex))\"></div>"
+        }
+
+        // A `[^id]: body` paragraph (the marker starts the paragraph's first
+        // Text child) is a footnote definition, not visible content — collect it
+        // for the bottom-of-page footnotes section instead of rendering in place.
+        let children = Array(paragraph.children)
+        if let first = children.first as? Text,
+           let (id, markerLength) = Self.footnoteDefinitionMarker(in: first.string) {
+            var bodyHTML = Self.renderInline(String(first.string.dropFirst(markerLength)))
+            for child in children.dropFirst() { bodyHTML += visit(child) }
+            footnotes.append((id: id, bodyHTML: bodyHTML))
+            return ""
         }
         return "<p>\(renderChildren(of: paragraph))</p>"
     }
@@ -387,11 +421,15 @@ struct HTMLRenderer: MarkupVisitor {
         SyntaxHighlighter.parseMath(s, into: &spans)        // inline $…$ only
         SyntaxHighlighter.parseWikiLinks(s, into: &spans)
         SyntaxHighlighter.parseComments(s, into: &spans)
+        SyntaxHighlighter.parseFootnotes(s, into: &spans)   // references only; a
+        // `.footnoteDefinition` match here is a false positive (mid-run text that
+        // happens to start with `[^id]:`) since real definitions are handled at
+        // the paragraph level in `visitParagraph` — ignored by the switch below.
 
         // Keep only the kinds we emit, ordered, non-overlapping (earliest wins).
         let relevant = spans.filter {
             switch $0.kind {
-            case .highlight, .math(false), .wikilink, .comment: return true
+            case .highlight, .math(false), .wikilink, .comment, .footnoteReference: return true
             default: return false
             }
         }.sorted { $0.fullRange.location < $1.fullRange.location }
@@ -419,6 +457,10 @@ struct HTMLRenderer: MarkupVisitor {
                 let encoded = target.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? target
                 let display = escape(ns.substring(with: span.contentRange))
                 out += "<a class=\"wikilink\" href=\"\(wikiScheme):\(encoded)\">\(display)</a>"
+            case .footnoteReference(let id):
+                let safeID = attr(id)
+                out += "<sup id=\"fnref-\(safeID)\" class=\"footnote-ref\">" +
+                       "<a href=\"#fn-\(safeID)\">\(escape(id))</a></sup>"
             case .comment:
                 break   // hidden in reading, like the editor
             default:
@@ -499,5 +541,22 @@ struct HTMLRenderer: MarkupVisitor {
         if let c = markup as? InlineCode { return c.code }
         if markup is SoftBreak || markup is LineBreak { return "\n" }
         return markup.children.map { plainText(of: $0) }.joined()
+    }
+
+    /// If `text` starts with a footnote definition marker `[^id]:` (optionally
+    /// followed by one space), returns the id and the marker's length so the
+    /// caller can split it off from the body. Mirrors
+    /// `SyntaxHighlighter.parseFootnotes`'s definition rule (which only matches
+    /// at the start of the string passed to it) without needing that file's
+    /// file-private regex.
+    private static func footnoteDefinitionMarker(in text: String) -> (id: String, markerLength: Int)? {
+        guard text.hasPrefix("[^"), let closeBracket = text[text.index(text.startIndex, offsetBy: 2)...].firstIndex(of: "]") else { return nil }
+        let id = text[text.index(text.startIndex, offsetBy: 2)..<closeBracket]
+        guard !id.isEmpty, !id.contains(where: { $0.isWhitespace }) else { return nil }
+        let afterBracket = text.index(after: closeBracket)
+        guard afterBracket < text.endIndex, text[afterBracket] == ":" else { return nil }
+        var markerEnd = text.index(after: afterBracket)
+        if markerEnd < text.endIndex, text[markerEnd] == " " { markerEnd = text.index(after: markerEnd) }
+        return (String(id), text.distance(from: text.startIndex, to: markerEnd))
     }
 }

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -168,6 +168,15 @@ enum HTMLTheme {
     sub, sup { font-size: 0.75em; line-height: 0; position: relative; vertical-align: baseline; }
     sup { top: -0.5em; }
     sub { bottom: -0.25em; }
+    /* Footnotes (see HTMLRenderer.renderFootnotesSection): in-text `[^id]` refs
+       are plain (undecorated) superscript links; the bottom-of-page list is a
+       smaller, dimmer <ol> below its own <hr>, each entry ending in a backref
+       arrow to the in-text marker. */
+    sup.footnote-ref a { text-decoration: none; }
+    hr.footnotes-sep { margin-bottom: 0.8em; }
+    ol.footnotes { font-size: 0.85em; color: var(--faint); }
+    ol.footnotes li { margin: 0.4em 0; }
+    a.footnote-backref { text-decoration: none; margin-left: 0.2em; font-size: 0.9em; line-height: 1; }
     /* Match the editor's list indentation: level-1 text begins at one marker
        slot past the marker (~2.25em), and each nesting level steps in by one
        slot (~1.25em). Same dot at every level, like Edit mode. */

--- a/Tests/EdmundTests/FormattingTests.swift
+++ b/Tests/EdmundTests/FormattingTests.swift
@@ -155,7 +155,9 @@ private func mk(_ content: String, _ sel: NSRange) -> EditorTextView {
     @Test func footnoteInsertsMarkerAndDefinition() {
         let e = mk("word", NSRange(location: 4, length: 0))
         e.formatFootnote(nil)
-        #expect(e.rawSource == "word[^1]\n[^1]: ")
+        // A blank line (not just \n) separates the definition from the reference's
+        // paragraph so it parses as its own block (needed for Read mode).
+        #expect(e.rawSource == "word[^1]\n\n[^1]: ")
         #expect(e.selectedRange() == NSRange(location: e.rawSource.utf16.count, length: 0))
     }
 

--- a/Tests/EdmundTests/HTMLRendererTests.swift
+++ b/Tests/EdmundTests/HTMLRendererTests.swift
@@ -181,6 +181,52 @@ struct HTMLRendererInlineTests {
     }
 }
 
+@Suite("HTMLRenderer — footnotes")
+struct HTMLRendererFootnoteTests {
+
+    private func html(_ md: String) -> String { HTMLRenderer.render(markdown: md) }
+
+    @Test("Reference becomes a superscript link; raw [^id] doesn't leak into the page")
+    func reference() {
+        let out = html("Hello world.[^1]\n\n[^1]: a note")
+        #expect(out.contains("<sup id=\"fnref-1\" class=\"footnote-ref\"><a href=\"#fn-1\">1</a></sup>"))
+        #expect(!out.contains("[^1]"))
+    }
+
+    @Test("Definition moves to a bottom section with a backlink, not rendered in place")
+    func definitionMovesToBottom() {
+        let out = html("See.[^1]\n\n[^1]: the note text\n\nMore content.")
+        #expect(!out.contains("<p>[^1]"))
+        #expect(out.contains("<hr class=\"footnotes-sep\"><ol class=\"footnotes\">"))
+        #expect(out.contains("<li id=\"fn-1\">the note text <a href=\"#fnref-1\" class=\"footnote-backref\">↩</a></li>"))
+        // The unrelated paragraph after the definition still renders normally.
+        #expect(out.contains("<p>More content.</p>"))
+    }
+
+    @Test("Definition body keeps its inline markdown formatting")
+    func definitionBodyKeepsFormatting() {
+        let out = html("See.[^1]\n\n[^1]: has **bold** text")
+        #expect(out.contains("<li id=\"fn-1\">has <strong>bold</strong> text"))
+    }
+
+    @Test("No footnotes: no bottom section emitted")
+    func noFootnotesNoSection() {
+        #expect(!html("plain paragraph, no notes").contains("footnotes-sep"))
+    }
+
+    @Test("Document produced by the Format-menu Insert Footnote command renders correctly in Read mode")
+    @MainActor func viaFormatMenuCommand() {
+        let editor = makeEditor()
+        editor.loadContent("Hello world.")
+        editor.formatFootnote(nil)
+        editor.insertText("This is the note.", replacementRange: editor.selectedRange())
+        let out = html(editor.rawSource)
+        #expect(out.contains("<sup id=\"fnref-1\" class=\"footnote-ref\"><a href=\"#fn-1\">1</a></sup>"))
+        #expect(out.contains("<li id=\"fn-1\">This is the note."))
+        #expect(!out.contains("[^1]"))
+    }
+}
+
 @Suite("HTMLRenderer — callouts")
 struct HTMLRendererCalloutTests {
 


### PR DESCRIPTION
## Summary
- Read mode's `HTMLRenderer` had no footnote handling at all — `[^id]` references and `[^id]:` definitions passed through as literal bracket text (Edit mode already styled them correctly via a separate per-block regex pass). References now render as superscript links; definitions move to a bottom-of-page list with backlinks, matching the Obsidian-style layout described in the backlog.
- Fixed the Format-menu "Insert Footnote" command, which separated the appended `[^n]: ` definition from the reference with a single `\n`. Read mode parses the whole document with swift-markdown's real block rules (unlike the editor's per-line block splitter), so a single newline fused the definition into the reference's paragraph as a lazy-continuation line — invisible to any correct CommonMark renderer. It now inserts a full blank line.
- Minor CSS tweak to the footnote backlink arrow's size/line-height.

## Test plan
- [x] `swift test` — 814 tests pass
- [x] New `HTMLRenderer — footnotes` suite covering: reference → superscript link, definition → bottom section with backlink, inline formatting preserved in definition body, no section when no footnotes, and the actual Format-menu → Read-mode path end to end
- [x] Updated `FormatFootnoteTests` for the new blank-line separator
- [x] Manually verified in a live debug build (Read mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)