### PR TITLE
docs(architecture): remove AI-writing patterns from developer write-ups

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,51 +1,51 @@
-# Edmund architecture — developer overview
+# Edmund architecture: developer overview
 
-The human-readable tour of Edmund's internals. This doc summarizes; it never
-owns a fact — every claim here points at the section or doc that does. If
-you're an agent making a change fast, read [`../ARCHITECTURE.md`](../ARCHITECTURE.md)
+The human-readable tour of Edmund's internals. This doc is a summary: every
+claim here points at the section or doc that owns it. If you're an agent
+making a change fast, read [`../ARCHITECTURE.md`](../ARCHITECTURE.md)
 instead; if you're a human getting oriented, start here.
 
 ## What Edmund is
 
 A native macOS Markdown editor with live preview: AppKit + TextKit 2, built
-with SwiftPM, targeting macOS 14+. Two SPM targets: `EdmundCore` — the
-library, holding all editor logic (parsing, rendering, the `EditorTextView`)
-and the test suite — and `edmd` — the executable, an `NSDocument` app shell
-(Settings, menus, window setup) that depends on `EdmundCore`. Source:
-`../ARCHITECTURE.md` §1.
+with SwiftPM, targeting macOS 14+. Two SPM targets: `EdmundCore`, the
+library that holds all editor logic (parsing, rendering, the
+`EditorTextView`) plus the test suite, and `edmd`, the executable, an
+`NSDocument` app shell (Settings, menus, window setup) that depends on
+`EdmundCore`. Source: `../ARCHITECTURE.md` §1.
 
 ## The two invariants
 
 Everything else in the codebase is built to hold these:
 
-1. **Text storage always equals `rawSource`.** Rendering is attribute-only —
+1. **Text storage always equals `rawSource`.** Rendering is attribute-only.
    Edmund never inserts or deletes display characters. Markdown delimiters
    are hidden (near-zero font, clear color), never stripped.
 2. **TextKit 2 only.** The editor never touches `NSTextView.layoutManager`
-   and never stores `NSTextBlock`/`NSTextTable` attributes — either silently
-   and permanently reverts the view to TextKit 1.
+   and never stores `NSTextBlock`/`NSTextTable` attributes. Either one
+   silently and permanently reverts the view to TextKit 1.
 
 The home of these rules is `../ARCHITECTURE.md` §2.
 
 ## Map of this folder
 
-- [`editor-pipeline.md`](editor-pipeline.md) — `rawSource` → parse → style →
+- [`editor-pipeline.md`](editor-pipeline.md): `rawSource` → parse → style →
   attributed storage, the recompose paths, lazy styling.
-- [`text-system.md`](text-system.md) — why TextKit 2 only, the custom
+- [`text-system.md`](text-system.md): why TextKit 2 only, the custom
   layout-fragment decoration mechanism, hiding, the height-estimate and
   image-wedge constraints.
-- [`extensibility.md`](extensibility.md) — the themes/extensions design.
+- [`extensibility.md`](extensibility.md): the themes/extensions design.
   **Design only, not yet implemented on `main`.**
 - Planned, not yet written: `reader-and-export.md`, `edit-flow-and-undo.md`,
   `app-shell-and-settings.md`.
 
 ## Map of sibling folders
 
-- [`../investigations/`](../investigations/) — chronicles of hard bugs, one
+- [`../investigations/`](../investigations/): chronicles of hard bugs, one
   doc per bug class, written up round by round. `archives/` holds closed
   classes (fixed and not expected to recur); the rest are still active.
-- [`../dev-guides/`](../dev-guides/) — method docs (how to do something),
-  not bug chronicles. Start with
+- [`../dev-guides/`](../dev-guides/): method docs (how to do something), not
+  bug chronicles. Start with
   [`live-repro-guide.md`](../dev-guides/live-repro-guide.md) if you're
   reproducing a live-app bug.
 
@@ -55,20 +55,21 @@ The home of these rules is `../ARCHITECTURE.md` §2.
   `Build complete!` after compiling a changed file without relinking `edmd`,
   so you run old code. `../ARCHITECTURE.md` §8 has the detection/cure.
 - **Delimiters are hidden, not stripped.** `**bold**` keeps its asterisks in
-  storage; they're rendered near-invisible. This is invariant 1 above —
-  home: `../ARCHITECTURE.md` §2.
+  storage; they're rendered near-invisible. This is invariant 1 above. Home:
+  `../ARCHITECTURE.md` §2.
 - **TextKit 2 height estimates cause most viewport glitches.** A fragment
   has a real frame only once laid out; everything else is an estimate that
   gets corrected as layout catches up. `../ARCHITECTURE.md` §8 covers the
   mitigations; the bug history is
   [`../investigations/viewport-glitch-investigation.md`](../investigations/viewport-glitch-investigation.md).
-- **Images can't be drawn on wrapping (multi-line) layout fragments** — it
-  collapses the fragment's layout to one line. `../ARCHITECTURE.md` §9; the
-  full saga (and the stroked-path workaround) is
+- **Images can't be drawn on wrapping (multi-line) layout fragments.**
+  Drawing one collapses the fragment's layout to one line.
+  `../ARCHITECTURE.md` §9; the full saga (and the stroked-path workaround)
+  is
   [`../investigations/archives/callout-title-wrap-investigation.md`](../investigations/archives/callout-title-wrap-investigation.md).
 - **Never mutate storage while an IME is composing.** Doing so can strand
