### PR TITLE
feat(math): render display math from inline $$…$$

### DIFF
--- a/Sources/EdmundCore/Parsing/SyntaxHighlighter+CustomParsers.swift
+++ b/Sources/EdmundCore/Parsing/SyntaxHighlighter+CustomParsers.swift
@@ -192,27 +192,55 @@ extension SyntaxHighlighter {
         }
     }
 
-    /// Recognizes a whole block as `$$…$$` display math. `BlockParser` has
-    /// already merged a multi-line `$$ … $$` run into a single block, so here we
-    /// only need to confirm the block opens and closes with `$$`.
+    /// Scans for `$$…$$` display math runs. A run can own its whole block
+    /// (`BlockParser` merges a multi-line `$$ … $$` into one block, so content
+    /// may span newlines) or sit inline within a prose line (`text $$x$$ more`).
+    ///
+    /// Tightness (space/tab, NOT newline) guards against prose false positives
+    /// like "pay $$5 and $$6": a `$$` delimiter must abut non-space on the inner
+    /// side — mirrors the Pandoc rule in `parseMath`. Newlines are allowed so a
+    /// block-merged `$$\n … \n$$` still matches. Runs before `parseMath`, which
+    /// skips ranges inside a `.math(display: true)` span.
     static func parseDisplayMath(_ text: String, into spans: inout [Span]) {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.hasPrefix("$$"), trimmed.hasSuffix("$$"), trimmed.count >= 4 else { return }
-
         let ns = text as NSString
-        let open = ns.range(of: "$$")
-        let close = ns.range(of: "$$", options: .backwards)
-        guard open.location != NSNotFound, close.location != NSNotFound,
-              close.location >= open.location + 2 else { return }
+        let n = ns.length
+        let dollar: unichar = 0x24, backslash: unichar = 0x5C
 
-        let full = NSRange(location: open.location, length: close.upperBound - open.location)
-        let content = NSRange(location: open.upperBound, length: close.location - open.upperBound)
-        spans.append(Span(
-            kind: .math(display: true),
-            fullRange: full,
-            contentRange: content,
-            delimiterRanges: [open, close]
-        ))
+        // Same-line whitespace only; newlines are legal inside a display block.
+        func isSpace(_ c: unichar) -> Bool { c == 0x20 || c == 0x09 }
+
+        var i = 0
+        while i < n {
+            let c = ns.character(at: i)
+            if c == backslash { i += 2; continue }   // skip escaped char
+            // Opening `$$`, abutting a non-space on its inner side.
+            guard c == dollar, i + 1 < n, ns.character(at: i + 1) == dollar else { i += 1; continue }
+            let afterOpen = i + 2
+            guard afterOpen < n, !isSpace(ns.character(at: afterOpen)) else { i += 1; continue }
+
+            // Find the closing `$$`, abutting a non-space on its inner side.
+            var j = afterOpen
+            var closeLoc = -1
+            while j + 1 < n {
+                let cj = ns.character(at: j)
+                if cj == backslash { j += 2; continue }
+                if cj == dollar && ns.character(at: j + 1) == dollar {
+                    if !isSpace(ns.character(at: j - 1)) { closeLoc = j; break }
+                    j += 2; continue      // `$$` preceded by space isn't a valid close
+                }
+                j += 1
+            }
+            guard closeLoc > afterOpen else { i += 2; continue }  // no close / empty content
+
+            spans.append(Span(
+                kind: .math(display: true),
+                fullRange: NSRange(location: i, length: closeLoc + 2 - i),
+                contentRange: NSRange(location: afterOpen, length: closeLoc - afterOpen),
+                delimiterRanges: [NSRange(location: i, length: 2),
+                                  NSRange(location: closeLoc, length: 2)]
+            ))
+            i = closeLoc + 2
+        }
     }
 
     /// Scans for inline `$…$` math. Uses Pandoc-style disambiguation so prose

