### PR TITLE
fix(gfm): wrap table cell content and add row grid lines in edit mode

### DIFF
--- a/Sources/EdmundCore/Rendering/EditorTextView+TableRendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+TableRendering.swift
@@ -150,7 +150,8 @@ extension EditorTextView {
                     value: BlockDecoration(.tableRow(columnXOffsets: borderXOffsets,
                                                      width: totalWidth,
                                                      leftInset: cellHPad,
-                                                     separator: i == 1)),
+                                                     separator: i == 1,
+                                                     bottomBorder: i > 1)),
                     range: lineRange)
 
                 // Cells whose styled width exceeds their column's (clamped)

--- a/Sources/EdmundCore/Rendering/EditorTextView+TableRendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+TableRendering.swift
@@ -27,7 +27,9 @@ extension EditorTextView {
         } else {
             // Non-active: bold header, hidden pipes, column-width alignment
             // via kern, drawn vertical + horizontal borders via TableRowTextBlock,
-            // with cell padding for breathing room.
+            // with cell padding for breathing room. A cell wider than its
+            // column instead hides its real characters and gets redrawn
+            // wrapped via `.tableCellWraps` (see EditorTextView+TextKit2.swift).
             let tableNS = (result.string as NSString)
             let tableStr = tableNS.substring(with: span.fullRange)
             let lines = tableStr.components(separatedBy: "\n")
@@ -43,11 +45,16 @@ extension EditorTextView {
             // ponytail: block-level markdown in a cell (`# x`, `- x`) keeps its
             // fonts but loses its block chrome (paragraph styles / decorations
             // are row-owned, see the transplant below); tall math or image
-            // overlays get no extra line height in cells.
+            // overlays get no extra line height in cells. A wrapped (overflowing)
+            // cell is drawn from a detached scratch text layout rather than the
+            // live glyph run, so click-to-caret placement inside it is
+            // approximate while the table is non-active — clicking anywhere in
+            // the cell still enters the table and lands the caret at the raw
+            // source's nearest position once active.
             let headerCells = splitTableRow(lines[0])
             let numCols = headerCells.count
             guard numCols > 0 else { return }
-            var colWidths = [CGFloat](repeating: 0, count: numCols)
+            var natural = [CGFloat](repeating: 0, count: numCols)
             // Per line: the cell's character range within the line + its
             // styled form (empty for the separator row).
             var rowCells: [[(start: Int, end: Int, styled: NSAttributedString)]] = []
@@ -75,10 +82,19 @@ extension EditorTextView {
                 }
                 rowCells.append(cells)
                 for ci in 0..<min(cells.count, numCols) {
-                    colWidths[ci] = max(colWidths[ci], cells[ci].styled.size().width)
+                    natural[ci] = max(natural[ci], cells[ci].styled.size().width)
                 }
             }
+            // Clamp column content widths to the available line width so a
+            // pathologically wide cell doesn't stretch the whole table off
+            // screen — the overflow gets wrapped (below) instead. Columns
+            // that already fit their fair share keep their natural width.
+            let minColWidth = bodyFont.pointSize * 3
+            let available = max(0, availableContentWidth - CGFloat(numCols) * 2 * cellHPad)
+            let clamped = distributeColumnWidths(natural: natural, available: available,
+                                                 minWidth: minColWidth)
             // Add horizontal padding to each column (space after cell text).
+            var colWidths = clamped
             for ci in 0..<numCols {
                 colWidths[ci] += 2 * cellHPad
             }
@@ -88,8 +104,10 @@ extension EditorTextView {
             // so the 2*cellHPad per column splits evenly: hPad of right
             // padding for the current cell, hPad of left padding for the next.
             var borderXOffsets: [CGFloat] = []
+            var colStartX: [CGFloat] = []
             var cumX: CGFloat = 0
             for ci in 0..<numCols {
+                colStartX.append(cumX + cellHPad)
                 cumX += colWidths[ci]
                 if ci < numCols - 1 { borderXOffsets.append(cumX - cellHPad) }
             }
@@ -135,6 +153,19 @@ extension EditorTextView {
                                                      separator: i == 1)),
                     range: lineRange)
 
