### PR TITLE
fix(edmd): close blank Untitled window on real file open

### DIFF
--- a/Sources/edmd/App/DocumentController.swift
+++ b/Sources/edmd/App/DocumentController.swift
@@ -55,4 +55,32 @@ class DocumentController: NSDocumentController {
             }
         }
     }
+
+    // MARK: - Untitled Window Cleanup
+    //
+    // Apple's documented single funnel for opening an existing file — the Open
+    // panel, Recent Items, and drag-and-drop all call this — so hooking it
+    // here catches every "open another file" path in one place.
+    override func openDocument(withContentsOf url: URL, display displayDocument: Bool,
+                               completionHandler: @escaping (NSDocument?, Bool, Error?) -> Void) {
+        super.openDocument(withContentsOf: url, display: displayDocument) { document, alreadyOpen, error in
+            if let document, error == nil {
+                self.closeUntouchedUntitledWindows(keeping: document)
+            }
+            completionHandler(document, alreadyOpen, error)
+        }
+    }
+
+    /// Closes any other blank Untitled window the user never typed into —
+    /// e.g. the automatic blank document from launch — once a real file opens.
+    /// `isDocumentEdited` already tracks this: edits call `updateChangeCount`
+    /// (`EditorTextView+EditFlow.swift`), so an untouched Untitled document is
+    /// never marked edited.
+    private func closeUntouchedUntitledWindows(keeping opened: NSDocument) {
+        for case let doc as Document in documents where doc !== opened {
+            if doc.fileURL == nil && !doc.isDocumentEdited {
+                doc.close()
+            }
+        }
+    }
 }

--- a/Sources/edmd/App/DocumentController.swift
+++ b/Sources/edmd/App/DocumentController.swift
@@ -65,22 +65,24 @@ class DocumentController: NSDocumentController {
                                completionHandler: @escaping (NSDocument?, Bool, Error?) -> Void) {
         super.openDocument(withContentsOf: url, display: displayDocument) { document, alreadyOpen, error in
             if let document, error == nil {
-                self.closeUntouchedUntitledWindows(keeping: document)
+                self.closeLastUntouchedUntitledWindow(keeping: document)
             }
             completionHandler(document, alreadyOpen, error)
         }
     }
 
-    /// Closes any other blank Untitled window the user never typed into —
-    /// e.g. the automatic blank document from launch — once a real file opens.
-    /// `isDocumentEdited` already tracks this: edits call `updateChangeCount`
-    /// (`EditorTextView+EditFlow.swift`), so an untouched Untitled document is
-    /// never marked edited.
-    private func closeUntouchedUntitledWindows(keeping opened: NSDocument) {
-        for case let doc as Document in documents where doc !== opened {
-            if doc.fileURL == nil && !doc.isDocumentEdited {
-                doc.close()
-            }
+    /// Closes the most-recently-opened blank Untitled window the user never
+    /// typed into — e.g. the automatic blank document from launch — once a
+    /// real file opens. Only the last one, so opening several Untitled
+    /// windows on purpose still leaves the earlier ones alone.
+    /// `isDocumentEdited` already tracks "untyped": edits call
+    /// `updateChangeCount` (`EditorTextView+EditFlow.swift`), so an untouched
+    /// Untitled document is never marked edited.
+    private func closeLastUntouchedUntitledWindow(keeping opened: NSDocument) {
+        let stale = documents.last { doc in
+            guard let doc = doc as? Document, doc !== opened else { return false }
+            return doc.fileURL == nil && !doc.isDocumentEdited
         }
+        stale?.close()
     }
 }


### PR DESCRIPTION
## Summary
- Auto-quit when no windows are open was already implemented (`applicationShouldTerminateAfterLastWindowClosed` returns `true`).
- New: when a real file opens, close the most-recently-opened blank Untitled window if it was never typed into (e.g. the automatic launch document). Multiple deliberately-opened Untitled windows are left alone — only the last untouched one goes.
- Hooks `NSDocumentController.openDocument(withContentsOf:display:completionHandler:)`, Apple's documented single funnel for Open panel, Recent Items, and drag-and-drop opens.
- "Untouched" reuses the existing `isDocumentEdited` flag, which real edits already set via `updateChangeCount` (`EditorTextView+EditFlow.swift`) — no new EdmundCore API needed.

## Test plan
- [x] `swift test` — 821 tests passing
- [x] `swift build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)