### PR TITLE
fix(editor): keep active heading marker visible

### DIFF
--- a/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
@@ -484,6 +484,11 @@ extension EditorTextView {
                     } else {
                         result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
                     }
+                } else if case .heading = span.kind, cursorPosition != nil {
+                    // A heading is one logical line. Keep its marker visible
+                    // while the caret is anywhere on that line so moving between
+                    // inline tokens does not make the leading `#` flicker.
+                    result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
                 } else if cursorInToken || !isDelimiterHideable(span.kind) {
                     // Visible: dim the delimiters
                     result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
@@ -601,5 +606,4 @@ extension EditorTextView {
 }
 
 // MARK: - ThematicBreakTextBlock
-
 

--- a/Tests/EdmundTests/EditorRenderingTests.swift
+++ b/Tests/EdmundTests/EditorRenderingTests.swift
@@ -263,6 +263,14 @@ struct EditorStylingTests {
         #expect(!isHidden(at: 0, in: styled))
     }
 
+    @Test("Heading # stays dimmed when cursor is in trailing whitespace")
+    @MainActor func headingMarkerDimmedOnActiveLine() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("# Hello   ", cursorPosition: 9)
+        #expect(isDimmed(at: 0, in: styled))
+        #expect(!isHidden(at: 0, in: styled))
+    }
+
     @Test("Heading content has bold scaled font")
     @MainActor func headingContentFont() {
         let editor = makeEditor()


### PR DESCRIPTION
Keeps the leading `#` marker dimmed-but-visible while the caret is anywhere on the heading line, so moving between inline tokens no longer makes it flicker. Includes a unit test; verified live via screencapture (marker visible with caret on the line, hidden with caret elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)