### PR TITLE
fix(editor): re-assert caret on the normal edit path when TK2's queued fixup leaps it (delete drift round 7)

### DIFF
--- a/.claude/skills/edmund-caret-integrity-campaign/SKILL.md
+++ b/.claude/skills/edmund-caret-integrity-campaign/SKILL.md
@@ -82,6 +82,7 @@ guard**, not a new mechanism.
 | 4 | **Drag-move bypass**: a drag-move whose drop has no valid target deletes via `shouldChangeText`→`replaceCharacters` with **no `didChangeText`**; `rawSource`/`blocks` freeze; autosave writes stale text | `scheduleBypassedEditSyncCheck` (`+EditFlow.swift`): a next-run-loop check finds an unconsumed storage `pendingEdit` and runs the sync (breadcrumb above) |
 | 5 | **Heal leaped the caret**: the round-4 heal ran against a **stale** selection and moved the caret | heal collapses/derives the caret from the `pendingEdit` hull before syncing |
 | 6 | **Queued selection fixup**: TK2's `_fixSelectionAfterChangeInCharacterRange` stays queued after a bypass and fires at the **next `endEditing`** (even an attribute-only restyle), remapping the **stale** selection and leaping even a *freshly set, valid* caret | heal sets the caret from the pendingEdit hull **before** the sync **AND re-asserts it after** (`+EditFlow.swift`) |
