### PR TITLE
View menu: zoom (Actual Size/Zoom In/Zoom Out) + menu cleanup

### DIFF
--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -193,11 +193,13 @@ public class EditorTextView: NSTextView {
         return ps
     }
 
-    /// Apply a new theme, persist it, and restyle every block in place.
-    public func applyTheme(_ newTheme: EditorTheme) {
+    /// Apply a new theme and restyle every block in place. `persist: false`
+    /// (used for zoom, which scales font sizes without changing the saved
+    /// preference) applies the theme live without writing it to defaults.
+    public func applyTheme(_ newTheme: EditorTheme, persist: Bool = true) {
         let antialiasChanged = theme.antialias != newTheme.antialias
         theme = newTheme
-        theme.save(to: themeDefaults)
+        if persist { theme.save(to: themeDefaults) }
         typingAttributes = baseAttributes
         recomposeAllDirty()
         // Antialiasing isn't a text attribute, so a recompose alone won't re-vend

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -14,6 +14,13 @@ class Document: NSDocument, HeadingNavigable {
     private var viewModeButton: NSButton?
     private static let viewModeItemID = NSToolbarItem.Identifier("viewMode")
 
+    /// Session-only zoom scale (View ▸ Actual Size/Zoom In/Zoom Out), applied on
+    /// top of the persisted font size and content width. Not saved — each new
+    /// window starts back at 100%.
+    private var zoomFactor: CGFloat = 1.0
+    private static let zoomStep: CGFloat = 0.1
+    private static let zoomRange: ClosedRange<CGFloat> = 0.5...3.0
+
     /// Editor scroll view and its container, held so Read mode can swap the
     /// editor out for a `ReadModeWebView` (created lazily on first read).
     private var scrollView: NSScrollView!
@@ -208,7 +215,33 @@ class Document: NSDocument, HeadingNavigable {
     @objc private func windowDidChangeScreen(_ notification: Notification) {
         guard let window = notification.object as? NSWindow,
               let screen = window.screen else { return }
-        editor?.maxContentWidthPoints = screen.cmToPoints(AppSettings.maxContentWidthCm)
+        editor?.maxContentWidthPoints = screen.cmToPoints(AppSettings.maxContentWidthCm) * zoomFactor
+    }
+
+    // MARK: - Zoom (View ▸ Actual Size / Zoom In / Zoom Out)
+
+    @objc func zoomIn(_ sender: Any?) { setZoom(zoomFactor + Self.zoomStep) }
+    @objc func zoomOut(_ sender: Any?) { setZoom(zoomFactor - Self.zoomStep) }
+    @objc func actualSize(_ sender: Any?) { setZoom(1.0) }
+
+    /// Scales font size (standard + code) and max content width together by
+    /// `factor`, off the persisted base values — never off the currently
+    /// applied (possibly already-zoomed) theme, so repeated zooming doesn't
+    /// compound rounding error and Actual Size always returns to the true base.
+    private func setZoom(_ factor: CGFloat) {
+        guard let editor else { return }
+        zoomFactor = min(Self.zoomRange.upperBound, max(Self.zoomRange.lowerBound, factor))
+
+        let base = EditorTheme.load(from: editor.themeDefaults)
+        var zoomed = base
+        zoomed.fontSize = base.fontSize * zoomFactor
+        zoomed.monospaceFontSize = base.monospaceFontSize * zoomFactor
+        editor.applyTheme(zoomed, persist: false)
+
+        let screen = editor.window?.screen ?? NSScreen.main
+        editor.maxContentWidthPoints = (screen?.cmToPoints(AppSettings.maxContentWidthCm) ?? 1000) * zoomFactor
+
+        refreshReadView()
     }
 
     @objc private func editorDidChange(_ notification: Notification) {

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -368,9 +368,10 @@ class Document: NSDocument, HeadingNavigable {
     private func icon(for mode: EditorTextView.ViewMode) -> NSImage? {
         let name: String
         switch mode {
-        case .edit:    name = "pencil"
-        case .reading: name = "book"
-        case .source:  name = "chevron.left.forwardslash.chevron.right"
+        // Source is a raw-text view of the same editing mode as Edit, so it
+        // shares the pencil icon rather than getting a distinct glyph.
+        case .edit, .source: name = "pencil"
+        case .reading:       name = "book"
         }
         return NSImage(systemSymbolName: name, accessibilityDescription: label(for: mode))
     }
@@ -386,11 +387,8 @@ class Document: NSDocument, HeadingNavigable {
     /// Shows the active mode's icon on the button and keeps the tooltip in sync.
     private func refreshViewModeButton() {
         guard let editor else { return }
-        // The `</>` source glyph reads wider/larger than pencil and book at the
-        // same point size, so render it a touch smaller to match visually.
-        let pointSize: CGFloat = editor.viewMode == .source ? 11 : 13
         viewModeButton?.image = icon(for: editor.viewMode)?
-            .withSymbolConfiguration(.init(pointSize: pointSize, weight: .regular))
+            .withSymbolConfiguration(.init(pointSize: 13, weight: .regular))
         viewModeButton?.toolTip = "View mode: \(label(for: editor.viewMode))"
     }
 
@@ -499,15 +497,15 @@ class Document: NSDocument, HeadingNavigable {
     @objc private func selectEditMode(_ sender: Any?)    { setViewMode(editingMode) }
     @objc private func selectReadingMode(_ sender: Any?) { setViewMode(.reading) }
 
-    /// The "Source mode" checkbox (button menu and View menu). Persists the
-    /// setting and, if we're in the editing view, swaps it to the new editing
-    /// mode right away.
+    /// The "Show source in editor" checkbox (button menu and View menu).
+    /// Persists the setting and, if we're in the editing view, swaps it to
+    /// the new editing mode right away.
     @objc func toggleSourceMode(_ sender: Any?) {
         AppSettings.sourceMode.toggle()
         if editor.viewMode != .reading { setViewMode(editingMode) }
     }
 
-    /// Keeps the View-menu "Source Mode" checkmark in sync with the setting.
+    /// Keeps the View-menu "Show Source in Editor" checkmark in sync with the setting.
     override func validateMenuItem(_ item: NSMenuItem) -> Bool {
         if item.action == #selector(toggleSourceMode(_:)) {
             item.state = AppSettings.sourceMode ? .on : .off
@@ -533,7 +531,7 @@ class Document: NSDocument, HeadingNavigable {
     }
 
     /// The right-click menu: Edit / Read selection, a divider, then the
-    /// "Source mode" checkbox. Built fresh each time so state stays current.
+    /// "Show source in editor" checkbox. Built fresh each time so state stays current.
     fileprivate func viewModeMenu() -> NSMenu {
         let menu = NSMenu()
         menu.autoenablesItems = false   // actions always fire on selection
@@ -543,7 +541,7 @@ class Document: NSDocument, HeadingNavigable {
         menu.addItem(menuItem("Read", icon(for: .reading),
                               #selector(selectReadingMode(_:)), on: !inEditing))
         menu.addItem(.separator())
-        menu.addItem(menuItem("Source mode", icon(for: .source),
+        menu.addItem(menuItem("Show source in editor", nil,
                               #selector(toggleSourceMode(_:)), on: AppSettings.sourceMode))
         return menu
     }

--- a/Sources/edmd/App/ViewMenu.swift
+++ b/Sources/edmd/App/ViewMenu.swift
@@ -1,0 +1,55 @@
+import AppKit
+import EdmundCore
+
+// MARK: - View menu
+
+@MainActor
+enum ViewMenu {
+
+    /// The top-level "View" menu item (with its submenu).
+    static func build() -> NSMenuItem {
+        let viewMenuItem = NSMenuItem()
+        let viewMenu = NSMenu(title: "View")
+
+        // Routes through the responder chain to the key window's toolbar.
+        // AppKit auto-inserts "Show Tab Bar"/"Show All Tabs" above this at
+        // runtime (window tabbing is on by default) — that position isn't
+        // ours to control short of disabling tabbing outright.
+        viewMenu.addItem(withTitle: "Customize Toolbar…",
+                         action: #selector(NSWindow.runToolbarCustomizationPalette(_:)),
+                         keyEquivalent: "")
+        viewMenu.addItem(.separator())
+
+        let typewriterItem = viewMenu.addItem(
+            withTitle: "Typewriter Scroll",
+            action: #selector(AppDelegate.toggleTypewriterMode(_:)),
+            keyEquivalent: "")
+        typewriterItem.state = AppDelegate.typewriterModeEnabled() ? .on : .off
+
+        // View-mode toggle (Edit ↔ Read) + the Source-mode checkbox.
+        viewMenu.addItem(.separator())
+        viewMenu.addItem(FormatMenu.viewModeToggleItem())
+        viewMenu.addItem(withTitle: "Source Mode",
+                         action: #selector(Document.toggleSourceMode(_:)),
+                         keyEquivalent: "")
+        viewMenu.addItem(.separator())
+
+        // Zoom (font size + max content width, scaled together). Target nil
+        // routes through the responder chain to the key window's Document.
+        // Kept last, directly above the separator AppKit inserts before its
+        // automatic "Enter/Exit Full Screen" item at the menu's end.
+        viewMenu.addItem(withTitle: "Actual Size",
+                         action: #selector(Document.actualSize(_:)),
+                         keyEquivalent: "0")
+        viewMenu.addItem(withTitle: "Zoom In",
+                         action: #selector(Document.zoomIn(_:)),
+                         keyEquivalent: "=")
+        viewMenu.addItem(withTitle: "Zoom Out",
+                         action: #selector(Document.zoomOut(_:)),
+                         keyEquivalent: "-")
+        viewMenu.addItem(.separator())
+
+        viewMenuItem.submenu = viewMenu
+        return viewMenuItem
+    }
+}

--- a/Sources/edmd/App/ViewMenu.swift
+++ b/Sources/edmd/App/ViewMenu.swift
@@ -29,7 +29,7 @@ enum ViewMenu {
         // View-mode toggle (Edit ↔ Read) + the Source-mode checkbox.
         viewMenu.addItem(.separator())
         viewMenu.addItem(FormatMenu.viewModeToggleItem())
-        viewMenu.addItem(withTitle: "Source Mode",
+        viewMenu.addItem(withTitle: "Show Source in Editor",
                          action: #selector(Document.toggleSourceMode(_:)),
                          keyEquivalent: "")
         viewMenu.addItem(.separator())

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -273,17 +273,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         let viewMenuItem = NSMenuItem()
         let viewMenu = NSMenu(title: "View")
 
-        // Zoom (font size + max content width, scaled together). Target nil
-        // routes through the responder chain to the key window's Document.
-        viewMenu.addItem(withTitle: "Actual Size",
-                         action: #selector(Document.actualSize(_:)),
-                         keyEquivalent: "0")
-        viewMenu.addItem(withTitle: "Zoom In",
-                         action: #selector(Document.zoomIn(_:)),
-                         keyEquivalent: "=")
-        viewMenu.addItem(withTitle: "Zoom Out",
-                         action: #selector(Document.zoomOut(_:)),
-                         keyEquivalent: "-")
+        // Routes through the responder chain to the key window's toolbar.
+        viewMenu.addItem(withTitle: "Customize Toolbar…",
+                         action: #selector(NSWindow.runToolbarCustomizationPalette(_:)),
+                         keyEquivalent: "")
         viewMenu.addItem(.separator())
 
         let typewriterItem = viewMenu.addItem(
@@ -298,12 +291,21 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         viewMenu.addItem(withTitle: "Source Mode",
                          action: #selector(Document.toggleSourceMode(_:)),
                          keyEquivalent: "")
-        viewMenu.addItem(.separator())
 
-        // Routes through the responder chain to the key window's toolbar.
-        viewMenu.addItem(withTitle: "Customize Toolbar…",
-                         action: #selector(NSWindow.runToolbarCustomizationPalette(_:)),
-                         keyEquivalent: "")
+        // Zoom (font size + max content width, scaled together). Target nil
+        // routes through the responder chain to the key window's Document.
+        // Kept last, directly above the separator AppKit inserts before its
+        // automatic "Enter/Exit Full Screen" item at the menu's end.
+        viewMenu.addItem(withTitle: "Actual Size",
+                         action: #selector(Document.actualSize(_:)),
+                         keyEquivalent: "0")
+        viewMenu.addItem(withTitle: "Zoom In",
+                         action: #selector(Document.zoomIn(_:)),
+                         keyEquivalent: "=")
+        viewMenu.addItem(withTitle: "Zoom Out",
+                         action: #selector(Document.zoomOut(_:)),
+                         keyEquivalent: "-")
+        viewMenu.addItem(.separator())
 
         viewMenuItem.submenu = viewMenu
         mainMenu.addItem(viewMenuItem)

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -269,46 +269,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         // Format menu — built from the declarative command registry.
         mainMenu.addItem(FormatMenu.build())
 
-        // View menu
-        let viewMenuItem = NSMenuItem()
-        let viewMenu = NSMenu(title: "View")
-
-        // Routes through the responder chain to the key window's toolbar.
-        viewMenu.addItem(withTitle: "Customize Toolbar…",
-                         action: #selector(NSWindow.runToolbarCustomizationPalette(_:)),
-                         keyEquivalent: "")
-        viewMenu.addItem(.separator())
-
-        let typewriterItem = viewMenu.addItem(
-            withTitle: "Typewriter Scroll",
-            action: #selector(AppDelegate.toggleTypewriterMode(_:)),
-            keyEquivalent: "")
-        typewriterItem.state = AppDelegate.typewriterModeEnabled() ? .on : .off
-
-        // View-mode toggle (Edit ↔ Read) + the Source-mode checkbox.
-        viewMenu.addItem(.separator())
-        viewMenu.addItem(FormatMenu.viewModeToggleItem())
-        viewMenu.addItem(withTitle: "Source Mode",
-                         action: #selector(Document.toggleSourceMode(_:)),
-                         keyEquivalent: "")
-
-        // Zoom (font size + max content width, scaled together). Target nil
-        // routes through the responder chain to the key window's Document.
-        // Kept last, directly above the separator AppKit inserts before its
-        // automatic "Enter/Exit Full Screen" item at the menu's end.
-        viewMenu.addItem(withTitle: "Actual Size",
-                         action: #selector(Document.actualSize(_:)),
-                         keyEquivalent: "0")
-        viewMenu.addItem(withTitle: "Zoom In",
-                         action: #selector(Document.zoomIn(_:)),
-                         keyEquivalent: "=")
-        viewMenu.addItem(withTitle: "Zoom Out",
-                         action: #selector(Document.zoomOut(_:)),
-                         keyEquivalent: "-")
-        viewMenu.addItem(.separator())
-
-        viewMenuItem.submenu = viewMenu
-        mainMenu.addItem(viewMenuItem)
+        // View menu — built in its own file (ViewMenu.swift).
+        mainMenu.addItem(ViewMenu.build())
 
         NSApplication.shared.mainMenu = mainMenu
     }

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -273,6 +273,19 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         let viewMenuItem = NSMenuItem()
         let viewMenu = NSMenu(title: "View")
 
+        // Zoom (font size + max content width, scaled together). Target nil
+        // routes through the responder chain to the key window's Document.
+        viewMenu.addItem(withTitle: "Actual Size",
+                         action: #selector(Document.actualSize(_:)),
+                         keyEquivalent: "0")
+        viewMenu.addItem(withTitle: "Zoom In",
+                         action: #selector(Document.zoomIn(_:)),
+                         keyEquivalent: "=")
+        viewMenu.addItem(withTitle: "Zoom Out",
+                         action: #selector(Document.zoomOut(_:)),
+                         keyEquivalent: "-")
+        viewMenu.addItem(.separator())
+
         let typewriterItem = viewMenu.addItem(
             withTitle: "Typewriter Scroll",
             action: #selector(AppDelegate.toggleTypewriterMode(_:)),


### PR DESCRIPTION
## Summary
- Adds View ▸ Actual Size (⌘0), Zoom In (⌘=), Zoom Out (⌘-): scales standard + code font size and max content width together, per document, session-only (not persisted). Scales off the persisted base theme so repeated zooming doesn't drift and Actual Size always returns to the true saved size.
- Reorders the View menu: Customize Toolbar… leads (own divider), zoom trio sits just above the divider before macOS's automatic Enter/Exit Full Screen item, with a divider separating it from Source Mode above.
- Extracts View menu construction out of `main.swift` into its own `ViewMenu.swift`, mirroring the existing `FormatMenu.build()` pattern.
- Renames "Source Mode" → "Show Source in Editor" (app menu) / "Show source in editor" (toolbar button's context menu, icon removed there). Source view now shares the pencil icon with Edit's rendered view instead of a separate chevron glyph, since both are the same editing mode.

## Test plan
- [x] `swift test` — 823/823 green
- [x] Built debug bundle, launched separately from the live daily-driver instance; screencapture-verified Zoom In grows font + content width proportionally, Actual Size resets pixel-identical to baseline
- [x] Screencapture-verified the reordered View menu and the button context menu (Edit/Read keep icons, Show source in editor doesn't; pencil icon consistent across Edit and Source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)