### PR TITLE
feat(gfm): resolve reference links across blocks in edit mode

### DIFF
--- a/Sources/EdmundCore/Editing/EditorTextView+FormattingCore.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+FormattingCore.swift
@@ -38,6 +38,7 @@ extension EditorTextView {
 
         rawSource = ns.replacingCharacters(in: clamped, with: replacement)
         rebuildListIndentState()
+        rebuildLinkDefState()
         blocks = BlockParser.parse(rawSource, previous: blocks)
 
         // The replaced region grew/shrank by `delta`; the new block-aligned span
@@ -74,6 +75,7 @@ extension EditorTextView {
 
         rawSource = newRawSource
         rebuildListIndentState()
+        rebuildLinkDefState()
         blocks = BlockParser.parse(rawSource, previous: blocks)
 
         let len = (rawSource as NSString).length

--- a/Sources/EdmundCore/Editing/EditorTextView+Indentation.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+Indentation.swift
@@ -99,6 +99,7 @@ extension EditorTextView {
         let oldIndentUnit = listIndentUnit
         rawSource = parts.joined(separator: blockSeparator)
         rebuildListIndentState()
+        rebuildLinkDefState()
 
         // Cursor in startBlock shifts by 1 indent; rawEnd in endBlock
         // shifts by (endBlock - startBlock + 1) indents (one per block).
@@ -180,6 +181,7 @@ extension EditorTextView {
         let oldIndentUnit = listIndentUnit
         rawSource = parts.joined(separator: blockSeparator)
         rebuildListIndentState()
+        rebuildLinkDefState()
 
         // Adjust rawStart (in startBlock).  No blocks before startBlock
         // were modified, so its start position is unchanged.

--- a/Sources/EdmundCore/Model/LinkDefinitionState.swift
+++ b/Sources/EdmundCore/Model/LinkDefinitionState.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Incremental backing for the document's link reference definitions.
+///
+/// GFM reference links (`[text][label]`, `[label][]`, `[label]`) resolve
+/// against `[label]: destination` definitions that may live in *other* blocks.
+/// Edmund styles one block at a time, so the editor collects every definition
+/// line here — built whole-document on load and maintained per changed block on
+/// the edit path (mirroring `ListIndentState`) — and appends `defsText` to each
+/// block's parse so swift-markdown's CommonMark parser resolves the references
+/// (see `SyntaxHighlighter.parse(_:linkDefinitions:)`).
+///
+/// A multiset of the raw definition *lines* is enough: swift-markdown applies
+/// CommonMark's "first definition wins" itself, and `defsText` is sorted so the
+/// incremental state and a from-scratch rebuild always produce the identical
+/// string (the full-recompose oracle depends on that determinism).
+struct LinkDefinitionState: Equatable {
+    /// Unique `[label]: url` source lines → occurrence count, so per-block
+    /// add/remove stays exact when the same line appears more than once.
+    private var lines: [String: Int] = [:]
+
+    /// The collected definition lines, sorted and newline-joined. Empty when the
+    /// document defines no references (then parsing skips the append entirely).
+    var defsText: String { lines.keys.sorted().joined(separator: "\n") }
+
+    mutating func add(_ content: String) { scan(content, sign: 1) }
+    mutating func remove(_ content: String) { scan(content, sign: -1) }
+
+    static func build(from source: String) -> LinkDefinitionState {
+        var state = LinkDefinitionState()
+        state.add(source)
+        return state
+    }
+
+    private mutating func scan(_ content: String, sign: Int) {
+        for line in content.split(separator: "\n", omittingEmptySubsequences: false) {
+            let key = String(line)
+            guard Self.isDefinitionLine(key) else { continue }
+            let count = (lines[key] ?? 0) + sign
+            lines[key] = count <= 0 ? nil : count
+        }
+    }
+
+    /// A CommonMark link reference definition line: up to 3 leading spaces, a
+    /// non-empty `[label]`, `:`, then a destination. (Rare multi-line / titled
+    /// forms aren't recognized; ponytail: single-line covers the common case.)
+    private static let defRegex = try! NSRegularExpression(
+        pattern: #"^ {0,3}\[[^\]\n]+\]:\s*\S.*$"#)
+
+    static func isDefinitionLine(_ line: String) -> Bool {
+        defRegex.firstMatch(in: line, range: NSRange(location: 0, length: (line as NSString).length)) != nil
+    }
+}

--- a/Sources/EdmundCore/Parsing/SyntaxHighlighter.swift
+++ b/Sources/EdmundCore/Parsing/SyntaxHighlighter.swift
@@ -86,12 +86,26 @@ public enum SyntaxHighlighter {
     // MARK: - Parsing
 
     /// Returns all inline syntax spans found in `text`, ordered by position.
-    public static func parse(_ text: String) -> [Span] {
+    ///
+    /// `linkDefinitions` (the document's collected `[label]: url` lines, from
+    /// `LinkDefinitionState.defsText`) is appended after the block so
+    /// swift-markdown can resolve GFM reference links whose definition lives in
+    /// another block; spans landing in the appended region are dropped. Empty
+    /// (the common case) means no append and no cost.
+    public static func parse(_ text: String, linkDefinitions: String = "") -> [Span] {
         guard !text.isEmpty else { return [] }
 
-        let doc = Document(parsing: text, options: [.disableSmartOpts])
-        var walker = SpanCollector(source: text)
+        // Walk the AST over the block plus any appended reference definitions,
+        // then keep only spans within the original block. Custom parsers below
+        // still run on `text`, so their offsets need no adjustment.
+        let textLen = (text as NSString).length
+        let parseText = linkDefinitions.isEmpty ? text : text + "\n\n" + linkDefinitions
+        let doc = Document(parsing: parseText, options: [.disableSmartOpts])
+        var walker = SpanCollector(source: parseText)
         walker.visit(doc)
+        if !linkDefinitions.isEmpty {
+            walker.spans.removeAll { $0.fullRange.upperBound > textLen }
+        }
 
         // ==highlight== is not supported by swift-markdown; parse with regex.
         parseHighlight(text, into: &walker.spans)

--- a/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
@@ -153,7 +153,7 @@ extension EditorTextView {
         let result = NSMutableAttributedString(string: markdown, attributes: baseAttributes)
         guard !markdown.isEmpty else { return result }
 
-        let spans = SyntaxHighlighter.parse(markdown)
+        let spans = SyntaxHighlighter.parse(markdown, linkDefinitions: linkDefState.defsText)
 
         // The font already applied at `loc` — the enclosing heading's when
         // inside one, else the base body font. Inline spans derive their font

--- a/Sources/EdmundCore/TextView/EditorTextView+EditFlow.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+EditFlow.swift
@@ -158,6 +158,10 @@ extension EditorTextView {
         // full positional-diff parse as the fallback.
         let newBlocks: [Block]
         let changed: Range<Int>
+        // Whether the document's link reference definitions changed — a `[label]:
+        // url` line added/removed/edited can affect a reference link in *any*
+        // block, so on change every bracket-bearing block is restyled below.
+        var defsChanged = false
         if let pending = (ts as? EditorTextStorage)?.consumePendingEdit(),
            let incremental = BlockParser.incrementalParse(text: rawSource,
                                                           old: blocks,
@@ -167,20 +171,27 @@ extension EditorTextView {
             #if DEBUG
             verifyIncrementalParse(newBlocks)
             #endif
-            // Update the indent histogram from exactly the replaced blocks
-            // (old) and their replacements (new) — O(edit), same effect as a
-            // whole-document rescan.
+            // Update the indent histogram and link definitions from exactly the
+            // replaced blocks (old) and their replacements (new) — O(edit), same
+            // effect as a whole-document rescan.
+            let oldDefState = linkDefState
             let suffixCount = newBlocks.count - changed.upperBound
             for i in changed.lowerBound ..< (oldCount - suffixCount) {
                 listIndentState.remove(blocks[i].content)
+                linkDefState.remove(blocks[i].content)
             }
             for i in changed {
                 listIndentState.add(newBlocks[i].content)
+                linkDefState.add(newBlocks[i].content)
             }
             listIndentUnit = listIndentState.unit
+            defsChanged = linkDefState != oldDefState
         } else {
             (newBlocks, changed) = BlockParser.parseWithDiff(rawSource, previous: blocks)
+            let oldDefState = linkDefState
             rebuildListIndentState()
+            rebuildLinkDefState()
+            defsChanged = linkDefState != oldDefState
         }
         blocks = newBlocks
 
@@ -209,6 +220,15 @@ extension EditorTextView {
         // indentation of every list block changes with it.
         if listIndentUnit != oldIndentUnit {
             for (i, block) in blocks.enumerated() where block.kind == .listItem {
+                dirty.insert(i)
+            }
+        }
+
+        // A changed link definition can flip any reference link (even a bare
+        // `[label]` shortcut) elsewhere in the document, so restyle every block
+        // that could hold one. Bracket-free blocks can't, so skip them.
+        if defsChanged {
+            for (i, block) in blocks.enumerated() where block.content.contains("[") {
                 dirty.insert(i)
             }
         }

--- a/Sources/EdmundCore/TextView/EditorTextView+Undo.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+Undo.swift
@@ -106,6 +106,7 @@ extension EditorTextView {
 
         rawSource = snapshot.rawSource
         rebuildListIndentState()
+        rebuildLinkDefState()
         let (newBlocks, changed) = BlockParser.parseWithDiff(rawSource, previous: blocks)
         blocks = newBlocks
 

--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -51,6 +51,15 @@ public class EditorTextView: NSTextView {
         listIndentState = ListIndentState.build(from: rawSource)
         listIndentUnit = listIndentState.unit
     }
+
+    /// Document-wide link reference definitions (`[label]: url`), fed into each
+    /// block's parse so GFM reference links resolve across blocks. Maintained
+    /// incrementally on the edit path; rebuilt by the whole-document paths.
+    var linkDefState = LinkDefinitionState()
+
+    func rebuildLinkDefState() {
+        linkDefState = LinkDefinitionState.build(from: rawSource)
+    }
     /// Line ending of the most recently loaded content. The buffer itself is
     /// always LF; this is remembered so saves preserve the file's style.
     public var originalLineEnding: LineEnding = .lf
@@ -277,6 +286,7 @@ public class EditorTextView: NSTextView {
 
         rawSource = ""
         rebuildListIndentState()
+        rebuildLinkDefState()
         blocks = BlockParser.parse(rawSource)
         recompose(cursorInRaw: 0)
 
@@ -438,6 +448,7 @@ public class EditorTextView: NSTextView {
         if hasMarkedText() { unmarkText() }
         rawSource = ts.string
         rebuildListIndentState()
+        rebuildLinkDefState()
         blocks = BlockParser.parse(rawSource, previous: blocks)
         recompose(cursorInRaw: min(selectedRange().location, (rawSource as NSString).length))
     }
@@ -495,6 +506,7 @@ public class EditorTextView: NSTextView {
             originalLineEnding = LineEnding.isInconsistent(in: content) ? .lf : LineEnding.detect(in: content)
             rawSource = LineEnding.normalize(content)
             rebuildListIndentState()
+            rebuildLinkDefState()
             blocks = BlockParser.parse(rawSource)
             Log.blockStructure(blocks)
             undoStack.removeAll()

--- a/Tests/EdmundTests/ReferenceLinkIntegrationTests.swift
+++ b/Tests/EdmundTests/ReferenceLinkIntegrationTests.swift
@@ -1,0 +1,27 @@
+import Testing
+import AppKit
+@testable import EdmundCore
+
+// Cross-block reference-link resolution in the live editor. "use [foo] here" is
+// block 0; the definition is block 2. Activating block 2 leaves block 0 styled,
+// so its `[foo]` must resolve against a definition parsed from another block.
+// 'f' of "foo" sits at offset 5.
+@Suite("Integration — Reference links")
+struct ReferenceLinkIntegrationTests {
+
+    @Test("A shortcut reference resolves against a definition in another block")
+    @MainActor func crossBlockResolves() {
+        let editor = makeEditor()
+        editor.loadContent("use [foo] here\n\n[foo]: https://e.com")
+        activateBlock(2, in: editor)
+        #expect(fgColor(at: 5, in: editor) == editor.linkColor)
+    }
+
+    @Test("With no matching definition the same text stays plain (not a link)")
+    @MainActor func noDefinitionStaysPlain() {
+        let editor = makeEditor()
+        editor.loadContent("use [foo] here\n\nprose only")
+        activateBlock(2, in: editor)
+        #expect(fgColor(at: 5, in: editor) != editor.linkColor)
+    }
+}

--- a/Tests/EdmundTests/ReferenceLinkTests.swift
+++ b/Tests/EdmundTests/ReferenceLinkTests.swift
@@ -1,0 +1,117 @@
+import Testing
+import Foundation
+import AppKit
+@testable import EdmundCore
+
+// MARK: - Reference link resolution (edit-mode parse)
+
+@Suite("SyntaxHighlighter — Reference links")
+struct ReferenceLinkTests {
+
+    private func linkSpans(_ text: String, defs: String = "")
+        -> [(range: NSRange, dest: String)] {
+        SyntaxHighlighter.parse(text, linkDefinitions: defs).compactMap { s in
+            guard case .link(let d) = s.kind else { return nil }
+            return (s.fullRange, d)
+        }
+    }
+
+    @Test("Full reference `[text][label]` resolves against an appended definition")
+    func fullReference() {
+        let links = linkSpans("see [text][bar] here", defs: "[bar]: https://e.com")
+        #expect(links.count == 1)
+        #expect(links[0].dest == "https://e.com")
+        #expect(links[0].range == NSRange(location: 4, length: 11))   // [text][bar]
+    }
+
+    @Test("Collapsed reference `[label][]` resolves")
+    func collapsedReference() {
+        let links = linkSpans("a [foo][] b", defs: "[foo]: https://f.com")
+        #expect(links.count == 1)
+        #expect(links[0].dest == "https://f.com")
+    }
+
+    @Test("Shortcut reference `[label]` resolves")
+    func shortcutReference() {
+        let links = linkSpans("a [foo] b", defs: "[foo]: https://f.com")
+        #expect(links.count == 1)
+        #expect(links[0].dest == "https://f.com")
+    }
+
+    @Test("Label matching is case-insensitive (CommonMark)")
+    func caseInsensitiveLabel() {
+        let links = linkSpans("[Foo]", defs: "[foo]: https://f.com")
+        #expect(links.count == 1)
+        #expect(links[0].dest == "https://f.com")
+    }
+
+    @Test("Unknown label produces no link span (stays plain text)")
+    func unknownLabel() {
+        #expect(linkSpans("see [text][bar]", defs: "[other]: https://e.com").isEmpty)
+    }
+
+    @Test("Without definitions, a bare `[foo]` is not a link (regression)")
+    func noDefinitionsNoLink() {
+        #expect(linkSpans("a [foo] b").isEmpty)
+    }
+
+    @Test("Inline link `[t](url)` is unaffected by the append")
+    func inlineLinkUnaffected() {
+        let links = linkSpans("[t](https://x.com)", defs: "[bar]: https://e.com")
+        #expect(links.count == 1)
+        #expect(links[0].dest == "https://x.com")
+    }
+
+    @Test("Appended definition never leaks a span past the block")
+    func noSpanLeaksIntoAppendedRegion() {
+        let text = "[foo]"
+        let spans = SyntaxHighlighter.parse(text, linkDefinitions: "[foo]: https://f.com")
+        #expect(spans.allSatisfy { $0.fullRange.upperBound <= (text as NSString).length })
+    }
+}
+
+// MARK: - LinkDefinitionState
+
+@Suite("LinkDefinitionState")
+struct LinkDefinitionStateTests {
+
+    @Test("build collects definition lines; defsText is sorted and deterministic")
+    func buildCollectsAndSorts() {
+        let s = LinkDefinitionState.build(from: "text\n[b]: u2\nmore\n[a]: u1")
+        #expect(s.defsText == "[a]: u1\n[b]: u2")
+    }
+
+    @Test("No definitions yields empty defsText (parse skips the append)")
+    func emptyWhenNoDefinitions() {
+        #expect(LinkDefinitionState.build(from: "just prose\n[not a def]").defsText == "")
+    }
+
+    @Test("add then remove of the same block content is exact")
+    func addRemoveExact() {
+        var s = LinkDefinitionState()
+        s.add("[a]: u1")
+        s.add("[b]: u2")
+        s.remove("[a]: u1")
+        #expect(s.defsText == "[b]: u2")
+        s.remove("[b]: u2")
+        #expect(s.defsText == "")
+    }
+
+    @Test("isDefinitionLine recognizes definitions and rejects non-definitions")
+    func definitionLineDetection() {
+        #expect(LinkDefinitionState.isDefinitionLine("[a]: https://e.com"))
+        #expect(LinkDefinitionState.isDefinitionLine("   [a]: /path"))          // ≤3 spaces
+        #expect(LinkDefinitionState.isDefinitionLine("[a]: u \"title\""))
+        #expect(!LinkDefinitionState.isDefinitionLine("    [a]: u"))            // 4 spaces = code
+        #expect(!LinkDefinitionState.isDefinitionLine("[a]:"))                  // empty dest
+        #expect(!LinkDefinitionState.isDefinitionLine("[a] not a def"))
+        #expect(!LinkDefinitionState.isDefinitionLine("plain text"))
+    }
+
+    @Test("Equatable ignores insertion order")
+    func equatableOrderIndependent() {
+        var a = LinkDefinitionState(); a.add("[x]: 1"); a.add("[y]: 2")
+        var b = LinkDefinitionState(); b.add("[y]: 2"); b.add("[x]: 1")
+        #expect(a == b)
+    }
+}


### PR DESCRIPTION
## What
GFM reference links now resolve in **edit mode** against `[label]: url` definitions in other blocks:
- full `[text][label]`, collapsed `[label][]`, shortcut `[label]`
- case-insensitive label matching (CommonMark)

Read mode already resolved them (it parses the whole document); this closes the edit-mode gap.

## How
- New **`LinkDefinitionState`** collects the document's `[label]: url` definitions — built whole-document on load, maintained per changed block on the edit path (mirrors `ListIndentState`).
- **`SyntaxHighlighter.parse(_:linkDefinitions:)`** appends the collected definitions after each block so swift-markdown's CommonMark parser does the resolution; spans landing in the appended region are dropped. No definitions → empty append → zero cost. No new span kind (`visitLink` already emits `.link`).
- **Invalidation:** a definition change can flip a reference (even a bare `[foo]` shortcut) in any block, so an edit that changes the definition set restyles every bracket-bearing block. Coarse but correct; def edits are rare.

## Verification
- `swift test` — **967 pass**, incl. 15 new tests (parse resolution for all three ref forms, `LinkDefinitionState`, cross-block live-editor integration) and the incremental-parse fuzz oracle (proves the edit-path `defsText` threading keeps incremental == full-recompose).
- Live `screencapture` (edit mode): full/collapsed/shortcut references all render as styled links resolved from a definition block below.

## Scope
Blockquote lazy continuation — the other cross-block GFM gap — is deferred to a follow-up PR (higher-risk block-segmentation change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)