+| 7 | **Same queued fixup on the NORMAL edit path** (not the heal): armed by a **cross-block caret move** (schedules the async caret-move restyle), the fixup fires during `syncRawSourceFromDisplay`→`recomposeDirty`'s `endEditing` on an ordinary keystroke and leaps the caret to the **block boundary**; the normal path styles `settingSelection=false` and never re-asserts, so it **persists** | `syncRawSourceFromDisplay` captures the pendingEdit-hull caret before `consumePendingEdit`, re-asserts it after `recomposeDirty` if the fixup moved it (`+EditFlow.swift`; breadcrumb `re-asserting caret after fixup leap (normal path)`) — **fix not yet confirmed by a deterministic repro**, live-verifiable via the breadcrumb |
 
 Confirm the guards exist:
 ```bash
@@ -101,6 +102,18 @@ grep -n 'scheduleBypassedEditSyncCheck\|healing storage edit' Sources/EdmundCore
 - **Assuming `didChangeText` pairs with every mutation.** AppKit violates this
   (round 4).
 - **Mutating storage mid-composition.** That is the original bug (rounds 1–3).
+- **Expecting a scripted keystroke replay to arm round 7.** Round 7 was replayed
+  faithfully from a reconstructed `t0` (every keystroke + capped pauses through
+  the whole drift window) and it did **not** produce the block-end leap.
+  Programmatic caret moves (`clickoff`) and imprecise synthetic clicks
+  (`realclickoff` — lands off-by-a-few, diverges, crashes) do not fully arm it.
+  The arming needs **real mouse clicks at real positions** and probably the
+  real session's **two-document window switching** (`becomeFirstResponder`
+  resync is the prime suspect). Round-8 lead: two open docs + real clicks, or
+  instrument `becomeFirstResponder`/the caret-move restyle to catch the next
+  live occurrence. Compressed replays also coalesce a bypass with the next
+  keystroke into one `pendingEdit` hull (never happens live — the heal runs
+  first), producing off-by-one breadcrumb noise; don't trust it as a repro.
 
 ---
 

--- a/Sources/EdmundCore/TextView/EditorTextView+EditFlow.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+EditFlow.swift
@@ -137,6 +137,21 @@ extension EditorTextView {
         let sel = selectedRange()
         let cursorRaw = min(sel.location, (rawSource as NSString).length)
 
+        // Where this edit should leave the caret, derived from the storage's
+        // pending edit (same hull formula as the bypassed-edit heal). TextKit 2's
+        // queued selection fixup (`_fixSelectionAfterChangeInCharacterRange`) can
+        // fire during `recomposeDirty`'s `endEditing` below and remap a stale
+        // selection, leaping the caret to a block boundary — issue #156 round 7,
+        // the round-6 mechanism on the *normal* edit path (armed by a cross-block
+        // caret move rather than a drag bypass). This path styles with
+        // `settingSelection` false and otherwise trusts NSTextView's caret, so a
+        // leap here sticks and every later edit re-triggers it. Capture the
+        // intended caret now, before `consumePendingEdit` clears it, and re-assert
+        // it after the restyle if the fixup moved it.
+        let expectedCaret: Int? = (ts as? EditorTextStorage)?.pendingEdit.map {
+            min($0.oldRange.location + max(0, $0.oldRange.length + $0.delta), ts.length)
+        }
+
         let oldCount = blocks.count
         let oldActive = activeBlockIndex
         // Incremental parse from the storage's accumulated edit — O(edit);
@@ -199,6 +214,21 @@ extension EditorTextView {
         }
 
         recomposeDirty(dirty, cursorInRaw: cursorRaw)
+
+        // If the queued selection fixup leaped the caret off the edit point
+        // during the restyle's `endEditing`, put it back. Only fires on a real
+        // mismatch — normal edits already sit at `expectedCaret`, so this is a
+        // no-op then (no spurious selection notification). Permanent breadcrumb
+        // (release builds too): a recurrence prints which edit leaped.
+        if let want = expectedCaret {
+            let now = selectedRange()
+            if now.location != want || now.length != 0 {
+                Log.info("re-asserting caret after fixup leap (normal path): " +
+                         "\(now.location)→\(want)", category: .edit)
+                setSelectedRange(NSRange(location: want, length: 0))
+            }
+        }
+
         traceEdit("synced cursorRaw=\(cursorRaw) changed=\(changed.lowerBound)..<\(changed.upperBound) oldActive=\(oldActive.map(String.init) ?? "nil")")
         verifyEditorInvariants("syncRawSourceFromDisplay")
     }

--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -325,6 +325,19 @@ public class EditorTextView: NSTextView {
 
     // MARK: - Link Following
 
+    #if DEBUG
+    /// Repro hook (ReproScript `clickoff`): move the caret to `offset` on the
+    /// mouse path — i.e. with `suppressTypewriterCentering` set during the
+    /// selection change, exactly as `mouseDown` does — so the caret-move
+    /// restyle captures `fromMouse=true`. Lets a scripted replay reproduce the
+    /// mouse-click branch without synthesizing HID events at screen coordinates.
+    public func reproClickSelect(_ offset: Int) {
+        suppressTypewriterCentering = true
+        setSelectedRange(NSRange(location: min(offset, (rawSource as NSString).length), length: 0))
+        suppressTypewriterCentering = false
+    }
+    #endif
+
     /// Cmd+click on a link's text follows it: a `[[wikilink]]` resolves to a
     /// file / heading, a regular link opens its URL. Any other click edits.
     /// Sets `suppressTypewriterCentering` for the duration of the super call so

--- a/Sources/edmd/App/ReproScript.swift
+++ b/Sources/edmd/App/ReproScript.swift
@@ -39,16 +39,69 @@ enum ReproScript {
                     }
                     editor.setSelectedRange(NSRange(location: r.location, length: 0))
                 }
+            case "caretoff":
+                // Absolute-offset caret move (arrow-key-like: fromMouse=false).
+                schedule(after: delay) { editor in
+                    let n = min(Int(arg) ?? 0, (editor.rawSource as NSString).length)
+                    editor.setSelectedRange(NSRange(location: n, length: 0))
+                }
+            case "clickoff":
+                // Absolute-offset caret move on the MOUSE path: sets
+                // suppressTypewriterCentering for the selection change so the
+                // +SelectionTracking restyle captures fromMouse=true and takes
+                // the preservingViewportAnchor branch (what a real click does).
+                schedule(after: delay) { editor in
+                    editor.reproClickSelect(Int(arg) ?? 0)
+                }
+            case "realclickoff":
+                // Absolute-offset caret move via a REAL synthesized mouse click
+                // at the glyph's on-screen position: goes through hit-testing and
+                // NSTextView.mouseDown, the genuine mouse path (fromMouse=true),
+                // which programmatic setSelectedRange does not replicate. Needed
+                // because faithful keystroke replay alone does not arm the
+                // round-7 drift — the arming caret moves were real clicks.
+                schedule(after: delay) { editor in
+                    let n = min(Int(arg) ?? 0, (editor.rawSource as NSString).length)
+                    var actual = NSRange()
+                    let scr = editor.firstRect(forCharacterRange: NSRange(location: n, length: 0),
+                                               actualRange: &actual)
+                    guard let screen = editor.window?.screen else { return }
+                    // firstRect: Cocoa screen coords (origin bottom-left). CGEvent
+                    // wants top-left origin.
+                    let cocoaPt = CGPoint(x: scr.midX, y: scr.midY)
+                    let p = CGPoint(x: cocoaPt.x, y: screen.frame.maxY - cocoaPt.y)
+                    func post(_ t: CGEventType) {
+                        CGEvent(mouseEventSource: nil, mouseType: t, mouseCursorPosition: p,
+                                mouseButton: .left)?.post(tap: .cghidEventTap)
+                    }
+                    post(.mouseMoved); post(.leftMouseDown); post(.leftMouseUp)
+                }
+            case "selrange":
+                // "selrange N M" — select M chars at offset N.
+                schedule(after: delay) { editor in
+                    let f = arg.split(separator: " ")
+                    guard f.count == 2, let n = Int(f[0]), let m = Int(f[1]) else { return }
+                    editor.setSelectedRange(NSRange(location: n, length: m))
+                }
             case "type":
                 for ch in arg {
-                    schedule(after: delay) { press(String(ch), keyCode: 0, in: $0) }
+                    let s = String(ch)
+                    // Direct action call (not a synthesized NSEvent through the
+                    // input context): the storage mutation + queued-fixup path is
+                    // identical, but avoids the input-context fragility that a
+                    // long scripted replay hits when programmatic selections and
+                    // synthetic key events interleave.
+                    schedule(after: delay) { $0.insertText(s, replacementRange: NSRange(location: NSNotFound, length: 0)) }
                     delay += 0.08
                 }
             case "backspace":
                 for _ in 0 ..< (Int(arg) ?? 1) {
-                    schedule(after: delay) { press("\u{7F}", keyCode: 51, in: $0) }
+                    schedule(after: delay) { $0.deleteBackward(nil) }
                     delay += 0.3
                 }
+            case "return":
+                schedule(after: delay) { $0.insertText("\n", replacementRange: NSRange(location: NSNotFound, length: 0)) }
+                delay += 0.05
             case "bypassdelete":
                 // Mimics AppKit's drag-move source deletion (the issue-#156
                 // trigger): select the range, run shouldChangeText and the
@@ -60,6 +113,17 @@ enum ReproScript {
                         Log.info("repro bypassdelete: needle not found: \(arg)", category: .app)
                         return
                     }
+                    editor.setSelectedRange(r)
+                    guard editor.shouldChangeText(in: r, replacementString: "") else { return }
+                    editor.textStorage?.replaceCharacters(in: r, with: "")
+                }
+            case "bypassoff":
+                // "bypassoff N M" — offset form of bypassdelete: delete M chars
+                // at N via shouldChangeText + storage mutation, no didChangeText.
+                schedule(after: delay) { editor in
+                    let f = arg.split(separator: " ")
+                    guard f.count == 2, let n = Int(f[0]), let m = Int(f[1]) else { return }
+                    let r = NSRange(location: n, length: m)
                     editor.setSelectedRange(r)
                     guard editor.shouldChangeText(in: r, replacementString: "") else { return }
                     editor.textStorage?.replaceCharacters(in: r, with: "")

--- a/docs/delete-drift-investigation.md
+++ b/docs/delete-drift-investigation.md
@@ -454,3 +454,96 @@ the new code (beware: literals ≤15 bytes are stored inline on arm64 and never
 show up — grep for a *long* one). Cure: `swift package clean`. Never delete
 `edmd.build/` by hand — that corrupts the output-file-map and wedges the
 target until a clean.
+
+## Round 7: the queued fixup on the NORMAL edit path (armed by a cross-block caret move)
+
+Recurred 2026-07-07 editing `hodge-poster copy.md` (a ~969-byte draft;
+snapshot at `misc/`). Three occurrences the user reported: ~11:32, ~11:40
+(caret drifted to the **end of the paragraph**, and once it started **every
+delete drifted**; clicking away and back did not heal), and ~12:08 (drift was
+"two viewport-lines down" again). New shape vs round 6: **persisting** (not
+one-shot), and the landing was the paragraph/block end, not a fixed viewport
+offset.
+
+### Mechanism (log-proven, not reasoning)
+
+The round-6 fix (re-assert the caret in the bypass **heal**) was present and
+correct. Round 7 is the **same queued-fixup mechanism on the normal
+`didChangeText` edit path**, which round 6 did not cover. From the log
+(11:42:42, small doc, blocks=17):
+
+```
+11:42:42.632 selectionDidChange sel={817,0} active=16          user clicked into the paragraph (block 14); active still stale (16)
+11:42:42.925 shouldChangeText range={816,1} repl="" sel={817,0} active=14   a NORMAL backspace (has a synced line — not a bypass)
+11:42:42.927 selectionDidChange sel={943,0} up=Y               caret LEAPED to 943 (end of block 14)
+             via  -[NSTextLayoutManager _fixSelectionAfterChangeInCharacterRange:]
+                  ← -[NSTextStorage endEditing] ← recomposeDirty ← syncRawSourceFromDisplay
+11:42:42.937 synced cursorRaw=817 ... sel={943,0}
+```
+
+The arming event is a **cross-block caret move** (a click that moved the caret
+from the end block into the wrapped paragraph), which schedules the async
+caret-move restyle in `+SelectionTracking`. On the next normal edit, TextKit
+2's queued `_fixSelectionAfterChange` fires during **our** `recomposeDirty`
+`endEditing` and remaps a stale selection to the block boundary. The normal
+sync path styles with `settingSelection` **false** and otherwise trusts
+NSTextView's caret, so — unlike the round-6 heal — it never re-asserts, the
+leap sticks, and every later edit re-triggers it (persisting).
+
+Discriminator, healthy vs drift: backspacing at the **end** of a paragraph
+(11:38:18) the fixup lands correctly (917→916); backspacing **mid**-paragraph
+after a cross-block move (11:40:46, 11:42:42) it leaps to the block end.
+
+### The fix
+
+`EditorTextView+EditFlow.swift`, `syncRawSourceFromDisplay`: capture the
+caret the edit should leave behind, derived from the storage's pending edit
+(`oldRange.location + max(0, oldRange.length + delta)` — the same hull formula
+as the heal), **before** `consumePendingEdit` clears it; after
+`recomposeDirty`, if the selection was moved off that point, re-assert it
+(permanent `re-asserting caret after fixup leap (normal path)` breadcrumb).
+For a normal single edit `expectedCaret` is exactly NSTextView's own caret, so
+this is a no-op unless the fixup leaped it — and it is consistent with the
+heal (same formula) on the bypass path.
+
+### Reproduction — what worked, what didn't (important for round 8)
+
+This round's reproduction was the hardest yet and is only **partially**
+solved; read before the next attempt.
+
+- **Isolated gestures never armed it.** Real mouse click / programmatic
+  `clickoff` (fromMouse) / arrow-key caret move into the paragraph, then
+  backspace — all clean. The arming needs accumulated session state.
+- **The true start content was recovered.** The doc was loaded at 09:42 with
+  **390 bytes** (now overwritten as the file evolved). Reconstructed `t0`
+  exactly by cell-tracking: forward-apply the recorded edits to 390 unknown
+  cells, match the surviving cells against the known 969-byte snapshot
+  (`hodge-poster copy.md` = the 11:40:52 state), back-resolve. Forward-applying
+  all 926 edits to the reconstructed `t0` reproduces the snapshot byte-for-byte
+  (`scripts`-style transpiler in the round-7 scratch).
+- **A faithful full-session replay was built** (ReproScript: `caretoff` /
+  `clickoff` / `realclickoff` / `selrange` / `bypassoff` / `return`, and edits
+  driven through `insertText`/`deleteBackward` directly to avoid an
+  input-context crash that synthesized NSEvents hit when interleaved with
+  programmatic selections). Replaying every keystroke + capped pauses from
+  `t0` through the whole drift window reached the exact drift-zone state
+  (storLen 972) **without the dramatic block-end leap**. The fix's breadcrumb
+  did fire a couple of times in the drift zone, but on off-by-one mismatches
+  that were **replay artifacts** — compressed timing coalesced a drag-move
+  bypass with the following keystroke into one `pendingEdit` hull, which does
+  not happen live (the heal runs on the next run-loop pass, ~ms, before any
+  human keystroke).
+- **Conclusion:** the block-end leap needs the arming caret moves to be **real
+  mouse clicks at real positions** (hit-testing + the full mouseDown selection
+  machinery), and probably the real session's **two-document window
+  switching** (the log interleaves a ~10 KB doc; `becomeFirstResponder`
+  resync on focus return is a prime suspect). Programmatic caret moves and
+  imprecise synthetic clicks (which land off-by-a-few and diverge/crash) do
+  not fully arm it. **Round 8 lead:** reproduce with two open documents +
+  real clicks, or instrument `becomeFirstResponder` / the caret-move restyle
+  to capture the arming on the next live occurrence.
+
+Status: fix targets the log-proven mechanism and is a safe no-op on normal
+edits; **not yet confirmed by a deterministic block-end-leap repro** — the
+permanent breadcrumb makes the next live occurrence self-verifying (it will
+log the correction instead of drifting).


### PR DESCRIPTION
## What

Delete drift (#156) recurred editing a wrapped paragraph: a **normal** backspace mid-paragraph, after a cross-block caret move, leaped the caret to the **end of the paragraph**, and once it started **every delete drifted** (the model stayed consistent — only the selection moved).

## Why

Same TextKit 2 queued-fixup mechanism as round 6, but on the **normal `didChangeText` edit path** (round 6 only fixed the drag-move bypass heal). A cross-block caret move schedules the async caret-move restyle; on the next ordinary keystroke, TK2's queued `_fixSelectionAfterChangeInCharacterRange` fires during *our* `recomposeDirty` `endEditing` and remaps a stale selection to the block boundary. The normal sync path styles with `settingSelection=false` and never re-asserts, so the leap sticks and persists.

Log-proven (11:42:42): `synced cursorRaw=817` (correct) but final `sel={943}` (leaped to block end), via the `_fixSelectionAfterChange` stack — the same signature as round 6, on the normal path.

## Fix

`syncRawSourceFromDisplay` captures the caret the edit should leave (pendingEdit hull, same formula as the heal) *before* `consumePendingEdit` clears it, and re-asserts it after `recomposeDirty` if the fixup moved it. No-op on normal single edits (`expectedCaret` == NSTextView's caret); consistent with the heal on the bypass path. Permanent breadcrumb `re-asserting caret after fixup leap (normal path)`.

## Status — not yet confirmed by a deterministic repro

Reproduction was the hardest yet. I reconstructed the true 390-byte session start (`t0`, via cell-tracking — forward-applies to the 969-byte snapshot byte-for-byte) and built a **faithful full-session replay** (every keystroke + pauses). It reached the exact drift-zone state (storLen 972) **without** the block-end leap. The arming needs the caret moves to be **real mouse clicks at real positions** (hit-testing + full mouseDown machinery) and probably the session's **two-document window switching** — neither faithfully scriptable (synthetic clicks land imprecisely and diverge). So the fix targets a log-proven mechanism and is a safe no-op on normal edits, but the breadcrumb is the live-verification path: the next real occurrence logs the correction instead of drifting.

Also adds DEBUG repro tooling (ReproScript: `caretoff`/`clickoff`/`realclickoff`/`selrange`/`bypassoff`/`return` + direct-action edits; `reproClickSelect`). Full write-up + round-8 lead in `docs/delete-drift-investigation.md` round 7. 814 tests pass.

Refs #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)