### PR TITLE
docs: adopt git worktree for concurrent local branches

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,17 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.command // empty' | { read -r cmd; if echo \"$cmd\" | grep -Eq '(^|&&|;|\\|)[[:space:]]*git[[:space:]]+(checkout[[:space:]]+-b|switch[[:space:]]+-c)\\b' || echo \"$cmd\" | grep -Eq '(^|&&|;|\\|)[[:space:]]*git[[:space:]]+branch[[:space:]]+[^-[:space:]][^[:space:]]*([[:space:]]|$)'; then printf '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Edmund prefers git worktrees over branch-switching for concurrent local work: git worktree add .worktrees/<branch> <branch> (branch keeps its normal type/slug name). See CLAUDE.md Git practices / docs/ARCHITECTURE.md \\u00a712.\"}}'; else echo '{}'; fi; }"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ sparkle_private_key.txt
 # AI
 /.claude/worktrees
 
+# Manual git-worktree checkouts (see CLAUDE.md Git practices)
+/.worktrees
+
 # Misc
 misc/
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ doc updated as you learn things.
 ## Git practices
 - Commit automatically and frequently. 
 - Branch off `main` for each fix (don't commit straight to `main`); one feature/fix per branch, small logical commits.
+- For concurrent local work, use `git worktree add .worktrees/<branch> <branch>` instead of stashing or switching branches. Branch names keep the normal `type/slug` convention (e.g. `fix/foo`) — never rename a branch to `worktree-*`. `.worktrees/` is gitignored. This is separate from `.claude/worktrees/`, which Claude Code's own EnterWorktree tool manages automatically; don't hand-edit that one.
 - **Never auto-push, PR, or merge — only when I explicitly ask.**
 - Never delete uncommitted changes. 
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -461,6 +461,13 @@ only with reason):
    (don't commit straight to it); each fix on its own branch.
 5. Touch only what the task needs; match surrounding style; don't refactor
    unrelated code.
+6. **Concurrent local work uses `git worktree`, not multiple clones or
+   branch-switching.** `git worktree add .worktrees/<branch> <branch>` — the
+   directory path mirrors the branch name (e.g. `.worktrees/fix/foo` for
+   `fix/foo`), so branches keep the normal `type/slug` naming and never get
+   renamed to `worktree-*`. `.worktrees/` is gitignored. This is distinct from
+   `.claude/worktrees/`, which Claude Code's own EnterWorktree tool manages
+   automatically for agent isolation — don't hand-edit that one.
 
 If you (the agent) improve this workflow or discover a better verification
 trick, update this section.


### PR DESCRIPTION
## Summary
- Document a worktree convention for concurrent local work: `git worktree add .worktrees/<branch> <branch>`, mirroring the branch path exactly so branches keep the existing `type/slug` naming (`fix/foo`, `docs/foo`, ...) and never get renamed to `worktree-*`. `.worktrees/` is gitignored. No bare repo — main stays a normal checkout.
- Called out as distinct from `.claude/worktrees/`, which Claude Code's own EnterWorktree tool manages automatically for agent isolation.
- Updated `CLAUDE.md` (Git practices) and `docs/ARCHITECTURE.md` §12 (item 6) with the convention.
- Added a project-level `PreToolUse` hook (`.claude/settings.json`) that denies direct branch creation (`git checkout -b`, `git switch -c`, bare `git branch <name>`) and points at the worktree convention instead. `git worktree add -b` (the correct path) is untouched.

## Test plan
- [x] `swift test` — 821 passed
- [x] Hook logic pipe-tested against 8 cases (checkout -b, switch -c, branch <name>, worktree add -b, branch -d, branch -a, status, compound command) — all correct
- [x] Live-fired the hook via an actual `git checkout -b` call — went through uncaught, traced to the known settings-watcher caveat (only watches dirs present at session start, not a worktree created mid-session), not a hook-logic bug. Will activate after `/hooks` reload or restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)