### PR TITLE
fix(gfm): collect reference definitions nested in quotes and lists

### DIFF
--- a/Sources/EdmundCore/Model/LinkDefinitionState.swift
+++ b/Sources/EdmundCore/Model/LinkDefinitionState.swift
@@ -34,8 +34,7 @@ struct LinkDefinitionState: Equatable {
 
     private mutating func scan(_ content: String, sign: Int) {
         for line in content.split(separator: "\n", omittingEmptySubsequences: false) {
-            let key = String(line)
-            guard Self.isDefinitionLine(key) else { continue }
+            guard let key = Self.canonicalDefinition(from: String(line)) else { continue }
             let count = (lines[key] ?? 0) + sign
             lines[key] = count <= 0 ? nil : count
         }
@@ -46,8 +45,51 @@ struct LinkDefinitionState: Equatable {
     /// forms aren't recognized; ponytail: single-line covers the common case.)
     private static let defRegex = try! NSRegularExpression(
         pattern: #"^ {0,3}\[[^\]\n]+\]:\s*\S.*$"#)
+    /// One leading list marker (`-`/`*`/`+` or `1.`/`1)`) plus its trailing run.
+    private static let listMarkerRegex = try! NSRegularExpression(
+        pattern: #"^[ \t]*(?:[-*+]|\d{1,9}[.)])[ \t]+"#)
 
     static func isDefinitionLine(_ line: String) -> Bool {
-        defRegex.firstMatch(in: line, range: NSRange(location: 0, length: (line as NSString).length)) != nil
+        canonicalDefinition(from: line) != nil
+    }
+
+    /// The canonical `[label]: destination` line if `line` is a definition,
+    /// else nil. Definitions may sit inside a block quote or list item and still
+    /// define references for the whole document (GFM ex. 187), so leading `>`
+    /// quote markers and one list marker are stripped first; the stripped form is
+    /// what gets appended and re-parsed, so it must be container-free. The strip
+    /// only consumes whitespace that belongs to a marker — a bare `    [x]: u`
+    /// (4-space indent) is still rejected as code by `defRegex`.
+    static func canonicalDefinition(from line: String) -> String? {
+        var s = Substring(line)
+        var stripped = false
+
+        // Block-quote markers: `>` optionally preceded by ≤3 spaces and followed
+        // by one space, repeated for nesting.
+        while true {
+            let t = s.drop { $0 == " " || $0 == "\t" }
+            guard t.first == ">" else { break }
+            var rest = t.dropFirst()
+            if rest.first == " " { rest = rest.dropFirst() }
+            s = rest
+            stripped = true
+        }
+
+        // One list marker on the same line as the definition.
+        let ns = String(s) as NSString
+        if let m = listMarkerRegex.firstMatch(in: String(s), range: NSRange(location: 0, length: ns.length)) {
+            s = Substring(ns.substring(from: m.range.length))
+            stripped = true
+        }
+
+        if stripped {
+            // Drop residual container indentation before the label.
+            s = s.drop { $0 == " " || $0 == "\t" }
+        }
+        let candidate = stripped ? String(s) : line
+        let cn = candidate as NSString
+        guard defRegex.firstMatch(in: candidate, range: NSRange(location: 0, length: cn.length)) != nil
+        else { return nil }
+        return candidate
     }
 }

--- a/Tests/EdmundTests/ReferenceLinkIntegrationTests.swift
+++ b/Tests/EdmundTests/ReferenceLinkIntegrationTests.swift
@@ -24,4 +24,12 @@ struct ReferenceLinkIntegrationTests {
         activateBlock(2, in: editor)
         #expect(fgColor(at: 5, in: editor) != editor.linkColor)
     }
+
+    @Test("A definition inside a block quote resolves a use in another block")
+    @MainActor func definitionInsideBlockQuoteResolves() {
+        let editor = makeEditor()
+        editor.loadContent("use [foo] here\n\n> [foo]: https://e.com")
+        activateBlock(2, in: editor)
+        #expect(fgColor(at: 5, in: editor) == editor.linkColor)
+    }
 }

--- a/Tests/EdmundTests/ReferenceLinkTests.swift
+++ b/Tests/EdmundTests/ReferenceLinkTests.swift
@@ -114,4 +114,31 @@ struct LinkDefinitionStateTests {
         var b = LinkDefinitionState(); b.add("[y]: 2"); b.add("[x]: 1")
         #expect(a == b)
     }
+
+    @Test("Definition inside a block quote is collected (GFM ex. 187)")
+    func definitionInsideBlockQuote() {
+        #expect(LinkDefinitionState.canonicalDefinition(from: "> [foo]: /url") == "[foo]: /url")
+        #expect(LinkDefinitionState.canonicalDefinition(from: ">> [foo]: /url") == "[foo]: /url")
+        #expect(LinkDefinitionState.build(from: "> [foo]: /url").defsText == "[foo]: /url")
+    }
+
+    @Test("Definition on a list-marker line is collected")
+    func definitionInsideListItem() {
+        #expect(LinkDefinitionState.canonicalDefinition(from: "- [foo]: /url") == "[foo]: /url")
+        #expect(LinkDefinitionState.canonicalDefinition(from: "1. [foo]: /url") == "[foo]: /url")
+    }
+
+    @Test("A task-list checkbox is not mistaken for a definition")
+    func taskListNotDefinition() {
+        #expect(LinkDefinitionState.canonicalDefinition(from: "- [ ] todo") == nil)
+        #expect(LinkDefinitionState.canonicalDefinition(from: "- [x] done") == nil)
+    }
+
+    @Test("Container and plain forms of the same def dedupe to one line")
+    func containerAndPlainDedupe() {
+        var s = LinkDefinitionState()
+        s.add("> [foo]: /url")
+        s.add("[foo]: /url")
+        #expect(s.defsText == "[foo]: /url")
+    }
 }


### PR DESCRIPTION
## What

Link reference definitions nested inside a block quote (`> [foo]: url`) or on a list-item marker line (`- [foo]: url`) now resolve document-wide in edit mode, matching GFM (example 187).

## Why

Follow-up to #205. `LinkDefinitionState.isDefinitionLine` only matched top-level `[label]: url` lines (≤3 leading spaces), so a definition inside a container was never collected — a `[foo]` use in another block stayed plain text in edit mode. (Read mode already parses whole-document, so it was unaffected.)

## How

`canonicalDefinition(from:)` strips leading block-quote `>` markers (nesting included) and one list marker, then tests the existing definition regex and stores the container-free form (the string that gets appended and re-parsed). The strip only consumes whitespace belonging to a marker, so:
- a 4-space-indented code line is still rejected as code,
- a `- [ ]` task-list checkbox never looks like a definition,
- container and plain forms of the same def dedupe to one line.

## Tests

972 pass (5 new: block-quote/list/task-list unit cases + a block-quote cross-block editor integration test that reads the rendered link color). Fuzz + full-recompose oracle stay green (canonicalization is pure per-line, so incremental state == from-scratch rebuild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)