### PR TITLE
fix(math): reserve display-math ascent and descent separately

### DIFF
--- a/Sources/EdmundCore/Rendering/EditorTextView+MathRendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+MathRendering.swift
@@ -155,16 +155,30 @@ extension EditorTextView {
     /// only to the image's (first) line — a multi-line `$$…$$` block is
     /// several paragraphs in the text storage (its hidden inner lines), so
     /// padding every paragraph would multiply into a huge gap.
-    /// `imageHeight` reserves the equation's height on that line: the line's
-    /// own characters are hidden (near-zero), so without it the line collapses.
-    func displayMathParagraphStyle(padded: Bool, imageHeight: CGFloat = 0) -> NSParagraphStyle {
+    ///
+    /// `imageAscent`/`imageDescent` reserve the equation's height on that line:
+    /// the line's own characters are hidden (near-zero), so without it the line
+    /// collapses. They're reserved separately, not as one combined height,
+    /// because of how TextKit 2 grows a line to meet `minimumLineHeight`: with
+    /// the hidden anchor's near-zero natural metrics, it adds ~all of the extra
+    /// height as ascent and pins the baseline at the box's bottom edge (measured
+    /// empirically — a tall multi-row image split ~54/46 ascent/descent left a
+    /// matching-sized gap above the equation and an overlap with the next
+    /// paragraph below, since `minimumLineHeight = full height` reserved that
+    /// height entirely above the baseline). Reserving only `imageAscent` in
+    /// `minimumLineHeight` sits the image's top flush with the box's top instead
+    /// of leaving a surplus gap, and folding `imageDescent` into the *following*
+    /// spacing (rather than the line's own height) gives the part of the image
+    /// that hangs below the baseline somewhere to go before the next paragraph.
+    func displayMathParagraphStyle(padded: Bool, imageAscent: CGFloat = 0,
+                                   imageDescent: CGFloat = 0) -> NSParagraphStyle {
         let ps = NSMutableParagraphStyle()
         ps.alignment = .center
         ps.lineSpacing = 0
         let pad = padded ? bodyFont.pointSize * 0.9 : 0
         ps.paragraphSpacingBefore = pad
-        ps.paragraphSpacing = pad
-        ps.minimumLineHeight = imageHeight
+        ps.paragraphSpacing = pad + imageDescent
+        ps.minimumLineHeight = imageAscent
         return ps
     }
 }

--- a/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
@@ -338,8 +338,8 @@ extension EditorTextView {
                                               in: result)
                         }
                         // Display math sits centered on its own line, with
-                        // vertical padding and the image's height reserved on
-                        // the (first) line that carries it.
+                        // vertical padding and the image's ascent/descent
+                        // reserved on the (first) line that carries it.
                         if display {
                             let fullStr = result.string as NSString
                             result.addAttribute(.paragraphStyle,
@@ -350,9 +350,12 @@ extension EditorTextView {
                                 ? span.fullRange
                                 : NSRange(location: span.fullRange.location,
                                           length: nl.location - span.fullRange.location + 1)
+                            let imageDescent = -overlay.bounds.minY
+                            let imageAscent = overlay.bounds.height - imageDescent
                             result.addAttribute(.paragraphStyle,
                                                 value: displayMathParagraphStyle(padded: true,
-                                                                                 imageHeight: overlay.bounds.height),
+                                                                                 imageAscent: imageAscent,
+                                                                                 imageDescent: imageDescent),
                                                 range: firstLine)
                         }
                     } else {

--- a/Tests/EdmundTests/MathRenderingTests.swift
+++ b/Tests/EdmundTests/MathRenderingTests.swift
@@ -123,6 +123,38 @@ struct DisplayMathRenderingTests {
         #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) == nil)
         #expect(!isHidden(at: 2, in: styled))             // source visible
     }
+
+    // Regression (misc/bug-repros/math-env-with-taller-lines-fractions-integral-limit-padding-bug.png):
+    // a tall multi-row environment (aligned/cases) has a large descent portion
+    // (much of the block sits below the anchor's baseline), unlike a typical
+    // single-row equation. Reserving the image's full height as the line's
+    // `minimumLineHeight` pins the whole height above the baseline, leaving a
+    // gap the size of the descent above the equation and an equal overlap
+    // with the paragraph below. The fix reserves ascent and descent
+    // separately: ascent as the line's own height, descent folded into the
+    // trailing paragraph spacing.
+    @Test("Tall multi-row display math reserves ascent as line height, descent as trailing spacing")
+    @MainActor func tallEquationReservesAscentAndDescentSeparately() {
+        let editor = makeEditor()
+        let tall = "$$\n\\begin{aligned} a&=1 \\\\ b&=2 \\\\ c&=3 \\end{aligned}\n$$"
+        let styled = editor.styleBlock(tall)
+        let overlay = styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) as? FragmentOverlay
+        #expect(overlay != nil)
+        guard let overlay else { return }
+        let descent = -overlay.bounds.minY
+        let ascent = overlay.bounds.height - descent
+        // A 3-row aligned block has a substantial descent (rows below the
+        // anchor's baseline) — the case that exposed the bug; a single-row
+        // equation's descent is comparatively tiny.
+        #expect(descent > 10)
+
+        let ps = styled.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        #expect(ps != nil)
+        guard let ps else { return }
+        #expect(abs(ps.minimumLineHeight - ascent) < 0.5)
+        let basePad = editor.bodyFont.pointSize * 0.9
+        #expect(abs(ps.paragraphSpacing - (basePad + descent)) < 0.5)
+    }
 }
 
 @Suite("Math — Fit to width")