-  marked text and permanently break the storage==rawSource sync, drifting
-  the caret on every later edit. `../ARCHITECTURE.md` §8; the full
+  marked text and permanently break the storage==rawSource sync, which
+  drifts the caret on every later edit. `../ARCHITECTURE.md` §8; the full
   investigation is
   [`../investigations/delete-drift-investigation.md`](../investigations/delete-drift-investigation.md).
 

--- a/docs/architecture/editor-pipeline.md
+++ b/docs/architecture/editor-pipeline.md
@@ -1,4 +1,4 @@
-# Editor pipeline — parsing to pixels
+# Editor pipeline: parsing to pixels
 
 Expands `../ARCHITECTURE.md` §3 (render pipeline) and the styling half of §4
 (edit flow). This doc narrates the mechanism; the invariant it serves
@@ -11,7 +11,7 @@ rawSource ──BlockParser──▶ [Block] ──SyntaxHighlighter──▶ sp
 ```
 
 1. **`BlockParser`** (`Sources/EdmundCore/Parsing/BlockParser.swift`) splits
-   `rawSource` into `Block`s — one per logical unit: paragraph, heading, list
+   `rawSource` into `Block`s, one per logical unit: paragraph, heading, list
    item, quote/callout run, code fence, display-math block, table. It merges
    multi-line constructs (an opening fence until its closing fence, a run of
    `>` lines, a table's header+separator+rows) into single blocks via a
@@ -19,14 +19,14 @@ rawSource ──BlockParser──▶ [Block] ──SyntaxHighlighter──▶ sp
    consume lines identically and can't diverge.
 2. **`SyntaxHighlighter`** and its extensions (`+Walker`, `+WalkerInline`,
    `+CustomParsers`) walk a block's content and produce a flat list of
-   `SyntaxHighlighter.Span`s — spans handle both CommonMark/GFM constructs
+   `SyntaxHighlighter.Span`s. Spans handle both CommonMark/GFM constructs
    (via `swift-markdown`'s walker) and Edmund's non-CommonMark syntax
    (callouts, `==highlight==`, wikilinks, footnotes, math, backslash escapes,
    inline HTML tags) through the custom parsers.
 3. **`styleBlock(_:cursorPosition:)`**
    (`Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift`) turns one
    block's spans into an `NSAttributedString` covering the *same* characters
-   as the raw markdown — never a stripped version. Each feature has its own
+   as the raw markdown, never a stripped version. Each feature has its own
    `Rendering/` extension (Callout, Code, Image, List, ListMarker, Math,
    Table, WikiLinks) that `styleBlock` dispatches into per span kind.
    Delimiters get attribute treatment, not deletion: `hiddenFont`
@@ -40,29 +40,29 @@ rawSource ──BlockParser──▶ [Block] ──SyntaxHighlighter──▶ sp
 place that writes styled attributes into the text storage. Three entry
 points, each used for a different class of change:
 
-- **`recompose(cursorInRaw:)`** — full: replaces the *entire* text storage
+- **`recompose(cursorInRaw:)`** (full): replaces the *entire* text storage
   with `rawSource` in base attributes, then restyles every block. Used when
   `rawSource` was rebuilt outside the edit path: initial load, undo/redo,
-  indent. Expensive — it discards every TextKit 2 layout fragment, resetting
-  all geometry to estimates (see `text-system.md` and
+  indent. Expensive: it discards every TextKit 2 layout fragment, which
+  resets all geometry to estimates (see `text-system.md` and
   `../investigations/viewport-glitch-investigation.md` for why that matters).
-- **`recomposeDirty(_:cursorInRaw:)`** — the workhorse: restyles exactly the
+- **`recomposeDirty(_:cursorInRaw:)`** (the workhorse): restyles exactly the
   given set of block indices in place. Attribute-only; the storage string
   itself is never touched. This is the single styling path for edits,
   activation changes (cursor moving in/out of a block), and theme/appearance
   refreshes.
-- **`recomposeIncremental(cursorInRaw:)`** — restyles just the old and new
+- **`recomposeIncremental(cursorInRaw:)`**: restyles just the old and new
   active blocks when the cursor moves between blocks without changing
-  content; a thin wrapper around `recomposeDirty`.
+  content. A thin wrapper around `recomposeDirty`.
 
 A fourth entry point, `recomposeReplacing(oldRange:with:dirty:cursorInRaw:)`,
 handles edits that rebuild a contiguous span of `rawSource` without a full
-replace (Tab/Shift-Tab indent) — it string-replaces only that span, so
+replace (Tab/Shift-Tab indent). It string-replaces only that span, so
 storage outside it (and its TextKit 2 layout) is untouched and the viewport
 can't lurch.
 
 **Active-block raw reveal**: the block under the caret renders its *raw*
-markdown — delimiters visible and editable. Every other block renders
+markdown, delimiters visible and editable. Every other block renders
 styled. `recomposeDirty` computes this by tracking `activeBlockIndex` and
 passing a `cursorInBlock` offset into `restyleBlock` for the active block
 only; that offset drives which token's delimiters get revealed vs. hidden as
@@ -82,7 +82,7 @@ Blocks left out of the synchronous set are marked unstyled and converge via
 two mechanisms in `Sources/EdmundCore/TextView/EditorTextView+LazyStyling.swift`:
 
 - **The idle drain** (`drainStylingSlice`): time-budgeted (~6 ms) main-thread
-  slices that restyle unstyled blocks, resuming from where the last slice
+  slices that restyle unstyled blocks and resume from where the last slice
   stopped, until none remain. Runs off `scheduleProgressiveStyling`,
   coalesced and re-entrant-safe.
 - **Scroll promotion** (`promoteVisibleUnstyledBlocks`, driven by
@@ -99,31 +99,31 @@ finishes the rest in the background.
 
 `EditorTextStorage` (`Sources/EdmundCore/TextView/EditorTextStorage.swift`)
 is the `NSTextStorage` subclass backing the editor. Every `replaceCharacters`
-call — typing, paste, IME commit — accumulates a `PendingEdit` (old-string
-range + length delta), coalescing multiple mutations within one event turn
-into their conservative hull. This is the single funnel `didChangeText`
+call (typing, paste, IME commit) accumulates a `PendingEdit` (old-string
+range + length delta), which coalesces multiple mutations within one event
+turn into their conservative hull. This is the single funnel `didChangeText`
 reads to drive `BlockParser.incrementalParse`, which re-splits only the
 affected lines (O(edit), not O(document)) instead of re-parsing the whole
 document on every keystroke. A `#if DEBUG` oracle
 (`verifyIncrementalParse`) cross-checks every incremental result against a
 from-scratch parse. Programmatic whole-document replacements (`recompose`
 after load/undo/indent) call `clearPendingEdit()` since they re-parse from