+                // Cells whose styled width exceeds their column's (clamped)
+                // content width can't be kern-aligned in place — they get
+                // hidden and redrawn wrapped by `.tableCellWraps` instead
+                // (see DecoratedTextLayoutFragment). Computed once per row so
+                // both the hide/transplant step and the kern step below agree.
+                var overflowsCol = [Bool](repeating: false, count: numCols)
+                if i != 1, i < rowCells.count {
+                    for ci in 0..<min(rowCells[i].count, numCols) {
+                        overflowsCol[ci] = rowCells[i][ci].styled.size().width
+                            > colWidths[ci] - 2 * cellHPad + 0.5
+                    }
+                }
+
                 if i == 1 {
                     // Separator row: hide all text
                     result.addAttribute(.font, value: hiddenFont, range: lineRange)
@@ -143,18 +174,34 @@ extension EditorTextView {
                     // Transplant each styled cell's attributes onto the table,
                     // skipping .paragraphStyle and .blockDecoration — row
                     // geometry and borders stay owned by the table code.
-                    for cell in rowCells[i] {
+                    // Overflowing cells instead hide their real characters and
+                    // get redrawn wrapped, since kern alone can't wrap text.
+                    var wraps: [TableCellWrap] = []
+                    for (ci, cell) in rowCells[i].enumerated() where ci < numCols {
                         let offset = lineOffset + cell.start
-                        cell.styled.enumerateAttributes(
-                            in: NSRange(location: 0, length: cell.styled.length)
-                        ) { attrs, r, _ in
-                            let target = NSRange(location: offset + r.location, length: r.length)
-                            guard target.upperBound <= result.length else { return }
-                            for (key, value) in attrs {
-                                guard key != .paragraphStyle && key != .blockDecoration else { continue }
-                                result.addAttribute(key, value: value, range: target)
+                        if overflowsCol[ci] {
+                            let hideRange = NSRange(location: offset, length: cell.end - cell.start)
+                            guard hideRange.upperBound <= result.length else { continue }
+                            result.addAttribute(.font, value: hiddenFont, range: hideRange)
+                            result.addAttribute(.foregroundColor, value: NSColor.clear, range: hideRange)
+                            wraps.append(TableCellWrap(styled: cell.styled, x: colStartX[ci],
+                                                       contentWidth: colWidths[ci] - 2 * cellHPad))
+                        } else {
+                            cell.styled.enumerateAttributes(
+                                in: NSRange(location: 0, length: cell.styled.length)
+                            ) { attrs, r, _ in
+                                let target = NSRange(location: offset + r.location, length: r.length)
+                                guard target.upperBound <= result.length else { return }
+                                for (key, value) in attrs {
+                                    guard key != .paragraphStyle && key != .blockDecoration else { continue }
+                                    result.addAttribute(key, value: value, range: target)
+                                }
                             }
                         }
+                    }
+                    if !wraps.isEmpty {
+                        result.addAttribute(.tableCellWraps, value: TableCellWrapList(wraps),
+                                            range: lineRange)
                     }
                 }
 
@@ -179,6 +226,7 @@ extension EditorTextView {
                 // "before" kern goes on the char preceding the cell content.
                 if i != 1, i < rowCells.count {
                     for ci in 0..<min(rowCells[i].count, numCols) {
+                        guard !overflowsCol[ci] else { continue }
                         let cr = rowCells[i][ci]
                         let cellWidth = cr.styled.size().width
                         let padding = colWidths[ci] - cellWidth

--- a/Sources/EdmundCore/Rendering/EditorTextView+TableSupport.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+TableSupport.swift
@@ -10,7 +10,38 @@ import AppKit
 // table row) that the BlockParser merges into a single block. Each row
 // carries a `.tableRow` BlockDecoration; because every row uses the same
 // column X offsets, the per-row vertical strokes line up into continuous
-// column borders.
+// column borders. A cell too wide for its column renders across multiple
+// *visual* sublines within that one paragraph, via `.tableCellWraps`
+// (EditorTextView+TextKit2.swift) — the paragraph/row count is unchanged.
+
+// MARK: - Column Width Distribution
+
+/// Clamps each column's natural (widest-cell) width to fit `available` total
+/// width, so one very wide cell doesn't stretch the whole table off screen.
+/// Columns already at or under their fair share (`available / count`) keep
+/// their natural width; the slack they don't use is handed to the columns
+/// that exceed fair share, split evenly among them and floored at `minWidth`.
+/// ponytail: single-pass, not CSS's iterative auto-table-layout fixed point —
+/// revisit only if real documents show pathological many-column cases.
+func distributeColumnWidths(natural: [CGFloat], available: CGFloat,
+                            minWidth: CGFloat) -> [CGFloat] {
+    let numCols = natural.count
+    guard numCols > 0, available > 0 else { return natural }
+    let fairShare = available / CGFloat(numCols)
+    var overIdx: [Int] = []
+    var usedByUnderShare: CGFloat = 0
+    for (ci, width) in natural.enumerated() {
+        if width <= fairShare { usedByUnderShare += width } else { overIdx.append(ci) }
+    }
+    guard !overIdx.isEmpty else { return natural }
+    let remaining = max(0, available - usedByUnderShare)
+    let perOverShare = remaining / CGFloat(overIdx.count)
+    var result = natural
+    for ci in overIdx {
+        result[ci] = max(minWidth, min(natural[ci], perOverShare))
+    }
+    return result
+}
 
 // MARK: - Column Alignment
 

--- a/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
@@ -61,9 +61,11 @@ public final class BlockDecoration: NSObject, @unchecked Sendable {
         /// Table-row chrome: vertical column borders at text-relative x
         /// offsets, and a horizontal rule through the separator row. `width`
         /// is the table's full width; `leftInset` the text's inset from the
-        /// table's left edge.
+        /// table's left edge. `bottomBorder` draws a full-width line at this
+        /// row's bottom edge — the grid line between data rows (the header/
+        /// separator boundary already gets its line from `separator`).
         case tableRow(columnXOffsets: [CGFloat], width: CGFloat,
-                      leftInset: CGFloat, separator: Bool)
+                      leftInset: CGFloat, separator: Bool, bottomBorder: Bool)
         /// Horizontal hairline across the text column, drawn `centerOffset`
         /// points below the fragment's vertical center. The offset compensates
         /// for adjacent text sitting at its baseline (low in its line box), so
@@ -509,7 +511,7 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
             context.fill(CGRect(x: point.x - width + decoration.inset, y: barTop,
                                 width: width, height: barHeight))
 
-        case .tableRow(let xOffsets, let width, let leftInset, let separator):
+        case .tableRow(let xOffsets, let width, let leftInset, let separator, let bottomBorder):
             // Offsets are text-relative; the fragment's origin is the text start.
             context.setStrokeColor(NSColor.separatorColor.cgColor)
             context.setLineWidth(1)
@@ -520,6 +522,11 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
             }
             if separator {
                 let y = round(point.y + frame.height / 2) + 0.5
+                context.move(to: CGPoint(x: point.x - leftInset, y: y))
+                context.addLine(to: CGPoint(x: point.x - leftInset + width, y: y))
+            }
+            if bottomBorder {
+                let y = round(point.y + frame.height) + 0.5
                 context.move(to: CGPoint(x: point.x - leftInset, y: y))
                 context.addLine(to: CGPoint(x: point.x - leftInset + width, y: y))
             }

--- a/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
@@ -21,6 +21,13 @@ import AppKit
 //   forbids. Instead the anchor character is hidden, `.kern` reserves the
 //   image's advance width (the same trick the table renderer uses for column
 //   alignment), and the fragment draws the image at the anchor's position.
+// - `.tableCellWraps` (paragraph-level): a table cell too wide for its column
+//   can't wrap in place — TextKit 2 only wraps a whole paragraph at the
+//   container's edge, it has no notion of an independent per-cell flow region
+//   (that's what NSTextTable/NSTextBlock exist for, and they're banned). So an
+//   overflowing cell's real characters are hidden, and its styled text is laid
+//   out separately in a small detached text stack sized to the column's
+//   width; the fragment draws the resulting lines stacked at the cell's x.
 
 public extension NSAttributedString.Key {
     /// Paragraph-level decoration drawn behind the text by
@@ -30,6 +37,9 @@ public extension NSAttributedString.Key {
     /// `DecoratedTextLayoutFragment`. Value: `FragmentOverlay`. The styling
     /// code pairs it with a hidden anchor glyph plus `.kern` for layout space.
     static let fragmentOverlay = NSAttributedString.Key("MarkdownEditor.fragmentOverlay")
+    /// A table row's overflowing cells, wrapped and drawn by
+    /// `DecoratedTextLayoutFragment`. Value: `TableCellWrapList`.
+    static let tableCellWraps = NSAttributedString.Key("MarkdownEditor.tableCellWraps")
 }
 
 /// Value object describing what to draw behind a decorated paragraph.
@@ -169,6 +179,47 @@ public final class FragmentOverlay: NSObject, @unchecked Sendable {
     public override var hash: Int { Int(bounds.width) ^ Int(bounds.height) }
 }
 
+/// A table cell too wide for its column: its real characters are hidden, and
+/// this holds what to draw instead. `x` is text-relative (same coordinate
+/// space as `BlockDecoration.tableRow`'s `columnXOffsets`) — the cell's
+/// content start. `contentWidth` is the column's clamped content width (the
+/// width the cell's text must wrap within).
+public final class TableCellWrap: NSObject, @unchecked Sendable {
+    public let styled: NSAttributedString
+    public let x: CGFloat
+    public let contentWidth: CGFloat
+
+    public init(styled: NSAttributedString, x: CGFloat, contentWidth: CGFloat) {
+        self.styled = styled
+        self.x = x
+        self.contentWidth = contentWidth
+    }
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? TableCellWrap else { return false }
+        return other.styled.string == styled.string
+            && abs(other.x - x) < 0.5 && abs(other.contentWidth - contentWidth) < 0.5
+    }
+
+    public override var hash: Int { styled.string.hashValue }
+}
+
+/// A table row's overflowing cells, one `TableCellWrap` per overflowing cell.
+public final class TableCellWrapList: NSObject, @unchecked Sendable {
+    public let wraps: [TableCellWrap]
+
+    public init(_ wraps: [TableCellWrap]) {
+        self.wraps = wraps
+    }
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? TableCellWrapList else { return false }
+        return wraps == other.wraps
+    }
+
+    public override var hash: Int { wraps.count }
+}
+
 /// Layout fragment that draws its paragraph's `BlockDecoration` behind the
 /// text and any `FragmentOverlay` images at their characters' positions.
 final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
@@ -179,15 +230,54 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
     let overlays: [(offset: Int, overlay: FragmentOverlay)]
     /// Whether the text is antialiased (editor-wide setting).
     let antialias: Bool
+    /// Each overflowing cell's x and pre-laid-out lines, from a detached
+    /// scratch text stack sized to the column's content width. The stack
+    /// itself is retained (`scratchStacks`) so the line fragments stay valid.
+    private let resolvedCellWraps: [(x: CGFloat, lines: [NSTextLineFragment])]
+    private let scratchStacks: [(NSTextContentStorage, NSTextLayoutManager, NSTextContainer)]
 
     init(textElement: NSTextElement, range: NSTextRange?,
          decorations: [BlockDecoration],
          overlays: [(offset: Int, overlay: FragmentOverlay)],
+         cellWraps: [TableCellWrap],
          antialias: Bool) {
         self.decorations = decorations
         self.overlays = overlays
         self.antialias = antialias
+        var resolved: [(x: CGFloat, lines: [NSTextLineFragment])] = []
+        var stacks: [(NSTextContentStorage, NSTextLayoutManager, NSTextContainer)] = []
+        for wrap in cellWraps {
+            let contentStorage = NSTextContentStorage()
+            contentStorage.textStorage = NSTextStorage(attributedString: wrap.styled)
+            let layoutManager = NSTextLayoutManager()
+            contentStorage.addTextLayoutManager(layoutManager)
+            let container = NSTextContainer(
+                size: NSSize(width: max(1, wrap.contentWidth), height: .greatestFiniteMagnitude))
+            container.lineFragmentPadding = 0
+            layoutManager.textContainer = container
+            var lines: [NSTextLineFragment] = []
+            layoutManager.enumerateTextLayoutFragments(
+                from: layoutManager.documentRange.location, options: [.ensuresLayout]
+            ) { frag in
+                lines.append(contentsOf: frag.textLineFragments)
+                return true
+            }
+            resolved.append((wrap.x, lines))
+            stacks.append((contentStorage, layoutManager, container))
+        }
+        self.resolvedCellWraps = resolved
+        self.scratchStacks = stacks
         super.init(textElement: textElement, range: range)
+    }
+
+    /// Extra row height needed to fit the tallest wrapped cell, beyond the
+    /// row's natural (single-line) height.
+    private var tableRowExtraHeight: CGFloat {
+        guard !resolvedCellWraps.isEmpty else { return 0 }
+        let tallest = resolvedCellWraps
+            .map { $0.lines.reduce(0) { $0 + $1.typographicBounds.height } }
+            .max() ?? 0
+        return max(0, tallest - super.layoutFragmentFrame.height)
     }
 
     required init?(coder: NSCoder) {
@@ -246,7 +336,9 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
 
     override var layoutFragmentFrame: CGRect {
         var frame = super.layoutFragmentFrame
-        frame.size.height += boxBottomPad
+        // A row is never both a box and a table row, so at most one of these
+        // two is ever nonzero.
+        frame.size.height += boxBottomPad + tableRowExtraHeight
         return frame
     }
 
@@ -315,6 +407,18 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
                 context.setLineJoin(.round)
                 context.strokePath()
                 context.restoreGState()
+            }
+        }
+        // Overflowing table cells: the real characters are hidden, so draw
+        // each cell's pre-wrapped lines here instead, stacked top-down at the
+        // cell's column x. Left-aligned regardless of the column's declared
+        // alignment (ponytail: not requested; upgrade path is the same
+        // per-line x-shift math the kern-based alignment above already uses).
+        for cellWrap in resolvedCellWraps {
+            var y = point.y
+            for line in cellWrap.lines {
+                line.draw(at: CGPoint(x: point.x + cellWrap.x, y: y), in: context)
+                y += line.typographicBounds.height
             }
         }
     }
@@ -463,10 +567,13 @@ extension EditorTextView: NSTextLayoutManagerDelegate {
                 overlays.append((range.location, overlay))
             }
         }
+        let cellWrapsValue = str.attribute(.tableCellWraps, at: 0, effectiveRange: nil)
+        let cellWraps = (cellWrapsValue as? TableCellWrapList)?.wraps ?? []
         // A plain fragment suffices only when there's nothing to draw over the
         // text and antialiasing is on (the default); otherwise vend the custom
         // fragment so its draw can disable antialiasing.
-        guard !decorations.isEmpty || !overlays.isEmpty || !textAntialias else {
+        guard !decorations.isEmpty || !overlays.isEmpty || !cellWraps.isEmpty || !textAntialias
+        else {
             return NSTextLayoutFragment(textElement: textElement,
                                         range: textElement.elementRange)
         }
@@ -474,6 +581,7 @@ extension EditorTextView: NSTextLayoutManagerDelegate {
                                            range: textElement.elementRange,
                                            decorations: decorations,
                                            overlays: overlays,
+                                           cellWraps: cellWraps,
                                            antialias: textAntialias)
     }
 }

--- a/Tests/EdmundTests/EditorRenderingTests.swift
+++ b/Tests/EdmundTests/EditorRenderingTests.swift
@@ -606,7 +606,7 @@ struct EditorStylingTests {
         #expect(isHidden(at: 10, in: styled))
         // Separator row carries a separator .tableRow decoration
         if let deco = blockDecoration(at: 10, in: styled),
-           case .tableRow(_, _, _, let separator) = deco.kind {
+           case .tableRow(_, _, _, let separator, _) = deco.kind {
             #expect(separator)
         } else {
             Issue.record("expected a .tableRow decoration on the separator row")

--- a/Tests/EdmundTests/TableWrapRenderingTests.swift
+++ b/Tests/EdmundTests/TableWrapRenderingTests.swift
@@ -72,7 +72,7 @@ struct TableWrapRenderingTests {
         let s = styled.string as NSString
         var lineStart = 0
         while lineStart <= s.length {
-            if case .tableRow(let offsets, _, _, _)? =
+            if case .tableRow(let offsets, _, _, _, _)? =
                 blockDecoration(at: lineStart, in: styled)?.kind {
                 offsetsPerRow.append(offsets)
             }
@@ -82,6 +82,26 @@ struct TableWrapRenderingTests {
         }
         #expect(offsetsPerRow.count >= 2)
         #expect(offsetsPerRow.dropFirst().allSatisfy { $0 == offsetsPerRow[0] })
+    }
+
+    @Test("Every data row gets a bottom grid line; header and separator rows don't")
+    func bottomBorderOnDataRowsOnly() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("| a | b |\n|---|---|\n| x | y |\n| p | q |", cursorPosition: nil)
+        var bottoms: [Bool] = []
+        let s = styled.string as NSString
+        var lineStart = 0
+        while lineStart <= s.length {
+            if case .tableRow(_, _, _, _, let bottomBorder)? =
+                blockDecoration(at: lineStart, in: styled)?.kind {
+                bottoms.append(bottomBorder)
+            }
+            let nl = s.range(of: "\n", range: NSRange(location: lineStart, length: s.length - lineStart))
+            guard nl.location != NSNotFound else { break }
+            lineStart = nl.upperBound
+        }
+        // Rows: header, separator, "x | y", "p | q".
+        #expect(bottoms == [false, false, true, true])
     }
 
     @Test("distributeColumnWidths keeps under-fair-share columns, clamps the rest")

--- a/Tests/EdmundTests/TableWrapRenderingTests.swift
+++ b/Tests/EdmundTests/TableWrapRenderingTests.swift
@@ -1,0 +1,100 @@
+import Testing
+import Foundation
+import AppKit
+@testable import EdmundCore
+
+// A table cell wider than its (clamped) column can't be kern-aligned in
+// place — TextKit 2 only wraps a whole paragraph at the container edge, and
+// NSTextTable/NSTextBlock are banned (they revert the view to TextKit 1). The
+// fix hides that cell's real characters and records a `.tableCellWraps`
+// attribute the layout fragment redraws wrapped. See EditorTextView+TextKit2.swift.
+
+@Suite("Table cell wrapping")
+@MainActor
+struct TableWrapRenderingTests {
+
+    private func lastRowStart(_ styled: NSAttributedString) -> Int {
+        let s = styled.string as NSString
+        let nl = s.range(of: "\n", options: .backwards)
+        return nl.location == NSNotFound ? 0 : nl.location + 1
+    }
+
+    private func cellWraps(at offset: Int, in styled: NSAttributedString) -> [TableCellWrap] {
+        guard offset < styled.length else { return [] }
+        let list = styled.attribute(.tableCellWraps, at: offset, effectiveRange: nil) as? TableCellWrapList
+        return list?.wraps ?? []
+    }
+
+    @Test("Cells that fit their column carry no wrap attribute")
+    func fittingCellsUnaffected() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("| a | b |\n|---|---|\n| x | y |", cursorPosition: nil)
+        let start = lastRowStart(styled)
+        #expect(cellWraps(at: start, in: styled).isEmpty)
+        // Existing kern-based alignment still runs for the fitting cell.
+        #expect(styled.attribute(.tableCellWraps, at: 0, effectiveRange: nil) == nil)
+    }
+
+    @Test("A cell wider than its column gets a wrap marker sized to overflow")
+    func overflowingCellGetsWrapMarker() {
+        let editor = makeEditor()
+        let longText = Array(repeating: "overflow", count: 30).joined(separator: " ")
+        let source = "| short | wide |\n|---|---|\n| x | \(longText) |"
+        let styled = editor.styleBlock(source, cursorPosition: nil)
+        let start = lastRowStart(styled)
+
+        let wraps = cellWraps(at: start, in: styled)
+        #expect(wraps.count == 1)
+        guard let wrap = wraps.first else { return }
+        // The cell's natural width must genuinely exceed the column it was
+        // clamped to — otherwise it wouldn't need to wrap at all.
+        #expect(wrap.styled.size().width > wrap.contentWidth)
+        #expect(wrap.contentWidth > 0)
+    }
+
+    @Test("Table storage stays byte-for-byte unchanged when a cell wraps")
+    func storageUnchangedByWrapping() {
+        let editor = makeEditor()
+        let longText = Array(repeating: "overflow", count: 30).joined(separator: " ")
+        let source = "| short | wide |\n|---|---|\n| x | \(longText) |"
+        let styled = editor.styleBlock(source, cursorPosition: nil)
+        #expect(styled.string == source)
+    }
+
+    @Test("Every row shares the same column border offsets even with a wrapping row")
+    func columnOffsetsConsistentAcrossRows() {
+        let editor = makeEditor()
+        let longText = Array(repeating: "overflow", count: 30).joined(separator: " ")
+        let source = "| short | wide |\n|---|---|\n| x | \(longText) |\n| a | b |"
+        let styled = editor.styleBlock(source, cursorPosition: nil)
+
+        var offsetsPerRow: [[CGFloat]] = []
+        let s = styled.string as NSString
+        var lineStart = 0
+        while lineStart <= s.length {
+            if case .tableRow(let offsets, _, _, _)? =
+                blockDecoration(at: lineStart, in: styled)?.kind {
+                offsetsPerRow.append(offsets)
+            }
+            let nl = s.range(of: "\n", range: NSRange(location: lineStart, length: s.length - lineStart))
+            guard nl.location != NSNotFound else { break }
+            lineStart = nl.upperBound
+        }
+        #expect(offsetsPerRow.count >= 2)
+        #expect(offsetsPerRow.dropFirst().allSatisfy { $0 == offsetsPerRow[0] })
+    }
+
+    @Test("distributeColumnWidths keeps under-fair-share columns, clamps the rest")
+    func distributeColumnWidthsClamps() {
+        let result = distributeColumnWidths(natural: [20, 200], available: 100, minWidth: 10)
+        #expect(result[0] == 20)
+        #expect(result[1] < 200)
+        #expect(result[1] >= 10)
+    }
+
+    @Test("distributeColumnWidths returns natural widths when everything fits")
+    func distributeColumnWidthsNoOp() {
+        let result = distributeColumnWidths(natural: [20, 30], available: 1000, minWidth: 10)
+        #expect(result == [20, 30])
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -469,6 +469,9 @@ them and route through the app's document graph without JavaScript.
   the container edge and has no per-cell flow region (that's what
   NSTextTable/NSTextBlock are for, and they're banned, see §2). Click-to-caret
   placement inside a wrapped, non-active cell is approximate as a result.
+  Every data row also draws a full-width bottom grid line (`.tableRow`'s
+  `bottomBorder`) — the header/body boundary already gets its line from
+  `separator`, so only rows after the separator set it.
 - *(Track larger roadmap items in README/ROADMAP; track code-debt here.)*
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -457,7 +457,18 @@ them and route through the app's document graph without JavaScript.
 - **Edit-mode table alignment** distributes each cell's slack via `.kern`,
   putting the right/center "before" pad on the cell's *hidden* leading pipe
   (0.01pt glyph) — kern still adds advance there. See
-  `EditorTextView+TableRendering.swift`.
+  `EditorTextView+TableRendering.swift`. Column widths are clamped to the
+  available line width (`distributeColumnWidths`, `EditorTextView+TableSupport.swift`)
+  so one very wide cell can't stretch the table off screen; a cell whose
+  styled width still exceeds its clamped column hides its real characters and
+  is redrawn wrapped instead, via a `.tableCellWraps` attribute
+  (`EditorTextView+TextKit2.swift`) resolved through a detached scratch
+  `NSTextContentStorage`/`NSTextLayoutManager` sized to the column's content
+  width — the same "hide the real chars, draw the visual yourself" pattern as
+  `.fragmentOverlay`, needed because TextKit 2 only wraps a whole paragraph at
+  the container edge and has no per-cell flow region (that's what
+  NSTextTable/NSTextBlock are for, and they're banned, see §2). Click-to-caret
+  placement inside a wrapped, non-active cell is approximate as a result.
 - *(Track larger roadmap items in README/ROADMAP; track code-debt here.)*
 
 ---


### PR DESCRIPTION
## Summary
- Edit-mode GFM tables had no wrap mechanism: rows were a single physical paragraph aligned by `.kern` text-advance padding, so a cell wider than its column drew straight past the column border into the neighbor's space. Column widths now clamp to the available line width, and an overflowing cell hides its real characters and is redrawn wrapped via a new `.tableCellWraps` attribute, resolved through a detached scratch TextKit 2 layout and drawn by `DecoratedTextLayoutFragment` (the same hide-and-custom-draw pattern already used for math/list/checkbox overlays — `NSTextTable`/`NSTextBlock` are banned in this codebase since they silently revert the view to TextKit 1).
- Every table row after the header separator now also draws a full-width bottom grid line (`.tableRow`'s new `bottomBorder`), so multi-row tables no longer look open-ended.

## Test plan
- [x] `swift test` — 991 tests pass, including 7 new targeted tests (fitting cells unaffected, overflow triggers wrap marker, storage stays byte-for-byte unchanged, column offsets consistent across rows, `distributeColumnWidths` clamp behavior, bottom-border-on-data-rows-only)
- [x] Live visual check: built debug bundle, opened a table with a long cell — confirmed it wraps within its column instead of bleeding into the neighbor, and row grid lines render correctly (including through wrapped rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)