### PR TITLE
docs(architecture): release pipeline ships the main app only

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -525,6 +525,14 @@ hit Gatekeeper on first launch; the README documents the
 `xattr -dr com.apple.quarantine` / right-click-Open workarounds. A Developer ID
 cert + notarization (see §8) would remove the prompt entirely.
 
+**Never release anything through this pipeline except the main app.** The
+tag-triggered flow above builds and ships `Edmund.app` only. Extension
+payloads (e.g. the RaTeX WASM) are a separate concern with their own
+hosting/release path — never bundled into or triggered by an Edmund version
+tag. Case in point: the RaTeX WASM asset was pulled from release pending
+`erweixin/RaTeX` inline-mode support and the Advanced Math extension's own
+repo migration — see `misc/backlog.md`.
+
 ---
 
 ## 14. References


### PR DESCRIPTION
## Summary
- Adds a rule to `docs/ARCHITECTURE.md` §13: the tag-triggered release pipeline builds and ships `Edmund.app` only — extension payloads (e.g. RaTeX's WASM) get their own hosting/release path and never ride an Edmund version tag.
- Prompted by pulling the RaTeX WASM asset from release pending upstream inline-mode support (`erweixin/RaTeX`) and the Advanced Math extension's own repo migration.

## Test plan
- [x] `swift test` (823 tests, green) — docs-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)