-scratch themselves — the incremental path is never asked to reconcile a
+scratch themselves. The incremental path is never asked to reconcile a
 change it didn't see.
 
 ## Worked example: typing one character inside a callout
 
-1. NSTextView calls `shouldChangeText(in:replacementString:)` — Edmund
+1. NSTextView calls `shouldChangeText(in:replacementString:)`. Edmund
    records an undo snapshot and returns `true`.
 2. NSTextView mutates the storage (`EditorTextStorage.replaceCharacters`),
    which accumulates the edit into `pendingEdit` and calls `edited(...)`.
 3. NSTextView calls `didChangeText()`
    (`Sources/EdmundCore/TextView/EditorTextView+EditFlow.swift`). Guarded by
    `!isUpdating` and `!hasMarkedText()` (never touch storage mid-IME-
-   composition — see `../ARCHITECTURE.md` §8), it calls
+   composition; see `../ARCHITECTURE.md` §8), it calls
    `syncRawSourceFromDisplay()`.
 4. `syncRawSourceFromDisplay` re-reads `rawSource` from storage, consumes the
-   storage's `pendingEdit`, and calls `BlockParser.incrementalParse` — for a
+   storage's `pendingEdit`, and calls `BlockParser.incrementalParse`. For a
    single character typed inside an existing callout block, the edit range
    sits entirely inside that one block, so the incremental parse re-splits
    just the callout's quote run (and, per the parser's lookback rule, the
@@ -133,7 +133,7 @@ change it didn't see.
    (none, for a callout edit).
 6. `recomposeDirty` restyles exactly that block: `styleBlock` re-runs
    `SyntaxHighlighter` on the callout's new content and produces fresh
-   attribute runs — the callout box decoration, header icon overlay, and
+   attribute runs: the callout box decoration, header icon overlay, and
    body text styling are all re-derived, not incrementally patched. TextKit 2
    layout is invalidated for the restyled block's range so the box's height
    picks up the new line if the character wrapped.
@@ -142,4 +142,4 @@ change it didn't see.
    restyle.
 
 No other block is touched, and the storage string outside the callout was
-never replaced — only its attributes changed.
+never replaced; only its attributes changed.

--- a/docs/architecture/extensibility.md
+++ b/docs/architecture/extensibility.md
@@ -1,32 +1,32 @@
-# Extensibility — themes & extensions design
+# Extensibility: themes & extensions design
 
-The design-of-record for Edmund's themes/extensions model. **This is a design
-doc, not an implementation** — `../ARCHITECTURE.md` documents what exists on
-`main` and gets no new section here until code lands (the same-PR rule).
-Everything below builds on the extension foundation that already exists on
-the unmerged branch `feat/extensions-registry-and-tab`; nothing here proposes
-a greenfield system.
+The design-of-record for Edmund's themes/extensions model. **This is a
+design doc, not an implementation.** `../ARCHITECTURE.md` documents what
+exists on `main` and gets no new section here until code lands (the
+same-PR rule). Everything below builds on the extension foundation that
+already exists on the unmerged branch `feat/extensions-registry-and-tab`;
+nothing here proposes a greenfield system.
 
 ## 1. Vision & model
 
 Adopt the VSCode/Obsidian user-directory model: a per-user directory
 (`~/.edmund/`) holds user-managed content, distinct from the app bundle and
 from UserDefaults. Concretely: `~/.edmund/themes/` for theme files
