### PR TITLE
feat(gfm): auto-renumber ordered lists at the modified level

### DIFF
--- a/Sources/EdmundCore/Editing/EditorTextView+Indentation.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+Indentation.swift
@@ -116,6 +116,10 @@ extension EditorTextView {
                                                      unitChanged: listIndentUnit != oldIndentUnit),
                                cursorInRaw: newRawStart, selectionInRaw: selInRaw)
         }
+        // The indented blocks changed depth: they may now belong to a
+        // different ordered run (or start a new one), and the old depth's
+        // remaining siblings lost a member — both need renumbering.
+        renumberOrderedListRunsIfNeeded(touching: startBlock..<(endBlock + 1))
         document?.updateChangeCount(.changeDone)
     }
 
@@ -209,6 +213,10 @@ extension EditorTextView {
                                                      unitChanged: listIndentUnit != oldIndentUnit),
                                cursorInRaw: newRawStart, selectionInRaw: selInRaw)
         }
+        // The dedented blocks changed depth: they may now belong to a
+        // different ordered run (or merge into an existing one), and the
+        // old depth's remaining siblings lost a member — both need renumbering.
+        renumberOrderedListRunsIfNeeded(touching: startBlock..<(endBlock + 1))
         document?.updateChangeCount(.changeDone)
     }
 }

--- a/Sources/EdmundCore/Editing/EditorTextView+Indentation.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+Indentation.swift
@@ -119,7 +119,8 @@ extension EditorTextView {
         // The indented blocks changed depth: they may now belong to a
         // different ordered run (or start a new one), and the old depth's
         // remaining siblings lost a member — both need renumbering.
-        renumberOrderedListRunsIfNeeded(touching: startBlock..<(endBlock + 1))
+        renumberOrderedListRunsIfNeeded(touching: startBlock..<(endBlock + 1),
+                                        depthChanged: Set(startBlock...endBlock))
         document?.updateChangeCount(.changeDone)
     }
 
@@ -216,7 +217,8 @@ extension EditorTextView {
         // The dedented blocks changed depth: they may now belong to a
         // different ordered run (or merge into an existing one), and the
         // old depth's remaining siblings lost a member — both need renumbering.
-        renumberOrderedListRunsIfNeeded(touching: startBlock..<(endBlock + 1))
+        renumberOrderedListRunsIfNeeded(touching: startBlock..<(endBlock + 1),
+                                        depthChanged: Set(startBlock...endBlock))
         document?.updateChangeCount(.changeDone)
     }
 }

