### PR TITLE
fix(images): stop full-width image overlays doubling their reserved height

### DIFF
--- a/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
@@ -425,12 +425,25 @@ extension EditorTextView {
     /// Renders `overlay` at `anchor` (a single character): hides the anchor
     /// glyph, reserves the image's advance width with kern so following text
     /// flows around it, and stores the overlay for the layout fragment to draw.
+    ///
+    /// The kern is capped just short of the full line width: a full-width
+    /// image/equation (the common case — anything wider than the column gets
+    /// scaled to exactly fill it) would otherwise reserve 100% of the line,
+    /// leaving zero room for the hidden markdown text that follows the anchor
+    /// on the same line. TextKit then force-wraps that hidden run onto a new
+    /// line fragment — and since `minimumLineHeight` (reserveLineHeight) is a
+    /// paragraph-wide property applying to every line fragment, that phantom
+    /// wrapped line also inflates to the overlay's full height, doubling the
+    /// reserved space below the image. The slack is comfortably larger than
+    /// any realistic hidden-text width (near-zero at `hiddenFont`'s size).
     func applyOverlay(_ overlay: FragmentOverlay, anchor: NSRange,
                       in result: NSMutableAttributedString) {
         guard anchor.upperBound <= result.length else { return }
+        let kernSlack: CGFloat = 8
+        let kernWidth = min(overlay.bounds.width, max(0, availableContentWidth - kernSlack))
         result.addAttribute(.font, value: hiddenFont, range: anchor)
         result.addAttribute(.foregroundColor, value: NSColor.clear, range: anchor)
-        result.addAttribute(.kern, value: overlay.bounds.width, range: anchor)
+        result.addAttribute(.kern, value: kernWidth, range: anchor)
         result.addAttribute(.fragmentOverlay, value: overlay, range: anchor)
     }
 

--- a/Tests/EdmundTests/RenderingRegressionTests.swift
+++ b/Tests/EdmundTests/RenderingRegressionTests.swift
@@ -49,6 +49,57 @@ struct RenderingRegressionTests {
                 "inline math line must reserve the equation's height")
     }
 
+    // MARK: Full-width image doesn't double its reserved height
+
+    /// Writes a square solid PNG wider than any reasonable text column, so the
+    /// image renderer scales it down to exactly fill the available width.
+    private func tempWidePNGPath() -> String {
+        let size = NSSize(width: 2000, height: 2000)
+        let img = NSImage(size: size)
+        img.lockFocus()
+        NSColor.systemBlue.setFill()
+        NSRect(origin: .zero, size: size).fill()
+        img.unlockFocus()
+        let rep = NSBitmapImageRep(data: img.tiffRepresentation!)!
+        let data = rep.representation(using: .png, properties: [:])!
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("md-wide-img-test-\(UUID().uuidString).png")
+        try! data.write(to: url)
+        return url.path
+    }
+
+    @Test("A full-width image's hidden markdown doesn't wrap onto a second, needlessly tall line")
+    @MainActor func fullWidthImageNoDoubleHeight() {
+        let path = tempWidePNGPath()
+        let doc = "![alt](\(path))\n# Next"
+        let (e, _) = windowed(doc)
+        // Move the cursor off the image block so it renders the overlay
+        // (not the raw, active markdown).
+        e.setSelectedRange(NSRange(location: (doc as NSString).length, length: 0))
+        e.recomposeIncremental(cursorInRaw: (doc as NSString).length)
+        ensureFullLayout(e); drainAllStyling(e)
+        e.sizeToFit(); e.layoutSubtreeIfNeeded(); ensureFullLayout(e)
+
+        guard let overlay = e.imageOverlay(destination: path) else {
+            Issue.record("expected an overlay for the wide image")
+            return
+        }
+        guard let tlm = e.textLayoutManager else { Issue.record("no text layout manager"); return }
+        var imageFragmentHeight: CGFloat?
+        tlm.enumerateTextLayoutFragments(from: tlm.documentRange.location, options: []) { frag in
+            if imageFragmentHeight == nil, frag.textLineFragments.count >= 1,
+               frag.layoutFragmentFrame.height >= overlay.bounds.height {
+                imageFragmentHeight = frag.layoutFragmentFrame.height
+                #expect(frag.textLineFragments.count == 1,
+                        "the hidden markdown after the image anchor must fit on the image's own line")
+            }
+            return true
+        }
+        #expect(imageFragmentHeight != nil)
+        #expect((imageFragmentHeight ?? 0) < overlay.bounds.height * 1.5,
+                "the image's fragment must not double-reserve height for a phantom wrapped line")
+    }
+
     @Test("Display math still reserves its own line height")
     @MainActor func displayMathReservesHeight() {
         let editor = makeEditor()


### PR DESCRIPTION
## Summary
- Fixes the known "image creates large empty space below" bug (`misc/backlog.md`, repro `misc/bug-repros/image-blank-after.mov`).
- Root cause: an overlay scaled to fill the full column width (any full-width image) reserved 100% of the line via `.kern` on its hidden anchor character, leaving zero room for the hidden markdown text that follows on the same line. TextKit force-wrapped that trailing run onto a second line fragment, and since `minimumLineHeight` applies per-paragraph (every line in it), that phantom wrapped line also inflated to the image's full height — doubling the blank space below the picture.
- Fix: cap the `.kern` reservation a few points short of the available content width in the shared `applyOverlay` helper, so the near-zero-width hidden text always fits on the anchor's own line. This covers all overlay types (images, math, list markers) at the one shared call site.

## Test plan
- [x] Added `RenderingRegressionTests.fullWidthImageNoDoubleHeight`, which reproduces the bug with a synthetic full-width image and fails without the fix (verified by temporarily reverting the source change).
- [x] `swift test` — all 815 tests pass.
- [x] Verified live in a debug build: a full-width image is immediately followed by the next heading with no gap (previously ~2x the image height of blank space).

🤖 Generated with [Claude Code](https://claude.com/claude-code)