### PR TITLE
chore: strip personal home paths from skill libraries

### DIFF
--- a/.agents/skills/edmund-architecture-contract/SKILL.md
+++ b/.agents/skills/edmund-architecture-contract/SKILL.md
@@ -31,7 +31,7 @@ count. The hardest live problem class to date is **delete-drift**
 were delete-drift and undo/redo viewport drift. Every rule below traces to one
 of those scars.
 
-Ground truth this file distills: `/Users/inatang/Developer/Edmund/docs/ARCHITECTURE.md`.
+Ground truth this file distills: `docs/ARCHITECTURE.md` (repo root).
 Treat that doc as authoritative if the two ever disagree, and fix this skill.
 
 ## Glossary (each term defined once)

--- a/.agents/skills/edmund-build-and-env/SKILL.md
+++ b/.agents/skills/edmund-build-and-env/SKILL.md
@@ -16,7 +16,7 @@ description: >
 
 # Edmund — build & environment runbook
 
-All paths relative to the repo root: `/Users/inatang/Developer/Edmund`.
+All paths relative to the repo root.
 Facts date-stamped 2026-07-05 are volatile — re-verify per the last section.
 
 ## When NOT to use this skill

--- a/.claude/skills/edmund-architecture-contract/SKILL.md
+++ b/.claude/skills/edmund-architecture-contract/SKILL.md
@@ -31,7 +31,7 @@ count. The hardest live problem class to date is **delete-drift**
 were delete-drift and undo/redo viewport drift. Every rule below traces to one
 of those scars.
 
-Ground truth this file distills: `/Users/inatang/Developer/Edmund/docs/ARCHITECTURE.md`.
+Ground truth this file distills: `docs/ARCHITECTURE.md` (repo root).
 Treat that doc as authoritative if the two ever disagree, and fix this skill.
 
 ## Glossary (each term defined once)

--- a/.claude/skills/edmund-build-and-env/SKILL.md
+++ b/.claude/skills/edmund-build-and-env/SKILL.md
@@ -16,7 +16,7 @@ description: >
 
 # Edmund — build & environment runbook
 
-All paths relative to the repo root: `/Users/inatang/Developer/Edmund`.
+All paths relative to the repo root.
 Facts date-stamped 2026-07-05 are volatile — re-verify per the last section.
 
 ## When NOT to use this skill


### PR DESCRIPTION
Removes absolute home paths from the two skill libraries (`.claude/skills` and `.agents/skills`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)