### PR TITLE
Nested block quotes: stacked bars, Obsidian-style indent, text-hugging bar height

### DIFF
--- a/Sources/EdmundCore/Parsing/SyntaxHighlighter+Walker.swift
+++ b/Sources/EdmundCore/Parsing/SyntaxHighlighter+Walker.swift
@@ -207,44 +207,73 @@ extension SyntaxHighlighter {
         // MARK: - Block Quotes
 
         mutating func visitBlockQuote(_ blockQuote: BlockQuote) {
-            // A block quote nested inside a plain block quote is fully literal:
-            // emit no span and don't descend (matches showing `> [!note]` raw
-            // inside an outer quote).
-            if plainQuoteDepth > 0 { return }
             guard let range = blockQuote.range else {
                 descendInto(blockQuote)
                 return
             }
             let full = nsRange(for: range)
             let nsSource = source as NSString
+            let opensCallout = Self.quoteOpensCallout(firstLineOf: full, in: nsSource)
 
-            // Scan each line within the blockquote for "> " prefixes
+            // A callout nested inside a plain quote is fully literal: emit no
+            // span and don't descend (matches showing `> [!note]` raw inside an
+            // outer quote — callouts render via their own recursive splice,
+            // which isn't set up to stack with an enclosing quote's bar). A
+            // nested *plain* quote is the one exception to "nested blocks stay
+            // literal": it gets its own span (below) so its marker hides and it
+            // draws its own bar, stacked with its ancestors'.
+            if plainQuoteDepth > 0 && opensCallout { return }
+
+            // `plainQuoteDepth` doubles as this quote's nesting depth (0 =
+            // outermost) — captured before incrementing for our own descent.
+            let depth = plainQuoteDepth
+
+            // Scan each line within the blockquote for its OWN "> " marker.
+            // swift-markdown's nested-BlockQuote `range` only skips ancestor
+            // markers on the *first* line (its start position lands right on
+            // this quote's own `>`) — every subsequent line is the raw source
+            // verbatim, ancestor markers and all. So each later line must peel
+            // exactly `depth` ancestor markers before this quote's own can be
+            // at hand. A line that runs out of markers partway through that
+            // peel is CommonMark "lazy continuation" (e.g. a bare `>` line
+            // right after a `> >` one, absorbed by swift-markdown as a
+            // continuation of the deepest active quote's paragraph) — it
+            // belongs to a shallower ancestor's span instead. Bail out of the
+            // scan there, clipping `fullRange` before that line.
             var delims: [NSRange] = []
             var cursor = full.location
-            while cursor < full.upperBound {
-                // Find the end of this line
-                let remaining = NSRange(location: cursor, length: full.upperBound - cursor)
+            var clippedEnd = full.upperBound
+            var isFirstLine = true
+            while cursor < clippedEnd {
+                let remaining = NSRange(location: cursor, length: clippedEnd - cursor)
                 let nlRange = nsSource.range(of: "\n", options: [], range: remaining)
-                let lineEnd = nlRange.location != NSNotFound ? nlRange.location : full.upperBound
+                let lineEnd = nlRange.location != NSNotFound ? nlRange.location : clippedEnd
 
-                // Check if line starts with optional spaces then ">"
-                let lineRange = NSRange(location: cursor, length: lineEnd - cursor)
-                let line = nsSource.substring(with: lineRange)
-                let stripped = line.drop(while: { $0 == " " })
-                if stripped.first == ">" {
-                    let prefixLen = line.count - stripped.count + 1  // spaces + ">"
-                    let delimLen = prefixLen + (stripped.dropFirst().first == " " ? 1 : 0)  // include trailing space
-                    delims.append(NSRange(location: cursor, length: delimLen))
+                var p = cursor
+                var ranOut = false
+                for _ in 0..<(isFirstLine ? 0 : depth) {
+                    guard let after = Self.peelOneMarker(nsSource, from: p, lineEnd: lineEnd) else {
+                        ranOut = true
+                        break
+                    }
+                    p = after
                 }
+                guard !ranOut, let markerEnd = Self.peelOneMarker(nsSource, from: p, lineEnd: lineEnd) else {
+                    clippedEnd = cursor
+                    break
+                }
+                delims.append(NSRange(location: p, length: markerEnd - p))
 
-                cursor = nlRange.location != NSNotFound ? nlRange.location + 1 : full.upperBound
+                cursor = nlRange.location != NSNotFound ? nlRange.location + 1 : clippedEnd
+                isFirstLine = false
             }
 
-            let content = contentRange(full: full, delims: delims)
+            let clippedFull = NSRange(location: full.location, length: clippedEnd - full.location)
+            let content = contentRange(full: clippedFull, delims: delims)
 
             spans.append(Span(
-                kind: .blockquote,
-                fullRange: full,
+                kind: .blockquote(depth: depth),
+                fullRange: clippedFull,
                 contentRange: content,
                 delimiterRanges: delims
             ))
@@ -252,12 +281,28 @@ extension SyntaxHighlighter {
             // A callout's body is rendered recursively by the styling layer
             // (which strips the `>` prefixes and re-parses), so don't descend —
             // doing so would emit nested spans over `>`-prefixed source ranges.
-            // A plain quote descends, but with a depth guard so only its inline
-            // content renders (nested blocks stay literal).
-            if Self.quoteOpensCallout(firstLineOf: full, in: nsSource) { return }
+            // A plain quote descends, but with a depth guard so only inline
+            // content and further nested plain quotes render (other nested
+            // blocks stay literal).
+            if opensCallout { return }
             plainQuoteDepth += 1
             descendInto(blockQuote)
             plainQuoteDepth -= 1
+        }
+
+        /// Peels one `>` marker (optional leading spaces, `>`, optional single
+        /// trailing space) starting at `from`, returning the position right
+        /// after it — or `nil` if `[from, lineEnd)` doesn't start with `>`
+        /// (after skipping spaces). Used both to skip `depth` ancestor
+        /// markers and to locate this quote's own marker on a line (see
+        /// `visitBlockQuote`).
+        private static func peelOneMarker(_ source: NSString, from: Int, lineEnd: Int) -> Int? {
+            var q = from
+            while q < lineEnd, source.character(at: q) == 0x20 { q += 1 }
+            guard q < lineEnd, source.character(at: q) == 0x3E else { return nil }
+            q += 1
+            if q < lineEnd, source.character(at: q) == 0x20 { q += 1 }
+            return q
         }
 
         /// Whether the first line of a block quote (its source `range`) opens a

--- a/Sources/EdmundCore/Parsing/SyntaxHighlighter.swift
+++ b/Sources/EdmundCore/Parsing/SyntaxHighlighter.swift
@@ -40,7 +40,10 @@ public enum SyntaxHighlighter {
             case heading(Int)
             case link(destination: String)
             case image(destination: String)
-            case blockquote
+            /// `depth` is the nesting level (0 = outermost, not itself inside
+            /// another plain quote). A `> > text` emits two spans, depth 0 and
+            /// depth 1, so each level's own marker hides and draws its own bar.
+            case blockquote(depth: Int)
             case listItem(ordered: Bool, checkbox: CheckboxState? = nil)
             case table
             case thematicBreak
@@ -142,13 +145,13 @@ public enum SyntaxHighlighter {
         // would double-style the body. Plain block quotes are unaffected: their
         // inline spans are intentionally kept.
         let calloutRanges: [NSRange] = walker.spans.compactMap { span in
-            guard case .blockquote = span.kind,
+            guard case .blockquote(_) = span.kind,
                   isCalloutFirstLine(of: span.fullRange, in: text) else { return nil }
             return span.fullRange
         }
         if !calloutRanges.isEmpty {
             walker.spans.removeAll { span in
-                if case .blockquote = span.kind { return false }
+                if case .blockquote(_) = span.kind { return false }
                 return calloutRanges.contains {
                     $0.location <= span.fullRange.location && $0.upperBound >= span.fullRange.upperBound
                 }

--- a/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
@@ -113,6 +113,15 @@ extension EditorTextView {
         return ps
     }
 
+    /// A `.leftBar` decoration pushed `step` further left — used when a nested
+    /// quote's own bar is stacked outside an ancestor quote's bar (which was
+    /// drawn first, at whatever inset was correct *before* this deeper level
+    /// existed). Other decoration kinds pass through unchanged.
+    private func bumpedBar(_ deco: BlockDecoration, by step: CGFloat) -> BlockDecoration {
+        guard case .leftBar = deco.kind else { return deco }
+        return BlockDecoration(deco.kind, inset: deco.inset + step)
+    }
+
     // MARK: - Delimiter Hiding Classification
 
     /// Returns true if this span kind's delimiters should be hidden (not just
@@ -121,7 +130,7 @@ extension EditorTextView {
         switch kind {
         case .bold, .italic, .boldItalic, .strikethrough, .highlight,
              .code, .link, .image, .lineBreak,
-             .heading, .blockquote, .footnoteReference, .escape:
+             .heading, .blockquote(_), .footnoteReference, .escape:
             return true
         case .listItem, .table, .codeBlock, .thematicBreak, .footnoteDefinition, .comment,
              .htmlTag, .htmlFormat:
@@ -249,26 +258,67 @@ extension EditorTextView {
                     result.addAttribute(.font, value: italic, range: span.contentRange)
                 }
 
-            case .blockquote:
+            case .blockquote(let depth):
                 guard span.fullRange.upperBound <= result.length else { continue }
                 // A block quote whose first line is `[!type]` is a callout
                 // (GitHub-flavored) — render it with an icon, colored label, and
-                // colored bar instead of the plain quote styling.
+                // colored bar instead of the plain quote styling. Only depth 0
+                // ever detects as a callout: a callout nested inside a plain
+                // quote stays literal (see SyntaxHighlighter+Walker's
+                // visitBlockQuote), so no deeper span is ever callout-shaped.
                 if let callout = calloutInfo(forBlockquote: span, markdown: markdown), !cursorInToken {
                     styleCalloutContent(result, span: span, info: callout)
                 } else {
-                    // Plain block quote — also the editing form of a callout: when
-                    // the cursor is inside a callout we fall through here so its raw
-                    // `>` / `[!type]` source shows (dimmed) and the markers can be
-                    // edited, instead of the box/header/nested chrome.
-                    // Attributes must cover fullRange so the first character of each
-                    // paragraph (the `> ` delimiter) carries the style/decoration —
-                    // the fragment vendor reads the paragraph's first character.
-                    result.addAttribute(.paragraphStyle, value: blockquoteParagraphStyle(), range: span.fullRange)
-                    result.addAttribute(.blockDecoration,
-                                        value: BlockDecoration(.leftBar(color: .tertiaryLabelColor, width: 2)),
-                                        range: span.fullRange)
-                    result.addAttribute(.foregroundColor, value: NSColor.secondaryLabelColor, range: span.contentRange)
+                    // Plain block quote (any nesting depth). Indent and draw
+                    // this level's own bar regardless of active/inactive — the
+                    // generic delimiter pass (elsewhere in this function)
+                    // separately decides whether this level's own `>` marker
+                    // is hidden (inactive) or shown dimmed (active/editing).
+                    //
+                    // A nested quote's span range is a *subset* of its
+                    // ancestors' (processed earlier, in outer-to-inner order:
+                    // the walker emits a parent before descending to its
+                    // children), so stacking here only has to bump whatever
+                    // decoration the ancestor already painted over this same
+                    // range — by construction that decoration only covers
+                    // lines that actually nest this deep.
+                    let step = 2 + quoteMarkerWidth
+                    let ps = blockquoteParagraphStyle().mutableCopy() as! NSMutableParagraphStyle
+                    ps.firstLineHeadIndent += CGFloat(depth) * step
+                    ps.headIndent += CGFloat(depth) * step
+                    result.addAttribute(.paragraphStyle, value: ps, range: span.fullRange)
+
+                    let ownBar = BlockDecoration(.leftBar(color: .tertiaryLabelColor, width: 2))
+                    if depth == 0 {
+                        result.addAttribute(.blockDecoration, value: ownBar, range: span.fullRange)
+                    } else {
+                        let ancestor = result.attribute(.blockDecoration, at: span.fullRange.location,
+                                                        effectiveRange: nil)
+                        let bumped: [BlockDecoration]
+                        if let list = ancestor as? BlockDecorationList {
+                            bumped = list.decorations.map { bumpedBar($0, by: step) }
+                        } else if let single = ancestor as? BlockDecoration {
+                            bumped = [bumpedBar(single, by: step)]
+                        } else {
+                            bumped = []
+                        }
+                        result.addAttribute(.blockDecoration,
+                                            value: BlockDecorationList(bumped + [ownBar]),
+                                            range: span.fullRange)
+                    }
+
+                    // Only the outermost span fills content color: `contentRange`
+                    // only trims a span's very first/last delimiter, not ones in
+                    // the middle (a nested quote's own markers on later lines) —
+                    // a nested span's fill would repaint an ancestor's marker
+                    // right back to visible, undoing that ancestor's delimiter
+                    // pass (which already ran, earlier in this same loop). The
+                    // outermost span's fill already covers all nested text, so
+                    // deeper spans don't need to (re-)apply it.
+                    if depth == 0 {
+                        result.addAttribute(.foregroundColor, value: NSColor.secondaryLabelColor,
+                                            range: span.contentRange)
+                    }
                 }
 
             case .listItem(let ordered, let checkbox):
@@ -487,7 +537,7 @@ extension EditorTextView {
                 } else if cursorInToken || !isDelimiterHideable(span.kind) {
                     // Visible: dim the delimiters
                     result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
-                } else if case .blockquote = span.kind {
+                } else if case .blockquote(_) = span.kind {
                     // Blockquote: invisible but preserve width for indentation
                     result.addAttribute(.foregroundColor, value: NSColor.clear, range: dr)
                 } else {

--- a/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
@@ -119,7 +119,8 @@ extension EditorTextView {
     /// existed). Other decoration kinds pass through unchanged.
     private func bumpedBar(_ deco: BlockDecoration, by step: CGFloat) -> BlockDecoration {
         guard case .leftBar = deco.kind else { return deco }
-        return BlockDecoration(deco.kind, inset: deco.inset + step)
+        return BlockDecoration(deco.kind, inset: deco.inset + step,
+                               hugsTextTop: deco.hugsTextTop)
     }
 
     // MARK: - Delimiter Hiding Classification
@@ -283,28 +284,54 @@ extension EditorTextView {
                     // range — by construction that decoration only covers
                     // lines that actually nest this deep.
                     let step = 2 + quoteMarkerWidth
+                    // The fragment vendor reads paragraph-level attributes at
+                    // paragraph offset 0, but a nested span's range starts at
+                    // its *own* `>` — past the ancestors' markers on its first
+                    // line. Extend back to the line start so the line's
+                    // paragraph carries this level's decoration/indent (else
+                    // the line draws only the ancestor's single bar).
+                    let lineStart = (markdown as NSString)
+                        .lineRange(for: NSRange(location: span.fullRange.location, length: 0)).location
+                    let paraRange = NSRange(location: lineStart,
+                                            length: span.fullRange.upperBound - lineStart)
                     let ps = blockquoteParagraphStyle().mutableCopy() as! NSMutableParagraphStyle
                     ps.firstLineHeadIndent += CGFloat(depth) * step
                     ps.headIndent += CGFloat(depth) * step
-                    result.addAttribute(.paragraphStyle, value: ps, range: span.fullRange)
+                    result.addAttribute(.paragraphStyle, value: ps, range: paraRange)
 
-                    let ownBar = BlockDecoration(.leftBar(color: .tertiaryLabelColor, width: 2))
-                    if depth == 0 {
-                        result.addAttribute(.blockDecoration, value: ownBar, range: span.fullRange)
-                    } else {
-                        let ancestor = result.attribute(.blockDecoration, at: span.fullRange.location,
-                                                        effectiveRange: nil)
-                        let bumped: [BlockDecoration]
-                        if let list = ancestor as? BlockDecorationList {
-                            bumped = list.decorations.map { bumpedBar($0, by: step) }
-                        } else if let single = ancestor as? BlockDecoration {
-                            bumped = [bumpedBar(single, by: step)]
+                    // The quote's own bar hugs the text top on its *first* line
+                    // only (see BlockDecoration.hugsTextTop) — interior lines
+                    // fill their whole fragment so the bar tiles gap-free. The
+                    // ancestor stack is read per sub-range: an ancestor's own
+                    // first line (hugging) can coincide with this span's first
+                    // line, but its interior lines never hug.
+                    let firstLineEnd = min((markdown as NSString)
+                        .lineRange(for: NSRange(location: lineStart, length: 0)).upperBound,
+                        paraRange.upperBound)
+                    let firstRange = NSRange(location: lineStart, length: firstLineEnd - lineStart)
+                    let restRange = NSRange(location: firstLineEnd,
+                                            length: paraRange.upperBound - firstLineEnd)
+                    for (range, hugs) in [(firstRange, true), (restRange, false)] {
+                        guard range.length > 0 else { continue }
+                        let ownBar = BlockDecoration(.leftBar(color: .tertiaryLabelColor, width: 2),
+                                                     hugsTextTop: hugs)
+                        if depth == 0 {
+                            result.addAttribute(.blockDecoration, value: ownBar, range: range)
                         } else {
-                            bumped = []
+                            let ancestor = result.attribute(.blockDecoration, at: range.location,
+                                                            effectiveRange: nil)
+                            let bumped: [BlockDecoration]
+                            if let list = ancestor as? BlockDecorationList {
+                                bumped = list.decorations.map { bumpedBar($0, by: step) }
+                            } else if let single = ancestor as? BlockDecoration {
+                                bumped = [bumpedBar(single, by: step)]
+                            } else {
+                                bumped = []
+                            }
+                            result.addAttribute(.blockDecoration,
+                                                value: BlockDecorationList(bumped + [ownBar]),
+                                                range: range)
                         }
-                        result.addAttribute(.blockDecoration,
-                                            value: BlockDecorationList(bumped + [ownBar]),
-                                            range: span.fullRange)
                     }
 
                     // Only the outermost span fills content color: `contentRange`

--- a/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
@@ -113,16 +113,6 @@ extension EditorTextView {
         return ps
     }
 
-    /// A `.leftBar` decoration pushed `step` further left — used when a nested
-    /// quote's own bar is stacked outside an ancestor quote's bar (which was
-    /// drawn first, at whatever inset was correct *before* this deeper level
-    /// existed). Other decoration kinds pass through unchanged.
-    private func bumpedBar(_ deco: BlockDecoration, by step: CGFloat) -> BlockDecoration {
-        guard case .leftBar = deco.kind else { return deco }
-        return BlockDecoration(deco.kind, inset: deco.inset + step,
-                               hugsTextTop: deco.hugsTextTop)
-    }
-
     // MARK: - Delimiter Hiding Classification
 
     /// Returns true if this span kind's delimiters should be hidden (not just
@@ -276,14 +266,20 @@ extension EditorTextView {
                     // separately decides whether this level's own `>` marker
                     // is hidden (inactive) or shown dimmed (active/editing).
                     //
+                    // Per-level indentation comes from the width-preserved
+                    // hidden `> ` markers alone (one more per level), so the
+                    // first-line indent stays constant — adding a paragraph
+                    // indent per depth too would double the step. Only the
+                    // hanging indent grows, to keep wrapped lines clear of
+                    // all this line's markers.
+                    //
                     // A nested quote's span range is a *subset* of its
                     // ancestors' (processed earlier, in outer-to-inner order:
                     // the walker emits a parent before descending to its
-                    // children), so stacking here only has to bump whatever
+                    // children), so stacking here only has to keep whatever
                     // decoration the ancestor already painted over this same
-                    // range — by construction that decoration only covers
-                    // lines that actually nest this deep.
-                    let step = 2 + quoteMarkerWidth
+                    // range and append this level's own bar — bar x positions
+                    // are absolute per level, independent of the line.
                     // The fragment vendor reads paragraph-level attributes at
                     // paragraph offset 0, but a nested span's range starts at
                     // its *own* `>` — past the ancestors' markers on its first
@@ -295,8 +291,7 @@ extension EditorTextView {
                     let paraRange = NSRange(location: lineStart,
                                             length: span.fullRange.upperBound - lineStart)
                     let ps = blockquoteParagraphStyle().mutableCopy() as! NSMutableParagraphStyle
-                    ps.firstLineHeadIndent += CGFloat(depth) * step
-                    ps.headIndent += CGFloat(depth) * step
+                    ps.headIndent += CGFloat(depth) * quoteMarkerWidth
                     result.addAttribute(.paragraphStyle, value: ps, range: paraRange)
 
                     // The quote's own bar hugs the text top on its *first* line
@@ -314,22 +309,23 @@ extension EditorTextView {
                     for (range, hugs) in [(firstRange, true), (restRange, false)] {
                         guard range.length > 0 else { continue }
                         let ownBar = BlockDecoration(.leftBar(color: .tertiaryLabelColor, width: 2),
+                                                     inset: CGFloat(depth) * quoteMarkerWidth,
                                                      hugsTextTop: hugs)
                         if depth == 0 {
                             result.addAttribute(.blockDecoration, value: ownBar, range: range)
                         } else {
                             let ancestor = result.attribute(.blockDecoration, at: range.location,
                                                             effectiveRange: nil)
-                            let bumped: [BlockDecoration]
+                            let kept: [BlockDecoration]
                             if let list = ancestor as? BlockDecorationList {
-                                bumped = list.decorations.map { bumpedBar($0, by: step) }
+                                kept = list.decorations
                             } else if let single = ancestor as? BlockDecoration {
-                                bumped = [bumpedBar(single, by: step)]
+                                kept = [single]
                             } else {
-                                bumped = []
+                                kept = []
                             }
                             result.addAttribute(.blockDecoration,
-                                                value: BlockDecorationList(bumped + [ownBar]),
+                                                value: BlockDecorationList(kept + [ownBar]),
                                                 range: range)
                         }
                     }

--- a/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
@@ -70,15 +70,24 @@ public final class BlockDecoration: NSObject, @unchecked Sendable {
     /// another quote's bar (e.g. `> > text`) draws further from the text,
     /// outermost quote's bar leftmost. Ignored by other kinds.
     public let inset: CGFloat
+    /// For `.leftBar`: start the bar at the first line's glyph top (baseline
+    /// minus ascender) instead of the fragment top. The line box carries its
+    /// extra spacing (lineSpacing) *above* the glyphs, so a bar over the full
+    /// fragment pokes past the text. Set only on a quote run's first line —
+    /// interior lines must fill the whole fragment so consecutive lines' bars
+    /// tile without gaps. Ignored by other kinds.
+    public let hugsTextTop: Bool
 
-    public init(_ kind: Kind, inset: CGFloat = 0) {
+    public init(_ kind: Kind, inset: CGFloat = 0, hugsTextTop: Bool = false) {
         self.kind = kind
         self.inset = inset
+        self.hugsTextTop = hugsTextTop
     }
 
     public override func isEqual(_ object: Any?) -> Bool {
         guard let other = object as? BlockDecoration else { return false }
         return kind == other.kind && inset == other.inset
+            && hugsTextTop == other.hugsTextTop
     }
 
     public override var hash: Int {
@@ -323,6 +332,18 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
                       height: overlay.bounds.height)
     }
 
+    /// Fragment-local y of the first line's glyph top (baseline minus the
+    /// line's font ascender). The line box can hold extra space above the
+    /// glyphs (lineSpacing lands there), which a text-hugging bar skips.
+    private var firstLineGlyphTop: CGFloat? {
+        guard let line = textLineFragments.first,
+              line.characterRange.length > 0,
+              let font = line.attributedString.attribute(
+                  .font, at: line.characterRange.location, effectiveRange: nil) as? NSFont
+        else { return nil }
+        return line.typographicBounds.minY + line.glyphOrigin.y - font.ascender
+    }
+
     private func drawDecoration(_ decoration: BlockDecoration, at point: CGPoint,
                                 in context: CGContext, bottomInset: CGFloat = 0) {
         let frame = layoutFragmentFrame
@@ -370,9 +391,15 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
             // The bar sits immediately left of the text (the paragraph style
             // insets the text by the bar's width) — or `inset` further left,
             // for a quote nested inside another quote's bar.
+            var barTop = point.y
+            var barHeight = fillHeight
+            if decoration.hugsTextTop, let glyphTop = firstLineGlyphTop {
+                barTop += glyphTop
+                barHeight -= glyphTop
+            }
             context.setFillColor(color.cgColor)
-            context.fill(CGRect(x: point.x - width - decoration.inset, y: point.y,
-                                width: width, height: fillHeight))
+            context.fill(CGRect(x: point.x - width - decoration.inset, y: barTop,
+                                width: width, height: barHeight))
 
         case .tableRow(let xOffsets, let width, let leftInset, let separator):
             // Offsets are text-relative; the fragment's origin is the text start.

--- a/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
@@ -66,9 +66,13 @@ public final class BlockDecoration: NSObject, @unchecked Sendable {
     /// For `.box`: horizontal inset (points) from the text column's left and
     /// right edges, non-zero for a box nested inside another box (e.g. a
     /// callout inside a callout), so the inner box sits within the outer one.
-    /// For `.leftBar`: extra leftward shift (points) so a bar nested inside
-    /// another quote's bar (e.g. `> > text`) draws further from the text,
-    /// outermost quote's bar leftmost. Ignored by other kinds.
+    /// For `.leftBar`: rightward shift (points) from the outermost bar
+    /// position — one `quoteMarkerWidth` per nesting level, mirroring the
+    /// hidden `> ` marker that indents the text, so each nested quote's bar
+    /// (e.g. `> > text`) sits just left of its own level's text. Absolute per
+    /// level: the same level's bar lands at the same x on every line, which
+    /// keeps stacked bars tiling into continuous columns. Ignored by other
+    /// kinds.
     public let inset: CGFloat
     /// For `.leftBar`: start the bar at the first line's glyph top (baseline
     /// minus ascender) instead of the fragment top. The line box carries its
@@ -389,8 +393,8 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
 
         case .leftBar(let color, let width):
             // The bar sits immediately left of the text (the paragraph style
-            // insets the text by the bar's width) — or `inset` further left,
-            // for a quote nested inside another quote's bar.
+            // insets the text by the bar's width) — or `inset` further right,
+            // for a nested quote's bar next to its own level's text.
             var barTop = point.y
             var barHeight = fillHeight
             if decoration.hugsTextTop, let glyphTop = firstLineGlyphTop {
@@ -398,7 +402,7 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
                 barHeight -= glyphTop
             }
             context.setFillColor(color.cgColor)
-            context.fill(CGRect(x: point.x - width - decoration.inset, y: barTop,
+            context.fill(CGRect(x: point.x - width + decoration.inset, y: barTop,
                                 width: width, height: barHeight))
 
         case .tableRow(let xOffsets, let width, let leftInset, let separator):

--- a/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
@@ -63,11 +63,12 @@ public final class BlockDecoration: NSObject, @unchecked Sendable {
     }
 
     public let kind: Kind
-    /// Horizontal inset (points) from the text column's left and right edges at
-    /// which a `.box` is drawn. Non-zero for boxes nested inside another box
-    /// (e.g. a callout inside a callout), so the inner box sits within the outer
-    /// one. Ignored by `.leftBar` (which draws relative to the indented text
-    /// origin and so already follows nesting) and the other kinds.
+    /// For `.box`: horizontal inset (points) from the text column's left and
+    /// right edges, non-zero for a box nested inside another box (e.g. a
+    /// callout inside a callout), so the inner box sits within the outer one.
+    /// For `.leftBar`: extra leftward shift (points) so a bar nested inside
+    /// another quote's bar (e.g. `> > text`) draws further from the text,
+    /// outermost quote's bar leftmost. Ignored by other kinds.
     public let inset: CGFloat
 
     public init(_ kind: Kind, inset: CGFloat = 0) {
@@ -367,9 +368,10 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
 
         case .leftBar(let color, let width):
             // The bar sits immediately left of the text (the paragraph style
-            // insets the text by the bar's width).
+            // insets the text by the bar's width) — or `inset` further left,
+            // for a quote nested inside another quote's bar.
             context.setFillColor(color.cgColor)
-            context.fill(CGRect(x: point.x - width, y: point.y,
+            context.fill(CGRect(x: point.x - width - decoration.inset, y: point.y,
                                 width: width, height: fillHeight))
 
         case .tableRow(let xOffsets, let width, let leftInset, let separator):

--- a/Tests/EdmundTests/BlockquoteRenderingTests.swift
+++ b/Tests/EdmundTests/BlockquoteRenderingTests.swift
@@ -45,6 +45,18 @@ struct BlockquoteNestingTests {
         #expect(insets == [0])
     }
 
+    @Test("Bar hugs the text top on the first line only; interior lines tile full-height")
+    func firstLineHugsTextTop() {
+        let editor = makeEditor()
+        let md = "> first\n> second"
+        let s = editor.styleBlock(md)
+        let first = s.attribute(.blockDecoration, at: 0, effectiveRange: nil) as? BlockDecoration
+        #expect(first?.hugsTextTop == true)
+        let secondLoc = (md as NSString).range(of: "> second").location
+        let second = s.attribute(.blockDecoration, at: secondLoc, effectiveRange: nil) as? BlockDecoration
+        #expect(second?.hugsTextTop == false)
+    }
+
     @Test("A nested quote (> >) hides both markers and stacks two bars, outer leftmost")
     func nestedOnce() {
         let editor = makeEditor()
@@ -56,12 +68,18 @@ struct BlockquoteNestingTests {
         // Inner marker (the second '>' on line 2) hidden too.
         let innerMarker = ns.range(of: "> inner").location
         #expect(isMarkerHidden(at: innerMarker, in: s))
-        // Inner text carries two stacked bars: outer bumped out, inner at 0.
-        let innerTextLoc = ns.range(of: "inner").location
-        let insets = barInsets(decorationList(at: innerTextLoc, in: s))
-        #expect(insets.count == 2)
-        #expect(insets.contains(0))
-        #expect(insets.max() ?? 0 > 0)
+        // The nested line carries two stacked bars (outer bumped out, inner at
+        // 0) — and crucially at the *line start*, not just at the nested
+        // span's own start: the layout-fragment vendor reads `.blockDecoration`
+        // at paragraph offset 0, so a decoration starting at the inner `>`
+        // (col 2) would never draw (the missing-nested-bar bug).
+        let lineStart = ns.range(of: "> > inner").location
+        for loc in [lineStart, ns.range(of: "inner").location] {
+            let insets = barInsets(decorationList(at: loc, in: s))
+            #expect(insets.count == 2)
+            #expect(insets.contains(0))
+            #expect(insets.max() ?? 0 > 0)
+        }
     }
 
     @Test("Triple nesting stacks three bars in order; dropping back to level 1 leaves one")
@@ -71,14 +89,21 @@ struct BlockquoteNestingTests {
         let s = editor.styleBlock(md)
         let ns = md as NSString
 
-        let l3Loc = ns.range(of: "level three").location
-        let l3Insets = barInsets(decorationList(at: l3Loc, in: s))
-        #expect(l3Insets.count == 3)
-        // Sorted ascending: deepest (0) ... outermost (largest).
-        let sorted = l3Insets.sorted()
-        #expect(sorted[0] == 0)
-        #expect(sorted[1] > sorted[0])
-        #expect(sorted[2] > sorted[1])
+        // Three bars both at the line start (what the fragment vendor reads)
+        // and at the text itself. The depth-2 line's *paragraph* must carry
+        // all three even though the depth-2 span starts at col 4.
+        let l2LineStart = ns.range(of: "> > level two").location
+        #expect(barInsets(decorationList(at: l2LineStart, in: s)).count == 2)
+        let l3LineStart = ns.range(of: "> > > level three").location
+        for loc in [l3LineStart, ns.range(of: "level three").location] {
+            let l3Insets = barInsets(decorationList(at: loc, in: s))
+            #expect(l3Insets.count == 3)
+            // Sorted ascending: deepest (0) ... outermost (largest).
+            let sorted = l3Insets.sorted()
+            #expect(sorted[0] == 0)
+            #expect(sorted[1] > sorted[0])
+            #expect(sorted[2] > sorted[1])
+        }
 
         // "back to one" is only nested one level deep — a single bar at inset 0.
         let backLoc = ns.range(of: "back to one").location

--- a/Tests/EdmundTests/BlockquoteRenderingTests.swift
+++ b/Tests/EdmundTests/BlockquoteRenderingTests.swift
@@ -68,8 +68,8 @@ struct BlockquoteNestingTests {
         // Inner marker (the second '>' on line 2) hidden too.
         let innerMarker = ns.range(of: "> inner").location
         #expect(isMarkerHidden(at: innerMarker, in: s))
-        // The nested line carries two stacked bars (outer bumped out, inner at
-        // 0) — and crucially at the *line start*, not just at the nested
+        // The nested line carries two stacked bars (outer at 0, inner shifted
+        // right) — and crucially at the *line start*, not just at the nested
         // span's own start: the layout-fragment vendor reads `.blockDecoration`
         // at paragraph offset 0, so a decoration starting at the inner `>`
         // (col 2) would never draw (the missing-nested-bar bug).
@@ -98,7 +98,8 @@ struct BlockquoteNestingTests {
         for loc in [l3LineStart, ns.range(of: "level three").location] {
             let l3Insets = barInsets(decorationList(at: loc, in: s))
             #expect(l3Insets.count == 3)
-            // Sorted ascending: deepest (0) ... outermost (largest).
+            // Sorted ascending: outermost (0, leftmost) ... deepest (largest,
+            // next to its own text).
             let sorted = l3Insets.sorted()
             #expect(sorted[0] == 0)
             #expect(sorted[1] > sorted[0])

--- a/Tests/EdmundTests/BlockquoteRenderingTests.swift
+++ b/Tests/EdmundTests/BlockquoteRenderingTests.swift
@@ -1,0 +1,116 @@
+import Testing
+import AppKit
+@testable import EdmundCore
+
+// Nested plain block quotes: each `>` level gets its own span (depth-tagged),
+// its own hidden marker, and its own left bar stacked with its ancestors' —
+// outermost bar leftmost, deepest adjacent to the text. Other nested block
+// constructs stay literal (covered by NestedBlockStylingTests).
+
+private func decorationList(at offset: Int, in s: NSAttributedString) -> BlockDecorationList? {
+    guard offset < s.length else { return nil }
+    return s.attribute(.blockDecoration, at: offset, effectiveRange: nil) as? BlockDecorationList
+}
+
+private func barInsets(_ deco: Any?) -> [CGFloat] {
+    func inset(_ d: BlockDecoration) -> CGFloat? {
+        guard case .leftBar = d.kind else { return nil }
+        return d.inset
+    }
+    if let list = deco as? BlockDecorationList { return list.decorations.compactMap(inset) }
+    if let single = deco as? BlockDecoration { return inset(single).map { [$0] } ?? [] }
+    return []
+}
+
+/// A blockquote `>` marker hides by going clear-colored at *normal* font size
+/// (not the near-zero `hiddenFont` other delimiters use) — its glyph advance
+/// is what makes a wrapping line's continuation land under the hanging
+/// indent. `isHidden` (TestHelpers) checks for the `hiddenFont` case and so
+/// doesn't apply here; this checks only the color.
+private func isMarkerHidden(at offset: Int, in s: NSAttributedString) -> Bool {
+    guard offset < s.length else { return false }
+    return (s.attribute(.foregroundColor, at: offset, effectiveRange: nil) as? NSColor) == .clear
+}
+
+@Suite("Blockquote rendering — nesting")
+@MainActor
+struct BlockquoteNestingTests {
+
+    @Test("A single-level quote renders one bar, marker hidden")
+    func singleLevel() {
+        let editor = makeEditor()
+        let s = editor.styleBlock("> hello")
+        #expect(isMarkerHidden(at: 0, in: s))
+        let insets = barInsets(s.attribute(.blockDecoration, at: 2, effectiveRange: nil))
+        #expect(insets == [0])
+    }
+
+    @Test("A nested quote (> >) hides both markers and stacks two bars, outer leftmost")
+    func nestedOnce() {
+        let editor = makeEditor()
+        let md = "> outer\n> > inner"
+        let s = editor.styleBlock(md)
+        let ns = md as NSString
+        // Outer marker (position 0) hidden.
+        #expect(isMarkerHidden(at: 0, in: s))
+        // Inner marker (the second '>' on line 2) hidden too.
+        let innerMarker = ns.range(of: "> inner").location
+        #expect(isMarkerHidden(at: innerMarker, in: s))
+        // Inner text carries two stacked bars: outer bumped out, inner at 0.
+        let innerTextLoc = ns.range(of: "inner").location
+        let insets = barInsets(decorationList(at: innerTextLoc, in: s))
+        #expect(insets.count == 2)
+        #expect(insets.contains(0))
+        #expect(insets.max() ?? 0 > 0)
+    }
+
+    @Test("Triple nesting stacks three bars in order; dropping back to level 1 leaves one")
+    func tripleNestingAndDropBack() {
+        let editor = makeEditor()
+        let md = "> level one\n> > level two\n> > > level three\n> back to one"
+        let s = editor.styleBlock(md)
+        let ns = md as NSString
+
+        let l3Loc = ns.range(of: "level three").location
+        let l3Insets = barInsets(decorationList(at: l3Loc, in: s))
+        #expect(l3Insets.count == 3)
+        // Sorted ascending: deepest (0) ... outermost (largest).
+        let sorted = l3Insets.sorted()
+        #expect(sorted[0] == 0)
+        #expect(sorted[1] > sorted[0])
+        #expect(sorted[2] > sorted[1])
+
+        // "back to one" is only nested one level deep — a single bar at inset 0.
+        let backLoc = ns.range(of: "back to one").location
+        let backDeco = s.attribute(.blockDecoration, at: backLoc, effectiveRange: nil)
+        #expect(barInsets(backDeco) == [0])
+        // And its marker (the lone '>' on that line) is hidden, not literal.
+        let backMarker = ns.range(of: "> back to one").location
+        #expect(isMarkerHidden(at: backMarker, in: s))
+    }
+
+    @Test("A callout nested inside a plain quote stays literal (unchanged from before)")
+    func calloutInsideQuoteStaysLiteral() {
+        let editor = makeEditor()
+        let s = editor.styleBlock("> intro\n> > [!note] still literal")
+        // No fragment overlay (header icon+title image) anywhere — the nested
+        // callout never renders as a callout.
+        var hasOverlay = false
+        s.enumerateAttribute(.fragmentOverlay, in: NSRange(location: 0, length: s.length),
+                             options: []) { v, _, stop in if v != nil { hasOverlay = true; stop.pointee = true } }
+        #expect(!hasOverlay)
+        // The raw "[!note]" text is visible, not hidden.
+        let ns = ("> intro\n> > [!note] still literal") as NSString
+        let bracket = ns.range(of: "[!note]").location
+        #expect(!isMarkerHidden(at: bracket, in: s))
+    }
+
+    @Test("Active (cursor inside) nested quote shows raw dimmed markers, not hidden")
+    func activeNestedQuoteShowsRaw() {
+        let editor = makeEditor()
+        let md = "> outer\n> > inner"
+        let s = editor.styleBlock(md, cursorPosition: (md as NSString).range(of: "inner").location)
+        // Cursor is inside — markers dimmed (visible), not hidden.
+        #expect(!isMarkerHidden(at: 0, in: s))
+    }
+}

--- a/Tests/EdmundTests/SyntaxHighlighterTests.swift
+++ b/Tests/EdmundTests/SyntaxHighlighterTests.swift
@@ -375,14 +375,14 @@ struct BlockquoteTests {
     @Test("Basic blockquote > text produces a blockquote span")
     func basicBlockquote() {
         let spans = SyntaxHighlighter.parse("> hello")
-        let quotes = spans.filter { $0.kind == .blockquote }
+        let quotes = spans.filter { $0.kind == .blockquote(depth: 0) }
         #expect(quotes.count == 1)
     }
 
     @Test("Blockquote delimiter is the > prefix")
     func blockquoteDelimiter() {
         let spans = SyntaxHighlighter.parse("> hello")
-        let quotes = spans.filter { $0.kind == .blockquote }
+        let quotes = spans.filter { $0.kind == .blockquote(depth: 0) }
         #expect(quotes.count == 1)
         #expect(quotes[0].delimiterRanges.count >= 1)
         // Content should be "hello"
@@ -392,7 +392,7 @@ struct BlockquoteTests {
     @Test("Bold inside blockquote is detected")
     func boldInsideBlockquote() {
         let spans = SyntaxHighlighter.parse("> **bold**")
-        let quotes = spans.filter { $0.kind == .blockquote }
+        let quotes = spans.filter { $0.kind == .blockquote(depth: 0) }
         let bolds = spans.filter { $0.kind == .bold }
         #expect(quotes.count == 1)
         #expect(bolds.count == 1)


### PR DESCRIPTION
Supersedes #196 — that branch carried pre-rewrite history (opened before the 2026-07-10 filter-repo force-push), so the work was rebased onto the rewritten `main` and re-pushed clean.

## What

**Nested plain block quotes now render** (`> > text`): each level gets its own depth-tagged span, its own width-preserved hidden `>` marker, and its own left bar — outermost bar leftmost, each nested bar just left of its own level's text.

- `SyntaxHighlighter.Span.Kind.blockquote` gains `depth`; the walker descends into nested plain quotes (callouts inside quotes stay literal, as before) and clips lazy-continuation over-extension so a `> back to one` line after a deeper quote keeps only its own level.
- Indentation follows the Obsidian reference (`misc/frontend-refs/blockquote-nested-obsidian.png`): one marker width per level, coming from the hidden `> ` markers alone — constant first-line paragraph indent, hanging indent grows per level so wrapped lines clear all markers.
- Bars are positioned absolutely per level (`inset = depth × markerWidth`), so the same level's bar tiles into a continuous column across lines.

## Fixes found along the way

- **Nested bars never drew live** (only in tests): the layout-fragment vendor reads `.blockDecoration` at paragraph offset 0, but a nested span starts at its own `>` past the ancestors' markers. Paragraph-level attributes now extend back to the line start; tests assert at line start too.
- **Bar poked ~9pt past the text top**: the line box carries its extra spacing above the glyphs. New `BlockDecoration.hugsTextTop` (set only on a quote run's first line so interior fragments still tile gap-free) starts the bar at the first line's ascender top, computed at draw time. Verified by pixel measurement: bar top now at ascender top, bottom flush at descender.

## Padding note

The originally reported top/bottom padding asymmetry did not reproduce: measured gaps around quote blocks are balanced within 1–2 device px on both `main` and this branch across several quote shapes (confirmed good on the latest build).

## Verification

- 829 tests pass, including 6 new blockquote-nesting regression tests.
- Live screencapture pixel measurements: bar columns continuous across fragments (no seams), hug-top correct on first lines, indent step = one marker width, drop-back-to-level-1 line renders a single bar with hidden marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)