--- a/Sources/EdmundCore/Editing/EditorTextView+ListRenumbering.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+ListRenumbering.swift
@@ -42,7 +42,14 @@ extension EditorTextView {
     /// depth). `touchedBlocks`' block count is assumed unchanged by any
     /// rewrite this makes (only digit widths inside existing lines change),
     /// so indices computed up front stay valid across the whole call.
-    func renumberOrderedListRunsIfNeeded(touching touchedBlocks: Range<Int>) {
+    ///
+    /// `depthChanged` — block indices whose nesting depth this specific edit
+    /// just altered (Tab/Shift-Tab; empty for every other caller, which never
+    /// change depth) — lets a run tell "merging into an existing list" apart
+    /// from "forming a brand-new one": a run made up entirely of just-moved
+    /// items starts at 1 instead of inheriting whatever number its first
+    /// member happened to have at its old depth.
+    func renumberOrderedListRunsIfNeeded(touching touchedBlocks: Range<Int>, depthChanged: Set<Int> = []) {
         guard !blocks.isEmpty else { return }
         let lo = max(0, touchedBlocks.lowerBound - 1)
         let hi = min(blocks.count, touchedBlocks.upperBound + 1)
@@ -55,24 +62,28 @@ extension EditorTextView {
                   orderedMarker(blocks[idx].content) != nil else { continue }
             let depth = depthOf(blocks[idx])
             let bounds = orderedRunBounds(seedIndex: idx, depth: depth)
-            // Only the same-depth members actually belong to this run's
-            // numbering — `bounds` also spans deeper nested children purely
-            // as pass-through text, and marking those processed here would
-            // wrongly suppress their own, separate depth's renumbering pass
-            // later in this loop.
-            let sequence = bounds.filter { depthOf(blocks[$0]) == depth }
+            // Only the same-depth ordered members actually belong to this
+            // run's numbering — `bounds` also spans deeper nested children
+            // and tolerated blank-line separators purely as pass-through
+            // text, and marking those processed here would wrongly suppress
+            // their own, separate depth's renumbering pass later in this loop.
+            let sequence = bounds.filter {
+                depthOf(blocks[$0]) == depth && orderedMarker(blocks[$0].content) != nil
+            }
             for seqIdx in sequence { processed.insert(seqIdx) }
-            renumberOrderedListRun(bounds: bounds, sequence: sequence)
+            renumberOrderedListRun(bounds: bounds, sequence: sequence, depthChanged: depthChanged)
         }
     }
 
     /// Walks outward from `seedIndex` to the bounds of the contiguous
-    /// same-depth ordered run: stops (exclusive) at a blank line, a
-    /// non-listItem block, a shallower list item, or a same-depth list item
-    /// that isn't ordered (a marker-type change starts a new list). A
+    /// same-depth ordered run: stops (exclusive) at a non-listItem block, a
+    /// shallower list item, a same-depth list item that isn't ordered (a
+    /// marker-type change starts a new list), or two consecutive blanks. A
+    /// single blank line is tolerated (CommonMark's "loose list" — one blank
+    /// line doesn't end a list) as long as the run continues past it; a
     /// deeper list item is included in the span but not the numbering.
     private func orderedRunBounds(seedIndex: Int, depth: Int) -> ClosedRange<Int> {
-        func continues(_ idx: Int) -> Bool {
+        func sameOrDeeper(_ idx: Int) -> Bool {
             guard blocks[idx].kind == .listItem else { return false }
             let d = depthOf(blocks[idx])
             if d < depth { return false }
@@ -80,19 +91,44 @@ extension EditorTextView {
             return true // deeper: nested child, part of the span
         }
         var lo = seedIndex
-        while lo > 0, continues(lo - 1) { lo -= 1 }
+        while lo > 0 {
+            if sameOrDeeper(lo - 1) { lo -= 1; continue }
+            if blocks[lo - 1].kind == .blank, lo >= 2, sameOrDeeper(lo - 2) { lo -= 2; continue }
+            break
+        }
         var hi = seedIndex
-        while hi < blocks.count - 1, continues(hi + 1) { hi += 1 }
+        while hi < blocks.count - 1 {
+            if sameOrDeeper(hi + 1) { hi += 1; continue }
+            if blocks[hi + 1].kind == .blank, hi + 2 < blocks.count, sameOrDeeper(hi + 2) { hi += 2; continue }
+            break
+        }
         return lo...hi
     }
 
     /// Renumbers the contiguous ordered run spanning `bounds`; `sequence` —
-    /// precomputed by the caller — is the same-depth subset of `bounds` that
-    /// actually gets numbered. Preserves the run's starting number. No-op
-    /// (no storage mutation) when the run is already sequential.
-    private func renumberOrderedListRun(bounds: ClosedRange<Int>, sequence: [Int]) {
-        guard let first = sequence.first,
-              let start = orderedMarker(blocks[first].content)?.number else { return }
+    /// precomputed by the caller — is the same-depth ordered subset of
+    /// `bounds` that actually gets numbered. No-op (no storage mutation)
+    /// when the run is already sequential.
+    ///
+    /// Start number: when at least one sequence member predates this edit
+    /// (isn't in `depthChanged`), this run is continuing/merging into
+    /// something that already existed, so it preserves whatever number its
+    /// first member already had — same as the plain-edit case, where
+    /// `depthChanged` is always empty. Only when EVERY member just arrived
+    /// together (a brand-new run, nothing pre-existing to continue) does it
+    /// start at 1 instead of inheriting a number from wherever its first
+    /// member used to live.
+    private func renumberOrderedListRun(bounds: ClosedRange<Int>, sequence: [Int], depthChanged: Set<Int>) {
+        guard let first = sequence.first else { return }
+        let isBrandNew = sequence.allSatisfy { depthChanged.contains($0) }
+        let start: Int
+        if isBrandNew {
+            start = 1
+        } else if let firstNumber = orderedMarker(blocks[first].content)?.number {
+            start = firstNumber
+        } else {
+            return
+        }
 
         var rewrites: [(idx: Int, digits: NSRange, newNumber: String)] = []
         for (i, idx) in sequence.enumerated() {

--- a/Sources/EdmundCore/Editing/EditorTextView+ListRenumbering.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+ListRenumbering.swift
@@ -1,0 +1,141 @@
+import AppKit
+
+// MARK: - Ordered List Renumbering
+//
+// Keeps a contiguous run of ordered ("1. ", "1) ") list items sequential
+// after an edit changes its item count (insert mid-list, delete an item,
+// paste). Scoped to the nesting depth the edit touched — sibling depths and
+// unrelated lists elsewhere in the document are never rewritten. Called once
+// per edit from `syncRawSourceFromDisplay` (EditorTextView+EditFlow.swift),
+// after `blocks` has been reparsed to the post-edit state.
+
+extension EditorTextView {
+
+    private static let orderedMarkerRegex = try! NSRegularExpression(
+        pattern: #"^([ \t]*)(\d+)([.)])[ ]"#
+    )
+
+    /// Leading indent, number, delimiter, and the digits' block-local NSRange
+    /// when `content` is an ordered list item line; nil otherwise.
+    private func orderedMarker(_ content: String) -> (indent: String, number: Int, digits: NSRange, delim: Character)? {
+        let ns = content as NSString
+        guard let m = Self.orderedMarkerRegex.firstMatch(in: content, range: NSRange(location: 0, length: ns.length)) else {
+            return nil
+        }
+        let indent = ns.substring(with: m.range(at: 1))
+        guard let number = Int(ns.substring(with: m.range(at: 2))) else { return nil }
+        let delim = ns.substring(with: m.range(at: 3)).first ?? "."
+        return (indent, number, m.range(at: 2), delim)
+    }
+
+    /// Reuses the render-time indent→depth mapping so renumbering agrees with
+    /// what's actually drawn.
+    private func depthOf(_ block: Block) -> Int {
+        let indent = block.content.prefix(while: { $0 == " " || $0 == "\t" })
+        return listDepth(leadingWhitespace: String(indent))
+    }
+
+    /// Entry point: renumbers every distinct contiguous ordered run touched
+    /// by the edit — including two disjoint runs at the same depth (e.g. an
+    /// edit that splits one list into two, or an indent/dedent that moves
+    /// items between an old list and a new/existing one at a different
+    /// depth). `touchedBlocks`' block count is assumed unchanged by any
+    /// rewrite this makes (only digit widths inside existing lines change),
+    /// so indices computed up front stay valid across the whole call.
+    func renumberOrderedListRunsIfNeeded(touching touchedBlocks: Range<Int>) {
+        guard !blocks.isEmpty else { return }
+        let lo = max(0, touchedBlocks.lowerBound - 1)
+        let hi = min(blocks.count, touchedBlocks.upperBound + 1)
+        guard lo < hi else { return }
+
+        var processed = IndexSet()
+        for idx in lo..<hi {
+            guard !processed.contains(idx),
+                  blocks[idx].kind == .listItem,
+                  orderedMarker(blocks[idx].content) != nil else { continue }
+            let depth = depthOf(blocks[idx])
+            let bounds = orderedRunBounds(seedIndex: idx, depth: depth)
+            // Only the same-depth members actually belong to this run's
+            // numbering — `bounds` also spans deeper nested children purely
+            // as pass-through text, and marking those processed here would
+            // wrongly suppress their own, separate depth's renumbering pass
+            // later in this loop.
+            let sequence = bounds.filter { depthOf(blocks[$0]) == depth }
+            for seqIdx in sequence { processed.insert(seqIdx) }
+            renumberOrderedListRun(bounds: bounds, sequence: sequence)
+        }
+    }
+
+    /// Walks outward from `seedIndex` to the bounds of the contiguous
+    /// same-depth ordered run: stops (exclusive) at a blank line, a
+    /// non-listItem block, a shallower list item, or a same-depth list item
+    /// that isn't ordered (a marker-type change starts a new list). A
+    /// deeper list item is included in the span but not the numbering.
+    private func orderedRunBounds(seedIndex: Int, depth: Int) -> ClosedRange<Int> {
+        func continues(_ idx: Int) -> Bool {
+            guard blocks[idx].kind == .listItem else { return false }
+            let d = depthOf(blocks[idx])
+            if d < depth { return false }
+            if d == depth { return orderedMarker(blocks[idx].content) != nil }
+            return true // deeper: nested child, part of the span
+        }
+        var lo = seedIndex
+        while lo > 0, continues(lo - 1) { lo -= 1 }
+        var hi = seedIndex
+        while hi < blocks.count - 1, continues(hi + 1) { hi += 1 }
+        return lo...hi
+    }
+
+    /// Renumbers the contiguous ordered run spanning `bounds`; `sequence` —
+    /// precomputed by the caller — is the same-depth subset of `bounds` that
+    /// actually gets numbered. Preserves the run's starting number. No-op
+    /// (no storage mutation) when the run is already sequential.
+    private func renumberOrderedListRun(bounds: ClosedRange<Int>, sequence: [Int]) {
+        guard let first = sequence.first,
+              let start = orderedMarker(blocks[first].content)?.number else { return }
+
+        var rewrites: [(idx: Int, digits: NSRange, newNumber: String)] = []
+        for (i, idx) in sequence.enumerated() {
+            guard let marker = orderedMarker(blocks[idx].content) else { continue }
+            let expected = start + i
+            if marker.number != expected {
+                rewrites.append((idx, marker.digits, String(expected)))
+            }
+        }
+        guard !rewrites.isEmpty else { return }
+
+        let oldSpan = NSRange(
+            location: blocks[bounds.lowerBound].range.location,
+            length: blocks[bounds.upperBound].range.upperBound - blocks[bounds.lowerBound].range.location)
+
+        let rewriteByIndex = Dictionary(uniqueKeysWithValues: rewrites.map { ($0.idx, $0) })
+        var netDelta = 0
+        let newText = bounds.map { idx -> String in
+            guard let r = rewriteByIndex[idx] else { return blocks[idx].content }
+            let content = blocks[idx].content as NSString
+            let newLine = content.replacingCharacters(in: r.digits, with: r.newNumber)
+            return newLine
+        }.joined(separator: "\n")
+
+        let caretBefore = selectedRange().location
+        for idx in bounds {
+            guard let r = rewriteByIndex[idx] else { continue }
+            let digitsStart = blocks[idx].range.location + r.digits.location
+            if digitsStart < caretBefore {
+                netDelta += (r.newNumber as NSString).length - r.digits.length
+            }
+        }
+        let caretAfter = max(0, caretBefore + netDelta)
+
+        rawSource = (rawSource as NSString).replacingCharacters(in: oldSpan, with: newText)
+        blocks = BlockParser.parse(rawSource, previous: blocks)
+
+        // `recomposeReplacing` wipes the whole replaced span to base
+        // attributes before restyling only the dirty blocks — every block in
+        // `bounds` sits inside that span, not just the ones whose digits
+        // changed, so all of them must be marked dirty or the untouched ones
+        // are left showing unstyled (undimmed) markers.
+        let dirty = IndexSet(bounds)
+        recomposeReplacing(oldRange: oldSpan, with: newText, dirty: dirty, cursorInRaw: caretAfter)
+    }
+}

--- a/Sources/EdmundCore/TextView/EditorTextView+EditFlow.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+EditFlow.swift
@@ -249,6 +249,8 @@ extension EditorTextView {
             }
         }
 
+        renumberOrderedListRunsIfNeeded(touching: changed)
+
         traceEdit("synced cursorRaw=\(cursorRaw) changed=\(changed.lowerBound)..<\(changed.upperBound) oldActive=\(oldActive.map(String.init) ?? "nil")")
         verifyEditorInvariants("syncRawSourceFromDisplay")
     }

--- a/Sources/edmd/App/ReproScript.swift
+++ b/Sources/edmd/App/ReproScript.swift
@@ -12,6 +12,7 @@ import EdmundCore
 ///   caret <needle>    place the caret before the first occurrence of <needle>
 ///   type <text>       type text, one key event per character
 ///   backspace <n>     press delete n times (300ms apart)
+///   tab / backtab     indent / dedent the selected list line(s)
 ///   scroll <y>        scroll the clip view to y (bypasses the caret/typewriter
 ///                     recentering, so a block can be driven off-screen)
 ///   logsel            log the current selection
@@ -109,6 +110,12 @@ enum ReproScript {
                 }
             case "return":
                 schedule(after: delay) { $0.insertText("\n", replacementRange: NSRange(location: NSNotFound, length: 0)) }
+                delay += 0.05
+            case "tab":
+                schedule(after: delay) { $0.insertTab(nil) }
+                delay += 0.05
+            case "backtab":
+                schedule(after: delay) { $0.insertBacktab(nil) }
                 delay += 0.05
             case "bypassdelete":
                 // Mimics AppKit's drag-move source deletion (the issue-#156

--- a/Tests/EdmundTests/ListContinuationTests.swift
+++ b/Tests/EdmundTests/ListContinuationTests.swift
@@ -67,6 +67,16 @@ struct ListContinuationTests {
         #expect(editor.rawSource == "1. first\n")
     }
 
+    @Test("Enter mid-list renumbers items below")
+    @MainActor func enterMidListRenumbers() {
+        let editor = makeEditor()
+        editor.loadContent("1. a\n2. b\n3. c")
+        // Cursor at end of "1. a" (offset 4)
+        editor.setSelectedRange(NSRange(location: 4, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "1. a\n2. \n3. b\n4. c")
+    }
+
     // MARK: - Checkbox Lists
 
     @Test("Enter after unchecked todo inserts new unchecked todo")

--- a/Tests/EdmundTests/ListRenumberingTests.swift
+++ b/Tests/EdmundTests/ListRenumberingTests.swift
@@ -1,0 +1,158 @@
+import Testing
+import AppKit
+@testable import EdmundCore
+
+// MARK: - Ordered List Renumbering
+//
+// Inserting/deleting an ordered list item should renumber the contiguous
+// run of siblings at the same nesting depth, preserving the run's starting
+// number, and leaving other depths / unrelated lists untouched.
+
+@Suite("EditorTextView — List Renumbering")
+struct ListRenumberingTests {
+
+    @Test("Whole-line delete of a mid-list item renumbers the tail")
+    @MainActor func wholeLineDeleteRenumbers() {
+        let editor = makeEditor()
+        editor.loadContent("1. a\n2. b\n3. c\n")
+        // Select the full "2. b\n" line.
+        let deleteRange = NSRange(location: 5, length: 5)
+        editor.setSelectedRange(deleteRange)
+        editor.insertText("", replacementRange: deleteRange)
+        #expect(editor.rawSource == "1. a\n2. c\n")
+    }
+
+    @Test("Backspace-merge into the previous item renumbers the tail")
+    @MainActor func backspaceMergeRenumbers() {
+        let editor = makeEditor()
+        editor.loadContent("1. a\n2. b\n3. c")
+        // Caret at the start of "2. b" (offset 5): one backspace deletes the
+        // preceding "\n", merging it onto "1. a"'s line — leaving "3. c" as
+        // the second item in the run, which should renumber to "2. c".
+        editor.setSelectedRange(NSRange(location: 5, length: 0))
+        pressBackspace(in: editor)
+        #expect(editor.rawSource == "1. a2. b\n2. c")
+    }
+
+    @Test("Deleting an item preserves the run's starting number")
+    @MainActor func startNumberPreserved() {
+        let editor = makeEditor()
+        editor.loadContent("5. a\n6. b\n7. c\n")
+        let deleteRange = NSRange(location: 5, length: 5)
+        editor.setSelectedRange(deleteRange)
+        editor.insertText("", replacementRange: deleteRange)
+        #expect(editor.rawSource == "5. a\n6. c\n")
+    }
+
+    @Test("Editing the top level leaves a nested ordered run untouched")
+    @MainActor func nestedLevelUntouchedWhenEditingParent() {
+        let editor = makeEditor()
+        editor.loadContent("1. a\n   1. x\n   2. y\n2. b\n3. c\n")
+        // Delete the top-level "2. b\n" line.
+        let range = (editor.rawSource as NSString).range(of: "2. b\n")
+        editor.setSelectedRange(range)
+        editor.insertText("", replacementRange: range)
+        #expect(editor.rawSource == "1. a\n   1. x\n   2. y\n2. c\n")
+    }
+
+    @Test("Editing a nested run leaves the parent level untouched")
+    @MainActor func parentLevelUntouchedWhenEditingNested() {
+        let editor = makeEditor()
+        editor.loadContent("1. a\n   1. x\n   2. y\n   3. z\n2. b\n")
+        let range = (editor.rawSource as NSString).range(of: "   2. y\n")
+        editor.setSelectedRange(range)
+        editor.insertText("", replacementRange: range)
+        #expect(editor.rawSource == "1. a\n   1. x\n   2. z\n2. b\n")
+    }
+
+    @Test("Deleting a bullet item does not trigger ordered renumbering")
+    @MainActor func unorderedListUnaffected() {
+        let editor = makeEditor()
+        editor.loadContent("- a\n- b\n- c\n")
+        let range = (editor.rawSource as NSString).range(of: "- b\n")
+        editor.setSelectedRange(range)
+        editor.insertText("", replacementRange: range)
+        #expect(editor.rawSource == "- a\n- c\n")
+    }
+
+    @Test("An untouched item inside the renumbered span keeps its dimmed marker")
+    @MainActor func untouchedItemInSpanStaysDimmed() {
+        // "1. a" sits in the same contiguous run as the renumbered items but
+        // is never itself rewritten and never the active block after the
+        // edit — `recomposeReplacing` wipes its WHOLE oldRange to base
+        // attributes before restyling only the dirty set, so every block in
+        // that span (not just the ones whose digits changed) must be marked
+        // dirty or this one is left showing an unstyled (undimmed) marker.
+        let editor = makeEditor()
+        editor.loadContent("1. a\n2. b\n3. c\n4. d\n5. e\n")
+        let range = (editor.rawSource as NSString).range(of: "2. b\n")
+        editor.setSelectedRange(range)
+        editor.insertText("", replacementRange: range)
+        #expect(editor.rawSource == "1. a\n2. c\n3. d\n4. e\n")
+
+        // The caret (and thus the active, intentionally-undimmed block) sits
+        // at the deletion point, on "2. c" — "1. a" stays inactive throughout.
+        #expect(editor.blocks[0].content == "1. a")
+        #expect(fgColor(at: editor.blocks[0].range.location, in: editor) == NSColor.tertiaryLabelColor)
+    }
+
+    @Test("Splitting one list into two at the same depth renumbers both halves")
+    @MainActor func splittingIntoTwoRunsRenumbersBoth() {
+        // Enter on an already-empty list item removes its marker
+        // (EditorTextView+ListContinuation.swift's root-level-empty branch),
+        // leaving a blank line that splits one depth-0 run into two disjoint
+        // ones. Both must still get renumbered independently — a naive
+        // "one depth, one run" dedup would fix the first (trivially, since
+        // "1." alone is already correct) and silently skip the second.
+        let editor = makeEditor()
+        editor.loadContent("1. a\n2. \n4. b\n4. c")
+        // Caret at the end of the empty "2. " item.
+        let caret = (editor.rawSource as NSString).range(of: "2. ").upperBound
+        editor.setSelectedRange(NSRange(location: caret, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "1. a\n\n4. b\n5. c")
+    }
+
+    @Test("Indenting a list item renumbers both the old and new level")
+    @MainActor func indentRenumbersBothLevels() {
+        let editor = makeEditor()
+        editor.loadContent("1. a\n2. b\n  1. x\n  2. y\n3. c")
+        // Tab-indent "2. b" into the nested (depth-1) run: the old top-level
+        // run loses a member (c should renumber 3→2), and the nested run
+        // gains a new head (x, y should renumber to 3, 4 after b's "2.").
+        let caret = (editor.rawSource as NSString).range(of: "2. b").location
+        editor.setSelectedRange(NSRange(location: caret, length: 0))
+        editor.insertTab(nil)
+        #expect(editor.rawSource == "1. a\n  2. b\n  3. x\n  4. y\n2. c")
+    }
+
+    @Test("Dedenting a list item renumbers both the old and new level")
+    @MainActor func dedentRenumbersBothLevels() {
+        let editor = makeEditor()
+        editor.loadContent("1. a\n  1. x\n  2. y\n2. b\n3. c")
+        // Shift-Tab-dedent "2. y": it stays in place (dedent only strips
+        // indent, it doesn't move lines), so it now sits at depth 0 between
+        // "a" and "b" in document order. The nested run loses its second
+        // member (x alone stays "1."), and the top-level run gains a new
+        // member right after "a", pushing b/c's numbers up by one.
+        let caret = (editor.rawSource as NSString).range(of: "2. y").location
+        editor.setSelectedRange(NSRange(location: caret, length: 0))
+        editor.insertBacktab(nil)
+        #expect(editor.rawSource == "1. a\n  1. x\n2. y\n3. b\n4. c")
+    }
+
+    @Test("Undo restores the pre-renumber text in a single step")
+    @MainActor func undoRestoresOriginalInOneStep() {
+        let editor = makeEditor()
+        editor.loadContent("1. a\n2. b\n3. c")
+        editor.setSelectedRange(NSRange(location: 4, length: 0))
+        editor.insertNewline(nil)
+        #expect(editor.rawSource == "1. a\n2. \n3. b\n4. c")
+
+        editor.undo(nil)
+        #expect(editor.rawSource == "1. a\n2. b\n3. c")
+
+        editor.redo(nil)
+        #expect(editor.rawSource == "1. a\n2. \n3. b\n4. c")
+    }
+}

--- a/Tests/EdmundTests/ListRenumberingTests.swift
+++ b/Tests/EdmundTests/ListRenumberingTests.swift
@@ -96,21 +96,76 @@ struct ListRenumberingTests {
         #expect(fgColor(at: editor.blocks[0].range.location, in: editor) == NSColor.tertiaryLabelColor)
     }
 
-    @Test("Splitting one list into two at the same depth renumbers both halves")
-    @MainActor func splittingIntoTwoRunsRenumbersBoth() {
+    @Test("Enter on an empty item leaves a blank line but still renumbers across it")
+    @MainActor func enterOnEmptyItemStillRenumbersAcrossBlankLine() {
         // Enter on an already-empty list item removes its marker
         // (EditorTextView+ListContinuation.swift's root-level-empty branch),
-        // leaving a blank line that splits one depth-0 run into two disjoint
-        // ones. Both must still get renumbered independently — a naive
-        // "one depth, one run" dedup would fix the first (trivially, since
-        // "1." alone is already correct) and silently skip the second.
+        // leaving a blank line — a single blank line is a CommonMark "loose
+        // list" separator, not a list boundary, so "b"/"c" after it are
+        // still part of the SAME run as "a" and renumber against its start.
         let editor = makeEditor()
         editor.loadContent("1. a\n2. \n4. b\n4. c")
         // Caret at the end of the empty "2. " item.
         let caret = (editor.rawSource as NSString).range(of: "2. ").upperBound
         editor.setSelectedRange(NSRange(location: caret, length: 0))
         editor.insertNewline(nil)
-        #expect(editor.rawSource == "1. a\n\n4. b\n5. c")
+        #expect(editor.rawSource == "1. a\n\n2. b\n3. c")
+    }
+
+    @Test("Two disjoint same-depth runs in one touched window both renumber")
+    @MainActor func twoDisjointSameDepthRunsBothRenumber() {
+        // Two consecutive blank lines are a real list boundary (only a
+        // single blank is tolerated as a loose-list separator), so "a, b"
+        // and "c, d" are genuinely disjoint runs at the same depth. Calling
+        // the hook with a window spanning both (as widening ±1 around a
+        // touched block near the boundary could) must renumber both — a
+        // naive "one depth, one run" dedup would fix the first and silently
+        // skip the second, leaving "d" duplicating "c"'s wrong number.
+        let editor = makeEditor()
+        editor.loadContent("1. a\n2. b\n\n\n5. c\n5. d")
+        editor.renumberOrderedListRunsIfNeeded(touching: 1..<5)
+        #expect(editor.rawSource == "1. a\n2. b\n\n\n5. c\n6. d")
+    }
+
+    @Test("Deleting a line's text but not its break still renumbers across the gap")
+    @MainActor func deleteLeavingBlankLineStillRenumbers() {
+        // Selecting a full line's text (e.g. via triple-click) and deleting
+        // it removes the content but not the line break, leaving a blank
+        // line behind rather than merging — "4. Four" then sits across a
+        // blank line from "1./2.", not immediately after them. It must
+        // still renumber: a single blank line is a CommonMark "loose list"
+        // separator, not a list boundary.
+        let editor = makeEditor()
+        editor.loadContent("1. One\n2. Two\n3. Three\n4. Four")
+        let range = (editor.rawSource as NSString).range(of: "3. Three")
+        editor.setSelectedRange(range)
+        editor.insertText("", replacementRange: range)
+        #expect(editor.rawSource == "1. One\n2. Two\n\n3. Four")
+    }
+
+    @Test("Indenting into a brand-new sublist restarts numbering at 1")
+    @MainActor func indentIntoBrandNewSublistRestartsAtOne() {
+        // Indenting a multi-line selection with no pre-existing nested
+        // siblings creates a sublist from scratch — it should start at 1,
+        // not inherit the top-level numbers ("2.", "3.") the moved items
+        // happened to have before the indent.
+        let editor = makeEditor()
+        editor.loadContent("1. One\n2. Two\n3. Three\n4. Four")
+        let start = (editor.rawSource as NSString).range(of: "2. Two").location
+        let end = (editor.rawSource as NSString).range(of: "3. Three").upperBound
+        editor.setSelectedRange(NSRange(location: start, length: end - start))
+        editor.insertTab(nil)
+        #expect(editor.rawSource == "1. One\n  1. Two\n  2. Three\n2. Four")
+    }
+
+    @Test("Indenting a single item into a brand-new sublist restarts at 1")
+    @MainActor func indentSingleItemIntoBrandNewSublistRestartsAtOne() {
+        let editor = makeEditor()
+        editor.loadContent("1. One\n2. Two\n3. Three")
+        let caret = (editor.rawSource as NSString).range(of: "2. Two").location
+        editor.setSelectedRange(NSRange(location: caret, length: 0))
+        editor.insertTab(nil)
+        #expect(editor.rawSource == "1. One\n  1. Two\n2. Three")
     }
 
     @Test("Indenting a list item renumbers both the old and new level")


### PR DESCRIPTION
## Summary
- Keeps a contiguous ordered-list run sequential after edits that change its item count: mid-list Enter, backspace-merge, whole-line delete, paste, and Tab/Shift-Tab re-indent — scoped to the edited nesting depth, preserving the run's own starting number.
- Fixes two gaps found during live verification: two disjoint ordered runs at the same depth inside one edit's touched window (a naive per-depth dedup silently skipped the second one), and indent/dedent, which changes an item's depth outside the normal edit pipeline entirely — both the losing (old) and gaining (new) level now renumber.
- Closes the backlog item at `misc/backlog.md:47` / `docs/ROADMAP.md:12`.

## Test plan
- [x] `swift test` — 996 tests green (11 new in `ListRenumberingTests.swift` + 1 in `ListContinuationTests.swift`)
- [x] Live verification: built `EdmundDbg.app`, drove a real `deleteBackward` merge via ReproScript against an 11-item list, confirmed exact byte-length arithmetic in the log and a clean screenshot (uniform marker dimming, correct digit-width realignment for 9→10 boundary)
- [x] Found and fixed a real visual bug via that live check: `recomposeReplacing` wipes its whole replaced span to base attributes, so the dirty set must cover every block in the renumbered span, not just the ones whose digits changed — caught with a headless regression test before re-verifying live