### PR TITLE
fix: stop callout box painting over the trailing empty line at doc end

### DIFF
--- a/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
@@ -207,6 +207,29 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
         }
     }
 
+    /// Height to actually paint a filled decoration (box / left bar) over,
+    /// which is *not* always the full frame height. When a callout or quote is
+    /// the last block AND the document ends with a newline, TextKit 2 folds the
+    /// document's final empty line into this (the preceding) layout fragment
+    /// instead of giving it its own fragment — it shows up as a trailing
+    /// zero-length line fragment. Painting the decoration over the full frame
+    /// then floods the callout color onto that trailing empty line (the
+    /// "extra colored line at the bottom" bug). Detect the absorbed empty line
+    /// and stop the fill at the last real content line plus the box's bottom
+    /// padding.
+    var decorationDrawHeight: CGFloat {
+        let full = layoutFragmentFrame.height
+        let lines = textLineFragments
+        guard lines.count > 1, let last = lines.last,
+              last.characterRange.length == 0 else { return full }
+        // Bottom of the last line that actually holds text (fragment-local).
+        let contentBottom = lines.dropLast().map { $0.typographicBounds.maxY }.max() ?? 0
+        // `super` frame excludes our bottomPad; its extent past the content is
+        // exactly the absorbed empty line. Remove that, keep the bottomPad.
+        let emptyLineHeight = max(0, super.layoutFragmentFrame.height - contentBottom)
+        return max(0, full - emptyLineHeight)
+    }
+
     override var layoutFragmentFrame: CGRect {
         var frame = super.layoutFragmentFrame
         frame.size.height += boxBottomPad
@@ -302,9 +325,12 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
     private func drawDecoration(_ decoration: BlockDecoration, at point: CGPoint,
                                 in context: CGContext, bottomInset: CGFloat = 0) {
         let frame = layoutFragmentFrame
+        // Filled decorations (box, bar) stop above an absorbed trailing empty
+        // line; center-line decorations (rule, table) still use the full frame.
+        let fillHeight = decorationDrawHeight
         // Fragment-local rect spanning the full text column for this fragment.
         let columnRect = CGRect(x: point.x + containerLeft, y: point.y,
-                                width: containerWidth, height: frame.height)
+                                width: containerWidth, height: fillHeight)
 
         switch decoration.kind {
         case .box(let background, let borderColor, let edges, let borderWidth, _):
@@ -344,7 +370,7 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
             // insets the text by the bar's width).
             context.setFillColor(color.cgColor)
             context.fill(CGRect(x: point.x - width, y: point.y,
-                                width: width, height: frame.height))
+                                width: width, height: fillHeight))
 
         case .tableRow(let xOffsets, let width, let leftInset, let separator):
             // Offsets are text-relative; the fragment's origin is the text start.

--- a/Sources/edmd/App/ReproScript.swift
+++ b/Sources/edmd/App/ReproScript.swift
@@ -39,6 +39,14 @@ enum ReproScript {
                     }
                     editor.setSelectedRange(NSRange(location: r.location, length: 0))
                 }