--- a/Tests/EdmundTests/RenderingRegressionTests.swift
+++ b/Tests/EdmundTests/RenderingRegressionTests.swift
@@ -49,7 +49,7 @@ struct RenderingRegressionTests {
                 "inline math line must reserve the equation's height")
     }
 
-    @Test("Display math still reserves its own line height")
+    @Test("Display math still reserves enough room for its equation image")
     @MainActor func displayMathReservesHeight() {
         let editor = makeEditor()
         let styled = editor.styleBlock("$$\n\\frac{a}{b}\n$$")
@@ -58,8 +58,17 @@ struct RenderingRegressionTests {
                                   in: NSRange(location: 0, length: styled.length)) { v, _, _ in
             if let o = v as? FragmentOverlay { overlayH = max(overlayH, o.bounds.height) }
         }
+        #expect(overlayH > 0)
         let ps = styled.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
-        #expect((ps?.minimumLineHeight ?? 0) >= overlayH - 0.5)
+        // The image's ascent is reserved as the line's own height and its
+        // descent is folded into the trailing spacing instead (see
+        // MathRenderingTests' "Tall multi-row display math..." for why a tall,
+        // descent-heavy equation can't reserve its *whole* height as
+        // minimumLineHeight without leaving a gap above it) — together they
+        // must still cover the whole image so it can't overlap what follows.
+        let reserved = (ps?.minimumLineHeight ?? 0) + (ps?.paragraphSpacing ?? 0)
+        #expect(reserved >= overlayH - 0.5,
+                "combined line height + trailing spacing must cover the equation image")
     }
 
     // MARK: Thematic break — symmetric breathing space


### PR DESCRIPTION
## Summary
- A tall multi-row environment (`\begin{aligned}`/`\begin{cases}`) has a much larger descent than a typical single-row equation — most of a stacked block sits below the anchor's baseline. `displayMathParagraphStyle` reserved the image's *full* height as `minimumLineHeight`, but TextKit 2 grows a line to meet `minimumLineHeight` by adding nearly all the extra height as ascent and pinning the (hidden anchor's near-zero-metric) baseline to the box's bottom edge — measured directly via an offscreen render + layout-fragment dump, not guessed.
- That put far more room above the baseline than the image's actual ascent needed, and far less below than its actual descent needed: a gap above the equation the size of the descent, and an equal overlap with the next paragraph.
- Fix: split the reservation — `minimumLineHeight` gets only the image's ascent (top sits flush with content start), and the descent is folded into the trailing `paragraphSpacing` (room for the part hanging below the baseline before the next paragraph starts).
- Also fixes `RenderingRegressionTests.displayMathReservesHeight`, which encoded the old (buggy) assumption that `minimumLineHeight` alone must cover the image's full height; it now checks the combined line height + trailing spacing, which is what actually has to cover the image.

## Test plan
- [x] `swift test` — 817 tests green
- [x] New regression test asserts the ascent/descent split directly (`MathRenderingTests.swift`)
- [x] Verified visually via offscreen render before/after (`misc/bug-repros/math-env-with-taller-lines-fractions-integral-limit-padding-bug.png` is the original repro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)