### PR TITLE
Add native Window menu to app menu bar

### DIFF
--- a/Sources/edmd/App/WindowMenu.swift
+++ b/Sources/edmd/App/WindowMenu.swift
@@ -1,0 +1,32 @@
+import AppKit
+
+// MARK: - Window menu
+
+@MainActor
+enum WindowMenu {
+
+    /// The top-level "Window" menu item (with its submenu). Setting this as
+    /// `NSApplication.windowsMenu` makes AppKit auto-populate the open-window
+    /// list and checkmark the key window below the static items.
+    static func build() -> NSMenuItem {
+        let windowMenuItem = NSMenuItem()
+        let windowMenu = NSMenu(title: "Window")
+
+        windowMenu.addItem(withTitle: "Minimize",
+                           action: #selector(NSWindow.performMiniaturize(_:)),
+                           keyEquivalent: "m")
+
+        windowMenu.addItem(withTitle: "Zoom",
+                           action: #selector(NSWindow.performZoom(_:)),
+                           keyEquivalent: "")
+
+        windowMenu.addItem(.separator())
+
+        windowMenu.addItem(withTitle: "Bring All to Front",
+                           action: #selector(NSApplication.arrangeInFront(_:)),
+                           keyEquivalent: "")
+
+        windowMenuItem.submenu = windowMenu
+        return windowMenuItem
+    }
+}

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -272,6 +272,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         // View menu — built in its own file (ViewMenu.swift).
         mainMenu.addItem(ViewMenu.build())
 
+        // Window menu — built in its own file (WindowMenu.swift). Assigning
+        // the submenu to `windowsMenu` (not just adding the item) makes
+        // AppKit auto-populate the open-window list and checkmark below the
+        // static Minimize/Zoom/Bring All to Front items.
+        let windowMenuItem = WindowMenu.build()
+        mainMenu.addItem(windowMenuItem)
+        NSApplication.shared.windowsMenu = windowMenuItem.submenu
+
         NSApplication.shared.mainMenu = mainMenu
     }
 }


### PR DESCRIPTION
## Summary
- Adds a standard macOS **Window** menu (Minimize, Zoom, Bring All to Front) to Edmund's menu bar, following the same per-file `NSMenuItem` pattern as `ViewMenu.swift`.
- Assigns the submenu to `NSApplication.shared.windowsMenu` so AppKit auto-populates the open-window list and checkmarks the key window below the static items.

## Why
Edmund's menu bar had no Window menu at all — no way to minimize/zoom via menu, no window list. This brings it in line with standard macOS app conventions.

## Test plan
- [x] `swift test` — 1012 tests pass
- [x] Built EdmundDbg.app and confirmed via screenshot that "Window" appears correctly in the live menu bar between View and the status icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)