### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported Versions
+
+Edmund is in beta (pre-1.0). Only the latest released version is supported
+with security fixes.
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | ✅ |
+| older   | ❌ |
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities privately using GitHub's
+[private vulnerability reporting](https://github.com/I7T5/Edmund/security/advisories/new)
+(Security tab → "Report a vulnerability"). Do not open a public issue for
+suspected vulnerabilities.
+
+Include as much detail as you can: affected version, reproduction steps,
+impact, and any proof-of-concept. You should get an initial response within
+7 days.
+
+Since Edmund is a local, offline-first macOS app (no server, no accounts, no
+telemetry), the main risk areas are:
+
+- Malicious Markdown/HTML content leading to code execution, sandbox escape,
+  or unintended network access when opening a file
+- Sparkle auto-update integrity (signature/verification bypass)
+- Arbitrary file read/write outside the file the user opened
+
+If confirmed, a fix will be released and credited in the release notes
+(unless you prefer to stay anonymous).
+
+## Disclosure
+
+Please give a reasonable amount of time to fix an issue before any public
+disclosure. There is no bug bounty program.


### PR DESCRIPTION
## Summary
- Adds SECURITY.md pointing reporters to GitHub private vulnerability reporting (Security tab) instead of public issues
- Documents supported versions (latest beta release only) and the app's actual risk surface (malicious Markdown/HTML content, Sparkle update integrity, file read/write scope)

## Test plan
- [ ] Enable "Private vulnerability reporting" in repo Settings → Security → Code security so the linked flow works