### PR TITLE
fix(images): shrink already-rendered images when max-content-width narrows

### DIFF
--- a/Sources/EdmundCore/TextView/EditorTextView+ContentWidth.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+ContentWidth.swift
@@ -24,13 +24,22 @@ extension EditorTextView {
     }
 
     /// Recomputes the horizontal text inset from the current bounds + max-column cap,
-    /// preserving the vertical inset. Cheap (no recompose) — only the inset changes.
+    /// preserving the vertical inset. Usually no recompose — only the inset
+    /// changes and TextKit 2 reflows wrapped text on its own. The exception is
+    /// image overlays: their scaled-to-fit size is baked into the styled
+    /// attribute at render time (§4 fragmentOverlay), not recomputed at draw
+    /// time, so a column narrower than an already-rendered image needs those
+    /// blocks restyled to shrink it.
     public func updateContentInset() {
         let target = Self.horizontalInset(viewWidth: bounds.width,
                                           maxContentWidth: maxContentWidthPoints)
-        if abs(textContainerInset.width - target) > 0.5 {
-            textContainerInset = NSSize(width: target, height: textContainerInset.height)
-        }
+        guard abs(textContainerInset.width - target) > 0.5 else { return }
+        textContainerInset = NSSize(width: target, height: textContainerInset.height)
+
+        let imageBlocks = IndexSet(blocks.indices.filter { blocks[$0].content.contains("![") })
+        guard !imageBlocks.isEmpty else { return }
+        for idx in imageBlocks { blocks[idx].isStyled = false }
+        recomposeDirty(imageBlocks, cursorInRaw: currentCursorInRaw(), settingSelection: true)
     }
 
     /// Recompute the centered inset as the view width changes (window resize).

--- a/Tests/EdmundTests/ImageRenderingTests.swift
+++ b/Tests/EdmundTests/ImageRenderingTests.swift
@@ -56,4 +56,34 @@ struct ImageRenderingTests {
         let styled = editor.styleBlock("![alt](/no/such/file.png)", cursorPosition: nil)
         #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) == nil)
     }
+
+    @Test("Narrowing the max-content-width column shrinks an already-rendered image")
+    func shrinksOnColumnNarrow() {
+        let editor = EditorTextView.makeTextKit2(
+            frame: NSRect(x: 0, y: 0, width: 800, height: 300),
+            containerSize: NSSize(width: 800, height: CGFloat.greatestFiniteMagnitude))
+        let suite = "EdmundTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        editor.themeDefaults = defaults
+        editor.theme = .load(from: defaults)
+
+        let content = "![alt](\(tempPNGPath()))\n\nsecond paragraph" // image is 24x16, well under 800pt
+        editor.loadContent(content)
+        // `loadContent` puts the cursor at offset 0, inside the image block,
+        // which renders raw markdown (no overlay) while active. Move the
+        // cursor to the second block so the image renders as an overlay.
+        editor.recomposeIncremental(cursorInRaw: content.count)
+        let before = editor.textStorage?.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) as? FragmentOverlay
+        #expect(before?.bounds.width == 24)
+
+        // Cap the column narrower than the image's natural width.
+        editor.maxContentWidthPoints = 22
+
+        let after = editor.textStorage?.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) as? FragmentOverlay
+        #expect((after?.bounds.width ?? 9999) <= editor.availableContentWidth + 0.01)
+        #expect(after!.bounds.width < before!.bounds.width)
+        // Aspect ratio preserved (24x16 -> half width -> half height).
+        #expect(abs(after!.bounds.height / after!.bounds.width - 16.0 / 24.0) < 0.01)
+    }
 }


### PR DESCRIPTION
## Summary
- Image overlay size in edit mode is baked into the styled attribute at render time (`imageOverlay(destination:)`), not recomputed at draw time.
- Narrowing the reading column (window resize, or lowering the max-content-width setting) only updated `textContainerInset` — an already-rendered image kept its old overlay size and overflowed the narrower column.
- `updateContentInset()` now restyles image-bearing blocks after an inset change so their overlays re-measure against the new `availableContentWidth` and shrink (aspect-ratio preserved).
- Read mode was already correctly bounded via `img { max-width: 100% }` in `HTMLTheme.swift` — no change needed there.

## Test plan
- [x] `swift test` — 822 tests pass, including new regression test `shrinksOnColumnNarrow` in `ImageRenderingTests.swift`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)