### PR TITLE
feat(gfm): blockquote lazy continuation in edit mode

### DIFF
--- a/Sources/EdmundCore/Export/HTMLRenderer.swift
+++ b/Sources/EdmundCore/Export/HTMLRenderer.swift
@@ -239,7 +239,7 @@ struct HTMLRenderer: MarkupVisitor {
             if let marker = Callout.parseMarker(firstLine),
                let style = Callout.style(for: marker.type) {
                 return renderCallout(marker: marker, style: style,
-                                     firstLine: firstLine, inner: inner)
+                                     firstLine: firstLine, blockQuote: blockQuote)
             }
         }
         return "<blockquote>\(renderChildren(of: blockQuote))</blockquote>"
@@ -515,7 +515,7 @@ struct HTMLRenderer: MarkupVisitor {
     // MARK: - Callouts
 
     private mutating func renderCallout(marker: Callout.Marker, style: CalloutStyle,
-                                        firstLine: String, inner: String) -> String {
+                                        firstLine: String, blockQuote: BlockQuote) -> String {
         // Custom title = whatever follows `]` on the first line.
         let ns = firstLine as NSString
         let afterMarker = marker.closeBracket.upperBound <= ns.length
@@ -523,14 +523,19 @@ struct HTMLRenderer: MarkupVisitor {
             : ""
         let title = Callout.title(type: marker.type, customTitle: afterMarker)
 
-        // Body = the de-quoted content after the first line, re-parsed and
-        // rendered fresh (mirrors the editor stripping `>` and re-parsing).
-        let body: String
-        if let nl = inner.firstIndex(of: "\n") {
-            body = String(inner[inner.index(after: nl)...])
-        } else {
-            body = ""
-        }
+        // Callouts are strict: only the leading run of `>`-prefixed lines is the
+        // callout body. swift-markdown's CommonMark parse lazily continues a
+        // following bare line into the blockquote, but the editor keeps callouts
+        // strict (BlockParser splits the lazy line off) so a following
+        // `> [!type]` can't be pulled into a prior callout (GFM ex. 228). Split
+        // the raw source the same way and render the lazy tail as sibling
+        // content after the callout, matching edit-mode segmentation exactly.
+        let rawLines = (sourceText(blockQuote) ?? "").components(separatedBy: "\n")
+        let quotedCount = rawLines.prefix(while: Self.isQuotedLine).count
+
+        // Body = the de-quoted `>`-run after the first (marker) line, re-parsed.
+        let body = rawLines[min(1, quotedCount)..<quotedCount]
+            .map(Self.deQuoteLine).joined(separator: "\n")
         let bodyHTML = body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             ? ""
             : HTMLRenderer.render(markdown: body, options: options)
@@ -539,24 +544,40 @@ struct HTMLRenderer: MarkupVisitor {
         // `currentColor`, so the `.callout-title` accent color tints it — no
         // per-appearance asset pass, and no SF Symbol shipped in the export.
         let icon = "<span class=\"callout-icon\">\(LucideIcons.inlineSVG(style.iconName) ?? "")</span>"
-        return "<div class=\"callout callout-\(Self.attr(marker.type))\">"
+        let calloutHTML = "<div class=\"callout callout-\(Self.attr(marker.type))\">"
             + "<div class=\"callout-title\">\(icon)<span class=\"callout-title-text\">\(Self.escape(title))</span></div>"
             + "<div class=\"callout-body\">\(bodyHTML)</div></div>"
+
+        // Lazy tail (bare lines swift-markdown folded in) → sibling markdown.
+        let tail = rawLines[quotedCount...].joined(separator: "\n")
+        let tailHTML = tail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? ""
+            : HTMLRenderer.render(markdown: tail, options: options)
+        return calloutHTML + tailHTML
     }
 
     /// The raw source text of a block quote with each line's `>` prefix removed.
     private func deQuoted(_ blockQuote: BlockQuote) -> String? {
         guard let quoted = sourceText(blockQuote) else { return nil }
-        let lines = quoted.components(separatedBy: "\n").map { line -> String in
-            var l = Substring(line)
-            while l.first == " " { l = l.dropFirst() }
-            if l.first == ">" {
-                l = l.dropFirst()
-                if l.first == " " { l = l.dropFirst() }
-            }
-            return String(l)
+        return quoted.components(separatedBy: "\n")
+            .map(Self.deQuoteLine).joined(separator: "\n")
+    }
+
+    /// Strips one leading `>` marker (optional spaces, `>`, optional space).
+    private static func deQuoteLine(_ line: String) -> String {
+        var l = Substring(line)
+        while l.first == " " { l = l.dropFirst() }
+        if l.first == ">" {
+            l = l.dropFirst()
+            if l.first == " " { l = l.dropFirst() }
         }
-        return lines.joined(separator: "\n")
+        return String(l)
+    }
+
+    /// Whether a line carries a `>` marker (optional leading spaces then `>`) —
+    /// the same predicate the editor's BlockParser uses for quote membership.
+    private static func isQuotedLine(_ line: String) -> Bool {
+        line.drop(while: { $0 == " " }).first == ">"
     }
 
     // MARK: - Inline non-GFM (highlight / math / wikilink / comment)

--- a/Sources/EdmundCore/Parsing/BlockParser.swift
+++ b/Sources/EdmundCore/Parsing/BlockParser.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Markdown
 
 /// Splits a document string into `Block`s and preserves block identity
 /// across re-parses so the "active block" doesn't jump around.
@@ -299,18 +300,40 @@ public enum BlockParser {
             return (merged.joined(separator: "\n"), .mathDisplay, j)
         }
 
-        // Merge a run of consecutive block-quote lines (`>`) into one block.
-        // This covers callouts and plain multi-line block quotes alike, and
-        // gives the editor one styling/activation unit per quote.
+        // Merge block-quote lines into one block (the editor's styling /
+        // activation unit per quote).
         if isBlockquoteLine(first) {
-            let isCallout = quoteRunOpensCallout(first)
+            // Callouts stay strict: only consecutive `>` lines. Lazy
+            // continuation is deliberately suppressed so a following `> [!type]`
+            // can't be pulled into a prior callout's paragraph (GFM ex. 228).
+            // Read mode matches this (HTMLRenderer.renderCallout splits at the
+            // first non-`>` line).
+            if quoteRunOpensCallout(first) {
+                var merged = [first]
+                var j = i + 1
+                while let line = buf.line(at: j), isBlockquoteLine(line) {
+                    merged.append(line)
+                    j += 1
+                }
+                return (merged.joined(separator: "\n"), .quoteRun(isCallout: true), j)
+            }
+            // Plain block quote: honor CommonMark lazy continuation (a bare
+            // non-blank line after a quote paragraph joins the quote). The
+            // extent depends only on this line and following lines up to the
+            // next blank (a blank always ends a quote), so the parse stays
+            // forward-only and the incremental invariant holds.
+            if let (content, next) = mergePlainQuote(&buf, at: i) {
+                return (content, .quoteRun(isCallout: false), next)
+            }
+            // Fallback (candidate's first child wasn't a BlockQuote — shouldn't
+            // happen): strict `>`-run.
             var merged = [first]
             var j = i + 1
             while let line = buf.line(at: j), isBlockquoteLine(line) {
                 merged.append(line)
                 j += 1
             }
-            return (merged.joined(separator: "\n"), .quoteRun(isCallout: isCallout), j)
+            return (merged.joined(separator: "\n"), .quoteRun(isCallout: false), j)
         }
 
         // Detect table: header row followed by separator row with the same
@@ -614,6 +637,40 @@ public enum BlockParser {
     /// then `>`).
     private static func isBlockquoteLine(_ line: String) -> Bool {
         return line.drop(while: { $0 == " " }).first == ">"
+    }
+
+    /// Extent of a plain block quote starting at line `i`, honoring CommonMark
+    /// lazy continuation. Gathers the run of non-blank candidate lines (a blank
+    /// always ends a quote), parses them with swift-markdown, and truncates the
+    /// quote to the first `BlockQuote` node's line span — so the exact rules
+    /// (heading/list/fence/thematic-break interrupt; an empty `>` closes the
+    /// paragraph; a bare paragraph line continues it) come straight from the
+    /// CommonMark parser, matching read mode. Returns the quote content and the
+    /// index of the line after it, or nil when the candidate's first child
+    /// isn't a BlockQuote (caller falls back to the strict `>`-run).
+    private static func mergePlainQuote(_ buf: inout LineBuffer, at i: Int)
+        -> (content: String, next: Int)? {
+        var candidate: [String] = []
+        var j = i
+        while let line = buf.line(at: j), !isBlankLine(line) {
+            candidate.append(line)
+            j += 1
+        }
+        let doc = Document(parsing: candidate.joined(separator: "\n"),
+                           options: [.disableSmartOpts])
+        guard doc.child(at: 0) is BlockQuote else { return nil }
+        // The candidate has no blank lines, so its top-level blocks are
+        // contiguous: the quote spans lines 1 ..< (second child's start line).
+        // swift-markdown line numbers are 1-based within the candidate, and
+        // candidate line 1 == buffer line `i`.
+        let quoteLineCount: Int
+        if doc.childCount > 1, let nextStart = doc.child(at: 1)?.range?.lowerBound.line {
+            quoteLineCount = min(max(nextStart - 1, 1), candidate.count)
+        } else {
+            quoteLineCount = candidate.count
+        }
+        let content = candidate[0..<quoteLineCount].joined(separator: "\n")
+        return (content, i + quoteLineCount)
     }
 
     /// Returns true if the line contains a pipe character (potential table row).

--- a/Sources/EdmundCore/Parsing/SyntaxHighlighter+Walker.swift
+++ b/Sources/EdmundCore/Parsing/SyntaxHighlighter+Walker.swift
@@ -299,12 +299,16 @@ extension SyntaxHighlighter {
             // this quote's own `>`) — every subsequent line is the raw source
             // verbatim, ancestor markers and all. So each later line must peel
             // exactly `depth` ancestor markers before this quote's own can be
-            // at hand. A line that runs out of markers partway through that
-            // peel is CommonMark "lazy continuation" (e.g. a bare `>` line
-            // right after a `> >` one, absorbed by swift-markdown as a
-            // continuation of the deepest active quote's paragraph) — it
-            // belongs to a shallower ancestor's span instead. Bail out of the
-            // scan there, clipping `fullRange` before that line.
+            // at hand.
+            //
+            // A no-marker line is CommonMark "lazy continuation". Which quote
+            // it belongs to depends on depth: at the OUTERMOST quote (depth 0)
+            // it continues *this* quote's paragraph — BlockParser already
+            // merged it into the block, so keep it in the span (the bar extends
+            // over it) with no marker to hide. Deeper in (depth > 0), a line
+            // that runs out of ancestor markers, or lacks this quote's own,
+            // belongs to a shallower ancestor's span — clip `fullRange` before
+            // it.
             var delims: [NSRange] = []
             var cursor = full.location
             var clippedEnd = full.upperBound
@@ -323,11 +327,23 @@ extension SyntaxHighlighter {
                     }
                     p = after
                 }
-                guard !ranOut, let markerEnd = Self.peelOneMarker(nsSource, from: p, lineEnd: lineEnd) else {
+                if ranOut {
+                    // Ran out of ancestor markers: line belongs to a shallower
+                    // ancestor (nested lazy continuation). Clip here.
                     clippedEnd = cursor
                     break
                 }
-                delims.append(NSRange(location: p, length: markerEnd - p))
+                if let markerEnd = Self.peelOneMarker(nsSource, from: p, lineEnd: lineEnd) {
+                    delims.append(NSRange(location: p, length: markerEnd - p))
+                } else if depth == 0 {
+                    // Lazy continuation of the outermost quote: keep it in the
+                    // span, no marker to hide, and keep scanning.
+                } else {
+                    // Nested quote missing its own marker: belongs to a
+                    // shallower ancestor. Clip here.
+                    clippedEnd = cursor
+                    break
+                }
 
                 cursor = nlRange.location != NSNotFound ? nlRange.location + 1 : clippedEnd
                 isFirstLine = false

--- a/Tests/EdmundTests/BlockParserTests.swift
+++ b/Tests/EdmundTests/BlockParserTests.swift
@@ -377,14 +377,14 @@ struct BlockParserTests {
         #expect(blocks[0].content == "> line1\n> line2\n> line3")
     }
 
-    @Test("Blockquote between paragraphs")
+    @Test("A blockquote lazily continues a following bare line")
     func blockquoteBetweenParagraphs() {
         let text = "above\n> line1\n> line2\nbelow"
         let blocks = BlockParser.parse(text)
-        #expect(blocks.count == 3)
+        // `below` lacks `>` but lazily continues the quote's paragraph (CommonMark).
+        #expect(blocks.count == 2)
         #expect(blocks[0].content == "above")
-        #expect(blocks[1].content == "> line1\n> line2")
-        #expect(blocks[2].content == "below")
+        #expect(blocks[1].content == "> line1\n> line2\nbelow")
     }
 
     @Test("Single blockquote line is one block")
@@ -403,14 +403,14 @@ struct BlockParserTests {
         #expect(blocks[0].range == NSRange(location: 0, length: 7))
     }
 
-    @Test("Non-consecutive blockquotes are separate blocks")
+    @Test("A bare line then `> second` all lazily continue one quote (GFM ex. 228)")
     func nonConsecutiveBlockquotes() {
         let text = "> first\nparagraph\n> second"
         let blocks = BlockParser.parse(text)
-        #expect(blocks.count == 3)
-        #expect(blocks[0].content == "> first")
-        #expect(blocks[1].content == "paragraph")
-        #expect(blocks[2].content == "> second")
+        // No blank line separates them, so `paragraph` lazily continues the
+        // quote and `> second` continues the same still-open paragraph.
+        #expect(blocks.count == 1)
+        #expect(blocks[0].content == "> first\nparagraph\n> second")
     }
 
     // MARK: - Changed Window (parseWithDiff)
@@ -442,14 +442,15 @@ struct BlockParserTests {
         #expect(b2[2].id == b1[1].id)   // suffix keeps its ID
     }
 
-    @Test("Merging two blocks yields a one-block window")
+    @Test("Deleting a blank merges a paragraph into the quote (lazy continuation)")
     func diffMerge() {
-        let (b1, _) = BlockParser.parseWithDiff("> a\nplain\ntail")
-        // "plain" becomes a quote line and merges into the run.
-        let (b2, changed) = BlockParser.parseWithDiff("> a\n> plain\ntail", previous: b1)
-        #expect(b2.count == 2)
-        #expect(changed == 0..<1)
-        #expect(b2[1].id == b1[2].id)
+        let (b1, _) = BlockParser.parseWithDiff("> a\n\ntail")   // quote, blank, paragraph
+        #expect(b1.count == 3)
+        // Removing the blank lets `tail` lazily continue the quote's paragraph.
+        let (b2, _) = BlockParser.parseWithDiff("> a\ntail", previous: b1)
+        #expect(b2.count == 1)
+        #expect(b2[0].content == "> a\ntail")
+        #expect(b2[0].kind == .quoteRun(isCallout: false))
     }
 
     @Test("Identical-content documents: window covers only the edit")

--- a/Tests/EdmundTests/BlockStylingTests.swift
+++ b/Tests/EdmundTests/BlockStylingTests.swift
@@ -134,7 +134,7 @@ struct BlockStylingActiveTests {
     @Test("Active blockquote shows its raw text")
     @MainActor func activeBlockquoteLine() {
         let editor = makeEditor()
-        editor.loadContent("> line1\n> line2\nother")
+        editor.loadContent("> line1\n> line2\n\nother")
         activateBlock(0, in: editor)
 
         // Consecutive `>` lines merge into one block.
@@ -353,7 +353,7 @@ struct BlockStylingNonActiveTests {
     @Test("Non-active > quote: prefix invisible (width-preserving), content has secondary color")
     @MainActor func nonActiveBlockquote() {
         let editor = makeEditor()
-        editor.loadContent("> wise words\nother")
+        editor.loadContent("> wise words\n\nother")
         activateBlock(1, in: editor)
 
         let text = displayText(for: 0, in: editor)
@@ -386,7 +386,7 @@ struct BlockStylingNonActiveTests {
     @MainActor func nonActiveConsecutiveBlockquoteLines() {
         let editor = makeEditor()
         // Consecutive `>` lines merge into one block; "other" is the next block.
-        editor.loadContent("> line1\n> line2\nother")
+        editor.loadContent("> line1\n> line2\n\nother")
         activateBlock(1, in: editor)   // activate "other"; the quote stays rendered
 
         #expect(displayText(for: 0, in: editor) == "> line1\n> line2")
@@ -410,7 +410,7 @@ struct BlockStylingNonActiveTests {
     @Test("Non-active bold inside blockquote: all delimiters hidden")
     @MainActor func nonActiveBoldInBlockquote() {
         let editor = makeEditor()
-        editor.loadContent("> **important**\nother")
+        editor.loadContent("> **important**\n\nother")
         activateBlock(1, in: editor)
 
         let text = displayText(for: 0, in: editor)

--- a/Tests/EdmundTests/BlockquoteLazyContinuationTests.swift
+++ b/Tests/EdmundTests/BlockquoteLazyContinuationTests.swift
@@ -1,0 +1,111 @@
+import Testing
+import Foundation
+import Markdown
+@testable import EdmundCore
+
+// CommonMark blockquote lazy continuation in edit-mode segmentation: a bare
+// non-blank line after a plain block-quote paragraph joins the quote. Callouts
+// stay strict (each `>`-run is its own block) so a following `> [!type]` can't
+// be swallowed into a prior callout's paragraph (GFM ex. 228).
+@Suite("BlockParser — blockquote lazy continuation")
+struct BlockquoteLazyContinuationTests {
+
+    // MARK: - Plain quotes: lazy continuation joins
+
+    @Test("A bare line after a quote paragraph joins the quote")
+    func lazyLineJoins() {
+        let blocks = BlockParser.parse("> a\nb")
+        #expect(blocks.count == 1)
+        #expect(blocks[0].content == "> a\nb")
+        #expect(blocks[0].kind == .quoteRun(isCallout: false))
+    }
+
+    @Test("A blank line ends the quote; the next line is a separate paragraph")
+    func blankBreaksContinuation() {
+        let blocks = BlockParser.parse("> a\n\nb")
+        #expect(blocks.count == 3)
+        #expect(blocks[0].content == "> a")
+        #expect(blocks[0].kind == .quoteRun(isCallout: false))
+        #expect(blocks[2].content == "b")
+        #expect(blocks[2].kind == .paragraph)
+    }
+
+    @Test("A heading after `>` does not lazily continue (it interrupts)")
+    func headingInterrupts() {
+        let blocks = BlockParser.parse("> a\n# h")
+        #expect(blocks.count == 2)
+        #expect(blocks[0].content == "> a")
+        #expect(blocks[1].content == "# h")
+        #expect(blocks[1].kind == .heading(level: 1))
+    }
+
+    @Test("A list item after `>` does not lazily continue")
+    func listInterrupts() {
+        let blocks = BlockParser.parse("> a\n- x")
+        #expect(blocks.count == 2)
+        #expect(blocks[0].content == "> a")
+        #expect(blocks[1].content == "- x")
+        #expect(blocks[1].kind == .listItem)
+    }
+
+    @Test("GFM ex. 228: mixed `>` and bare lines collapse to one quote")
+    func example228() {
+        let blocks = BlockParser.parse("> bar\nbaz\n> foo")
+        #expect(blocks.count == 1)
+        #expect(blocks[0].content == "> bar\nbaz\n> foo")
+        #expect(blocks[0].kind == .quoteRun(isCallout: false))
+    }
+
+    @Test("An empty `>` closes the paragraph — the next bare line is separate")
+    func emptyQuoteNoLazy() {
+        let blocks = BlockParser.parse(">\nb")
+        #expect(blocks.count == 2)
+        #expect(blocks[0].content == ">")
+        #expect(blocks[1].content == "b")
+        #expect(blocks[1].kind == .paragraph)
+    }
+
+    // MARK: - Callouts stay strict
+
+    @Test("A callout body does not lazily continue (strict `>`-run)")
+    func calloutStaysStrict() {
+        let blocks = BlockParser.parse("> [!note] x\nlazy")
+        #expect(blocks.count == 2)
+        #expect(blocks[0].content == "> [!note] x")
+        #expect(blocks[0].kind == .quoteRun(isCallout: true))
+        #expect(blocks[1].content == "lazy")
+        #expect(blocks[1].kind == .paragraph)
+    }
+
+    // MARK: - Differential oracle vs whole-doc CommonMark
+
+    // For an isolated plain-quote doc, the first block's line span must equal
+    // swift-markdown's first BlockQuote node span (edit segmentation == read).
+    @Test("Plain-quote extent matches swift-markdown's BlockQuote span", arguments: [
+        "> a\nb",
+        "> a\nb\nc",
+        "> bar\nbaz\n> foo",
+        "> a\n# h",
+        "> a\n- x",
+        ">\nb",
+    ])
+    func matchesCommonMark(_ doc: String) {
+        let blocks = BlockParser.parse(doc)
+        let firstQuoteLines = blocks[0].content.split(separator: "\n",
+            omittingEmptySubsequences: false).count
+
+        let parsed = Document(parsing: doc, options: [.disableSmartOpts])
+        guard let quote = parsed.child(at: 0) as? BlockQuote, let r = quote.range else {
+            Issue.record("expected a leading BlockQuote in \(doc.debugDescription)")
+            return
+        }
+        let cmarkQuoteLines: Int
+        if parsed.childCount > 1, let nextStart = parsed.child(at: 1)?.range?.lowerBound.line {
+            cmarkQuoteLines = nextStart - 1
+        } else {
+            cmarkQuoteLines = r.upperBound.line - r.lowerBound.line + 1
+        }
+        #expect(firstQuoteLines == cmarkQuoteLines,
+                "quote extent mismatch for \(doc.debugDescription)")
+    }
+}

--- a/Tests/EdmundTests/BlockquoteRenderingTests.swift
+++ b/Tests/EdmundTests/BlockquoteRenderingTests.swift
@@ -57,6 +57,22 @@ struct BlockquoteNestingTests {
         #expect(second?.hugsTextTop == false)
     }
 
+    @Test("A lazy continuation line carries the quote bar and hides no marker")
+    func lazyContinuationBar() {
+        let editor = makeEditor()
+        let md = "> a\nb"   // `b` lazily continues the quote (one block)
+        let s = editor.styleBlock(md)
+        let ns = md as NSString
+        // First line: marker hidden, bar at inset 0.
+        #expect(isMarkerHidden(at: 0, in: s))
+        #expect(barInsets(s.attribute(.blockDecoration, at: 2, effectiveRange: nil)) == [0])
+        // Lazy line: the span extends over it, so the bar is present too; there
+        // is no `>` on this line, so nothing is marker-hidden.
+        let bLoc = ns.range(of: "b").location
+        #expect(barInsets(s.attribute(.blockDecoration, at: bLoc, effectiveRange: nil)) == [0])
+        #expect(!isMarkerHidden(at: bLoc, in: s))
+    }
+
     @Test("A nested quote (> >) hides both markers and stacks two bars, outer leftmost")
     func nestedOnce() {
         let editor = makeEditor()

--- a/Tests/EdmundTests/HTMLRendererTests.swift
+++ b/Tests/EdmundTests/HTMLRendererTests.swift
@@ -449,4 +449,34 @@ struct HTMLRendererCalloutTests {
         #expect(out.hasPrefix("<blockquote>"))
         #expect(!out.contains("callout"))
     }
+
+    // Callouts are strict in BOTH modes: a bare (lazy) line after a callout body
+    // does NOT join the callout — it renders as a sibling, matching edit-mode
+    // block segmentation (BlockParser keeps callouts strict; see
+    // BlockquoteLazyContinuationTests.calloutStaysStrict for the edit side).
+    @Test("A lazy line after a callout renders as a sibling, not in the body")
+    func calloutBodyStrict() {
+        let out = html("> [!note]\n> body\nlazy")
+        #expect(out.contains("<div class=\"callout-body\"><p>body</p></div>"))
+        // `lazy` sits after the callout div closes, not inside the body.
+        #expect(out.contains("</div></div><p>lazy</p>"))
+        #expect(!out.contains("body\nlazy"))
+    }
+
+    @Test("GFM ex.228 tail: `> y` after a lazy line is a sibling quote, not the callout")
+    func calloutLazyTailWithQuote() {
+        let out = html("> [!note]\n> body\nlazy\n> y")
+        #expect(out.contains("<div class=\"callout-body\"><p>body</p></div>"))
+        #expect(out.contains("<p>lazy</p>"))
+        #expect(out.contains("<blockquote><p>y</p></blockquote>"))
+        // Exactly one callout — the second `> y` was not pulled into it.
+        #expect(out.components(separatedBy: "class=\"callout ").count == 2)
+    }
+
+    @Test("A fully `>`-prefixed callout body is unchanged (no lazy split)")
+    func calloutFullyQuotedUnchanged() {
+        let out = html("> [!note]\n> a\n> b")
+        #expect(out.contains("<div class=\"callout-body\"><p>a\nb</p></div>"))
+        #expect(!out.contains("</div></div><p>"))
+    }
 }

--- a/Tests/EdmundTests/IncrementalParseFuzzTests.swift
+++ b/Tests/EdmundTests/IncrementalParseFuzzTests.swift
@@ -23,7 +23,9 @@ struct IncrementalParseFuzzTests {
                          "===\n", "===", "    code\n", "\tcode\n",
                          "<div>", "</div>\n", "<!--", "-->", "<script>",
                          "</script>\n", "<pre>", "<?", "<!DOCTYPE ",
-                         "<![CDATA[", "]]>", "<custom-tag>\n"]
+                         "<![CDATA[", "]]>", "<custom-tag>\n",
+                         // Blockquote lazy continuation: bare lines after `>`.
+                         "> q\nlazy", "> a\nb\n> c", "> a\n\nb", "lazy\n"]
 
         for _ in 0..<120 {
             let ns = editor.rawSource as NSString


### PR DESCRIPTION
## What

CommonMark blockquote **lazy continuation** in edit mode: a bare non-blank line right after a plain block-quote paragraph joins the quote (GFM ex. 228 — `> bar` / `baz` / `> foo` → one blockquote, one paragraph). This closes the last GFM edit/read gap.

Read mode already did this (whole-doc swift-markdown parse); only edit mode split the lazy line into its own block.

## How

Delegate segmentation to swift-markdown rather than hand-roll the lazy rules:

- **`BlockParser`** — the plain-quote branch gathers the candidate run of non-blank lines (a blank always ends a quote), parses it with swift-markdown, and truncates the quote block to the first `BlockQuote` node's line span. The extent depends only on the quote's own line + following lines up to the next blank — **forward-only**, so the parse-isolation invariant holds and the incremental window needs **no lookback change** (confirmed by the fuzz oracle).
- **Walker** — at the outermost quote (depth 0) a no-`>` line is this quote's lazy continuation: keep it in the span (bar extends over it, no marker to hide) instead of clipping. Nested clipping (depth > 0) unchanged.

## Callouts stay strict in BOTH modes

A bare line after a callout body does **not** join the callout, so a following `> [!type]` can't be swallowed into a prior callout's paragraph (ex. 228). Edit mode was already strict; `HTMLRenderer.renderCallout` is conformed — it splits the callout source at the first non-`>` line and renders the lazy tail as sibling markdown. **No edit/read divergence remains.**

## Verification

- 984 tests pass. New `BlockquoteLazyContinuationTests` (cases + differential oracle vs whole-doc swift-markdown); read-mode strict-callout cases; an edit-mode bar test; fuzz-corpus lazy fragments. Existing quote fixtures that assumed strict segmentation updated to the new (correct) behavior.
- **Fuzz oracle green** (`verifyIncrementalParse` / full-recompose) — confirms the no-lookback claim under randomized editing.
- **Live caret repro** (ReproScript): deleting the blank between a quote and a paragraph merges them (block count 8→6) with the caret held exactly in place (`assertcaret PASS` ×3), `up=N`, no bypass-heal breadcrumb — the segmentation change is caret-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)