### PR TITLE
GFM raw-HTML pass: §6.10 inline, §6.11 tagfilter, §4.6 blocks + small gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,15 @@ GFM pass: closing the gaps between Edmund and the GFM spec in both edit and read
 - Autolinks ([GFM extension](https://github.github.com/gfm/#autolinks-extension-)): bare `www.…`, `http(s)://…`, and email addresses become links in both modes, with CMD+click to follow
 - Inline styling (bold, code, links, ==marks==, …) now renders inside table cells in edit mode; column widths align on the *styled* text, not the raw source
 - Inline styling inside headings keeps the heading's font size (`# **bold** and `code``), for ATX and setext headings
+- Raw HTML renders in read mode per GFM ([§4.6](https://github.github.com/gfm/#html-blocks)/[§6.10](https://github.github.com/gfm/#raw-html)) with the tagfilter extension ([§6.11](https://github.github.com/gfm/#disallowed-raw-html-extension-)) plus hardening: `on*` event-handler attributes and `javascript:`/`vbscript:` URLs stripped, and a `script-src 'none'` CSP on the page (JS was already disabled)
+- HTML blocks (all seven GFM §4.6 start conditions) parse as blocks in edit mode and show as colored source
+- Full GFM §6.10 inline tag grammar in edit mode: hyphenated tag names, single-quoted/unquoted attribute values, `>` inside quoted values, and PI/declaration/CDATA tokens
+- Multi-backtick code spans in edit mode (`` ``a`b`` ``) style with their real delimiter length
+- Loose vs tight lists in read mode: tight lists drop the `<p>` wrapper inside items per GFM §5.3
+- Link `title` attributes carry into read-mode/exported HTML
 
 ### Changed
+- Read mode no longer escapes unknown HTML — GFM passthrough (with tagfilter + hardening) replaces the escape-by-default whitelist
 - A `---` line directly under a paragraph is now a setext h2 underline per GFM, no longer a thematic break — put a blank line between the paragraph and `---` to keep the rule
 - `==highlight==` now follows GFM-style flanking: content can't begin or end with whitespace (`== spaced ==` stays literal)
 - Setext heading content spans the whole preceding paragraph run (`Foo\nbar\n---` is one h2), matching GFM Example 51

--- a/Sources/EdmundCore/Diagnostics/Log.swift
+++ b/Sources/EdmundCore/Diagnostics/Log.swift
@@ -127,6 +127,7 @@ public enum Log {
             case .table:                  return "table·\(c)c"
             case .listItem:               return "listItem·\(c)c"
             case .thematicBreak:          return "hr·\(c)c"
+            case .htmlBlock:              return "htmlBlock·\(c)c"
             case .blank:                  return "blank·\(c)c"
             }
         }

--- a/Sources/EdmundCore/Export/DocumentHTML.swift
+++ b/Sources/EdmundCore/Export/DocumentHTML.swift
@@ -8,7 +8,10 @@ import SwiftMath
 // fills the renderer's placeholder elements with inlined assets (SwiftMath
 // glyphs and local images) as data URIs. Callout/checkbox icons are inline
 // Lucide SVGs emitted by `HTMLRenderer` (no asset pass needed). Inlining keeps
-// the document self-contained — the webview needs no file/network access (§G).
+// the document self-contained — the webview needs no file/network access.
+// Raw HTML in the markdown passes through per GFM, filtered by
+// `HTMLRenderer.filterRawHTML` (tagfilter + hardening); the page also carries a
+// `script-src 'none'` CSP meta as defense-in-depth (§G, ARCHITECTURE §10).
 @MainActor
 enum DocumentHTML {
 
@@ -28,6 +31,7 @@ enum DocumentHTML {
         return """
         <!DOCTYPE html>
         <html><head><meta charset="utf-8">
+        <meta http-equiv="Content-Security-Policy" content="script-src 'none'">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <style>
         \(css)

--- a/Sources/EdmundCore/Export/HTMLRenderer.swift
+++ b/Sources/EdmundCore/Export/HTMLRenderer.swift
@@ -42,6 +42,10 @@ struct HTMLRenderer: MarkupVisitor {
     /// instead of in place. Order is document order of the *definitions*.
     private var footnotes: [(id: String, bodyHTML: String)] = []
 
+    /// Tightness of each list currently being walked (stack: nested lists).
+    /// See `isTight(_:)`.
+    private var listIsTight: [Bool] = []
+
     private init(source: String, options: ReadRenderOptions) {
         self.source = source
         self.sourceLines = source.components(separatedBy: "\n")
@@ -241,11 +245,36 @@ struct HTMLRenderer: MarkupVisitor {
         return "<blockquote>\(renderChildren(of: blockQuote))</blockquote>"
     }
 
+    /// GFM §5.3: a list is LOOSE iff any two adjacent blocks inside it — between
+    /// items, or between blocks within one item — are separated by a blank source
+    /// line. swift-markdown doesn't expose cmark's tight flag; recover it from
+    /// source-line gaps, clamping each block's end past cmark's folded trailing
+    /// blanks (same trick as visitDocument).
+    private func isTight(_ list: Markup) -> Bool {
+        var prevEnd: Int? = nil
+        for item in list.children {
+            guard let r = item.range else { continue }
+            if let p = prevEnd, r.lowerBound.line - p > 1 { return false }
+            var innerPrev: Int? = nil
+            for block in item.children {
+                guard let br = block.range else { continue }
+                if let ip = innerPrev, br.lowerBound.line - ip > 1 { return false }
+                innerPrev = lastContentLine(atOrBefore: br.upperBound.line)
+            }
+            prevEnd = lastContentLine(atOrBefore: r.upperBound.line)
+        }
+        return true
+    }
+
     mutating func visitUnorderedList(_ list: UnorderedList) -> String {
-        "<ul>\(renderChildren(of: list))</ul>"
+        listIsTight.append(isTight(list))
+        defer { listIsTight.removeLast() }
+        return "<ul>\(renderChildren(of: list))</ul>"
     }
 
     mutating func visitOrderedList(_ list: OrderedList) -> String {
+        listIsTight.append(isTight(list))
+        defer { listIsTight.removeLast() }
         let start = list.startIndex == 1 ? "" : " start=\"\(list.startIndex)\""
         return "<ol\(start)>\(renderChildren(of: list))</ol>"
     }
@@ -258,9 +287,25 @@ struct HTMLRenderer: MarkupVisitor {
             let mark = "<span class=\"task-check task-check--\(checked ? "checked" : "unchecked")\">"
                 + "\(LucideIcons.checkboxSVG(checked: checked))</span>"
             let checkedClass = checked ? " task--checked" : ""
-            return "<li class=\"task\(checkedClass)\">\(mark)\(renderChildren(of: listItem))</li>"
+            return "<li class=\"task\(checkedClass)\">\(mark)\(renderListItemContents(listItem))</li>"
         }
-        return "<li>\(renderChildren(of: listItem))</li>"
+        return "<li>\(renderListItemContents(listItem))</li>"
+    }
+
+    /// Item contents; in a tight list, each direct Paragraph child loses its
+    /// <p></p> wrapper (visit-then-strip, so visitParagraph's math/footnote
+    /// special cases still run).
+    private mutating func renderListItemContents(_ item: ListItem) -> String {
+        guard listIsTight.last == true else { return renderChildren(of: item) }
+        var out = ""
+        for child in item.children {
+            var html = visit(child)
+            if child is Paragraph, html.hasPrefix("<p>"), html.hasSuffix("</p>") {
+                html = String(html.dropFirst(3).dropLast(4))
+            }
+            out += html
+        }
+        return out
     }
 
     mutating func visitTable(_ table: Table) -> String {
@@ -304,6 +349,7 @@ struct HTMLRenderer: MarkupVisitor {
     mutating func visitLink(_ link: Link) -> String {
         let dest = link.destination ?? ""
         let inner = renderChildren(of: link)
+        let title = link.title.map { " title=\"\(Self.attr($0))\"" } ?? ""
         // In-page `#fragment` anchors and external links (http/https/mailto, or
         // any explicit scheme) keep their real href — the nav policy lets the
         // anchor scroll and hands external schemes to the browser. A relative /
@@ -311,10 +357,10 @@ struct HTMLRenderer: MarkupVisitor {
         // through the app's document graph reliably (independent of how WebKit
         // rewrites relative hrefs under `baseURL: nil`).
         if dest.hasPrefix("#") || Self.hasExternalScheme(dest) {
-            return "<a href=\"\(Self.attr(dest))\">\(inner)</a>"
+            return "<a href=\"\(Self.attr(dest))\"\(title)>\(inner)</a>"
         }
         let encoded = dest.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? dest
-        return "<a href=\"\(Self.linkScheme):\(encoded)\">\(inner)</a>"
+        return "<a href=\"\(Self.linkScheme):\(encoded)\"\(title)>\(inner)</a>"
     }
 
     /// Whether a link destination carries an explicit URL scheme (`http:`,

--- a/Sources/EdmundCore/Export/HTMLRenderer.swift
+++ b/Sources/EdmundCore/Export/HTMLRenderer.swift
@@ -448,14 +448,16 @@ struct HTMLRenderer: MarkupVisitor {
     }
 
     /// A `md-image` placeholder for a raw `<img src="…">` tag, or nil when it
-    /// has no double-quoted `src`. Attribute extraction shares the Edit-mode
-    /// regexes so the two back-ends accept the same tags; every value is
-    /// re-escaped, so no raw attribute text passes through.
+    /// has no `src`. Attribute extraction shares the Edit-mode regexes so the
+    /// two back-ends accept the same tags (double-, single-, and unquoted
+    /// values, §6.10); every value is re-escaped, so no raw attribute text
+    /// passes through.
     static func imgPlaceholder(_ raw: String) -> String? {
         let ns = raw as NSString
         let whole = NSRange(location: 0, length: ns.length)
         func attrValue(_ regex: NSRegularExpression) -> String? {
-            regex.firstMatch(in: raw, range: whole).map { ns.substring(with: $0.range(at: 1)) }
+            regex.firstMatch(in: raw, range: whole)
+                .map { ns.substring(with: SyntaxHighlighter.attrValueRange($0)) }
         }
         guard let src = attrValue(SyntaxHighlighter.imgSrcRegex) else { return nil }
         var out = "<img class=\"md-image\" data-src=\"\(attr(src))\""

--- a/Sources/EdmundCore/Export/HTMLRenderer.swift
+++ b/Sources/EdmundCore/Export/HTMLRenderer.swift
@@ -340,24 +340,44 @@ struct HTMLRenderer: MarkupVisitor {
         return "<img class=\"md-image\" data-src=\"\(src)\" alt=\"\(alt)\">"
     }
 
-    // Inline HTML: a whitelisted formatting tag (u/kbd/mark/sub/sup) passes
-    // through so the browser renders it; every other tag is escaped to literal
-    // text. Block HTML is always escaped (below) — a document still can't inject
-    // markup/script (§G).
+    // Inline HTML (§6.10): full GFM raw-HTML passthrough, filtered through
+    // tagfilter (§6.11) + hardening (§G — see ARCHITECTURE §10). Block HTML
+    // gets the same filter (below).
     mutating func visitInlineHTML(_ inlineHTML: InlineHTML) -> String {
         Self.sanitizeInlineHTML(inlineHTML.rawHTML)
     }
     mutating func visitHTMLBlock(_ html: HTMLBlock) -> String {
         // A block-level `<!-- comment -->` is invisible, like in a browser.
-        // Any other block HTML is still escaped to literal text (§G), except a
-        // lone `<img …>` tag, which becomes the same sanitized placeholder as
-        // an inline one.
         let trimmed = html.rawHTML.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.hasPrefix("<!--") && trimmed.hasSuffix("-->") { return "" }
         if isSingleTag(trimmed, named: "img"), let img = Self.imgPlaceholder(trimmed) {
             return "<p>\(img)</p>"
         }
-        return "<p>\(Self.escape(html.rawHTML))</p>"
+        // GFM passthrough (§4.6): tagfilter + hardening, then rewrite interior
+        // `<img src=…>` tags to asset-pass placeholders (same baseURL-nil reason
+        // as inline; also the remote-image-policy enforcement point). No <p>
+        // wrapper, no escaping. filterRawHTML runs FIRST: the placeholders carry
+        // only class/data-src/alt/width/height attrs, which the hardening
+        // regexes can't touch.
+        return Self.rewriteImgs(in: Self.filterRawHTML(html.rawHTML))
+    }
+
+    /// Full §6.10 open-tag grammar for `img` (quoted values may contain `>`).
+    private static let imgTagRegex = try! NSRegularExpression(
+        pattern: #"<img(?:\s+[a-zA-Z_:][a-zA-Z0-9:._-]*(?:\s*=\s*(?:[^\s"'=<>`]+|'[^']*'|"[^"]*"))?)*\s*/?>"#,
+        options: [.caseInsensitive])
+
+    /// Replaces every `<img …>` that has a usable src with the md-image
+    /// placeholder; src-less imgs pass through untouched (they simply won't load).
+    static func rewriteImgs(in html: String) -> String {
+        let ns = html as NSString
+        let out = NSMutableString(string: html)
+        for m in imgTagRegex.matches(in: html, range: NSRange(location: 0, length: ns.length)).reversed() {
+            if let placeholder = imgPlaceholder(ns.substring(with: m.range)) {
+                out.replaceCharacters(in: m.range, with: placeholder)
+            }
+        }
+        return out as String
     }
 
     /// True when `raw` is exactly one `<name …>` tag (no trailing content —
@@ -373,28 +393,58 @@ struct HTMLRenderer: MarkupVisitor {
     private static let inlineTagRegex =
         try! NSRegularExpression(pattern: #"^<(/?)([A-Za-z][A-Za-z0-9]*)[^>]*>$"#)
 
-    /// Passes a whitelisted inline tag through as a sanitized *bare* tag (`<u>` /
-    /// `</u>`, attributes dropped); escapes anything else. The read webview
-    /// disables JavaScript, but dropping attributes is defense-in-depth against
-    /// attribute-based injection (`<mark onmouseover=…>`). Mirrors the Edit-mode
-    /// whitelist via `SyntaxHighlighter.htmlFormatTags`.
+    // MARK: - GFM tagfilter (§6.11) + hardening
+
+    /// Tagfilter (§6.11): the leading `<` of the nine disallowed tag names
+    /// (open or closing, case-insensitive) becomes `&lt;`. Lookahead only —
+    /// nothing else is consumed.
+    private static let tagfilterRegex = try! NSRegularExpression(
+        pattern: #"<(?=/?(?:title|textarea|style|xmp|iframe|noembed|noframes|script|plaintext)(?:[\s/>]|$))"#,
+        options: [.caseInsensitive])
+
+    /// Hardening (beyond spec): strip `on*` event-handler attributes.
+    /// ponytail: plain-text regex, not an HTML parser — a literal ` onclick="x"`
+    /// in text between tags is also stripped; harmless for a hardening pass.
+    private static let eventAttrRegex = try! NSRegularExpression(
+        pattern: #"\son[a-zA-Z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'=<>`]+)"#,
+        options: [.caseInsensitive])
+
+    /// Hardening: neutralize javascript:/vbscript: schemes in URL-carrying
+    /// attributes (the scheme is deleted; the rest becomes a harmless relative URL).
+    private static let scriptURLRegex = try! NSRegularExpression(
+        pattern: #"(\s(?:href|src|action|formaction|xlink:href|data)\s*=\s*["']?\s*)(?:javascript|vbscript)\s*:"#,
+        options: [.caseInsensitive])
+
+    /// GFM raw-HTML output filter: tagfilter + Edmund's hardening. Defense-in-depth
+    /// on top of the read webview's JS-off + CSP script-src 'none' + baseURL nil.
+    static func filterRawHTML(_ raw: String) -> String {
+        func sub(_ s: String, _ rx: NSRegularExpression, _ template: String) -> String {
+            rx.stringByReplacingMatches(in: s, range: NSRange(location: 0, length: (s as NSString).length),
+                                        withTemplate: template)
+        }
+        var out = sub(raw, tagfilterRegex, "&lt;")
+        out = sub(out, eventAttrRegex, "")
+        out = sub(out, scriptURLRegex, "$1")
+        return out
+    }
+
+    /// GFM raw-HTML passthrough (§6.10) with tagfilter (§6.11) + hardening.
+    /// Comments stay invisible. A lone `<img src=…>` becomes the asset-pass
+    /// placeholder — REQUIRED, not just policy: the page loads with `baseURL: nil`,
+    /// so a raw relative `<img src>` could never resolve; the placeholder routes
+    /// it through DocumentHTML.fillImages (data-URI inlining + remote-image policy,
+    /// declared width/height carried through). Everything else passes through
+    /// filtered. Whitelisted formatting tags now keep their (hardened) attributes.
     static func sanitizeInlineHTML(_ raw: String) -> String {
-        // An inline `<!-- comment -->` is invisible, not literal text.
         if raw.hasPrefix("<!--") { return "" }
         let ns = raw as NSString
-        if let m = inlineTagRegex.firstMatch(in: raw, range: NSRange(location: 0, length: ns.length)) {
-            let isClose = ns.substring(with: m.range(at: 1)) == "/"
-            let name = ns.substring(with: m.range(at: 2)).lowercased()
-            if SyntaxHighlighter.htmlFormatTags.contains(name) {
-                return isClose ? "</\(name)>" : "<\(name)>"
-            }
-            // `<img src="…">` becomes the same asset-pass placeholder as a
-            // markdown image, carrying declared width/height through.
-            if name == "img", !isClose, let img = imgPlaceholder(raw) {
-                return img
-            }
+        if let m = inlineTagRegex.firstMatch(in: raw, range: NSRange(location: 0, length: ns.length)),
+           ns.substring(with: m.range(at: 1)).isEmpty,                    // open tag
+           ns.substring(with: m.range(at: 2)).lowercased() == "img",
+           let img = imgPlaceholder(raw) {
+            return img
         }
-        return escape(raw)
+        return filterRawHTML(raw)
     }
 
     /// A `md-image` placeholder for a raw `<img src="…">` tag, or nil when it

--- a/Sources/EdmundCore/Export/ReadModeWebView.swift
+++ b/Sources/EdmundCore/Export/ReadModeWebView.swift
@@ -4,10 +4,12 @@ import WebKit
 // MARK: - ReadModeWebView
 //
 // The WKWebView that backs Read mode. It is a pure renderer of the user's own
-// document: JavaScript is disabled, all assets are inlined (so no file/network
-// reach), and navigation is intercepted — internal scrolling stays, external
-// links open in the default browser, and the view never navigates away from the
-// rendered document (§G).
+// document: JavaScript is disabled (plus a `script-src 'none'` CSP meta in the
+// page itself), all assets are inlined (so no file/network reach), raw HTML
+// passes through per GFM but filtered by `HTMLRenderer.filterRawHTML`
+// (tagfilter + hardening), and navigation is intercepted — internal scrolling
+// stays, external links open in the default browser, and the view never
+// navigates away from the rendered document (§G, ARCHITECTURE §10).
 //
 // The navigation delegate is a *separate* object (not the webview itself). A
 // WKWebView that is its own `navigationDelegate` does not reliably receive the

--- a/Sources/EdmundCore/Model/Block.swift
+++ b/Sources/EdmundCore/Model/Block.swift
@@ -15,6 +15,7 @@ public enum BlockKind: Equatable, Sendable {
     case table
     case listItem
     case thematicBreak
+    case htmlBlock
     case blank
 }
 

--- a/Sources/EdmundCore/Parsing/BlockParser.swift
+++ b/Sources/EdmundCore/Parsing/BlockParser.swift
@@ -114,6 +114,12 @@ public enum BlockParser {
                     // old parse from here isn't provably identical. Bail to
                     // the full parse (rare and cheap).
                     if isIndentedCodeLine(firstLine(of: old[j].content)) { return nil }
+                    // Same bail for HTML-block-ish starts: type 7 depends on the
+                    // line above (which the edit may have changed), so an old
+                    // block whose first line looks like ANY html-block opener
+                    // isn't provably re-derivable — full parse (rare and cheap).
+                    // prevLine: nil = most permissive check.
+                    if htmlBlockStart(firstLine(of: old[j].content), prevLine: nil) != nil { return nil }
                     suffixStart = j
                     break
                 }
@@ -346,6 +352,40 @@ public enum BlockParser {
             return (merged.joined(separator: "\n"), .indentedCode, j)
         }
 
+        // GFM §4.6 HTML block. Types 1–5 scan forward for the end-condition line
+        // (included; the end may already be on the start line; unterminated runs
+        // to EOF — spec: end of document closes it). Types 6/7 end BEFORE the
+        // first blank line (the blank stays its own `.blank` block). Type 7
+        // can't interrupt a paragraph — htmlBlockStart gates it on prevLine.
+        // Placement: after indented code (the ≤3-space guard keeps a 4-space-
+        // indented `<div>` as indented code); a `<`-line forming a valid table
+        // header+separator still becomes a table (deliberate divergence, tables
+        // win — this branch sits below the table branch); must precede the
+        // setext scan so an HTML start isn't swallowed as heading content.
+        // Edit mode shows the block as colored SOURCE (read mode renders it) —
+        // same split as GitHub's editor; rendered HTML in edit mode is
+        // impossible under the storage==rawSource invariant.
+        if let type = htmlBlockStart(first, prevLine: prevLine) {
+            var merged = [first]
+            var j = i + 1
+            switch type {
+            case .scriptPreStyle, .comment, .processing, .declaration, .cdata:
+                if !htmlBlockEnds(first, type: type) {
+                    while let line = buf.line(at: j) {
+                        merged.append(line)
+                        j += 1
+                        if htmlBlockEnds(line, type: type) { break }
+                    }
+                }
+            case .blockTag, .completeTag:
+                while let line = buf.line(at: j), !isBlankLine(line) {
+                    merged.append(line)
+                    j += 1
+                }
+            }
+            return (merged.joined(separator: "\n"), .htmlBlock, j)
+        }
+
         // Setext heading: a paragraph line underlined by `===` (h1) or `---`
         // (h2). Consuming the underline here means a `---` after a paragraph
         // is a heading underline (GFM setext wins over thematic break); only
@@ -375,6 +415,12 @@ public enum BlockParser {
                    splitTableRow(line).count == splitTableRow(next).count {
                     break
                 }
+                // An HTML block start (types 1–6 interrupt paragraphs; type 7 is
+                // gated on the previous line) terminates the run, mirroring the
+                // table break above — otherwise "Foo\n<div>\n---" would merge
+                // into a setext heading instead of paragraph + HTML block
+                // (GFM: the `---` belongs to the HTML block).
+                if htmlBlockStart(line, prevLine: buf.line(at: j - 1)) != nil { break }
                 j += 1
             }
             // No underline: everything up to the terminator at `j` is plain
@@ -475,6 +521,65 @@ public enum BlockParser {
 
     private static func isBlankLine(_ line: String) -> Bool {
         line.allSatisfy { $0 == " " || $0 == "\t" }
+    }
+
+    /// GFM §4.6 HTML block start conditions.
+    enum HTMLBlockType {
+        case scriptPreStyle   // 1: <script|<pre|<style  — ends ON the line containing </script>|</pre>|</style>
+        case comment          // 2: <!--                 — ends ON the line containing -->
+        case processing       // 3: <?                   — ends ON the line containing ?>
+        case declaration      // 4: <! + ASCII uppercase — ends ON the line containing >
+        case cdata            // 5: <![CDATA[            — ends ON the line containing ]]>
+        case blockTag         // 6: one of the 62 block tag names — ends BEFORE a blank line
+        case completeTag      // 7: a complete lone tag  — ends BEFORE a blank line; can't interrupt a paragraph
+    }
+
+    private static let htmlType1Regex = try! NSRegularExpression(
+        pattern: #"^ {0,3}<(?:script|pre|style)(?:[ \t>]|$)"#, options: [.caseInsensitive])
+
+    private static let htmlType6Regex = try! NSRegularExpression(
+        pattern: #"^ {0,3}</?(?:address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h1|h2|h3|h4|h5|h6|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|section|source|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)(?:[ \t]|/?>|$)"#,
+        options: [.caseInsensitive])
+
+    /// One COMPLETE open tag (full §6.10 attribute grammar — quoted values may
+    /// contain `>`) or closing tag, alone on the line. Check order 1→7 means a
+    /// normal `<script …>` is always claimed by type 1 first; the one leak is a
+    /// self-closing `<script/>` lone tag, which spec calls a paragraph but we
+    /// call type 7 — deliberate, harmless divergence (ARCHITECTURE §10).
+    private static let htmlType7Regex = try! NSRegularExpression(
+        pattern: #"^ {0,3}(?:<[A-Za-z][A-Za-z0-9-]*(?:\s+[a-zA-Z_:][a-zA-Z0-9:._-]*(?:\s*=\s*(?:[^\s"'=<>`]+|'[^']*'|"[^"]*"))?)*\s*/?>|</[A-Za-z][A-Za-z0-9-]*\s*>)[ \t]*$"#)
+
+    /// GFM §4.6: the HTML-block type `line` opens, or nil. `prevLine` gates type 7
+    /// (it cannot interrupt a paragraph — same backward context as indented code).
+    /// O(line), and only `<`-prefixed lines get past the cheap guard.
+    static func htmlBlockStart(_ line: String, prevLine: String?) -> HTMLBlockType? {
+        let trimmed = line.drop(while: { $0 == " " })
+        guard line.count - trimmed.count <= 3, trimmed.first == "<" else { return nil }
+        let range = NSRange(location: 0, length: (line as NSString).length)
+        if htmlType1Regex.firstMatch(in: line, range: range) != nil { return .scriptPreStyle }
+        if trimmed.hasPrefix("<!--") { return .comment }
+        if trimmed.hasPrefix("<?") { return .processing }
+        if trimmed.hasPrefix("<![CDATA[") { return .cdata }
+        if trimmed.hasPrefix("<!"), let c = trimmed.dropFirst(2).first,
+           c.isASCII, c.isUppercase { return .declaration }
+        if htmlType6Regex.firstMatch(in: line, range: range) != nil { return .blockTag }
+        if prevLine == nil || isBlankLine(prevLine!),
+           htmlType7Regex.firstMatch(in: line, range: range) != nil { return .completeTag }
+        return nil
+    }
+
+    /// End condition for types 1–5 (the matching line is INCLUDED in the block).
+    private static func htmlBlockEnds(_ line: String, type: HTMLBlockType) -> Bool {
+        switch type {
+        case .scriptPreStyle:
+            let l = line.lowercased()
+            return l.contains("</script>") || l.contains("</pre>") || l.contains("</style>")
+        case .comment:     return line.contains("-->")
+        case .processing:  return line.contains("?>")
+        case .declaration: return line.contains(">")
+        case .cdata:       return line.contains("]]>")
+        case .blockTag, .completeTag: return false
+        }
     }
 
     /// Returns true for a thematic break: 3+ of the same `-`/`*`/`_` character

--- a/Sources/EdmundCore/Parsing/BlockParser.swift
+++ b/Sources/EdmundCore/Parsing/BlockParser.swift
@@ -534,6 +534,8 @@ public enum BlockParser {
         case completeTag      // 7: a complete lone tag  — ends BEFORE a blank line; can't interrupt a paragraph
     }
 
+    // Tag set pinned to CommonMark 0.29 / GFM (script|pre|style — no textarea,
+    // which later CommonMark added); deliberate, documented in ARCHITECTURE §10.
     private static let htmlType1Regex = try! NSRegularExpression(
         pattern: #"^ {0,3}<(?:script|pre|style)(?:[ \t>]|$)"#, options: [.caseInsensitive])
 

--- a/Sources/EdmundCore/Parsing/SyntaxHighlighter+CustomParsers.swift
+++ b/Sources/EdmundCore/Parsing/SyntaxHighlighter+CustomParsers.swift
@@ -331,6 +331,9 @@ extension SyntaxHighlighter {
     /// Whitelisted HTML formatting tags rendered (not just colored). The inner
     /// content keeps its own markdown styling. Built from `htmlFormatTags` so the
     /// Edit and Read whitelists share one source of truth.
+    /// Known ceiling: the open tag's attr swallow `(?:\s[^>]*)?` breaks on a `>`
+    /// inside a quoted attribute of a whitelist pair open tag — the pair then
+    /// falls back to two colored `.htmlTag` tokens (acceptable).
     private static let htmlPairRegex: NSRegularExpression = {
         let names = htmlFormatTags.sorted().joined(separator: "|")
         return try! NSRegularExpression(
@@ -338,18 +341,37 @@ extension SyntaxHighlighter {
             options: [.caseInsensitive, .dotMatchesLineSeparators])
     }()
 
-    /// Any single inline HTML tag (open, close, or self-closing). Group 1 is the
-    /// element name.
-    private static let htmlTagRegex = try! NSRegularExpression(
-        pattern: #"</?([A-Za-z][A-Za-z0-9]*)(?:\s[^<>]*)?/?>"#)
+    /// Any single inline HTML tag per GFM §6.10: an open tag (group 1 = name,
+    /// full attribute grammar — names may contain hyphens, attribute values may
+    /// be double-quoted, single-quoted, or unquoted, and quoted values may
+    /// contain `>`), or a closing tag (group 2 = name; no attributes allowed).
+    private static let htmlTagRegex = try! NSRegularExpression(pattern:
+        #"<(?:([A-Za-z][A-Za-z0-9-]*)(?:\s+[a-zA-Z_:][a-zA-Z0-9:._-]*(?:\s*=\s*(?:[^\s"'=<>`]+|'[^']*'|"[^"]*"))?)*\s*/?|/([A-Za-z][A-Za-z0-9-]*)\s*)>"#)
 
-    // `<img>` attribute extractors, double-quoted values only (ponytail:
-    // single/unquoted attrs stay colored source). Shared with the read-mode
-    // sanitizer so both back-ends accept exactly the same tags.
-    static let imgSrcRegex = try! NSRegularExpression(pattern: #"\ssrc="([^"]*)""#)
-    static let imgAltRegex = try! NSRegularExpression(pattern: #"\salt="([^"]*)""#)
-    static let imgWidthRegex = try! NSRegularExpression(pattern: #"\swidth="(\d+)""#)
-    static let imgHeightRegex = try! NSRegularExpression(pattern: #"\sheight="(\d+)""#)
+    /// §6.10 processing instructions `<?…?>`, declarations `<!NAME …>`, and
+    /// CDATA `<![CDATA[…]]>` — shown as dimmed source. HTML comments are handled
+    /// (more laxly than spec — interior `--` allowed, deliberate divergence) by
+    /// parseHTMLComments, which runs first.
+    private static let htmlOtherRegex = try! NSRegularExpression(
+        pattern: #"<\?[\s\S]*?\?>|<![A-Z]+\s+[^>]*>|<!\[CDATA\[[\s\S]*?\]\]>"#)
+
+    // `<img>` attribute extractors — double-, single-, and unquoted values
+    // (§6.10). Exactly one of groups 1–3 participates per match. Shared with the
+    // read-mode renderer so both back-ends accept the same tags.
+    static let imgSrcRegex = try! NSRegularExpression(
+        pattern: #"\ssrc\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))"#, options: [.caseInsensitive])
+    static let imgAltRegex = try! NSRegularExpression(
+        pattern: #"\salt\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))"#, options: [.caseInsensitive])
+    static let imgWidthRegex = try! NSRegularExpression(
+        pattern: #"\swidth\s*=\s*(?:"(\d+)"|'(\d+)'|(\d+))"#, options: [.caseInsensitive])
+    static let imgHeightRegex = try! NSRegularExpression(
+        pattern: #"\sheight\s*=\s*(?:"(\d+)"|'(\d+)'|(\d+))"#, options: [.caseInsensitive])
+
+    /// The matched value range: whichever of groups 1–3 participated.
+    static func attrValueRange(_ m: NSTextCheckingResult) -> NSRange {
+        for i in 1...3 where m.range(at: i).location != NSNotFound { return m.range(at: i) }
+        return m.range(at: 0)
+    }
 
     /// Parses inline HTML tags. Two tiers:
     ///   - a whitelisted pair (`<u>…</u>`, `<kbd>`, `<mark>`, `<sub>`, `<sup>`)
@@ -404,7 +426,8 @@ extension SyntaxHighlighter {
             if pairTagRanges.contains(where: {
                 $0.location <= full.location && $0.upperBound >= full.upperBound
             }) { continue }
-            let nameR = m.range(at: 1)
+            // Group 1 = open-tag name, group 2 = closing-tag name.
+            let nameR = m.range(at: 1).location != NSNotFound ? m.range(at: 1) : m.range(at: 2)
 
             // `<img src="…">` renders as an inline image (like `![](…)`),
             // optionally at declared pixel dimensions. Without a src the tag
@@ -413,14 +436,14 @@ extension SyntaxHighlighter {
                let srcM = imgSrcRegex.firstMatch(in: text, range: full) {
                 func intAttr(_ regex: NSRegularExpression) -> Int? {
                     regex.firstMatch(in: text, range: full)
-                        .map { ns.substring(with: $0.range(at: 1)) }.flatMap(Int.init)
+                        .map { ns.substring(with: attrValueRange($0)) }.flatMap(Int.init)
                 }
                 spans.append(Span(
-                    kind: .image(destination: ns.substring(with: srcM.range(at: 1)),
+                    kind: .image(destination: ns.substring(with: attrValueRange(srcM)),
                                  width: intAttr(imgWidthRegex),
                                  height: intAttr(imgHeightRegex)),
                     fullRange: full,
-                    contentRange: srcM.range(at: 1),
+                    contentRange: attrValueRange(srcM),
                     delimiterRanges: []))
                 continue
             }
@@ -428,6 +451,17 @@ extension SyntaxHighlighter {
             let post = NSRange(location: nameR.upperBound, length: full.upperBound - nameR.upperBound)
             spans.append(Span(kind: .htmlTag, fullRange: full, contentRange: nameR,
                               delimiterRanges: [pre, post]))
+        }
+
+        // Pass 3: PI / declaration / CDATA → dimmed source. Zero-length content +
+        // full-range delimiter ⇒ the whole token dims (like a comment); tokens
+        // inside a real <!-- comment --> are dropped by the opaque-range pass.
+        for m in htmlOtherRegex.matches(in: text, range: whole) {
+            let full = m.range(at: 0)
+            guard !guarded(full) else { continue }
+            spans.append(Span(kind: .htmlTag, fullRange: full,
+                              contentRange: NSRange(location: full.location, length: 0),
+                              delimiterRanges: [full]))
         }
     }
 

--- a/Sources/EdmundCore/Parsing/SyntaxHighlighter+WalkerInline.swift
+++ b/Sources/EdmundCore/Parsing/SyntaxHighlighter+WalkerInline.swift
@@ -121,16 +121,28 @@ extension SyntaxHighlighter.SpanCollector {
         let full = nsRange(for: range)
         guard full.length >= 2 else { return }
 
-        let openDelim = NSRange(location: full.location, length: 1)
-        let closeDelim = NSRange(location: full.upperBound - 1, length: 1)
-        let content = NSRange(location: full.location + 1,
-                              length: max(0, full.length - 2))
+        // GFM §6.3: the delimiters are equal-length backtick runs of ANY length.
+        // Measure the actual runs in the raw source (the AST doesn't carry them).
+        let ns = source as NSString
+        let backtick: unichar = 0x60
+        var open = 0
+        while full.location + open < full.upperBound,
+              ns.character(at: full.location + open) == backtick { open += 1 }
+        var close = 0
+        while full.upperBound - 1 - close > full.location + open - 1,
+              ns.character(at: full.upperBound - 1 - close) == backtick { close += 1 }
+        // cmark guarantees matching runs; clamp defensively so a surprise can't
+        // produce inverted ranges.
+        let d = max(1, min(min(open, close), full.length / 2))
 
+        // NOTE: the §6.3 one-space strip (`` ` `` → "`") is a render rule; in
+        // edit mode the padding spaces are source and stay in contentRange.
         spans.append(SyntaxHighlighter.Span(
             kind: .code,
             fullRange: full,
-            contentRange: content,
-            delimiterRanges: [openDelim, closeDelim]
+            contentRange: NSRange(location: full.location + d, length: max(0, full.length - 2 * d)),
+            delimiterRanges: [NSRange(location: full.location, length: d),
+                              NSRange(location: full.upperBound - d, length: d)]
         ))
     }
 

--- a/Tests/EdmundTests/BlockParserTests.swift
+++ b/Tests/EdmundTests/BlockParserTests.swift
@@ -657,6 +657,82 @@ struct BlockParserTests {
     }
 }
 
+// GFM §4.6: the seven HTML-block start conditions and their end conditions.
+@Suite("BlockParser — HTML blocks")
+struct BlockParserHTMLBlockTests {
+
+    @Test("Type 6 block tag runs to the blank line")
+    func type6() {
+        let blocks = BlockParser.parse("<div>\n*foo*\n</div>\n\npara")
+        #expect(blocks.map(\.kind) == [.htmlBlock, .blank, .paragraph])
+        #expect(blocks[0].content == "<div>\n*foo*\n</div>")
+    }
+
+    @Test("Type 6 unterminated runs to EOF")
+    func type6EOF() {
+        let blocks = BlockParser.parse("<div>\n*foo*")
+        #expect(blocks.map(\.kind) == [.htmlBlock])
+    }
+
+    @Test("Type 6 interrupts a paragraph")
+    func type6Interrupts() {
+        let blocks = BlockParser.parse("para\n<div>\nx")
+        #expect(blocks.map(\.kind) == [.paragraph, .htmlBlock])
+    }
+
+    @Test("Type 1 <script> ends ON the </script> line")
+    func type1() {
+        let blocks = BlockParser.parse("<script>\nalert(1)\n</script>\nafter")
+        #expect(blocks.map(\.kind) == [.htmlBlock, .paragraph])
+        #expect(blocks[0].content == "<script>\nalert(1)\n</script>")
+    }
+
+    @Test("Type 1 end condition can be on the start line")
+    func type1OneLine() {
+        let blocks = BlockParser.parse("<pre role=\"x\">y</pre>")
+        #expect(blocks.map(\.kind) == [.htmlBlock])
+    }
+
+    @Test("Types 2–5: comment, PI, declaration, CDATA")
+    func types2to5() {
+        let comment = BlockParser.parse("<!--\nnote\n-->\nok")
+        #expect(comment.map(\.kind) == [.htmlBlock, .paragraph])
+        #expect(comment[0].content == "<!--\nnote\n-->")
+        #expect(BlockParser.parse("<?php\necho\n?>").map(\.kind) == [.htmlBlock])
+        #expect(BlockParser.parse("<!DOCTYPE html>").map(\.kind) == [.htmlBlock])
+        #expect(BlockParser.parse("<![CDATA[\ndata\n]]>").map(\.kind) == [.htmlBlock])
+    }
+
+    @Test("Type 2 unterminated comment runs to EOF")
+    func type2EOF() {
+        #expect(BlockParser.parse("<!-- open\nrest\nmore").map(\.kind) == [.htmlBlock])
+    }
+
+    @Test("Type 7 lone complete tag after a blank line")
+    func type7() {
+        let blocks = BlockParser.parse("para\n\n<custom-tag attr='x'>\ncontent")
+        #expect(blocks.map(\.kind) == [.paragraph, .blank, .htmlBlock])
+        #expect(blocks[2].content == "<custom-tag attr='x'>\ncontent")
+    }
+
+    @Test("Type 7 cannot interrupt a paragraph")
+    func type7NoInterrupt() {
+        #expect(BlockParser.parse("para\n<custom-tag>").map(\.kind) == [.paragraph, .paragraph])
+    }
+
+    @Test("A 4-space-indented tag is indented code, not an HTML block")
+    func indentedNotHTML() {
+        #expect(BlockParser.parse("    <div>").map(\.kind) == [.indentedCode])
+    }
+
+    @Test("An HTML start under a paragraph isn't swallowed as setext content")
+    func setextDoesNotSwallowHTML() {
+        let blocks = BlockParser.parse("Foo\n<div>\n---")
+        #expect(blocks.map(\.kind) == [.paragraph, .htmlBlock])
+        #expect(blocks[1].content == "<div>\n---")
+    }
+}
+
 @Suite("BlockParser — performance guards")
 struct BlockParserPerfTests {
 
@@ -669,6 +745,31 @@ struct BlockParserPerfTests {
     func hugeParagraphRun() {
         let doc = Array(repeating: "just a plain prose line with words",
                         count: 10_000).joined(separator: "\n")
+        let t0 = DispatchTime.now()
+        let blocks = BlockParser.parse(doc)
+        let seconds = Double(DispatchTime.now().uptimeNanoseconds - t0.uptimeNanoseconds) / 1e9
+        #expect(blocks.count == 10_000)
+        #expect(seconds < 10)
+    }
+
+    /// HTML-block end scans are consumed (the parser advances past them), so a
+    /// huge blank-line-free type-6 block must merge in one linear pass.
+    @Test("A 10k-line HTML block parses in linear-ish time")
+    func hugeHTMLBlockRun() {
+        let doc = Array(repeating: "<div>x</div>", count: 10_000).joined(separator: "\n")
+        let t0 = DispatchTime.now()
+        let blocks = BlockParser.parse(doc)
+        let seconds = Double(DispatchTime.now().uptimeNanoseconds - t0.uptimeNanoseconds) / 1e9
+        #expect(blocks.count == 1)
+        #expect(seconds < 10)
+    }
+
+    /// `<custom> trailing words` opens no HTML block (name not in the type-6
+    /// list; the trailing words defeat type 7), so the start check must stay
+    /// O(line) across a huge run of such paragraphs.
+    @Test("A 10k-line angle-bracket paragraph run parses in linear-ish time")
+    func hugeAngleParagraphRun() {
+        let doc = Array(repeating: "<custom> trailing words", count: 10_000).joined(separator: "\n")
         let t0 = DispatchTime.now()
         let blocks = BlockParser.parse(doc)
         let seconds = Double(DispatchTime.now().uptimeNanoseconds - t0.uptimeNanoseconds) / 1e9

--- a/Tests/EdmundTests/DocumentHTMLTests.swift
+++ b/Tests/EdmundTests/DocumentHTMLTests.swift
@@ -177,4 +177,19 @@ struct DocumentHTMLTests {
             #expect(out.contains("HTTP connection not supported"))
         }
     }
+
+    @Test("Page carries the script-src 'none' CSP meta")
+    func cspMeta() {
+        #expect(doc("hi").contains(
+            "<meta http-equiv=\"Content-Security-Policy\" content=\"script-src 'none'\">"))
+    }
+
+    // Caution: the page head legitimately contains a <style> from HTMLTheme —
+    // never assert !contains("<style") globally.
+    @Test("Full pipeline: a script block arrives tagfiltered, not executable")
+    func fullPipelineScript() {
+        let out = doc("<script>alert(1)</script>")
+        #expect(!out.contains("<script>alert"))
+        #expect(out.contains("&lt;script>"))
+    }
 }

--- a/Tests/EdmundTests/HTMLRendererTests.swift
+++ b/Tests/EdmundTests/HTMLRendererTests.swift
@@ -135,19 +135,78 @@ struct HTMLRendererEscapingTests {
 
     private func html(_ md: String) -> String { HTMLRenderer.render(markdown: md) }
 
-    @Test("Leaf text is HTML-escaped (no script injection)")
+    @Test("Inline <script> is tagfiltered (no script injection)")
     func escapesText() {
         let out = html("a <script>alert(1)</script> & b")
-        #expect(!out.contains("<script>"))
-        #expect(out.contains("&lt;script&gt;"))
+        #expect(!out.contains("<script"))
+        #expect(out.contains("&lt;script>alert(1)&lt;/script>"))
         #expect(out.contains("&amp;"))
     }
 
-    @Test("Raw HTML block is escaped, not passed through")
-    func escapesHTMLBlock() {
+    @Test("Raw HTML block passes through with event handlers stripped")
+    func blockPassthroughHardened() {
         let out = html("<div onclick=\"x\">hi</div>")
-        #expect(!out.contains("<div onclick"))
-        #expect(out.contains("&lt;div"))
+        #expect(out.contains("<div>hi</div>"))
+        #expect(!out.contains("onclick"))
+    }
+}
+
+@Suite("HTMLRenderer — GFM raw HTML, tagfilter & hardening")
+struct HTMLRendererRawHTMLTests {
+
+    private func html(_ md: String) -> String { HTMLRenderer.render(markdown: md) }
+
+    // GFM §6.11 spec example: only the leading `<` of a disallowed tag becomes
+    // `&lt;` (the `>` stays literal); everything else passes through raw.
+    @Test("Tagfilter spec example: disallowed tags get &lt;, others pass")
+    func tagfilterSpecExample() {
+        let out = html("<strong> <title> <style> <em>\n\n<blockquote>\n  <xmp> is disallowed.  <XMP> is also disallowed.\n</blockquote>")
+        #expect(out.contains("<strong> &lt;title> &lt;style> <em>"))
+        #expect(out.contains("&lt;xmp>"))
+        #expect(out.contains("&lt;XMP>"))
+        #expect(out.contains("<blockquote>"))
+    }
+
+    @Test("HTML block passes through raw; markdown inside is NOT rendered")
+    func blockPassthroughRaw() {
+        let out = html("<div>\n*hello*\n</div>")
+        #expect(out.contains("<div>\n*hello*\n</div>"))
+        #expect(!out.contains("<em>"))
+    }
+
+    @Test("A <script> block is tagfiltered, content inert")
+    func scriptBlockTagfiltered() {
+        let out = html("<script>\nalert(1)\n</script>")
+        #expect(!out.contains("<script"))
+        #expect(out.contains("&lt;script>"))
+        #expect(out.contains("alert(1)"))
+    }
+
+    @Test("javascript: href is neutralized")
+    func jsHrefNeutralized() {
+        let out = html("<a href=\"javascript:alert(1)\">x</a>")
+        #expect(!out.lowercased().contains("javascript:"))
+        #expect(out.contains("<a href="))
+    }
+
+    @Test("vbscript: action and single-quoted onmouseover are hardened")
+    func moreHardening() {
+        let out = html("<form action=\"vbscript:evil()\"><span onmouseover='x()'>t</span></form>")
+        #expect(!out.lowercased().contains("vbscript:"))
+        #expect(!out.contains("onmouseover"))
+    }
+
+    @Test("An <img> inside an HTML block becomes the asset-pass placeholder")
+    func blockInteriorImg() {
+        let out = html("<div><img src=\"cat.png\" alt=\"c\"></div>")
+        #expect(out.contains("<div>"))
+        #expect(out.contains("<img class=\"md-image\" data-src=\"cat.png\""))
+    }
+
+    @Test("A raw <table> block passes through")
+    func tableBlock() {
+        let out = html("<table><tr><td>x</td></tr></table>")
+        #expect(out.contains("<table><tr><td>x</td></tr></table>"))
     }
 }
 
@@ -233,11 +292,11 @@ struct HTMLRendererInlineTests {
         #expect(out.contains("<img class=\"md-image\" data-src=\"cat.png\" alt=\"\">"))
     }
 
-    @Test("An <img> without a quoted src stays escaped")
+    @Test("An <img> without a src passes through raw (no placeholder)")
     func imgWithoutSrc() {
         let out = html("x <img width=\"9\"> y")
-        #expect(!out.contains("<img class=\"md-image\""))
-        #expect(out.contains("&lt;img"))
+        #expect(!out.contains("md-image"))
+        #expect(out.contains("<img width=\"9\">"))
     }
 
     @Test("Bare www autolink renders as a real anchor")

--- a/Tests/EdmundTests/HTMLRendererTests.swift
+++ b/Tests/EdmundTests/HTMLRendererTests.swift
@@ -208,6 +208,12 @@ struct HTMLRendererRawHTMLTests {
         let out = html("<table><tr><td>x</td></tr></table>")
         #expect(out.contains("<table><tr><td>x</td></tr></table>"))
     }
+
+    @Test("A single-quoted <img src> still becomes the asset-pass placeholder")
+    func singleQuotedImgRead() {
+        let out = html("pic <img src='cat.png'> x")
+        #expect(out.contains("data-src=\"cat.png\""))
+    }
 }
 
 @Suite("HTMLRenderer — non-GFM inline")

--- a/Tests/EdmundTests/HTMLRendererTests.swift
+++ b/Tests/EdmundTests/HTMLRendererTests.swift
@@ -46,12 +46,47 @@ struct HTMLRendererCoreTests {
 
     @Test("Unordered, ordered, and task lists")
     func lists() {
-        #expect(html("- a\n- b") == "<ul><li><p>a</p></li><li><p>b</p></li></ul>")
+        // A tight list (GFM §5.3): no <p> wrapper inside items.
+        #expect(html("- a\n- b") == "<ul><li>a</li><li>b</li></ul>")
         #expect(html("1. a").hasPrefix("<ol>"))
         #expect(html("3. a\n4. b").hasPrefix("<ol start=\"3\">"))
         let task = html("- [ ] todo\n- [x] done")
         #expect(task.contains("<li class=\"task\"><span class=\"task-check task-check--unchecked\"><svg"))
         #expect(task.contains("<span class=\"task-check task-check--checked\"><svg"))
+    }
+
+    @Test("A loose list (blank line between items) keeps <p> wrappers")
+    func looseList() {
+        let out = html("- a\n\n- b")
+        #expect(out.contains("<li><p>a</p></li>"))
+        #expect(out.contains("<li><p>b</p></li>"))
+    }
+
+    @Test("A multi-block item with a blank gap makes the whole list loose")
+    func looseByMultiBlockItem() {
+        let out = html("- a\n\n  second\n- b")
+        #expect(out.contains("<p>a</p>"))
+        #expect(out.contains("<p>second</p>"))
+        #expect(out.contains("<li><p>b</p></li>"))
+    }
+
+    @Test("Nested loose list gets <p>; the tight outer list doesn't")
+    func mixedNesting() {
+        let out = html("- a\n  - x\n\n  - y\n- b")
+        #expect(out.contains("<li><p>x</p></li>"))
+        #expect(out.contains("<p>y</p>"))
+        #expect(!out.contains("<p>a</p>"))
+        #expect(out.contains("<li>b</li>"))
+    }
+
+    @Test("Link title renders as an escaped title attribute")
+    func linkTitle() {
+        #expect(html("[x](https://example.com \"hi there\")")
+            == "<p><a href=\"https://example.com\" title=\"hi there\">x</a></p>")
+        #expect(html("[x](https://example.com \"a & b\")").contains("title=\"a &amp; b\""))
+        let internalLink = html("[o](other.md \"note\")")
+        #expect(internalLink.contains("<a href=\"x-edmund-link:"))
+        #expect(internalLink.contains("title=\"note\""))
     }
 
     @Test("Table emits thead/tbody with per-column alignment")

--- a/Tests/EdmundTests/HTMLTagRenderingTests.swift
+++ b/Tests/EdmundTests/HTMLTagRenderingTests.swift
@@ -5,8 +5,8 @@ import AppKit
 
 // HTML tags in edit mode: every recognized tag is colored source (name red,
 // brackets dimmed); a whitelist (u/kbd/mark/sub/sup) additionally renders its
-// formatting when the caret is outside the token. Read mode is unchanged
-// (HTML stays escaped).
+// formatting when the caret is outside the token. Read mode passes raw HTML
+// through per GFM, filtered by tagfilter (§6.11) + hardening.
 
 @Suite("SyntaxHighlighter — HTML tags")
 struct HTMLTagParseTests {
@@ -199,11 +199,10 @@ struct HTMLTagExportTests {
         #expect(html("<small>fine</small>").contains("<small>fine</small>"))
     }
 
-    @Test("Attributes are stripped (bare tag only)")
-    func stripsAttributes() {
+    @Test("Benign attributes kept, event handlers stripped")
+    func hardensAttributes() {
         let out = html("<u class=\"x\" onclick=\"y\">hi</u>")
-        #expect(out.contains("<u>hi</u>"))
-        #expect(!out.contains("class"))
+        #expect(out.contains("<u class=\"x\">hi</u>"))
         #expect(!out.contains("onclick"))
     }
 
@@ -212,18 +211,17 @@ struct HTMLTagExportTests {
         #expect(html("<u>**b**</u>").contains("<u><strong>b</strong></u>"))
     }
 
-    @Test("Non-whitelisted inline tag stays escaped")
-    func unknownEscaped() {
+    @Test("Non-whitelisted inline tag passes through raw (GFM)")
+    func unknownPassesThrough() {
         let out = html("a <span>x</span> b")
-        #expect(out.contains("&lt;span&gt;"))
-        #expect(!out.contains("<span>"))
+        #expect(out.contains("<span>x</span>"))
     }
 
-    @Test("A nested script inside a passed tag is still escaped")
-    func nestedScriptEscaped() {
+    @Test("A nested script inside a passed tag is tagfiltered")
+    func nestedScriptTagfiltered() {
         let out = html("<u><script>alert(1)</script></u>")
         #expect(out.contains("<u>"))
-        #expect(!out.contains("<script>"))
-        #expect(out.contains("&lt;script&gt;"))
+        #expect(!out.contains("<script"))
+        #expect(out.contains("&lt;script"))
     }
 }

--- a/Tests/EdmundTests/HTMLTagRenderingTests.swift
+++ b/Tests/EdmundTests/HTMLTagRenderingTests.swift
@@ -182,6 +182,17 @@ struct HTMLTagRenderingTests {
         let f = attr(.font, at: 5, in: styled) as? NSFont
         #expect(f != nil && NSFontManager.shared.traits(of: f!).contains(.boldFontMask))
     }
+
+    @Test("An .htmlBlock renders as colored source: tags colored, markdown literal")
+    func htmlBlockSource() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("<div>\n**text**\n</div>", cursorPosition: nil)
+        // "div" name colored like any recognized tag (offset 1).
+        #expect(attr(.foregroundColor, at: 1, in: styled) as? NSColor == editor.theme.mathOperatorColor)
+        // The `**` asterisks stay visible — raw HTML source, no markdown spans.
+        #expect(!isHidden(at: 6, in: styled))
+        #expect(!isHidden(at: 7, in: styled))
+    }
 }
 
 @Suite("HTMLRenderer — whitelisted HTML passes through")

--- a/Tests/EdmundTests/HTMLTagRenderingTests.swift
+++ b/Tests/EdmundTests/HTMLTagRenderingTests.swift
@@ -104,6 +104,50 @@ struct HTMLTagParseTests {
         #expect(!k.contains { if case .image = $0 { return true }; return false })
         #expect(k.contains { if case .htmlTag = $0 { return true }; return false })
     }
+
+    @Test("Hyphenated element name is a tag (§6.10)")
+    func hyphenName() {
+        let spans = SyntaxHighlighter.parse("a <my-element> b")
+        let tag = spans.first { if case .htmlTag = $0.kind { return true }; return false }
+        #expect(tag?.contentRange == NSRange(location: 3, length: 10))   // "my-element"
+    }
+
+    @Test("A quoted attribute value may contain `>`")
+    func quotedGT() {
+        let text = "<span title=\"a>b\">"
+        let spans = SyntaxHighlighter.parse(text)
+        let tags = spans.filter { if case .htmlTag = $0.kind { return true }; return false }
+        #expect(tags.count == 1)
+        #expect(tags.first?.fullRange == NSRange(location: 0, length: (text as NSString).length))
+    }
+
+    @Test("<img> accepts single-quoted and unquoted attribute values")
+    func imgAltQuoting() {
+        guard case .image(let dest1, _, _)? = SyntaxHighlighter.parse("<img src='cat.png'>")
+            .first(where: { if case .image = $0.kind { return true }; return false })?.kind
+        else { Issue.record("no image span for single-quoted src"); return }
+        #expect(dest1 == "cat.png")
+
+        guard case .image(let dest2, let w, _)? = SyntaxHighlighter.parse("<img src=cat.png width=120>")
+            .first(where: { if case .image = $0.kind { return true }; return false })?.kind
+        else { Issue.record("no image span for unquoted src"); return }
+        #expect(dest2 == "cat.png")
+        #expect(w == 120)
+    }
+
+    @Test("A closing tag with attributes is not a tag (§6.10)")
+    func badCloseTag() {
+        let k = kinds("</div class=\"x\">")
+        #expect(!k.contains { if case .htmlTag = $0 { return true }; return false })
+    }
+
+    @Test("PI, declaration, and CDATA tokens become dimmed source")
+    func otherRawHTML() {
+        for text in ["x <?php echo ?> y", "x <!DOCTYPE html> y", "x <![CDATA[>&<]]> y"] {
+            #expect(kinds(text).contains { if case .htmlTag = $0 { return true }; return false },
+                    "no htmlTag span in \(text)")
+        }
+    }
 }
 
 @Suite("Rendering — HTML tags")

--- a/Tests/EdmundTests/IncrementalParseFuzzTests.swift
+++ b/Tests/EdmundTests/IncrementalParseFuzzTests.swift
@@ -20,7 +20,10 @@ struct IncrementalParseFuzzTests {
         let fragments = ["\n", "\n\n", "```", "```\n", "$$", "|", ">", "> ",
                          "# ", "- ", "---\n", "x", "hello **world**",
                          "| a | b |", "[!note]", "  - indented\n", "\t- tabbed\n",
-                         "===\n", "===", "    code\n", "\tcode\n"]
+                         "===\n", "===", "    code\n", "\tcode\n",
+                         "<div>", "</div>\n", "<!--", "-->", "<script>",
+                         "</script>\n", "<pre>", "<?", "<!DOCTYPE ",
+                         "<![CDATA[", "]]>", "<custom-tag>\n"]
 
         for _ in 0..<120 {
             let ns = editor.rawSource as NSString

--- a/Tests/EdmundTests/SyntaxHighlighterTests.swift
+++ b/Tests/EdmundTests/SyntaxHighlighterTests.swift
@@ -107,6 +107,28 @@ struct CodeTests {
         #expect(spans.count == 1)
         #expect(spans[0].kind == .code)
     }
+
+    @Test("``a`b`` uses 2-backtick delimiters (GFM §6.3)")
+    func doubleBacktickCode() {
+        let spans = SyntaxHighlighter.parse("``a`b``")
+        #expect(spans.count == 1)
+        let s = spans[0]
+        #expect(s.kind == .code)
+        #expect(s.delimiterRanges == [NSRange(location: 0, length: 2),
+                                      NSRange(location: 5, length: 2)])
+        #expect(s.contentRange == NSRange(location: 2, length: 3))   // "a`b"
+    }
+
+    @Test("`` ` `` keeps its padding spaces in contentRange (edit mode shows source)")
+    func paddedBacktick() {
+        let spans = SyntaxHighlighter.parse("`` ` ``")
+        #expect(spans.count == 1)
+        let s = spans[0]
+        #expect(s.kind == .code)
+        #expect(s.delimiterRanges == [NSRange(location: 0, length: 2),
+                                      NSRange(location: 5, length: 2)])
+        #expect(s.contentRange == NSRange(location: 2, length: 3))   // " ` "
+    }
 }
 
 // MARK: - Headings

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -208,7 +208,9 @@ editor parses (one parser, two back-ends: `SpanCollector` → editor attributes,
 `HTMLRenderer` → HTML), themed from the *same* `EditorTheme`/`CalloutStyle` via
 `HTMLTheme`, so the two can't drift. The webview disables JavaScript and inlines
 every asset (math/icons as data URIs) so it needs no file/network reach; external
-links open in the default browser. **File ▸ Export as PDF… / Print… (⌘P)** run
+links open in the default browser. Raw HTML passes through per GFM, filtered by
+tagfilter + hardening, and the page carries a `script-src 'none'` CSP meta
+(see §10 for the full policy). **File ▸ Export as PDF… / Print… (⌘P)** run
 the same HTML through `WKWebView.printOperation` for real vector (selectable)
 text — `MarkdownPrinter`. Math glyphs are high-DPI PNG (SwiftMath has no SVG
 path yet); callout/checkbox icons are inline Lucide SVG (vector); everything
@@ -423,21 +425,33 @@ them and route through the app's document graph without JavaScript.
 
 ## 10. Still to address
 
-- **Inline HTML renders in both modes for a fixed whitelist** —
-  `SyntaxHighlighter.htmlFormatTags` (`u`/`kbd`/`mark`/`sub`/`sup`/`small`), the
-  single source of truth. Edit: `parseHTMLTags` colors any tag (name red,
-  brackets dimmed) and renders the whitelist by hiding the tags + styling the
-  inner content. Read: `HTMLRenderer.sanitizeInlineHTML` passes the same
-  whitelist through as *bare* tags (attributes dropped — defense-in-depth; the
-  read webview also disables JS); every other inline tag and **all** block HTML
-  (`visitHTMLBlock`) stays escaped, except `<!-- comments -->` (invisible in
-  both modes) and a lone `<img src="…">` tag (rendered in both modes, with
-  optional declared `width`/`height`; double-quoted attributes only). `<br>`
-  and non-whitelisted tags are color-only in Edit / escaped in Read (a real
-  `<br>` break would need to mutate storage, breaking the storage==rawSource
-  invariant). Minor divergence: an *unpaired* whitelist tag is color-only
-  source in Edit but follows browser HTML balancing in Read. Full HTML block
-  support (type-6 multi-line blocks) is still deferred.
+- **Raw HTML (§G): Read renders it per GFM; Edit shows colored source** — the
+  GitHub split (their editor shows source too; rendered HTML in Edit is
+  impossible under the storage==rawSource invariant). Read mode passes raw
+  HTML through (GFM §6.10 inline / §4.6 blocks) filtered by
+  `HTMLRenderer.filterRawHTML` = the spec tagfilter (§6.11: the nine dangerous
+  tag names get `<` → `&lt;`) **plus** Edmund hardening beyond spec: `on*`
+  event-handler attributes stripped, `javascript:`/`vbscript:` URL schemes
+  neutralized. Defense layers behind that filter: the read webview disables
+  JS, the page carries a `script-src 'none'` CSP meta (`DocumentHTML.full` —
+  Read view and Print/PDF both consume it), and it loads with `baseURL: nil`.
+  A raw `<img src=…>` (lone or inside a block) is rewritten to the `md-image`
+  placeholder — the only way images load under `baseURL: nil`, and the
+  remote-image-policy chokepoint (`DocumentHTML.fillImages`). Edit mode:
+  `.htmlBlock` blocks (all seven §4.6 start conditions in `BlockParser`) and
+  inline tags (full §6.10 grammar in `parseHTMLTags`) render as colored
+  source; the `SyntaxHighlighter.htmlFormatTags` whitelist
+  (`u`/`kbd`/`mark`/`sub`/`sup`/`small`) is *presentation* in Edit (rendered
+  formatting), not sanitization. Deliberate divergences from spec: the HTML
+  comment regex is laxer (interior `--` allowed); a `<`-line that forms a
+  valid table header+separator becomes a table (tables win); the type-1 tag
+  set is pinned to CommonMark 0.29 (`script|pre|style`, no `textarea`); a
+  lone self-closing `<script/>` is a type-7 HTML block, not a paragraph; the
+  Edit-mode `htmlPairRegex` attr swallow breaks on `>` inside a quoted
+  attribute of a whitelist open tag (falls back to colored source). Still
+  deferred in Edit mode: reference links/definitions, blockquote lazy
+  continuation, entity-reference styling, the 2-trailing-space hard-break
+  span.
 - **Edit-mode table alignment** distributes each cell's slack via `.kern`,
   putting the right/center "before" pad on the cell's *hidden* leading pipe
   (0.01pt glyph) — kern still adds advance there. See


### PR DESCRIPTION
## Summary
Closes the HTML gaps left after #199: GFM raw HTML now works end-to-end in both view modes, plus a few small conformance fixes found in the same audit.

- **Read mode**: raw HTML passes through per GFM (§4.6 blocks / §6.10 inline) instead of being escaped, filtered through the §6.11 tagfilter (9 dangerous tag names) plus hardening beyond spec — `on*` event-handler attributes stripped, `javascript:`/`vbscript:` URLs neutralized, `script-src 'none'` CSP meta added. Defense-in-depth on top of existing JS-off + `baseURL: nil`.
- **Edit mode**: all seven §4.6 HTML block start conditions now parse as a `.htmlBlock` kind (colored source, GitHub-editor style); inline tag grammar covers the full §6.10 grammar (hyphenated names, single-quoted/unquoted attribute values, `>` inside quoted values, PI/declaration/CDATA tokens).
- **Small gaps**: multi-backtick code spans measure their real delimiter length in edit mode; read mode now distinguishes loose vs tight lists (§5.3) and carries link `title` attributes into exported HTML.
- Deliberate divergences and deferred items (reference links/definitions, blockquote lazy continuation, entity styling, 2-space hard break — all edit mode) documented in `ARCHITECTURE.md` §10.

Executed by a sonnet subagent from a written plan, verified by: full test suite, a temporary 20k-line perf benchmark (ruling out a repeat of the quadratic-scan regression from the prior GFM pass), and visual screencapture verification of both edit and read mode.

## Test plan
- [x] `swift test` — 940/940 passing
- [x] Perf: new `BlockParserPerfTests` HTML cases + ad-hoc 20k-line benchmark, all well under budget
- [x] Visual: screencapture-verified edit mode (colored HTML source) and read mode (rendered HTML, tagfiltered script inert, tight/loose list spacing, titled links)
- [x] Security: script tagfiltered, `onclick` stripped, `javascript:` neutralized, CSP meta present — all codified as tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)