### PR TITLE
Investigate callout-as-last-block extra line bug (no fix yet)

### DIFF
--- a/Sources/edmd/App/ReproScript.swift
+++ b/Sources/edmd/App/ReproScript.swift
@@ -12,6 +12,8 @@ import EdmundCore
 ///   caret <needle>    place the caret before the first occurrence of <needle>
 ///   type <text>       type text, one key event per character
 ///   backspace <n>     press delete n times (300ms apart)
+///   scroll <y>        scroll the clip view to y (bypasses the caret/typewriter
+///                     recentering, so a block can be driven off-screen)
 ///   logsel            log the current selection
 @MainActor
 enum ReproScript {
@@ -78,6 +80,21 @@ enum ReproScript {
                              "rawLen=\((editor.rawSource as NSString).length) " +
                              "docs=\(NSDocumentController.shared.documents.count)",
                              category: .app)
+                }
+            case "scroll":
+                // Scrolls the clip view directly (bypassing the caret, so the
+                // active block can be driven off-screen independent of where
+                // typewriter-mode recentering would otherwise put it).
+                // `scroll(to:)` posts boundsDidChange, same as a real drag/wheel
+                // scroll, so promotion/idle-drain react exactly as they would live.
+                schedule(after: delay) { editor in
+                    guard let clipView = editor.enclosingScrollView?.contentView else { return }
+                    let y = CGFloat(Double(arg) ?? 0)
+                    let proposed = NSRect(origin: NSPoint(x: 0, y: y), size: clipView.bounds.size)
+                    let clamped = clipView.constrainBoundsRect(proposed)
+                    clipView.scroll(to: clamped.origin)
+                    editor.enclosingScrollView?.reflectScrolledClipView(clipView)
+                    Log.info("repro scroll y=\(y) clamped=\(clamped.origin.y)", category: .app)
                 }
             default:
                 break

--- a/docs/callout-bottom-line-investigation.md
+++ b/docs/callout-bottom-line-investigation.md
@@ -50,37 +50,50 @@ either. No divergence found between the static and live paths in this logic.
    separator and everything after it is actually removed via
    `shouldChangeText`/`didChangeText`, not a fresh load) — then deactivated.
    Still clean.