+            case "caretend":
+                // Place the caret at the very end of the document (the phantom
+                // empty final line when rawSource ends in "\n"). Needles can't
+                // target an empty line, so this is the only way to sit there.
+                schedule(after: delay) { editor in
+                    let end = (editor.rawSource as NSString).length
+                    editor.setSelectedRange(NSRange(location: end, length: 0))
+                }
             case "type":
                 for ch in arg {
                     schedule(after: delay) { press(String(ch), keyCode: 0, in: $0) }

--- a/Tests/EdmundTests/CalloutLastBlockRenderingTests.swift
+++ b/Tests/EdmundTests/CalloutLastBlockRenderingTests.swift
@@ -1,0 +1,74 @@
+import Testing
+import AppKit
+@testable import EdmundCore
+
+/// Regression: a callout that is the last block of a document that ends in a
+/// newline must NOT paint its colored box over the trailing empty line.
+///
+/// TextKit 2 folds the document's final empty line (from the trailing "\n")
+/// into the *preceding* layout fragment rather than giving it its own — it
+/// appears as a trailing zero-length line fragment. The callout's last-line
+/// `DecoratedTextLayoutFragment` then had its box fill the full frame height,
+/// flooding the callout color onto that trailing line (the reported
+/// "extra colored line at the bottom" bug, misc/bug-repros/
+/// callout-extra-line-rendered-at-bottom.mov). The fill height must exclude
+/// the absorbed empty line, so it matches the same callout without a trailing
+/// newline.
+@Suite("Callout as last block — no extra colored line")
+struct CalloutLastBlockRenderingTests {
+
+    @MainActor private func windowed() -> EditorTextView {
+        let e = makeEditor()
+        let win = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 500, height: 500),
+                           styleMask: [.titled], backing: .buffered, defer: false)
+        let scroll = NSScrollView(frame: win.contentLayoutRect)
+        scroll.documentView = e
+        win.contentView = scroll
+        win.makeFirstResponder(e)
+        return e
+    }
+
+    /// The `DecoratedTextLayoutFragment` covering the last line of the document,
+    /// with its full frame height and the height it actually fills.
+    @MainActor private func lastDecoratedFragment(_ e: EditorTextView)
+        -> (fill: CGFloat, frame: CGFloat, emptyTrailingLine: Bool)? {
+        guard let tlm = e.textLayoutManager else { return nil }
+        ensureFullLayout(e)
+        var result: (CGFloat, CGFloat, Bool)?
+        tlm.enumerateTextLayoutFragments(from: tlm.documentRange.location,
+                                         options: [.ensuresLayout]) { frag in
+            if let d = frag as? DecoratedTextLayoutFragment {
+                let hasEmptyTail = (frag.textLineFragments.count > 1)
+                    && (frag.textLineFragments.last?.characterRange.length == 0)
+                result = (d.decorationDrawHeight, d.layoutFragmentFrame.height, hasEmptyTail)
+            }
+            return true
+        }
+        return result
+    }
+
+    @Test("Box fill excludes the absorbed trailing empty line")
+    @MainActor func trailingNewlineDoesNotExtendBox() {
+        let withNL = windowed()
+        withNL.loadContent("# H\n\n> [!tip] Short title\n> Body text here.\n")
+        withNL.recompose(cursorInRaw: 0)
+        guard let a = lastDecoratedFragment(withNL) else { Issue.record("no fragment"); return }
+
+        let withoutNL = windowed()
+        withoutNL.loadContent("# H\n\n> [!tip] Short title\n> Body text here.")
+        withoutNL.recompose(cursorInRaw: 0)
+        guard let b = lastDecoratedFragment(withoutNL) else { Issue.record("no fragment"); return }
+
+        // The trailing-newline document really does absorb an empty line into
+        // the callout fragment (frame taller than the no-newline case)...
+        #expect(a.emptyTrailingLine == true)
+        #expect(b.emptyTrailingLine == false)
+        #expect(a.frame > b.frame)
+        // ...but the box is DRAWN to the same height either way — the extra
+        // empty line is not painted.
+        #expect(abs(a.fill - b.fill) < 0.5,
+                "box fill \(a.fill) (with trailing \\n) should match \(b.fill) (without)")
+        #expect(a.fill < a.frame,
+                "fill \(a.fill) must stop above the absorbed empty line (frame \(a.frame))")
+    }
+}

--- a/docs/callout-bottom-line-investigation.md
+++ b/docs/callout-bottom-line-investigation.md
@@ -90,10 +90,62 @@ path through to its first on-screen paint.
   referenced in the bug report — ask for it directly, or for the exact
   keystroke sequence that triggers it.
 
