### PR TITLE
Tables wrap/scroll correctly in read mode

### DIFF
--- a/Sources/EdmundCore/Export/HTMLRenderer.swift
+++ b/Sources/EdmundCore/Export/HTMLRenderer.swift
@@ -273,7 +273,7 @@ struct HTMLRenderer: MarkupVisitor {
             case .right:  return " style=\"text-align:right\""
             }
         }
-        var html = "<table><thead><tr>"
+        var html = "<div class=\"table-wrap\"><table><thead><tr>"
         for (col, cell) in table.head.cells.enumerated() {
             html += "<th\(cellStyle(col))>\(renderChildren(of: cell))</th>"
         }
@@ -285,7 +285,7 @@ struct HTMLRenderer: MarkupVisitor {
             }
             html += "</tr>"
         }
-        html += "</tbody></table>"
+        html += "</tbody></table></div>"
         return html
     }
 

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -230,7 +230,11 @@ enum HTMLTheme {
     li.task::after { content: ""; display: block; clear: both; }
     .blank-line { height: calc(var(--body-size) * var(--line-height)); }
     table { border-collapse: collapse; margin: 1em 0; width: 100%; }
-    th, td { border: 1px solid var(--rule); padding: 6px 10px; }
+    /* overflow-wrap: anywhere lets a long unbreakable word (URL, token) wrap
+       inside its cell — without it, the browser's min-content width for that
+       cell is the word's full width, so the table overflows past the page's
+       max content width instead of shrinking to fit. */
+    th, td { border: 1px solid var(--rule); padding: 6px 10px; overflow-wrap: anywhere; }
     thead th { background: var(--code-bg); }
     img { max-width: 100%; }
     img.math { vertical-align: middle; }

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -229,12 +229,12 @@ enum HTMLTheme {
        number marker to the right — so sibling markers stop lining up. */
     li.task::after { content: ""; display: block; clear: both; }
     .blank-line { height: calc(var(--body-size) * var(--line-height)); }
-    table { border-collapse: collapse; margin: 1em 0; width: 100%; }
-    /* overflow-wrap: anywhere lets a long unbreakable word (URL, token) wrap
-       inside its cell — without it, the browser's min-content width for that
-       cell is the word's full width, so the table overflows past the page's
-       max content width instead of shrinking to fit. */
-    th, td { border: 1px solid var(--rule); padding: 6px 10px; overflow-wrap: anywhere; }
+    /* Tables keep their natural (content-driven) width and scroll horizontally
+       inside .table-wrap instead of squeezing columns or forcing cell text to
+       wrap — same idiom as `pre`'s overflow-x below. */
+    .table-wrap { overflow-x: auto; margin: 1em 0; }
+    table { border-collapse: collapse; }
+    th, td { border: 1px solid var(--rule); padding: 6px 10px; }
     thead th { background: var(--code-bg); }
     img { max-width: 100%; }
     img.math { vertical-align: middle; }
@@ -294,7 +294,7 @@ enum HTMLTheme {
          keeps them. `print-color-adjust: exact` forces faithful color output
          so callout backgrounds, code blocks, and highlights survive printing. */
       * { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-      .callout, pre, blockquote, table, .math-display { break-inside: avoid; }
+      .callout, pre, blockquote, .table-wrap, .math-display { break-inside: avoid; }
       h1, h2, h3, h4, h5, h6 { break-after: avoid; }
       thead { display: table-header-group; }
     }

--- a/Tests/EdmundTests/HTMLRendererTests.swift
+++ b/Tests/EdmundTests/HTMLRendererTests.swift
@@ -51,7 +51,8 @@ struct HTMLRendererCoreTests {
     @Test("Table emits thead/tbody with per-column alignment")
     func table() {
         let out = html("| a | b | c |\n|:--|:-:|--:|\n| 1 | 2 | 3 |")
-        #expect(out.contains("<table><thead><tr>"))
+        #expect(out.contains("<div class=\"table-wrap\"><table><thead><tr>"))
+        #expect(out.contains("</tbody></table></div>"))
         #expect(out.contains("<th style=\"text-align:left\">a</th>"))
         #expect(out.contains("<th style=\"text-align:center\">b</th>"))
         #expect(out.contains("<th style=\"text-align:right\">c</th>"))

--- a/Tests/EdmundTests/HTMLThemeTests.swift
+++ b/Tests/EdmundTests/HTMLThemeTests.swift
@@ -55,6 +55,14 @@ struct HTMLThemeTests {
         #expect(css(dark: true).contains("--bg: #1e1e1e;"))
     }
 
+    @Test("Table cells allow wrapping long unbreakable tokens")
+    func tableCellWrap() {
+        let out = css(dark: false)
+        #expect(out.contains("overflow-wrap: anywhere"))
+        // Must be scoped to th/td, not applied globally.
+        #expect(out.contains("th, td { border: 1px solid var(--rule); padding: 6px 10px; overflow-wrap: anywhere; }"))
+    }
+
     @Test("Emits code token colors from the shared palette, per appearance")
     func codeTokenColors() {
         let light = css(dark: false)

--- a/Tests/EdmundTests/HTMLThemeTests.swift
+++ b/Tests/EdmundTests/HTMLThemeTests.swift
@@ -55,12 +55,11 @@ struct HTMLThemeTests {
         #expect(css(dark: true).contains("--bg: #1e1e1e;"))
     }
 
-    @Test("Table cells allow wrapping long unbreakable tokens")
-    func tableCellWrap() {
+    @Test("Wide tables scroll horizontally instead of wrapping cell text")
+    func tableScrolls() {
         let out = css(dark: false)
-        #expect(out.contains("overflow-wrap: anywhere"))
-        // Must be scoped to th/td, not applied globally.
-        #expect(out.contains("th, td { border: 1px solid var(--rule); padding: 6px 10px; overflow-wrap: anywhere; }"))
+        #expect(out.contains(".table-wrap { overflow-x: auto; margin: 1em 0; }"))
+        #expect(!out.contains("overflow-wrap"))
     }
 
     @Test("Emits code token colors from the shared palette, per appearance")


### PR DESCRIPTION
## Summary
- Table cells in read mode couldn't shrink below a long unbreakable token's width, so a wide cell overflowed the page instead of adjusting — first fix added `overflow-wrap: anywhere` to force wrapping.
- Follow-up: replaced that forced wrap with the more common table UX — `<table>` is now wrapped in a `.table-wrap` div with `overflow-x: auto` (same idiom already used for `pre` blocks), so tables keep natural column widths and scroll horizontally instead of squeezing every column into the page's max content width.

## Test plan
- [x] `swift test` — 822 tests pass
- [x] New/updated tests in `HTMLThemeTests` and `HTMLRendererTests` covering the `.table-wrap` scroll CSS and the wrapped `<table>` markup
- [x] Visual check: rendered a wide multi-column table and a table with a long unbreakable token through `DocumentHTML`, loaded in Safari, confirmed content clips/scrolls at the wrapper boundary rather than overflowing the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)