### PR TITLE
Block external images: settings toggle, edit/read-mode placeholders

### DIFF
--- a/Sources/EdmundCore/Export/DocumentHTML.swift
+++ b/Sources/EdmundCore/Export/DocumentHTML.swift
@@ -100,50 +100,57 @@ enum DocumentHTML {
     /// Resolves each `md-image` placeholder: local/relative paths are read and
     /// inlined as a data URI (self-contained, no file access needed at render
     /// time); a `data:` source passes through; remote `https` sources load only
-    /// when `options.allowRemoteImages` is set, else the alt text shows; plain
-    /// `http` never loads — App Transport Security refuses an insecure
-    /// connection regardless of the setting — so it always gets a visible
-    /// blocked-image placeholder instead of silently showing nothing.
+    /// when `options.allowRemoteImages` is set. Anything that can't be shown
+    /// gets a visible icon + reason (`ImageLoadFailure`, shared with Edit
+    /// mode's inline preview) instead of silently showing nothing.
     private static func fillImages(_ html: String, baseURL: URL?,
                                    options: ReadRenderOptions) -> String {
         var cache: [String: String] = [:]   // resolved path → data URI
         return replaceMatches(html, pattern: imagePattern) { groups in
             let src = unescapeAttr(groups[1])
             let alt = groups[2]   // already attribute-escaped by the renderer
-            func placeholder() -> String { "<img class=\"md-image\" alt=\"\(alt)\">" }
 
-            if src.isEmpty { return placeholder() }
+            if src.isEmpty { return blockedImagePlaceholder(reason:.notFound) }
             let lower = src.lowercased()
             if lower.hasPrefix("data:") {
                 return "<img class=\"md-image\" src=\"\(HTMLRenderer.attr(src))\" alt=\"\(alt)\">"
             }
             if lower.hasPrefix("http://") {
-                return blockedImagePlaceholder(alt: alt)
+                return blockedImagePlaceholder(reason:.httpUnsupported)
             }
             if lower.hasPrefix("https://") {
-                guard options.allowRemoteImages else { return placeholder() }
+                guard options.allowRemoteImages else {
+                    return blockedImagePlaceholder(reason:.blockedBySetting)
+                }
                 return "<img class=\"md-image\" src=\"\(HTMLRenderer.attr(src))\" alt=\"\(alt)\">"
             }
             // Local: resolve against the document directory, read, inline.
-            guard let fileURL = resolveLocalImage(src, baseURL: baseURL) else { return placeholder() }
-            let uri: String
-            if let cached = cache[fileURL.path] {
-                uri = cached
-            } else {
-                uri = imageDataURI(fileURL) ?? ""
-                cache[fileURL.path] = uri
+            guard let fileURL = resolveLocalImage(src, baseURL: baseURL) else {
+                return blockedImagePlaceholder(reason:.notFound)
             }
-            guard !uri.isEmpty else { return placeholder() }
+            if let cached = cache[fileURL.path] {
+                return "<img class=\"md-image\" src=\"\(cached)\" alt=\"\(alt)\">"
+            }
+            // `resolveLocalImage`'s absolute/`~` branches don't check existence
+            // (only the relative-path branch does), so a missing file and an
+            // undecodable one would otherwise fail `imageDataURI` identically —
+            // check existence first so the two get distinct, accurate messages.
+            guard FileManager.default.fileExists(atPath: fileURL.path) else {
+                return blockedImagePlaceholder(reason:.notFound)
+            }
+            guard let uri = imageDataURI(fileURL) else {
+                return blockedImagePlaceholder(reason:.notAnImage)
+            }
+            cache[fileURL.path] = uri
             return "<img class=\"md-image\" src=\"\(uri)\" alt=\"\(alt)\">"
         }
     }
 
-    /// A visible stand-in for a plain-`http` image, which never loads (ATS
-    /// refuses the insecure connection outright): an icon plus the alt text,
-    /// instead of just empty space.
-    private static func blockedImagePlaceholder(alt: String) -> String {
+    /// A visible stand-in for an image that can't be shown: an icon plus a
+    /// short reason, instead of just empty space.
+    private static func blockedImagePlaceholder(reason: ImageLoadFailure) -> String {
         let icon = LucideIcons.inlineSVG("image-off") ?? ""
-        return "<span class=\"md-image-blocked\">\(icon)<span>\(alt)</span></span>"
+        return "<span class=\"md-image-blocked\">\(icon)<span>\(reason.label)</span></span>"
     }
 
     /// Resolves a local image `path` to a file URL: absolute / `~` / `file:`
@@ -160,9 +167,13 @@ enum DocumentHTML {
     }
 
     /// Reads an image file and returns a `data:` URI, with the MIME type guessed
-    /// from the file extension (covers the common web image formats).
+    /// from the file extension (covers the common web image formats). Decodes
+    /// the bytes first (discarding the result) so a file that merely has an
+    /// image extension but isn't actually image data is caught here — as
+    /// "Not an image" — rather than silently inlining garbage the browser
+    /// then fails to render with no explanation.
     private static func imageDataURI(_ url: URL) -> String? {
-        guard let data = try? Data(contentsOf: url) else { return nil }
+        guard let data = try? Data(contentsOf: url), NSImage(data: data) != nil else { return nil }
         let mime: String
         switch url.pathExtension.lowercased() {
         case "png":          mime = "image/png"

--- a/Sources/EdmundCore/Export/DocumentHTML.swift
+++ b/Sources/EdmundCore/Export/DocumentHTML.swift
@@ -99,8 +99,11 @@ enum DocumentHTML {
 
     /// Resolves each `md-image` placeholder: local/relative paths are read and
     /// inlined as a data URI (self-contained, no file access needed at render
-    /// time); a `data:` source passes through; remote `http(s)` sources load
-    /// only when `options.allowRemoteImages` is set, else the alt text shows.
+    /// time); a `data:` source passes through; remote `https` sources load only
+    /// when `options.allowRemoteImages` is set, else the alt text shows; plain
+    /// `http` never loads — App Transport Security refuses an insecure
+    /// connection regardless of the setting — so it always gets a visible
+    /// blocked-image placeholder instead of silently showing nothing.
     private static func fillImages(_ html: String, baseURL: URL?,
                                    options: ReadRenderOptions) -> String {
         var cache: [String: String] = [:]   // resolved path → data URI
@@ -114,7 +117,10 @@ enum DocumentHTML {
             if lower.hasPrefix("data:") {
                 return "<img class=\"md-image\" src=\"\(HTMLRenderer.attr(src))\" alt=\"\(alt)\">"
             }
-            if lower.hasPrefix("http://") || lower.hasPrefix("https://") {
+            if lower.hasPrefix("http://") {
+                return blockedImagePlaceholder(alt: alt)
+            }
+            if lower.hasPrefix("https://") {
                 guard options.allowRemoteImages else { return placeholder() }
                 return "<img class=\"md-image\" src=\"\(HTMLRenderer.attr(src))\" alt=\"\(alt)\">"
             }
@@ -130,6 +136,14 @@ enum DocumentHTML {
             guard !uri.isEmpty else { return placeholder() }
             return "<img class=\"md-image\" src=\"\(uri)\" alt=\"\(alt)\">"
         }
+    }
+
+    /// A visible stand-in for a plain-`http` image, which never loads (ATS
+    /// refuses the insecure connection outright): an icon plus the alt text,
+    /// instead of just empty space.
+    private static func blockedImagePlaceholder(alt: String) -> String {
+        let icon = LucideIcons.inlineSVG("image-off") ?? ""
+        return "<span class=\"md-image-blocked\">\(icon)<span>\(alt)</span></span>"
     }
 
     /// Resolves a local image `path` to a file URL: absolute / `~` / `file:`

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -239,6 +239,12 @@ enum HTMLTheme {
     img { max-width: 100%; }
     img.math { vertical-align: middle; }
     .math-display { text-align: center; margin: 1em 0; }
+    /* Stand-in for a plain-http image, which never loads under ATS. */
+    .md-image-blocked { display: inline-flex; align-items: center; gap: 0.4em;
+                        color: var(--faint); background: var(--code-bg);
+                        border: 1px dashed var(--rule); border-radius: 6px;
+                        padding: 0.3em 0.6em; font-size: 0.9em; }
+    .md-image-blocked svg { width: 1.1em; height: 1.1em; flex: 0 0 auto; }
 
     /* Callouts: tinted box + colored title; the icon sits as a non-shrinking
        flex child so a long custom title wraps under the title text, never under

--- a/Sources/EdmundCore/Model/LucideIcons.swift
+++ b/Sources/EdmundCore/Model/LucideIcons.swift
@@ -45,10 +45,16 @@ enum LucideIcons {
     }
 
     /// An `NSImage` of the icon stroked in `color`, sized to a `pointSize`
-    /// square. Renders the SVG (in black) then tints with `.sourceAtop` so the
+    /// square. Renders the SVG (in black) then tints with `.sourceIn` so the
     /// glyph matches `color` exactly regardless of the SVG decoder's color space
-    /// — the same technique the PDF icon path used. `nil` for an unknown id or if
-    /// the platform SVG decoder can't build the image.
+    /// — the same technique the PDF icon path used. `sourceIn` (not
+    /// `sourceAtop`) matters when `color` is itself translucent (e.g. a dynamic
+    /// system color like `.secondaryLabelColor`): `sourceIn`'s result alpha is
+    /// `color.alpha * baseGlyphAlpha`, so the tint's own translucency survives;
+    /// `sourceAtop` keeps only the base glyph's alpha, silently discarding the
+    /// tint's alpha — invisible with the opaque theme colors this was first
+    /// used with, but it flattens a translucent tint to solid opaque. `nil` for
+    /// an unknown id or if the platform SVG decoder can't build the image.
     static func image(_ name: String, color: NSColor, pointSize: CGFloat) -> NSImage? {
         guard let g = geometry[name],
               let data = strokeSVG(geometry: g, stroke: "#000000").data(using: .utf8),
@@ -58,7 +64,7 @@ enum LucideIcons {
         let image = NSImage(size: box, flipped: false) { rect in
             base.draw(in: rect)
             color.setFill()
-            NSGraphicsContext.current?.cgContext.setBlendMode(.sourceAtop)
+            NSGraphicsContext.current?.cgContext.setBlendMode(.sourceIn)
             rect.fill()
             return true
         }

--- a/Sources/EdmundCore/Model/LucideIcons.swift
+++ b/Sources/EdmundCore/Model/LucideIcons.swift
@@ -34,6 +34,7 @@ enum LucideIcons {
         "list": #"<path d="M3 5h.01"/><path d="M3 12h.01"/><path d="M3 19h.01"/><path d="M8 5h13"/><path d="M8 12h13"/><path d="M8 19h13"/>"#,
         "quote": #"<path d="M16 3a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2 1 1 0 0 1 1 1v1a2 2 0 0 1-2 2 1 1 0 0 0-1 1v2a1 1 0 0 0 1 1 6 6 0 0 0 6-6V5a2 2 0 0 0-2-2z"/><path d="M5 3a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2 1 1 0 0 1 1 1v1a2 2 0 0 1-2 2 1 1 0 0 0-1 1v2a1 1 0 0 0 1 1 6 6 0 0 0 6-6V5a2 2 0 0 0-2-2z"/>"#,
         "circle": #"<circle cx="12" cy="12" r="10"/>"#,
+        "image-off": #"<line x1="2" x2="22" y1="2" y2="22"/><path d="M10.41 10.41a2 2 0 1 1-2.83-2.83"/><line x1="13.5" x2="6" y1="13.5" y2="21"/><line x1="18" x2="21" y1="12" y2="15"/><path d="M3.59 3.59A1.99 1.99 0 0 0 3 5v14a2 2 0 0 0 2 2h14c.55 0 1.052-.22 1.41-.59"/><path d="M21 15V5a2 2 0 0 0-2-2H9"/>"#,
     ]
 
     /// Raw `<svg>…</svg>` with `stroke="currentColor"` for inlining into HTML;

--- a/Sources/EdmundCore/Rendering/EditorTextView+ImageRendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+ImageRendering.swift
@@ -4,10 +4,12 @@ import AppKit
 //
 // `![alt](path)` renders the referenced image inline when the cursor is outside
 // the token, and shows the raw, editable markdown when the cursor is inside it
-// (the `.image` branch of `styleBlock`). The image is drawn by a
+// (the `.image` branch of `styleBlock`). A loaded image is drawn by a
 // `FragmentOverlay` anchored on the leading `!` — the same mechanism math and
 // list markers use — with the rest of the markdown hidden and the line height
-// reserved for the picture.
+// reserved for the picture. An image that can't be shown (outside the token)
+// gets the same overlay treatment, but with a small icon + reason in place of
+// the picture, so the user knows *why* — not just that nothing rendered.
 //
 // Resolution: absolute paths, `~`-paths, and `file:` URLs load directly;
 // relative paths resolve against the document's directory. A remote `https`
@@ -29,47 +31,91 @@ nonisolated(unsafe) private let imageCache = NSCache<NSString, NSImage>()
 // fetch completion's `@MainActor` hop.
 nonisolated(unsafe) private var inFlightRemoteImages = Set<String>()
 
+// Remote URLs that were fetched and turned out not to decode as an image, so
+// repeated re-styles show "Not an image" instead of re-fetching forever.
+nonisolated(unsafe) private var undecodableRemoteImages = Set<String>()
+
 extension EditorTextView {
 
-    /// Loads the image referenced by an `![alt](destination)` link, or nil if it
-    /// can't be resolved/loaded (yet) — the caller then shows the raw alt text.
-    func loadImage(destination: String) -> NSImage? {
-        let dest = destination.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let scheme = URL(string: dest)?.scheme?.lowercased(), scheme == "http" || scheme == "https" {
-            guard scheme == "https", allowRemoteImages else { return nil }
-            return loadRemoteImage(dest)
+    /// Why an `![alt](destination)` couldn't be shown — the short label the
+    /// placeholder overlay draws next to its icon.
+    enum ImageLoadFailure {
+        case httpUnsupported
+        case blockedBySetting
+        case notAnImage
+        case notFound
+
+        var label: String {
+            switch self {
+            case .httpUnsupported: return "HTTP connection not supported"
+            case .blockedBySetting: return "External images blocked"
+            case .notAnImage: return "Not an image"
+            case .notFound: return "Image not found"
+            }
         }
-        guard let url = resolveImageURL(dest) else { return nil }
-        let key = url.path as NSString
-        if let cached = imageCache.object(forKey: key) { return cached }
-        guard let image = NSImage(contentsOf: url) else { return nil }
-        imageCache.setObject(image, forKey: key)
-        return image
     }
 
-    /// Returns the cached image for a remote `urlString` if already downloaded;
-    /// otherwise starts an async fetch (once per URL, while one is already in
-    /// flight) and returns nil for now. The completion caches the image and
-    /// re-styles the document so it appears — without blocking the main thread
-    /// on network I/O.
-    private func loadRemoteImage(_ urlString: String) -> NSImage? {
+    /// What `styleBlock` should show for an image token when the cursor is
+    /// outside it.
+    enum ImageDisplay {
+        /// The image loaded; draw it.
+        case image(NSImage)
+        /// It can't be shown; draw an icon + `failure.label` in its place.
+        case blocked(ImageLoadFailure)
+        /// A remote fetch is in flight — transient, not an error; the caller
+        /// falls back to plain alt text until a recompose picks up the result.
+        case pending
+    }
+
+    /// Resolves and (for local files) loads the image referenced by
+    /// `destination`, classifying why it can't be shown when it can't.
+    func imageDisplay(destination: String) -> ImageDisplay {
+        let dest = destination.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !dest.isEmpty else { return .blocked(.notFound) }
+
+        if let scheme = URL(string: dest)?.scheme?.lowercased(), scheme == "http" || scheme == "https" {
+            guard scheme == "https" else { return .blocked(.httpUnsupported) }
+            guard allowRemoteImages else { return .blocked(.blockedBySetting) }
+            return loadRemoteImage(dest)
+        }
+        guard let url = resolveImageURL(dest) else { return .blocked(.notFound) }
+        let key = url.path as NSString
+        if let cached = imageCache.object(forKey: key) { return .image(cached) }
+        // `resolveImageURL` builds a URL from the path string alone (it doesn't
+        // check existence), so a missing file and an undecodable one both fail
+        // `NSImage(contentsOf:)` the same way — check existence first so the two
+        // get distinct, accurate messages.
+        guard FileManager.default.fileExists(atPath: url.path) else { return .blocked(.notFound) }
+        guard let image = NSImage(contentsOf: url) else { return .blocked(.notAnImage) }
+        imageCache.setObject(image, forKey: key)
+        return .image(image)
+    }
+
+    /// Returns the cached/decoded outcome for a remote `urlString`; otherwise
+    /// starts an async fetch (once per URL, while one is already in flight)
+    /// and returns `.pending`. The completion caches the image (or remembers a
+    /// decode failure) and re-styles the document so the result appears —
+    /// without blocking the main thread on network I/O.
+    private func loadRemoteImage(_ urlString: String) -> ImageDisplay {
         let key = urlString as NSString
-        if let cached = imageCache.object(forKey: key) { return cached }
-        guard !inFlightRemoteImages.contains(urlString), let url = URL(string: urlString) else { return nil }
+        if let cached = imageCache.object(forKey: key) { return .image(cached) }
+        if undecodableRemoteImages.contains(urlString) { return .blocked(.notAnImage) }
+        guard !inFlightRemoteImages.contains(urlString), let url = URL(string: urlString) else { return .pending }
         inFlightRemoteImages.insert(urlString)
 
         URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
-            guard let data, let image = NSImage(data: data) else {
-                Task { @MainActor in inFlightRemoteImages.remove(urlString) }
-                return
-            }
+            let image = data.flatMap { NSImage(data: $0) }
             Task { @MainActor in
-                imageCache.setObject(image, forKey: urlString as NSString)
                 inFlightRemoteImages.remove(urlString)
+                if let image {
+                    imageCache.setObject(image, forKey: urlString as NSString)
+                } else {
+                    undecodableRemoteImages.insert(urlString)
+                }
                 self?.recomposeAllDirty()
             }
         }.resume()
-        return nil
+        return .pending
     }
 
     /// Resolves a destination string to a local file URL. Returns nil for a
@@ -93,11 +139,23 @@ extension EditorTextView {
         return nil
     }
 
-    /// A `FragmentOverlay` for the image, scaled down to fit the text width while
-    /// keeping its aspect ratio. `bounds.minY == 0` sits the image bottom on the
-    /// text baseline (the reserved line height makes room above it).
+    /// A `FragmentOverlay` for `destination`'s image or placeholder, or nil
+    /// while a remote fetch is pending (the caller then shows plain alt text).
     func imageOverlay(destination: String) -> FragmentOverlay? {
-        guard let image = loadImage(destination: destination) else { return nil }
+        switch imageDisplay(destination: destination) {
+        case .image(let image):
+            return scaledOverlay(image: image)
+        case .blocked(let failure):
+            return placeholderOverlay(failure: failure)
+        case .pending:
+            return nil
+        }
+    }
+
+    /// Scales `image` down to fit the text width while keeping its aspect
+    /// ratio. `bounds.minY == 0` sits the image bottom on the text baseline
+    /// (the reserved line height makes room above it).
+    private func scaledOverlay(image: NSImage) -> FragmentOverlay? {
         var size = image.size
         guard size.width > 0, size.height > 0 else { return nil }
 
@@ -107,5 +165,33 @@ extension EditorTextView {
         }
         return FragmentOverlay(image: image,
                                bounds: CGRect(x: 0, y: 0, width: size.width, height: size.height))
+    }
+
+    /// Draws "icon  reason" into one image (same technique as the callout
+    /// header: `LucideIcons.image` tinted to match the muted text), so a
+    /// blocked/missing/undecodable image reads at a glance instead of just
+    /// showing nothing.
+    private func placeholderOverlay(failure: ImageLoadFailure) -> FragmentOverlay? {
+        let pointSize = bodyFont.pointSize
+        guard let icon = LucideIcons.image("image-off", color: .secondaryLabelColor, pointSize: pointSize)
+        else { return nil }
+
+        let labelAttrs: [NSAttributedString.Key: Any] = [.font: bodyFont, .foregroundColor: NSColor.secondaryLabelColor]
+        let label = NSAttributedString(string: failure.label, attributes: labelAttrs)
+        let labelSize = label.size()
+
+        let gap = pointSize * 0.3
+        let iconW = icon.size.width, iconH = icon.size.height
+        let height = ceil(max(iconH, labelSize.height))
+        let width = ceil(iconW + gap + labelSize.width)
+
+        let image = NSImage(size: NSSize(width: width, height: height), flipped: false) { _ in
+            icon.draw(in: NSRect(x: 0, y: (height - iconH) / 2, width: iconW, height: iconH))
+            label.draw(at: NSPoint(x: iconW + gap, y: (height - labelSize.height) / 2))
+            return true
+        }
+        image.cacheMode = .never   // re-rasterize at the screen's backing scale, like the callout header
+
+        return FragmentOverlay(image: image, bounds: CGRect(x: 0, y: 0, width: width, height: height))
     }
 }

--- a/Sources/EdmundCore/Rendering/EditorTextView+ImageRendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+ImageRendering.swift
@@ -10,20 +10,36 @@ import AppKit
 // reserved for the picture.
 //
 // Resolution: absolute paths, `~`-paths, and `file:` URLs load directly;
-// relative paths resolve against the document's directory. Remote (http(s))
-// images are skipped for now — loading them synchronously would block the main
-// thread — so they fall back to the alt text.
+// relative paths resolve against the document's directory. A remote `https`
+// image loads only when `allowRemoteImages` is on (mirrors Read mode's
+// `allowRemoteImages`/`blockExternalImages`), and asynchronously — loading it
+// synchronously on the styling path would block the main thread. `http` never
+// loads: App Transport Security refuses the insecure connection outright,
+// regardless of the setting (same reasoning as Read mode's DocumentHTML).
 
-// Loaded images are cached by resolved absolute path so a recompose doesn't
-// re-read them from disk. NSCache is internally thread-safe.
+// Loaded images are cached by resolved absolute path (local) or URL string
+// (remote), so a recompose doesn't re-read/re-fetch them. NSCache is
+// internally thread-safe.
 nonisolated(unsafe) private let imageCache = NSCache<NSString, NSImage>()
+
+// Remote URLs currently being fetched, so a burst of re-styles (scrolling,
+// cursor moves near the image) doesn't kick off duplicate downloads. Mutated
+// only on the main actor: inserted synchronously from `loadRemoteImage`
+// (called while styling, always on the main thread) and removed inside the
+// fetch completion's `@MainActor` hop.
+nonisolated(unsafe) private var inFlightRemoteImages = Set<String>()
 
 extension EditorTextView {
 
     /// Loads the image referenced by an `![alt](destination)` link, or nil if it
-    /// can't be resolved/loaded (the caller then shows the raw alt text).
+    /// can't be resolved/loaded (yet) — the caller then shows the raw alt text.
     func loadImage(destination: String) -> NSImage? {
-        guard let url = resolveImageURL(destination) else { return nil }
+        let dest = destination.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let scheme = URL(string: dest)?.scheme?.lowercased(), scheme == "http" || scheme == "https" {
+            guard scheme == "https", allowRemoteImages else { return nil }
+            return loadRemoteImage(dest)
+        }
+        guard let url = resolveImageURL(dest) else { return nil }
         let key = url.path as NSString
         if let cached = imageCache.object(forKey: key) { return cached }
         guard let image = NSImage(contentsOf: url) else { return nil }
@@ -31,14 +47,40 @@ extension EditorTextView {
         return image
     }
 
-    /// Resolves a destination string to a local file URL. Returns nil for remote
-    /// URLs (handled as a fallback) or when a relative path can't be anchored.
+    /// Returns the cached image for a remote `urlString` if already downloaded;
+    /// otherwise starts an async fetch (once per URL, while one is already in
+    /// flight) and returns nil for now. The completion caches the image and
+    /// re-styles the document so it appears — without blocking the main thread
+    /// on network I/O.
+    private func loadRemoteImage(_ urlString: String) -> NSImage? {
+        let key = urlString as NSString
+        if let cached = imageCache.object(forKey: key) { return cached }
+        guard !inFlightRemoteImages.contains(urlString), let url = URL(string: urlString) else { return nil }
+        inFlightRemoteImages.insert(urlString)
+
+        URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
+            guard let data, let image = NSImage(data: data) else {
+                Task { @MainActor in inFlightRemoteImages.remove(urlString) }
+                return
+            }
+            Task { @MainActor in
+                imageCache.setObject(image, forKey: urlString as NSString)
+                inFlightRemoteImages.remove(urlString)
+                self?.recomposeAllDirty()
+            }
+        }.resume()
+        return nil
+    }
+
+    /// Resolves a destination string to a local file URL. Returns nil for a
+    /// remote URL (handled separately, before this is reached) or when a
+    /// relative path can't be anchored.
     private func resolveImageURL(_ destination: String) -> URL? {
         let dest = destination.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !dest.isEmpty else { return nil }
 
         if let url = URL(string: dest), let scheme = url.scheme {
-            return scheme == "file" ? url : nil   // skip http(s)/data for now
+            return scheme == "file" ? url : nil
         }
         if dest.hasPrefix("/") { return URL(fileURLWithPath: dest) }
         if dest.hasPrefix("~") {

--- a/Sources/EdmundCore/Rendering/EditorTextView+ImageRendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+ImageRendering.swift
@@ -35,25 +35,27 @@ nonisolated(unsafe) private var inFlightRemoteImages = Set<String>()
 // repeated re-styles show "Not an image" instead of re-fetching forever.
 nonisolated(unsafe) private var undecodableRemoteImages = Set<String>()
 
-extension EditorTextView {
+/// Why an `![alt](destination)` couldn't be shown — the short label a
+/// blocked-image placeholder draws next to its icon. Shared by Edit mode
+/// (this file) and Read mode/export (`DocumentHTML`) so the two report the
+/// same reason, in the same words, for the same failure.
+enum ImageLoadFailure {
+    case httpUnsupported
+    case blockedBySetting
+    case notAnImage
+    case notFound
 
-    /// Why an `![alt](destination)` couldn't be shown — the short label the
-    /// placeholder overlay draws next to its icon.
-    enum ImageLoadFailure {
-        case httpUnsupported
-        case blockedBySetting
-        case notAnImage
-        case notFound
-
-        var label: String {
-            switch self {
-            case .httpUnsupported: return "HTTP connection not supported"
-            case .blockedBySetting: return "External images blocked"
-            case .notAnImage: return "Not an image"
-            case .notFound: return "Image not found"
-            }
+    var label: String {
+        switch self {
+        case .httpUnsupported: return "HTTP connection not supported"
+        case .blockedBySetting: return "External images blocked"
+        case .notAnImage: return "Not an image"
+        case .notFound: return "Image not found"
         }
     }
+}
+
+extension EditorTextView {
 
     /// What `styleBlock` should show for an image token when the cursor is
     /// outside it.

--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -160,6 +160,18 @@ public class EditorTextView: NSTextView {
         }
     }
 
+    /// Whether a remote (`https`) image referenced by `![alt](url)` may load
+    /// inline while editing. Mirrors Read mode's `allowRemoteImages`; set from
+    /// `AppSettings.blockExternalImages`. Defaults off (the safe default until
+    /// the app layer pushes the real setting in). See
+    /// EditorTextView+ImageRendering for the load path.
+    public var allowRemoteImages: Bool = false {
+        didSet {
+            guard oldValue != allowRemoteImages else { return }
+            recomposeAllDirty()
+        }
+    }
+
     // MARK: - Derived Visual Properties
 
     /// The app accent: the macOS system accent (`controlAccentColor`), which

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -117,6 +117,7 @@ class Document: NSDocument, HeadingNavigable {
         let initScreen = NSScreen.main
         editor.maxContentWidthPoints = initScreen?.cmToPoints(AppSettings.maxContentWidthCm) ?? 1000
         editor.updateContentInset()
+        editor.allowRemoteImages = !AppSettings.blockExternalImages
         editor.typewriterModeEnabled = AppDelegate.typewriterModeEnabled()
         editor.document = self
 

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -432,6 +432,7 @@ class Document: NSDocument, HeadingNavigable {
     /// the window's screen PPI) so Read mode's column matches Edit mode's.
     private var renderOptions: ReadRenderOptions {
         ReadRenderOptions(preserveBlankLines: AppSettings.renderBlankLinesAsBreaks,
+                         allowRemoteImages: !AppSettings.blockExternalImages,
                          maxContentWidthPoints: Double(editor.maxContentWidthPoints))
     }
 

--- a/Sources/edmd/Settings/AdvancedSettingsView.swift
+++ b/Sources/edmd/Settings/AdvancedSettingsView.swift
@@ -2,8 +2,6 @@ import SwiftUI
 import AppKit
 
 struct AdvancedSettingsView: View {
-    @AppStorage(AppSettings.Key.automaticallyChecksForUpdates)
-    private var autoCheckUpdates = true
     @AppStorage(AppSettings.Key.blockExternalImages) private var blockExternalImages = true
     @AppStorage(AppSettings.Key.diagnosticLogging) private var diagnosticLogging = false
     @AppStorage(AppSettings.Key.verboseEditorDiagnostics) private var verboseEditorDiagnostics = false
@@ -16,16 +14,6 @@ struct AdvancedSettingsView: View {
 
     var body: some View {
         Grid(alignment: .leadingFirstTextBaseline, verticalSpacing: 18) {
-            GridRow {
-                Text("Software update:")
-                    .gridColumnAlignment(.trailing)
-                Toggle("Automatically check for updates", isOn: $autoCheckUpdates)
-            }
-
-            GridRow {
-                Divider().gridCellColumns(2)
-            }
-
             GridRow {
                 Text("Privacy & Security:")
                     .gridColumnAlignment(.trailing)

--- a/Sources/edmd/Settings/AdvancedSettingsView.swift
+++ b/Sources/edmd/Settings/AdvancedSettingsView.swift
@@ -103,9 +103,11 @@ struct AdvancedSettingsView: View {
         }
     }
 
-    /// Re-renders every open Read view so a toggle change takes effect immediately.
+    /// Pushes the toggle to every open document's editor (Edit mode's inline
+    /// image overlay) and Read view, so the change takes effect immediately.
     private func refreshOpenReadViews() {
         for case let document as Document in NSDocumentController.shared.documents {
+            document.editor?.allowRemoteImages = !blockExternalImages
             document.refreshReadView()
         }
     }

--- a/Sources/edmd/Settings/AdvancedSettingsView.swift
+++ b/Sources/edmd/Settings/AdvancedSettingsView.swift
@@ -20,13 +20,7 @@ struct AdvancedSettingsView: View {
                 VStack(alignment: .leading, spacing: 6) {
                     Toggle("Block external images", isOn: $blockExternalImages)
                         .onChange(of: blockExternalImages) { refreshOpenReadViews() }
-                    Text("HTTPS connections only. Plain HTTP images never load, since the connection isn't encrypted.")
-                        .foregroundStyle(.secondary)
-                        .controlSize(.small)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(width: 380, alignment: .leading)
-                        .padding(.leading, 20)
-                    Text("Increases security. Refer to this [proposal](https://github.com/opencloud-eu/opencloud/issues/1145) for more information.")
+                    Text("For more information, refer to this [proposal](https://github.com/opencloud-eu/opencloud/issues/1145).")
                         .foregroundStyle(.secondary)
                         .controlSize(.small)
                         .fixedSize(horizontal: false, vertical: true)

--- a/Sources/edmd/Settings/AdvancedSettingsView.swift
+++ b/Sources/edmd/Settings/AdvancedSettingsView.swift
@@ -20,6 +20,12 @@ struct AdvancedSettingsView: View {
                 VStack(alignment: .leading, spacing: 6) {
                     Toggle("Block external images", isOn: $blockExternalImages)
                         .onChange(of: blockExternalImages) { refreshOpenReadViews() }
+                    Text("HTTPS connections only. Plain HTTP images never load, since the connection isn't encrypted.")
+                        .foregroundStyle(.secondary)
+                        .controlSize(.small)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(width: 380, alignment: .leading)
+                        .padding(.leading, 20)
                     Text("Increases security. Refer to this [proposal](https://github.com/opencloud-eu/opencloud/issues/1145) for more information.")
                         .foregroundStyle(.secondary)
                         .controlSize(.small)

--- a/Sources/edmd/Settings/AdvancedSettingsView.swift
+++ b/Sources/edmd/Settings/AdvancedSettingsView.swift
@@ -4,6 +4,7 @@ import AppKit
 struct AdvancedSettingsView: View {
     @AppStorage(AppSettings.Key.automaticallyChecksForUpdates)
     private var autoCheckUpdates = true
+    @AppStorage(AppSettings.Key.blockExternalImages) private var blockExternalImages = true
     @AppStorage(AppSettings.Key.diagnosticLogging) private var diagnosticLogging = false
     @AppStorage(AppSettings.Key.verboseEditorDiagnostics) private var verboseEditorDiagnostics = false
     @AppStorage(AppSettings.Key.logRetention) private var logRetention = AppSettings.LogRetention.twoWeeks
@@ -19,6 +20,25 @@ struct AdvancedSettingsView: View {
                 Text("Software update:")
                     .gridColumnAlignment(.trailing)
                 Toggle("Automatically check for updates", isOn: $autoCheckUpdates)
+            }
+
+            GridRow {
+                Divider().gridCellColumns(2)
+            }
+
+            GridRow {
+                Text("Privacy & Security:")
+                    .gridColumnAlignment(.trailing)
+                VStack(alignment: .leading, spacing: 6) {
+                    Toggle("Block external images", isOn: $blockExternalImages)
+                        .onChange(of: blockExternalImages) { refreshOpenReadViews() }
+                    Text("Increases security. The dev has subscribed to [this proposal](https://github.com/opencloud-eu/opencloud/issues/1145) to receive updates on the research.")
+                        .foregroundStyle(.secondary)
+                        .controlSize(.small)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(width: 380, alignment: .leading)
+                        .padding(.leading, 20)
+                }
             }
 
             GridRow {
@@ -87,6 +107,13 @@ struct AdvancedSettingsView: View {
         .settingsPanePadding()
         .sheet(isPresented: $showingWarnings) {
             ManageWarningsView()
+        }
+    }
+
+    /// Re-renders every open Read view so a toggle change takes effect immediately.
+    private func refreshOpenReadViews() {
+        for case let document as Document in NSDocumentController.shared.documents {
+            document.refreshReadView()
         }
     }
 }

--- a/Sources/edmd/Settings/AdvancedSettingsView.swift
+++ b/Sources/edmd/Settings/AdvancedSettingsView.swift
@@ -20,12 +20,17 @@ struct AdvancedSettingsView: View {
                 VStack(alignment: .leading, spacing: 6) {
                     Toggle("Block external images", isOn: $blockExternalImages)
                         .onChange(of: blockExternalImages) { refreshOpenReadViews() }
-                    Text("Increases security. The dev has subscribed to [this proposal](https://github.com/opencloud-eu/opencloud/issues/1145) to receive updates on the research.")
+                    Text("Increases security. Refer to this [proposal](https://github.com/opencloud-eu/opencloud/issues/1145) for more information.")
                         .foregroundStyle(.secondary)
                         .controlSize(.small)
                         .fixedSize(horizontal: false, vertical: true)
                         .frame(width: 380, alignment: .leading)
                         .padding(.leading, 20)
+                        
+                    // TODO: Add a "Enable HTTP whitelist" toggle here
+                    // with a short scrollable view of the whitelist that allows user addition
+                    // with +/- signs at the bottom-right corner
+                    // Implement later
                 }
             }
 

--- a/Sources/edmd/Settings/AppSettings.swift
+++ b/Sources/edmd/Settings/AppSettings.swift
@@ -90,6 +90,7 @@ enum AppSettings {
         static let suppressInconsistentLineEndingWarning = "settings.general.suppressInconsistentLineEndingWarning"
         static let diagnosticLogging = "settings.general.diagnosticLogging"
         static let verboseEditorDiagnostics = "settings.advanced.verboseEditorDiagnostics"
+        static let blockExternalImages = "settings.advanced.blockExternalImages"
         static let logRetention = "settings.general.logRetention"
         static let renderBlankLinesAsBreaks = "settings.reading.renderBlankLinesAsBreaks"
         static let sourceMode = "settings.view.sourceMode"
@@ -223,6 +224,18 @@ enum AppSettings {
     static var verboseEditorDiagnostics: Bool {
         get { UserDefaults.standard.bool(forKey: Key.verboseEditorDiagnostics) }
         set { UserDefaults.standard.set(newValue, forKey: Key.verboseEditorDiagnostics) }
+    }
+
+    /// Whether Read mode / export blocks remote (`http`/`https`) image loads.
+    /// Defaults on: no surprise network requests until the user opts out.
+    static var blockExternalImages: Bool {
+        get {
+            guard UserDefaults.standard.object(forKey: Key.blockExternalImages) != nil else {
+                return true
+            }
+            return UserDefaults.standard.bool(forKey: Key.blockExternalImages)
+        }
+        set { UserDefaults.standard.set(newValue, forKey: Key.blockExternalImages) }
     }
 
     /// Whether to auto-send crash reports on launch. Opt-in: defaults off, since

--- a/Sources/edmd/Settings/GeneralSettingsView.swift
+++ b/Sources/edmd/Settings/GeneralSettingsView.swift
@@ -6,6 +6,8 @@ import AppKit
 // MARK: - General
 
 struct GeneralSettingsView: View {
+    @AppStorage(AppSettings.Key.automaticallyChecksForUpdates)
+    private var autoCheckUpdates = true
     @AppStorage(AppSettings.Key.reopenWindows) private var reopenWindows = false
     @AppStorage(AppSettings.Key.startupAction) private var startupAction = AppSettings.StartupAction.createNewDocument
     @AppStorage(AppSettings.Key.autoSaveWithVersions) private var autoSave = true
@@ -17,6 +19,7 @@ struct GeneralSettingsView: View {
                 Text("On startup:")
                     .gridColumnAlignment(.trailing)
                 VStack(alignment: .leading, spacing: 6) {
+                    Toggle("Automatically check for updates", isOn: $autoCheckUpdates)
                     Toggle("Reopen windows from last session", isOn: $reopenWindows)
                     Text("When nothing else is open:")
                     Picker("", selection: $startupAction) {

--- a/Sources/edmd/Settings/GeneralSettingsView.swift
+++ b/Sources/edmd/Settings/GeneralSettingsView.swift
@@ -16,10 +16,21 @@ struct GeneralSettingsView: View {
     var body: some View {
         Grid(alignment: .leadingFirstTextBaseline, verticalSpacing: 18) {
             GridRow {
-                Text("On startup:")
+                Text("Software updates:")
                     .gridColumnAlignment(.trailing)
                 VStack(alignment: .leading, spacing: 6) {
                     Toggle("Automatically check for updates", isOn: $autoCheckUpdates)
+                }
+            }
+            
+            GridRow {
+                Divider().gridCellColumns(2)
+            }
+            
+            GridRow {
+                Text("On startup:")
+                    .gridColumnAlignment(.trailing)
+                VStack(alignment: .leading, spacing: 6) {
                     Toggle("Reopen windows from last session", isOn: $reopenWindows)
                     Text("When nothing else is open:")
                     Picker("", selection: $startupAction) {

--- a/Sources/edmd/Settings/SettingsControls.swift
+++ b/Sources/edmd/Settings/SettingsControls.swift
@@ -7,7 +7,7 @@ extension View {
     /// the top, a little more on the sides and bottom).
     func settingsPanePadding() -> some View {
         self.padding(EdgeInsets(top: 20, leading: 28, bottom: 28, trailing: 28))
-            .frame(width: 560, alignment: .leading)
+            .frame(width: 600, alignment: .leading)
             // Don't auto-focus (and draw a focus ring around) the first control
             // when a pane opens — Settings has no use for keyboard-focus rings.
             .focusEffectDisabled()

--- a/Tests/EdmundTests/BlockStylingTests.swift
+++ b/Tests/EdmundTests/BlockStylingTests.swift
@@ -702,10 +702,15 @@ struct ImageNonActiveTests {
         #expect(f!.pointSize < 1.0)
     }
 
-    @Test("Non-active image has italic font on content")
+    @Test("Non-active image has italic font on content while its load is pending")
     @MainActor func nonActiveImageItalic() {
+        // See ImageRenderingTests: a destination that resolves to a definite
+        // failure (`.notFound`/`.notAnImage`/`.blockedBySetting`) now gets a
+        // placeholder overlay instead of italic alt text. This styling remains
+        // only for a remote fetch still in flight (`.pending`).
         let editor = makeEditor()
-        editor.loadContent("![photo](url)\nother")
+        editor.allowRemoteImages = true
+        editor.loadContent("![photo](https://example.invalid/\(UUID().uuidString).png)\nother")
         activateBlock(1, in: editor)
 
         // "photo" is at positions 2-6

--- a/Tests/EdmundTests/DocumentHTMLTests.swift
+++ b/Tests/EdmundTests/DocumentHTMLTests.swift
@@ -119,4 +119,17 @@ struct DocumentHTMLTests {
                                    options: ReadRenderOptions(allowRemoteImages: true))
         #expect(on.contains("src=\"https://example.com/x.png\""))
     }
+
+    @Test("Plain-http image always shows the blocked-image placeholder, even opted in")
+    func httpImageAlwaysBlocked() {
+        let md = "![r](http://example.com/x.png)"
+        for allow in [false, true] {
+            let out = DocumentHTML.full(markdown: md, theme: .default,
+                                        callouts: Callout.defaultStyles, dark: false,
+                                        options: ReadRenderOptions(allowRemoteImages: allow))
+            #expect(!out.contains("http://example.com/x.png"))
+            #expect(out.contains("md-image-blocked"))
+            #expect(out.contains(">r<"))
+        }
+    }
 }

--- a/Tests/EdmundTests/DocumentHTMLTests.swift
+++ b/Tests/EdmundTests/DocumentHTMLTests.swift
@@ -80,16 +80,28 @@ struct DocumentHTMLTests {
 
     // MARK: Images
 
+    /// A tiny but fully valid, decodable PNG (a solid-color square) — real
+    /// image bytes are required now that `imageDataURI` decodes to catch
+    /// undecodable files (see `undecodableLocalImage`), not just the magic
+    /// header bytes this used to get away with.
+    private func validPNGData() -> Data {
+        let size = NSSize(width: 4, height: 4)
+        let img = NSImage(size: size)
+        img.lockFocus()
+        NSColor.systemBlue.setFill()
+        NSRect(origin: .zero, size: size).fill()
+        img.unlockFocus()
+        let rep = NSBitmapImageRep(data: img.tiffRepresentation!)!
+        return rep.representation(using: .png, properties: [:])!
+    }
+
     @Test("Local image is read and inlined as a data URI")
     func localImageInlined() throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("edmund-img-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
-        // The file's bytes are irrelevant to the inlining path; an 8-byte PNG
-        // signature is enough to exercise read + base64 + MIME-by-extension.
-        let png = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
-        try png.write(to: dir.appendingPathComponent("pic.png"))
+        try validPNGData().write(to: dir.appendingPathComponent("pic.png"))
 
         let out = DocumentHTML.full(markdown: "![cat](pic.png)", theme: .default,
                                     callouts: Callout.defaultStyles, dark: false,
@@ -99,11 +111,27 @@ struct DocumentHTMLTests {
         #expect(out.contains("alt=\"cat\""))
     }
 
-    @Test("Unresolvable local image falls back to alt only (no src)")
+    @Test("Unresolvable local image shows the blocked-image placeholder with 'Image not found'")
     func missingImage() {
         let out = doc("![gone](nope.png)")   // no baseURL → can't resolve
-        #expect(out.contains("<img class=\"md-image\" alt=\"gone\">"))
+        #expect(out.contains("md-image-blocked"))
+        #expect(out.contains("Image not found"))
         #expect(!out.contains("src="))
+    }
+
+    @Test("An existing-but-undecodable local file shows 'Not an image'")
+    func undecodableLocalImage() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("edmund-img-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try Data("not a png".utf8).write(to: dir.appendingPathComponent("bad.png"))
+
+        let out = DocumentHTML.full(markdown: "![bad](bad.png)", theme: .default,
+                                    callouts: Callout.defaultStyles, dark: false,
+                                    baseURL: dir)
+        #expect(out.contains("md-image-blocked"))
+        #expect(out.contains("Not an image"))
     }
 
     @Test("Remote image is suppressed by default, emitted when opted in")
@@ -111,7 +139,8 @@ struct DocumentHTMLTests {
         let md = "![r](https://example.com/x.png)"
         let off = DocumentHTML.full(markdown: md, theme: .default,
                                     callouts: Callout.defaultStyles, dark: false)
-        #expect(off.contains("<img class=\"md-image\" alt=\"r\">"))
+        #expect(off.contains("md-image-blocked"))
+        #expect(off.contains("External images blocked"))
         #expect(!off.contains("https://example.com/x.png"))
 
         let on = DocumentHTML.full(markdown: md, theme: .default,
@@ -129,7 +158,7 @@ struct DocumentHTMLTests {
                                         options: ReadRenderOptions(allowRemoteImages: allow))
             #expect(!out.contains("http://example.com/x.png"))
             #expect(out.contains("md-image-blocked"))
-            #expect(out.contains(">r<"))
+            #expect(out.contains("HTTP connection not supported"))
         }
     }
 }

--- a/Tests/EdmundTests/EditorRenderingTests.swift
+++ b/Tests/EdmundTests/EditorRenderingTests.swift
@@ -221,10 +221,15 @@ struct EditorStylingTests {
         #expect(isHidden(at: 0, in: styled))
     }
 
-    @Test("Image content has accent color and italic font")
+    @Test("Image content has accent color and italic font while its load is pending")
     @MainActor func imageStyling() {
+        // A resolvable-but-unresolved destination (a `.notFound`/`.notAnImage`/
+        // `.blockedBySetting` one) now gets a placeholder overlay instead — see
+        // ImageRenderingTests. Alt-text-as-link styling remains for the one
+        // case with nothing to show yet: a remote fetch still in flight.
         let editor = makeEditor()
-        let styled = editor.styleBlock("![photo](url)")
+        editor.allowRemoteImages = true
+        let styled = editor.styleBlock("![photo](https://example.invalid/\(UUID().uuidString).png)")
         // "photo" is at positions 2-6
         let color = styled.attribute(.foregroundColor, at: 2, effectiveRange: nil) as? NSColor
         #expect(color != nil)

--- a/Tests/EdmundTests/ImageRenderingTests.swift
+++ b/Tests/EdmundTests/ImageRenderingTests.swift
@@ -50,27 +50,60 @@ struct ImageRenderingTests {
         #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) == nil)
     }
 
-    @Test("Unloadable image falls back to alt text (no overlay)")
-    func fallbackNoOverlay() {
+    @Test("Missing local image shows a blocked-image placeholder overlay, not just alt text")
+    func fallbackShowsPlaceholder() {
         let editor = makeEditor()
         let styled = editor.styleBlock("![alt](/no/such/file.png)", cursorPosition: nil)
-        #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) == nil)
+        #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) != nil)
+        guard case .blocked(.notFound) = editor.imageDisplay(destination: "/no/such/file.png") else {
+            Issue.record("expected .blocked(.notFound)"); return
+        }
     }
 
-    @Test("Plain-http image never overlays, even with remote images allowed")
-    func httpImageNeverOverlays() {
+    @Test("A path that resolves but isn't image data is classified as 'not an image'")
+    func notAnImage() {
+        let editor = makeEditor()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("md-not-image-\(UUID().uuidString).png")
+        try! Data("not a png".utf8).write(to: url)
+        guard case .blocked(.notAnImage) = editor.imageDisplay(destination: url.path) else {
+            Issue.record("expected .blocked(.notAnImage)"); return
+        }
+    }
+
+    @Test("Plain-http image always shows the placeholder, even with remote images allowed")
+    func httpImageAlwaysBlocked() {
         let editor = makeEditor()
         editor.allowRemoteImages = true
         let styled = editor.styleBlock("![alt](http://example.com/x.png)", cursorPosition: nil)
-        #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) == nil)
+        #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) != nil)
+        guard case .blocked(.httpUnsupported) = editor.imageDisplay(destination: "http://example.com/x.png") else {
+            Issue.record("expected .blocked(.httpUnsupported)"); return
+        }
     }
 
-    @Test("Https image doesn't overlay while remote images are disallowed")
+    @Test("Https image shows the placeholder while remote images are disallowed")
     func httpsImageBlockedByDefault() {
         let editor = makeEditor()
         editor.allowRemoteImages = false
         let styled = editor.styleBlock("![alt](https://example.com/x.png)", cursorPosition: nil)
-        #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) == nil)
+        #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) != nil)
+        guard case .blocked(.blockedBySetting) = editor.imageDisplay(destination: "https://example.com/x.png") else {
+            Issue.record("expected .blocked(.blockedBySetting)"); return
+        }
+    }
+
+    @Test("Https image is pending (no placeholder yet) while the fetch is in flight")
+    func httpsImagePendingWhileFetching() {
+        let editor = makeEditor()
+        editor.allowRemoteImages = true
+        // `.invalid` is RFC 2606-reserved (never resolves) — the request
+        // fails async, off the assertion below; only the synchronous
+        // first-call return value (.pending, before any response) matters.
+        let dest = "https://example.invalid/pending-\(UUID().uuidString).png"
+        guard case .pending = editor.imageDisplay(destination: dest) else {
+            Issue.record("expected .pending"); return
+        }
     }
 
     @Test("Narrowing the max-content-width column shrinks an already-rendered image")

--- a/Tests/EdmundTests/ImageRenderingTests.swift
+++ b/Tests/EdmundTests/ImageRenderingTests.swift
@@ -57,6 +57,22 @@ struct ImageRenderingTests {
         #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) == nil)
     }
 
+    @Test("Plain-http image never overlays, even with remote images allowed")
+    func httpImageNeverOverlays() {
+        let editor = makeEditor()
+        editor.allowRemoteImages = true
+        let styled = editor.styleBlock("![alt](http://example.com/x.png)", cursorPosition: nil)
+        #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) == nil)
+    }
+
+    @Test("Https image doesn't overlay while remote images are disallowed")
+    func httpsImageBlockedByDefault() {
+        let editor = makeEditor()
+        editor.allowRemoteImages = false
+        let styled = editor.styleBlock("![alt](https://example.com/x.png)", cursorPosition: nil)
+        #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) == nil)
+    }
+
     @Test("Narrowing the max-content-width column shrinks an already-rendered image")
     func shrinksOnColumnNarrow() {
         let editor = EditorTextView.makeTextKit2(


### PR DESCRIPTION
## Summary
- Adds a "Block external images" checkbox in Settings > Advanced (Privacy & Security section), default on, wired into both Read mode and Edit mode's remote-image loading.
- Moves "Automatically check for updates" into General > Software updates (splitting it out of the old Advanced layout), per follow-up request.
- Edit mode's inline image preview now actually loads `https` images (async, off the main thread) when the setting is off, instead of always skipping remote images — this was previously hardcoded, disconnected from any setting.
- Any image that can't be shown (missing file, undecodable data, blocked/unsupported remote URL) now gets a visible icon + specific reason ("Image not found", "Not an image", "HTTP connection not supported", "External images blocked") instead of silently showing nothing — consistent between Edit mode and Read mode, sharing one `ImageLoadFailure` type.
- Along the way, fixed two real bugs found while wiring this up:
  - A missing local file and an undecodable one were both misclassified as "Not an image" (added an existence check).
  - `LucideIcons.image`'s tint used `sourceAtop` blending, which silently discarded a translucent tint color's own alpha (invisible until this work's `.secondaryLabelColor` icon exposed it) — switched to `sourceIn`.
  - Read mode's `imageDataURI` never actually decoded image bytes, so garbage data with an image extension would silently produce a broken `data:` URI — now decodes and reports "Not an image" when it fails.

## Test plan
- [x] `swift test` — 829/829 passing
- [x] Live-verified in a debug build: Settings toggle, Edit-mode placeholders (icon + reason, correct muted color), Read-mode HTML output (via targeted unit tests asserting exact reason strings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)