+## RESOLVED (2026-07-06, second session) — root cause found and fixed
+
+The user provided the real screen recording
+(`misc/bug-repros/callout-extra-line-rendered-at-bottom.mov`, from
+2026-06-20 11:26). Watching it changed the picture completely: the trailing
+block is **not** a plain paragraph and the doc **does end in a newline**, so
+the last block is the *phantom empty final line* the `BlockParser` creates
+for a trailing `\n`. My earlier repros all failed because they used a
+trailing *text* block ("END") or no trailing newline — never a trailing
+empty line after a callout.
+
+**Reproduced deterministically** by reconstructing the doc
+(`callout_wrap.md`: three callouts, the last one `> [!tip] Short title\n>
+Body text here.` followed by a trailing `\n`) and placing the caret at
+end-of-document. Reproduces with typewriter mode **ON and OFF** — so
+typewriter mode is *not* involved; the caret position in the video was
+incidental.
+
+**Root cause (proved by dumping fragment geometry, not reasoning):** TextKit
+2 does **not** give the document's final empty line (from the trailing `\n`)
+its own layout fragment — it folds that line into the *preceding* layout
+fragment as a trailing **zero-length line fragment**. When the preceding
+fragment is a callout's last-line `DecoratedTextLayoutFragment`, its
+`layoutFragmentFrame.height` grows by one line (measured: 46.2pt → 74.2pt for
+the same callout with vs without the trailing newline; the delta equals one
+empty line's height). `draw` fills the box across the full frame height, so
+the callout color floods that absorbed empty line — the "extra colored line".
+Only happens when the callout is the **last** block: mid-document, the `\n`
+after a callout starts the *next* block's fragment instead of being absorbed.
+
+**Why the static/storage checks (both sessions) missed it:** the phantom
+line carries no `.blockDecoration` in storage (verified: block deco = none,
+the separator `\n` reset to base) — the bug is purely in fragment *drawing
+geometry*, invisible to any storage-attribute inspection.
+
+**Fix** (`EditorTextView+TextKit2.swift`): a new `decorationDrawHeight` on
+`DecoratedTextLayoutFragment` detects an absorbed trailing empty line (last
+line fragment with `characterRange.length == 0` and more than one line
+fragment) and returns the frame height minus that empty line's contribution,
+so filled decorations (`.box`, `.leftBar`) stop at the last real content line
+plus the box's bottom padding. Center-line decorations (rule, table) still
+use the full frame. Verified live (the tip box shrank from 222px to 170px,
+matching the sibling Note box exactly) and headless
+(`CalloutLastBlockRenderingTests`: box fill is identical with and without the
+trailing newline, and strictly less than the absorbed frame height).
+
+**Answer to "would the delete-drift fixes have fixed this?"** — No. Delete
+drift is a caret/selection *position* desync in the live input layer; this is
+a static fragment-*drawing* geometry issue that reproduces on a fresh load
+with no delete, edit, or caret interaction at all. Different class entirely.
+
+`ReproScript` gained two reusable DEBUG commands across the two sessions:
+`scroll <y>` (viewport control independent of the caret) and `caretend`
+(place the caret on the phantom final line, which needles can't target).
+
 ## Status
 
-Still open. No fix attempted — the standing rule from the prior
-investigation holds: don't ship a speculative tweak to the (provably
-correct) static box geometry. `ReproScript`'s new `scroll` command is a
-reusable addition (viewport control independent of the caret), kept
-regardless of this bug's outcome.
+**Fixed.** Branch `fix/callout-last-block-extra-line`. Backlog entry can be
+closed once merged.


### PR DESCRIPTION
## What

When a callout is the last block of a document that ends in a newline, the
editor painted an extra line in the callout's color below the callout's last
line, not prefixed by `>`
(`misc/bug-repros/callout-extra-line-rendered-at-bottom.mov`).

## Why / root cause

The trailing `\n` makes the document's last block a phantom empty final line.
TextKit 2 does **not** give that final empty line its own layout fragment — it
folds it into the *preceding* layout fragment as a trailing zero-length line
fragment, growing that fragment's frame by one line (measured 46.2pt → 74.2pt
for the same callout with vs without the trailing newline). When the preceding
fragment is a callout's last-line `DecoratedTextLayoutFragment`, `draw` filled
the box across the full frame height, flooding the callout color onto the
absorbed empty line.

Only the **last** block is affected — mid-document, the `\n` after a callout
starts the next block's fragment instead of being absorbed. The phantom line
carries no `.blockDecoration` in storage, so this is purely a fragment-drawing
geometry issue (which is why earlier storage-attribute checks never caught it,
and wrongly concluded it was a live-restyle-path bug).

## Fix

Add `decorationDrawHeight` on `DecoratedTextLayoutFragment`: it detects an
absorbed trailing empty line (a zero-length last line fragment, with more than
one line fragment) and returns the frame height minus that line's
contribution. Filled decorations (`.box`, `.leftBar`) use it so they stop at
the last real content line plus the box's bottom padding; center-line
decorations (rule, table) still use the full frame.

Also adds two DEBUG-only `ReproScript` commands used to pin this down:
`caretend` (place the caret on the phantom final line, which needles can't
target) and `scroll` (viewport control independent of the caret).

## Test plan

- [x] `swift test` — 815/815 passing (adds `CalloutLastBlockRenderingTests`,
      which fails without the fix)
- [x] Verified live: the tip callout box shrank from 222px to 170px, exactly
      matching its sibling Note box
- [x] Not a delete-drift regression — this reproduces on a fresh load with no
      edit or caret interaction, typewriter mode on or off

Root-cause writeup: `docs/callout-bottom-line-investigation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)