-(greenfield — `~/.edmund/` today holds only `logs/`, created by
+(greenfield: `~/.edmund/` today holds only `logs/`, created by
 `Log.swift`). Settings *choices* (which theme is active, feature toggles)
 stay in UserDefaults, as they do today; only theme/extension *content* moves
 to disk.
 
-**The full v2.0.0 vision, recorded (not designed here)** — from the
+**The full v2.0.0 vision** is recorded here, not designed, from the
 maintainer's own `misc/extensions.md`: a GUI theme preview/editor; a script
 that converts VSCode themes to Edmund themes; an "Advanced Theme" extension
 carrying the fine-grained knobs deferred out of core theming (see §3); and a
-marketplace. None of this is scoped or scheduled by this doc — it's recorded
-so the near-term design (§3–§5) doesn't paint itself into a corner.
+marketplace. None of this is scoped or scheduled by this doc. It's recorded
+so the near-term design (§3-§5) doesn't paint itself into a corner.
 
 **ROADMAP's "primitive marketplace"** is defined here as: a curated index
 file in a repo, mapping extension IDs to their own repos/release assets, with
-a download-or-move install and no server component — the shape
+a download-or-move install and no server component, the shape
 `obsidianmd/obsidian-releases` uses. This precedent is already cited in
 `EdmundExtension.swift` on the branch (`ExtensionRegistry`'s doc comment),
 independently arrived at before this design doc, which is a good sign the
@@ -40,7 +40,7 @@ shape fits.
   themeable surface today: 4 color hexes (`linkBlueHex`, `codeHex`,
   `mathOperatorHex`, `mathNumberHex`) plus fonts (body + monospace, sizes,
   ligature flags) and spacing (line spacing, paragraph spacing before). One
-  wrinkle: `linkBlueHex` is force-reset to the default on every `load()` —
+  wrinkle: `linkBlueHex` is force-reset to the default on every `load()`:
   "the accent color is not user-customizable" (a comment left from a removed
   in-app accent picker), so it's currently *not* actually themeable despite
   living in the struct.
@@ -52,25 +52,25 @@ shape fits.
   `NSColor(calibratedWhite: 0.5, alpha: 0.1)`, and the blockquote left bar
   uses `.tertiaryLabelColor`. Foreground/background/caret colors use system
   semantic `NSColor`s (so they already track light/dark and accent
-  automatically — no theme plumbing needed for those).
+  automatically; no theme plumbing needed for those).
 - **Three consumers branch on dark mode independently**: the editor's own
   `NSColor` palette (system semantic colors resolve automatically; hardcoded
   ones don't), `HTMLTheme.css(_:callouts:dark:...)`
   (`Export/HTMLTheme.swift`) picks its own light/dark hex pairs for
   background/foreground/rule/code-background, and `CodeSyntaxPalette`
-  (`Parsing/CodeSyntaxPalette.swift`) holds two complete hex tables —
-  Tomorrow (light) and One Dark (dark) — for 6 `CodeHighlighter.TokenType`
+  (`Parsing/CodeSyntaxPalette.swift`) holds two complete hex tables,
+  Tomorrow (light) and One Dark (dark), for 6 `CodeHighlighter.TokenType`
   values (`keyword`, `type`, `string`, `number`, `comment`, `function`) plus
   the untokenized-text color. Nothing forces these three to agree except
   discipline; see §6 for why that's a risk.
 - `Callout.style(for:overrides:)` already accepts an `overrides:
-  [String: CalloutStyle]` dictionary — an existing seam a future theme layer
+  [String: CalloutStyle]` dictionary, an existing seam a future theme layer
   can hand a resolved override map into, with no signature change needed.
 - **Two UserDefaults key conventions coexist**: `AppSettings.Key` uses
   dotted, namespaced strings (`"settings.appearance.mode"`,
   `"settings.general.diagnosticLogging"`); `EditorTheme`'s private `Keys`
   enum uses flat legacy names (`"EditorFontName"`, `"EditorLinkBlueHex"`).
-  Any new theme/extension setting has to pick a side (or unify them — see
+  Any new theme/extension setting has to pick a side (or unify them, see
   §5 Stage 1).
 
 **On `feat/extensions-registry-and-tab`** (unmerged; verified via `git show
@@ -84,7 +84,7 @@ feat/extensions-registry-and-tab:<path>`):
   `installedSizeDescription`, `lastUpdated`, `downloadCount`,
   `longDescriptionURL`, `donateURL`, `hasUpdate`). The protocol's own doc
   comment is explicit that this is **not** a third-party code-loading
-  mechanism — "that would mean running arbitrary code against
+  mechanism: "that would mean running arbitrary code against
   storage/undo/the TextKit 2 stack, a separate, much larger
   security/sandboxing project." `ExtensionRegistry.all` is a static array
   (today: just `AdvancedMathExtension.shared`), not a fetched registry.
@@ -93,7 +93,7 @@ feat/extensions-registry-and-tab:<path>`):
   `RaTeXInstaller` downloads a pinned `.tar.gz` release archive, SHA-256-
   verifies it **before** unpacking (a corrupted/tampered archive is never
   installed), and installs atomically into
-  `~/Library/Application Support/Edmund/Math/ratex-<version>/` — a
+  `~/Library/Application Support/Edmund/Math/ratex-<version>/`, a
   version-stamped path, so a new pinned version installs fresh alongside (or
   instead of) the old one. A `.verified-sha256` stamp file lets a relaunch
   skip re-downloading without re-hashing every unpacked file (the trust
@@ -103,7 +103,7 @@ feat/extensions-registry-and-tab:<path>`):
 - `Sources/edmd/Settings/ExtensionsSettingsView.swift` is the Settings pane
   (sidebar/detail split, enable/disable toggle, install-size/version/
   download-count display) that lists `ExtensionRegistry.all`.
-- This is **the foundation** — the design in §4–§5 extends this registry and
+- This is **the foundation**: the design in §4-§5 extends this registry and
   Settings pane; it never replaces them.
 
 ## 3. Themes design
@@ -114,14 +114,14 @@ Two kinds, matching `misc/extensions.md`'s own split:
   selection, checkbox) plus fonts. An optional "use system accent" flag lets
   caret/selection/checkbox track the user's system accent color instead of a
   fixed value (mirroring how `EditorTextView` already uses system semantic
-  colors for foreground/background/caret today — see §2). Fonts are either
+  colors for foreground/background/caret today; see §2). Fonts are either
   agnostic (inherit whatever the editor's current standard/monospace fonts
   are) or theme-named with default sizes, so the editor can scale a
   theme-supplied font proportionally against the user's chosen size (some
   fonts read bigger/smaller at the same point size). An editor theme
   references a syntax theme by name.
 - **Syntax theme**: the 6 `CodeHighlighter.TokenType` colors (§2) as a named,
-  swappable set — replacing today's two hardcoded tables
+  swappable set that replaces today's two hardcoded tables
   (`CodeSyntaxPalette`) with data.
 
 **JSON schema sketch** (both kinds; decision 6 fixes the format as JSON):
@@ -159,17 +159,17 @@ Two kinds, matching `misc/extensions.md`'s own split:
 ```
 
 Every color key is a `{"light": "#…", "dark": "#…"}` pair, **resolved at
-draw/CSS-generation time, never at load** — appearance switches (system
+draw/CSS-generation time, never at load.** Appearance switches (system
 dark-mode toggle, mid-session) must not go stale, the same reason
 `EditorTheme.load()` doesn't bake in an appearance today.
 
-**Discovery**: scan `~/.edmund/themes/*.json` at launch and whenever Settings
-opens — no file-watching in v1 (matches the "no speculative flexibility"
-guidance; add it only if users actually edit theme files while the app is
-running and file a complaint). An invalid file is skipped and logged to
-`~/.edmund/logs` (the existing `Log` facility), never a crash. A
+**Discovery**: scan `~/.edmund/themes/*.json` at launch and whenever
+Settings opens. No file-watching in v1 (matches the "no speculative
+flexibility" guidance; add it only if users actually edit theme files while
+the app is running and file a complaint). An invalid file is skipped and
+logged to `~/.edmund/logs` (the existing `Log` facility), never a crash. A
 missing/invalid *selection* falls back to a built-in default theme that
-ships in the app binary, not on disk — so a corrupted or deleted theme
+ships in the app binary, not on disk, so a corrupted or deleted theme
 directory can never leave the editor without a valid theme.
 
 Theme *choice* (which theme is active) persists in UserDefaults, matching
@@ -181,7 +181,7 @@ extension per the maintainer's own scoping in `misc/extensions.md`:
 highlight/link/inline-code/checkbox/blockquote/callout colors beyond the
 core palette, padding and width tweaks, custom bullets, image framing. Note
 `Callout.style(for:overrides:)` (§2) as this extension's natural first
-client — the override-dict seam already exists.
+client: the override-dict seam already exists.
 
 ## 4. Extensions design
 
@@ -189,90 +189,90 @@ client — the override-dict seam already exists.
 files live under `~/.edmund/extensions/<id>/` with a `manifest.json` (id,
 name, version, minimum-Edmund-version, kind); machine-managed *verified
 payloads* stay under Application Support, version-stamped, following the
-RaTeX precedent exactly (§2) — `RaTeXInstaller` doesn't move.
+RaTeX precedent exactly (§2). `RaTeXInstaller` doesn't move.
 
 **Distribution**: on the GitHub build, an extension's payload is a runtime
 download from a GitHub release asset (as RaTeX already does). On a future
 App Store build, sandboxing forbids that kind of runtime fetch-and-execute,
 so the same manifest/folder shape is populated by a manual download-and-move
 instead (the user downloads a release asset and drops it into
-`~/.edmund/extensions/`) — both paths converge on "a folder appears in the
+`~/.edmund/extensions/`). Both paths converge on "a folder appears in the
 right place with the right manifest," so the loader doesn't need to know
 which build produced it.
 
 **Sandbox-forward path-provider seam**: every place that computes
-`~/.edmund/...` today does it independently — `Log.swift` (line ~158) and
+`~/.edmund/...` today does it independently: `Log.swift` (line ~158) and
 `AppSettings.logDirectory` (`Sources/edmd/Settings/AppSettings.swift`)
 duplicate the exact same
 `FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".edmund/…")`
 computation. Before adding `themes/` and `extensions/` subdirectories to
 that duplication, collapse it into one path-provider seam. That seam is also
 where a future sandboxed build swaps in a security-scoped bookmark (granted
-during onboarding — `misc/extensions.md` already anticipates this: "I will
+during onboarding, `misc/extensions.md` already anticipates this: "I will
 ask the user to grant access to `~/.edmund/` in the onboarding process")
 instead of a raw `FileManager` home-directory path. One seam, one place to
 swap.
 
-**Execution model for community extensions is OPEN** — deliberately not
-decided by this doc. The maintainer's own uncertainty in `misc/extensions.md`
-("I know App Bundles are finicky to work with, so that will definitely not
-be the recommended way for community extensions... I am aware I need to
-design Edmund better for such extensions") is exactly why this doc defers
-the decision to a dedicated tradeoff analysis:
-`misc/native-bundle-extensions-tradeoffs.md` (gitignored, local-only — not
+**Execution model for community extensions is OPEN.** It is deliberately
+not decided by this doc. The maintainer's own uncertainty in
+`misc/extensions.md` ("I know App Bundles are finicky to work with, so that
+will definitely not be the recommended way for community extensions... I am
+aware I need to design Edmund better for such extensions") is exactly why
+this doc defers the decision to a dedicated tradeoff analysis:
+`misc/native-bundle-extensions-tradeoffs.md` (gitignored, local-only, not
 part of this PR; see the final summary for how to find it).
 
 **Official roster** (extends today's registry of one):
 
-- **Advanced Math** — exists today (§2), blocked on an upstream RaTeX
-  release fixing two bugs (`aligned` row-spacing, inline-renders-as-display —
+- **Advanced Math**: exists today (§2), blocked on an upstream RaTeX
+  release fixing two bugs (`aligned` row-spacing, inline-renders-as-display,
   see `misc/backlog.md`). Ships on its own release path, never through the
   main app's tag-triggered pipeline (`../ARCHITECTURE.md` §13 is explicit:
   "Never release anything through this pipeline except the main app").
-- **Advanced Syntax Highlighting** — real language grammars replacing the
+- **Advanced Syntax Highlighting**: real language grammars that replace the
   heuristic `CodeHighlighter` tokenizer; the first extension to prove the
   declarative (non-code) extension path end to end (§5 Stage 4).
-- **Advanced Theme** — the v2.0.0 fine-grained knobs extension from §3.
+- **Advanced Theme**: the v2.0.0 fine-grained knobs extension from §3.
 
 ## 5. Staged implementation plan
 
-Each stage is a future standalone task — scope, files, risks, and tests
+Each stage is a future standalone task: scope, files, risks, and tests
 noted so a later implementer (agent or human) can pick one up without
 re-deriving this design.
 
-- **Stage 0 — color consolidation (prerequisite for everything else).**
+- **Stage 0: color consolidation** (prerequisite for everything else).
   Move every hardcoded editor color (§2: selection orange, highlight yellow,
   inline-code background, blockquote bar) into `EditorTheme`, and make dark-
   mode resolution happen at exactly one point instead of three independently
   branching consumers. Add a parity test asserting the editor's resolved
   `NSColor` for each theme key equals `HTMLTheme`'s generated CSS hex for the
-  same key, in both light and dark — the anti-drift contract that makes
+  same key, in both light and dark, the anti-drift contract that makes
   every later stage safe. Files: `EditorTheme.swift`, `EditorTextView.swift`,
   `Rendering/EditorTextView+Rendering.swift`, `Export/HTMLTheme.swift`,
   `Parsing/CodeSyntaxPalette.swift`. Risk: this touches rendering-visible
-  colors across both Edit and Read mode — needs the full visual-QA pass
+  colors across both Edit and Read mode; it needs the full visual-QA pass
   (`../ARCHITECTURE.md` §12), not just `swift test`.
-- **Stage 1 — theme file loading + Settings picker.** Codable schema for the
+- **Stage 1: theme file loading + Settings picker.** Codable schema for the
   JSON in §3; scan `~/.edmund/themes/`, validate, fall back to the built-in
   default on any error; live theme switching via the existing `applyTo…`
   broadcast pattern (`FontSettings.applyToDocuments`, which already pushes
-  an updated `EditorTheme` to every open `Document.editor` — the same
+  an updated `EditorTheme` to every open `Document.editor`, the same
   mechanism a theme picker would reuse). New picker UI in the Appearance
   pane or a new Settings pane (`SettingsWindowController.addPane`). **Open
   decision to surface, not resolve, here**: whether to unify the two
-  UserDefaults key conventions (§2) as part of this stage or defer it —
-  flag it in the PR, don't decide it in this design doc.
-- **Stage 2 — syntax themes.** Make `CodeSyntaxPalette` data-driven from the
+  UserDefaults key conventions (§2) as part of this stage or defer it.
+  Flag it in the PR; don't decide it in this design doc.
+- **Stage 2: syntax themes.** Make `CodeSyntaxPalette` data-driven from the
   loaded syntax theme instead of its two hardcoded tables; the existing
   Tomorrow/One Dark tables become the built-in default theme's data. Extend
   the Stage 0 parity test to cover token colors too.
-- **Stage 3 — community extension manifest + loader (blocked on the
-  execution-model decision in §4).** Versioned `manifest.json` schema,
+- **Stage 3: community extension manifest + loader** (blocked on the
+  execution-model decision in §4). Versioned `manifest.json` schema,
   directory scan of `~/.edmund/extensions/`, minimum-Edmund-version gate,
-  enable/disable — extending the branch's `ExtensionRegistry` and
+  enable/disable. This extends the branch's `ExtensionRegistry` and
   `ExtensionsSettingsView` rather than replacing them.
-- **Stage 4 — distribution + first community-facing extension.** Checksum/
-  signature discipline on distributed archives, extending the SHA-256 +
+- **Stage 4: distribution + first community-facing extension.** Checksum/
+  signature discipline on distributed archives that extends the SHA-256 +
   EdDSA practice already proven for RaTeX (§2) and Sparkle releases
   (`../ARCHITECTURE.md` §13). Advanced Syntax Highlighting (§4) proves the
   declarative extension path; Advanced Math re-integrates once RaTeX
@@ -282,10 +282,10 @@ re-deriving this design.
 
 | Decision | Status |
 | --- | --- |
-| Community extension execution model | Open — see `misc/native-bundle-extensions-tradeoffs.md` |
-| Marketplace shape | Recorded as a curated index repo (§1) — not built |
+| Community extension execution model | Open, see `misc/native-bundle-extensions-tradeoffs.md` |
+| Marketplace shape | Recorded as a curated index repo (§1), not built |
 | UserDefaults key-convention unification | Surfaced in Stage 1, not resolved |
-| Whether `misc/extensions.md` gets a superseded-by line | The maintainer's file — his call, not edited here |
+| Whether `misc/extensions.md` gets a superseded-by line | The maintainer's file; his call, not edited here |
 
 ## 6. Honest risks
 
@@ -293,22 +293,22 @@ re-deriving this design.
   editor `NSColor`s, `HTMLTheme` CSS, and `CodeSyntaxPalette` already branch
   on dark mode independently on `main` today, with nothing but discipline
   keeping them in sync. Adding user-supplied theme files without Stage 0's
-  consolidation first would triple the surface a color bug can hide in —
-  Stage 0 is not optional groundwork, it's the mitigation.
+  consolidation first would triple the surface a color bug can hide in.
+  Stage 0 is not optional groundwork; it's the mitigation.
 - **Dark-variant staleness** if a theme's colors were ever resolved at load
-  instead of at draw/CSS-generation time (§3) — a `EditorTheme.load()`-style
+  instead of at draw/CSS-generation time (§3), a `EditorTheme.load()`-style
   bug (the `linkBlueHex` force-reset, §2, is exactly this class of bug
   already present once) would make a theme file appear to "not update" on
   an appearance switch until relaunch.
 - **No sandbox today.** The app is ad-hoc signed, not notarized
-  (`../ARCHITECTURE.md` §13), and ships no entitlements — so the path-
-  provider seam in §4 is future-proofing, not a currently-enforced boundary.
+  (`../ARCHITECTURE.md` §13), and ships no entitlements. The path-provider
+  seam in §4 is future-proofing, not a currently-enforced boundary.
 - **Key-convention split** (§2) will only get more expensive to unify the
   longer new settings keep picking a side arbitrarily.
 - **Why executable community extensions are dangerous on this app,
   specifically**: Edmund is not sandboxed and not notarized, so any native
   code an extension loads runs with the *user's full permissions* and no
-  Gatekeeper/App-Store backstop — a malicious or merely buggy community
+  Gatekeeper/App-Store backstop. A malicious or merely buggy community
   `.bundle` isn't contained the way it would be in a sandboxed host. This is
   the core tension `misc/native-bundle-extensions-tradeoffs.md` works
   through in full; it's why §4 leaves the execution model open rather than

--- a/docs/architecture/text-system.md
+++ b/docs/architecture/text-system.md
@@ -1,4 +1,4 @@
-# Text system — TextKit 2 drawing model
+# Text system: TextKit 2 drawing model
 
 Expands `../ARCHITECTURE.md` §2 (invariants) and §5 (TextKit 2 specifics).
 Seeded also from the two archived callout investigations
@@ -7,11 +7,11 @@ Seeded also from the two archived callout investigations
 ## Why TextKit 2 only
 
 TextKit 2 (`NSTextLayoutManager`) lays out only what's on screen (viewport-
-based layout), which is what makes large documents tractable — a TextKit 1
+based layout), which is what makes large documents tractable. A TextKit 1
 document lays out the whole thing up front. The constraint this buys: the
 editor must **never** touch `NSTextView.layoutManager` and must **never**
 store `NSTextBlock`/`NSTextTable` attributes in the text storage. Either one
-silently and permanently switches the view back to TextKit 1 — AppKit falls
+silently and permanently switches the view back to TextKit 1. AppKit falls
 back without an error, so a stray `layoutManager` access anywhere in the call
 graph (including in a debugger inspection or a well-meaning "just check the
 line count" helper) can quietly regress the whole editor to whole-document
@@ -22,7 +22,7 @@ this with a `#if DEBUG` tripwire: it observes
 `NSTextView.willSwitchToNSLayoutManagerNotification` and calls
 `assertionFailure` if it ever fires, so a debug build crashes loudly at the
 moment of the regression instead of silently degrading. Release builds have
-no such guard — the regression there is just slow.
+no such guard. The regression there is just slow.
 
 ## `DecoratedTextLayoutFragment`
 
@@ -30,51 +30,51 @@ A custom `NSTextLayoutFragment` subclass
 (`Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift`) draws two kinds
 of custom attribute behind/over the laid-out text:
 
-- **`.blockDecoration`** (paragraph-level) — callout boxes, quote bars, table
+- **`.blockDecoration`** (paragraph-level): callout boxes, quote bars, table
   borders, thematic-break rules, code-block backgrounds. Fragment frames tile
   vertically, so a multi-line quote/callout run renders as one continuous
   box or bar across its fragments. A `.box` decoration's `bottomPad` grows
   the *last* fragment's own `layoutFragmentFrame` (not just its drawing):
   TextKit 2 excludes trailing `paragraphSpacing` from a fragment's height, so
-  padding added only at draw time would be dead space — clicks there would
+  padding added only at draw time would be dead space. Clicks there would
   miss the text. Growing the frame instead keeps the extra height genuinely
   part of the fragment (clickable, and tiling correctly against the next
   block). A related wrinkle: when a callout is the document's last block and
   the source ends with a trailing newline, TextKit 2 folds that empty final
-  line into the *preceding* fragment instead of giving it its own — painting
+  line into the *preceding* fragment instead of giving it its own. Painting
   the decoration over the full frame height would flood callout color onto
   that empty line. `decorationDrawHeight` detects the absorbed empty line and
   stops the fill at the last real content line plus `bottomPad`.
-- **`.fragmentOverlay`** (character-level) — an image *or* a stroked vector
-  path drawn at one character's laid-out position: rendered math, list
-  bullets/checkboxes, the callout header icon+name image, the custom-title
-  callout icon. The mechanism: the anchor character is hidden (see below),
-  and `.kern` on that character reserves the overlay's drawing width as
-  advance space, so the following text starts clear of where the overlay
-  will be painted — the same trick the table renderer uses for column
-  alignment. `draw(at:in:)` then paints the image or strokes the path at the
-  anchor's computed position once the surrounding text has laid out.
+- **`.fragmentOverlay`** (character-level): an image *or* a stroked vector
+  path drawn at one character's laid-out position. Examples: rendered math,
+  list bullets/checkboxes, the callout header icon+name image, the
+  custom-title callout icon. The mechanism: the anchor character is hidden
+  (see below), and `.kern` on that character reserves the overlay's drawing
+  width as advance space, so the following text starts clear of where the
+  overlay will be painted, using the same trick the table renderer uses for
+  column alignment. `draw(at:in:)` then paints the image or strokes the path
+  at the anchor's computed position once the surrounding text has laid out.
 
 ## Hiding mechanics
 
 Delimiters and synthesized-but-in-source markers vanish from view without
 changing the string: `hiddenFont` is `NSFont.systemFont(ofSize: 0.01)`,
-paired with a clear `foregroundColor`. The character is still there — a
-selection can still span it, undo still round-trips it — it simply occupies
+paired with a clear `foregroundColor`. The character is still there (a
+selection can still span it, undo still round-trips it); it simply occupies
 no visible space and paints nothing.
 
 This is also why `NSTextAttachment` is off the table entirely: TextKit 2 only
 honors an attachment on the placeholder character U+FFFC, and `rawSource`
 (the storage==rawSource invariant, `../ARCHITECTURE.md` §2) never contains
-that character — Edmund's content is always real Markdown text. Every image
+that character. Edmund's content is always real Markdown text. Every image
 or icon the editor draws is therefore a `.fragmentOverlay`, anchored to a
 real (hidden) character, never an attachment.
 
 ## Height estimates: the root of most viewport glitches
 
 TextKit 2 only gives a layout fragment a *real* frame once it has actually
-been laid out; everything else — including the running total used for
-document height and scroll-position math — is an *estimate* that gets
+been laid out; everything else (including the running total used for
+document height and scroll-position math) is an *estimate* that gets
 corrected as layout catches up to it. That correction is what makes the
 scroller jump, drag-selection autoscroll oscillate, and a scroll-to-target
 land in the wrong place; it's a widely documented TextKit 2 limitation (even
@@ -87,7 +87,7 @@ Edmund's mitigations, all converging in
   **fully laid out** once styling converges, via a coalesced next-run-loop
   settle (`scheduleFullLayoutSettle`) wrapped in `preservingViewportAnchor`
   so the correction can't visibly shift what's on screen. Larger documents
-  keep viewport-based (estimate-tolerant) layout — a full layout there would
+  keep viewport-based (estimate-tolerant) layout. A full layout there would
   be the process-killing path that motivated other mitigations.
 - `repairContentAboveOrigin` detects a first-fragment origin that has drifted
   *above* y=0 (edits near the top can leave the scroller stuck at the top
@@ -103,12 +103,12 @@ one root cause explained: `../investigations/viewport-glitch-investigation.md`.
 
 Drawing an *image* `.fragmentOverlay` on a **wrapping, multi-line** layout
 fragment re-triggers a TextKit 2 layout pass that collapses ("wedges") that
-fragment to a single line — clipping whatever wrapped. Drawing a *shape*
+fragment to a single line, clipping whatever wrapped. Drawing a *shape*
 (a stroked `CGPath`) on the same fragment does not trigger this. Default
 callout headers get away with an image overlay because their synthesized
 icon+name text is short and never wraps; the **custom-title** callout header
 can wrap (user-supplied title text), so its icon is a stroked `CGPath`
-instead — parsed from the vendored Lucide SVG geometry by `SVGPath`
+instead, parsed from the vendored Lucide SVG geometry by `SVGPath`
 (`Sources/EdmundCore/Model/SVGPath.swift`), scaled and drawn directly in
 `CGContext` rather than rasterized to an `NSImage` first. Any *new* overlay
 that could end up sharing a line with wrapping text inherits this same


### PR DESCRIPTION
## What

Prose-only editing pass over the four `docs/architecture/` write-ups that landed in #184: drop em/en dashes, present-participle tack-ons, copula avoidance, and negative parallelisms. 4 files, +141/−140.

## Why

The write-ups read like generated text in places. This pass makes the prose plainer and more natural while keeping every technical fact, file path, symbol, §N reference, and link target unchanged.

## Verification

- `grep -n '—\|–' docs/architecture/*.md` returns nothing.
- Every relative markdown link in the four files resolves.
- Full diff reviewed: no fact, path, or link changed meaning.
- `swift test`: 823 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)