--- a/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
@@ -428,10 +428,25 @@ extension EditorTextView {
                         applyOverlay(overlay,
                                      anchor: NSRange(location: span.fullRange.location, length: 1),
                                      in: result)
-                        if !display {
-                            // Inline math flows within a text line; reserve the
-                            // line height so a tall equation (e.g. scaled to a
-                            // heading's font) doesn't overlap the line below.
+                        // A `$$…$$` run gets block layout (centered on its own
+                        // line) only when it owns the whole block. A run sharing
+                        // its line with prose flows inline like `$…$` math.
+                        let displayOwnsBlock: Bool = {
+                            guard display else { return false }
+                            let blockNS = markdown as NSString
+                            let full = span.fullRange
+                            let nonWS = CharacterSet.whitespacesAndNewlines.inverted
+                            let before = NSRange(location: 0, length: full.location)
+                            let after = NSRange(location: full.upperBound,
+                                                length: blockNS.length - full.upperBound)
+                            return blockNS.rangeOfCharacter(from: nonWS, options: [], range: before).location == NSNotFound
+                                && blockNS.rangeOfCharacter(from: nonWS, options: [], range: after).location == NSNotFound
+                        }()
+                        if !displayOwnsBlock {
+                            // Inline math — and a display run sharing its line
+                            // with prose — flows within the text line; reserve
+                            // the line height so a tall equation (e.g. scaled to
+                            // a heading's font) doesn't overlap the line below.
                             reserveLineHeight(overlay.bounds.height,
                                               forOverlayAt: span.fullRange.location,
                                               in: result)
@@ -439,7 +454,7 @@ extension EditorTextView {
                         // Display math sits centered on its own line, with
                         // vertical padding and the image's ascent/descent
                         // reserved on the (first) line that carries it.
-                        if display {
+                        if displayOwnsBlock {
                             let fullStr = result.string as NSString
                             result.addAttribute(.paragraphStyle,
                                                 value: displayMathParagraphStyle(padded: false),

--- a/Tests/EdmundTests/SyntaxHighlighterTests.swift
+++ b/Tests/EdmundTests/SyntaxHighlighterTests.swift
@@ -1101,6 +1101,33 @@ struct DisplayMathTests {
     func paragraphNotDisplay() {
         #expect(mathSpans("just a paragraph").isEmpty)
     }
+
+    @Test("Inline $$…$$ sharing a line with prose is display math")
+    func inlineDisplayInProse() {
+        let text = "text $$x$$ more"
+        let spans = mathSpans(text)
+        #expect(spans.count == 1)
+        #expect(spans[0].kind == .math(display: true))
+        #expect(spans[0].fullRange == NSRange(location: 5, length: 5))
+        #expect((text as NSString).substring(with: spans[0].contentRange) == "x")
+    }
+
+    @Test("Two $$…$$ runs on one line produce two display spans")
+    func twoRunsOneLine() {
+        let spans = mathSpans("$$a$$ and $$b$$")
+        #expect(spans.count == 2)
+        #expect(spans.allSatisfy { $0.kind == .math(display: true) })
+    }
+
+    @Test("$$ with space after the delimiter is not display math")
+    func spaceAfterDelimiterNotDisplay() {
+        #expect(mathSpans("a $$ x $$ b").isEmpty)
+    }
+
+    @Test("Loose $$ in prose (close preceded by space) is not display math")
+    func looseProseDollarsNotDisplay() {
+        #expect(mathSpans("cost $$5 for $$10 today").isEmpty)
+    }
 }
 
 // MARK: - Autolinks (GFM extension)


### PR DESCRIPTION
## What
`$$…$$` now renders as display math even when the delimiters sit **inline** within a prose line (`text $$x$$ more`), not only when they own the whole line/block.

- **`parseDisplayMath`** rewritten from a whole-block `hasPrefix`/`hasSuffix` check to a scanner that emits a `.math(display: true)` span for each `$$…$$` run anywhere in the block. Same-line tightness (space/tab, **not** newline) rejects prose false positives like `pay $$5 and $$6`, while block-merged `$$\n…\n$$` still matches.
- **Renderer** gates the centered display paragraph-style on whole-block ownership: a run owning its block still centers on its own line; a run sharing the line with prose flows inline via `reserveLineHeight` like `$…$` math.
- No `BlockParser` change — `styleBlock` parses every block's content regardless of kind.

## Why
Last piece of near-complete GFM math handling. Ruled **not** related to the deferred reference-links / blockquote-lazy-continuation work: those are cross-block/document-level; inline `$$` is purely local to one block, so it's independent and cheap. Backlog item `misc/backlog.md:204`.

## Verification
- `swift test` — 917 pass; added parse tests (inline-in-prose, two runs one line, tightness false-positive guard, whole-block regression) + existing "Display math is centered" regression holds.
- Visual (edit mode): inline `$$\frac{a}{b}=c$$` flows in the prose line with prose intact; standalone `$$\int…$$` block still centers; two runs on one line both render inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)