-3. Did **not** manage to force the off-screen deferred-restyle branch
-   (`EditorTextView+SelectionTracking.swift`'s `else { self.blocks[old].isStyled
-   = false }`), which prior memory flagged as the most likely suspect
-   mechanism: typewriter mode (`typewriterModeEnabled = true` by default)
-   re-centers the viewport on every caret move via `scrollCursorToCenter()`,
-   so a `ReproScript caret` jump never leaves the old active block
-   off-screen — the visibility check that picks sync-vs-defer always sees it
-   as visible. `ReproScript` has no scroll command, and CGEvent-driven
-   trackpad/wheel scrolling wasn't attempted this session (out of budget).
+3. **The off-screen deferred-restyle branch itself, forced deliberately and
+   confirmed to fire** — still clean. Added a `scroll <y>` command to
+   `ReproScript` (clamped via `NSClipView.constrainBoundsRect`, so it behaves
+   like a real scroll rather than overshooting into blank overscroll).
+   Launched with `-EditorTypewriterMode NO` so caret moves don't recenter the
+   viewport; a 124-block document (60 filler paragraphs + a trailing
+   callout) kept the viewport pinned at y=0 while the callout (~2700pt below,
+   confirmed via the clamped scroll target) was activated then deactivated —
+   at deactivation the callout was verifiably outside `syncStylingBlockRange`
+   (viewport showed only the first ~30 paragraphs), so `blocks[old].isStyled
+   = false` / the deferred path is what ran, not the sync path. Scrolled to
+   the clamped bottom afterward for the *first-ever paint* of that region.
+   Box rendered correctly, no stray line, no color bleed below the box.
+
+All four architectures that plausibly match "live incremental restyle" (per
+the prior investigation's framing) have now been tried and are clean:
+sync-path activate/deactivate while visible, sync-path deactivate via a real
+delete-edit at the exact last-block boundary, and the deferred/off-screen
+path through to its first on-screen paint.
 
 ## What to try next
 
-- Disable typewriter mode via launch default (`-EditorTypewriterMode NO`,
-  see `AppDelegate.typewriterModeKey` in `Sources/edmd/App/main.swift`) so a
-  `ReproScript` caret jump does **not** recentre the viewport, then drive the
-  editor into the deferred/off-screen branch deliberately: caret into the
-  callout, caret to a block far above (off-screen deactivation, `isStyled =
-  false`), let `drainStylingSlice`/`promoteVisibleUnstyledBlocks` process it,
-  then find a way to bring it back on screen and screenshot the first paint.
-  `ReproScript` has no scroll primitive — either add one (see its "~10 lines
-  each" extension note) or drive scrolling with the CGEvent driver
-  (`edmund-live-repro-and-diagnostics` §4).
+- **Typewriter-mode-ON recentering race** (default is ON; this session
+  disabled it to isolate the defer path — untested with it on). With
+  typewriter mode enabled, deactivating the trailing callout triggers
+  `scrollCursorToCenter()` in the same async block right after
+  `recomposeDirty` — if the centering scroll animates while TextKit2 is mid
+  layout-pass for the just-resized (shrunk/grown) last fragment, a
+  transient stale frame during the animation itself (not the settled state,
+  which is what every screenshot in this session caught) could be the
+  "extra line" — screen recordings catch exactly this kind of one-frame
+  glitch that a `screencapture` poll will almost always miss. Try scripted
+  recording (`gif_creator`-style continuous capture, or `screencapture -v`)
+  through the deactivation moment with typewriter mode on.
+- **Read mode** (`viewMode == .reading`) — not tested this session at all.
 - Get the actual screen recording. `~/Desktop/callout-bottom-bug.mov` does
   not exist on disk as of this session (checked 2026-07-06) despite being
   referenced in the bug report — ask for it directly, or for the exact
   keystroke sequence that triggers it.
-- Consider whether the bug needs `viewMode == .reading` (Read mode) rather
-  than edit mode — not tested this session.
 
 ## Status
 
 Still open. No fix attempted — the standing rule from the prior
 investigation holds: don't ship a speculative tweak to the (provably
-correct) static box geometry.
+correct) static box geometry. `ReproScript`'s new `scroll` command is a
+reusable addition (viewport control independent of the caret), kept
+regardless of this bug's outcome.

--- a/docs/callout-bottom-line-investigation.md
+++ b/docs/callout-bottom-line-investigation.md
@@ -1,0 +1,86 @@
+# Callout-as-last-block extra line — investigation notes
+
+## Goal
+
+Bug report (`~/Desktop/callout-bottom-bug.mov`, referenced twice: June and
+2026-07-06): when a callout is the last element in a file, the editor renders
+an extra line, in the callout's tinted color, not prefixed by `>`. Only seen
+when the callout is the file's last block. Tracked in `misc/backlog.md` and
+`edmund-debugging-playbook`'s open-bug inventory.
+
+Prior investigation (2026-06-ish) already ruled out the static composition
+pipeline: `styleCalloutContent` geometry (`EditorTextView+CalloutRendering.swift`)
+is correct in every constructible state via offscreen bitmap rendering —
+active→leftBar, inactive→box, trailing empty `> ` continuation line, callout
+as last block, tall view. The bug was concluded to live in the **live
+incremental restyle path**, not reproducible via `loadContent`/`recompose`.
+
+## What this session ruled out (2026-07-06)
+
+**Hypothesis: the trailing-newline phantom paragraph inherits the box
+decoration.** `BlockParser.LineBuffer` does append a synthetic empty final
+block when `rawSource` ends with `\n` (see the "Trailing newline: one final
+empty segment" comment). But `EditorTextView+TextKit2.swift`'s
+`textLayoutFragment(for:)` vends a **plain** `NSTextLayoutFragment` for any
+`NSTextParagraph` with `attributedString.length == 0` — decorations never
+draw for it regardless of what attribute might be present. Dead end,
+confirmed by code reading, not tested live.
+
+**Hypothesis: the separator-reset in `recomposeDirty`/`drainStylingSlice`
+misses the callout-as-last-block case.** Read closely: `recomposeDirty`
+(`EditorTextView+Composition.swift:118-126`) and `drainStylingSlice`
+(`EditorTextView+LazyStyling.swift:73-76`) both reset the block's trailing
+separator character to base attributes whenever that block is in the
+restyled set — the guard `sep < nsString.length` simply skips the reset when
+there's no separator (block is at the true end of the string), which is
+correct, not a bug. `applyBlockStyle()` (`EditorTextView+Rendering.swift:583`,
+the per-keystroke path) never does this reset, but it also never writes past
+the block's own range, so it can't leave anything stale on the separator
+either. No divergence found between the static and live paths in this logic.
+
+**Live repro attempts — all clean, no artifact observed:**
+
+1. Small doc (paragraph + trailing callout, whole doc visible, no
+   scrolling), `ReproScript` caret moves in and out of the callout
+   repeatedly. Screenshots taken before/during/after each transition
+   (`~/.claude/jobs/e0af50f0/tmp/s*.png` this session). Box renders cleanly
+   both directions.
+2. Same, but the callout became the last block via a **real delete-edit
+   sequence** (`backspace` through a trailing paragraph so the callout's
+   separator and everything after it is actually removed via
+   `shouldChangeText`/`didChangeText`, not a fresh load) — then deactivated.
+   Still clean.
+3. Did **not** manage to force the off-screen deferred-restyle branch
+   (`EditorTextView+SelectionTracking.swift`'s `else { self.blocks[old].isStyled
+   = false }`), which prior memory flagged as the most likely suspect
+   mechanism: typewriter mode (`typewriterModeEnabled = true` by default)
+   re-centers the viewport on every caret move via `scrollCursorToCenter()`,
+   so a `ReproScript caret` jump never leaves the old active block
+   off-screen — the visibility check that picks sync-vs-defer always sees it
+   as visible. `ReproScript` has no scroll command, and CGEvent-driven
+   trackpad/wheel scrolling wasn't attempted this session (out of budget).
+
+## What to try next
+
+- Disable typewriter mode via launch default (`-EditorTypewriterMode NO`,
+  see `AppDelegate.typewriterModeKey` in `Sources/edmd/App/main.swift`) so a
+  `ReproScript` caret jump does **not** recentre the viewport, then drive the
+  editor into the deferred/off-screen branch deliberately: caret into the
+  callout, caret to a block far above (off-screen deactivation, `isStyled =
+  false`), let `drainStylingSlice`/`promoteVisibleUnstyledBlocks` process it,
+  then find a way to bring it back on screen and screenshot the first paint.
+  `ReproScript` has no scroll primitive — either add one (see its "~10 lines
+  each" extension note) or drive scrolling with the CGEvent driver
+  (`edmund-live-repro-and-diagnostics` §4).
+- Get the actual screen recording. `~/Desktop/callout-bottom-bug.mov` does
+  not exist on disk as of this session (checked 2026-07-06) despite being
+  referenced in the bug report — ask for it directly, or for the exact
+  keystroke sequence that triggers it.
+- Consider whether the bug needs `viewMode == .reading` (Read mode) rather
+  than edit mode — not tested this session.
+
+## Status
+
+Still open. No fix attempted — the standing rule from the prior
+investigation holds: don't ship a speculative tweak to the (provably
+correct) static box geometry.


### PR DESCRIPTION
## Summary

Investigation write-up for the known bug where a callout renders an extra
colored line when it's the last element in a file (tracked in
`misc/backlog.md`, `edmund-debugging-playbook`'s open-bug inventory). No fix
is included — this documents what was ruled out and what to try next.

- Ruled out two static-attribute hypotheses by code reading (the
  trailing-newline phantom paragraph can't inherit the box decoration;
  the separator-reset logic in the styling paths is correct).
- Ran four live-repro architectures via `ReproScript` (sync-path
  activate/deactivate while visible, deactivation via a real delete-edit at
  the last-block boundary, and — after adding a `scroll` command — the
  deferred off-screen-restyle path through its first on-screen paint). All
  four rendered clean, no artifact.
- Added a `scroll <y>` command to `ReproScript` (DEBUG-only), clamped via
  `NSClipView.constrainBoundsRect` so it behaves like a real scroll instead
  of overshooting into blank overscroll — useful generally for driving the
  viewport independent of the caret in future live repros.
- Full findings and next leads (typewriter-recentering-animation frame,
  Read mode, or getting the actual screen recording) in
  `docs/callout-bottom-line-investigation.md`.

## Test plan

- [x] `swift test` — 814/814 passing
- [x] Docs-only + DEBUG-only tooling change, no product behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)