### PR TITLE
Line-accurate viewport preservation across Edit/Read mode switches

### DIFF
--- a/Sources/EdmundCore/Export/DocumentHTML.swift
+++ b/Sources/EdmundCore/Export/DocumentHTML.swift
@@ -43,19 +43,24 @@ enum DocumentHTML {
     // MARK: Math (SwiftMath → PNG data URI)
 
     private static let inlineMathPattern = "<span class=\"math-inline\" data-tex=\"([^\"]*)\"></span>"
-    private static let displayMathPattern = "<div class=\"math-display\" data-tex=\"([^\"]*)\"></div>"
+    // Group 1 is the block's `edmund-l<N>` source-line anchor (see
+    // `HTMLRenderer.addingAnchorID`), when the display-math div is a top-level
+    // block — carried through into the replacement so the anchor survives the
+    // asset-fill pass.
+    private static let displayMathPattern = "<div( id=\"[^\"]*\")? class=\"math-display\" data-tex=\"([^\"]*)\"></div>"
 
     private static func fillMath(_ html: String, theme: EditorTheme, dark: Bool) -> String {
         let color = NSColor(hex: dark ? "#e6e6e6" : "#1a1a1a") ?? .textColor
         var out = replaceMatches(html, pattern: displayMathPattern) { groups in
-            let tex = unescapeAttr(groups[1])
+            let id = groups[1]
+            let tex = unescapeAttr(groups[2])
             guard let r = mathImage(latex: tex, display: true,
                                     fontSize: theme.fontSize, color: color),
                   let data = pngData(r.image, scale: 2) else {
-                return "<div class=\"math-display\"><code>\(HTMLRenderer.escape(tex))</code></div>"
+                return "<div\(id) class=\"math-display\"><code>\(HTMLRenderer.escape(tex))</code></div>"
             }
             let uri = "data:image/png;base64,\(data.base64EncodedString())"
-            return "<div class=\"math-display\"><img class=\"math\" style=\"height:\(fmt(r.image.size.height))px\" src=\"\(uri)\" alt=\"\(HTMLRenderer.attr(tex))\"></div>"
+            return "<div\(id) class=\"math-display\"><img class=\"math\" style=\"height:\(fmt(r.image.size.height))px\" src=\"\(uri)\" alt=\"\(HTMLRenderer.attr(tex))\"></div>"
         }
         out = replaceMatches(out, pattern: inlineMathPattern) { groups in
             let tex = unescapeAttr(groups[1])

--- a/Sources/EdmundCore/Export/HTMLRenderer.swift
+++ b/Sources/EdmundCore/Export/HTMLRenderer.swift
@@ -97,22 +97,47 @@ struct HTMLRenderer: MarkupVisitor {
     /// back to its last non-blank source line; the blank run between blocks A and
     /// B is then `B.firstLine - clamp(A.end) - 1`.
     mutating func visitDocument(_ document: Document) -> String {
-        guard options.preserveBlankLines else { return renderChildren(of: document) }
         var out = ""
         var prevEndLine: Int?
         for child in document.children {
-            if let prevEndLine, let range = child.range {
+            if options.preserveBlankLines, let prevEndLine, let range = child.range {
                 let blanks = range.lowerBound.line - prevEndLine - 1
                 if blanks > 1 {
                     out += String(repeating: "<div class=\"blank-line\"></div>", count: blanks - 1)
                 }
             }
-            out += visit(child)
+            var html = visit(child)
             if let range = child.range {
+                html = addingAnchorID(html, line: range.lowerBound.line)
+            }
+            out += html
+            if options.preserveBlankLines, let range = child.range {
                 prevEndLine = lastContentLine(atOrBefore: range.upperBound.line)
             }
         }
         return out
+    }
+
+    /// Inserts `id="edmund-l<line>"` into the first opening tag of `html` — the
+    /// tag for a top-level block (`<p>`, `<ul>`, a raw `<div>` HTML block, …) —
+    /// so Read mode can scroll to the block whose source starts at `line` and
+    /// the editor can find the anchor nearest a given viewport line (see
+    /// `ReadModeAnchors`). Skips (returns `html` unchanged) when there's no tag
+    /// to anchor: empty (footnote-definition paragraphs render `""`), a closing
+    /// tag, or a `<!--`/`<!DOCTYPE` declaration — none of which should happen
+    /// for a top-level block, but the guard is cheap insurance against ever
+    /// emitting broken markup. A block whose visitor returns multiple sibling
+    /// elements (callouts: the callout `<div>` plus a lazy-tail sibling) only
+    /// gets the id on the first one, which is correct — that's the element that
+    /// starts at `line`.
+    private func addingAnchorID(_ html: String, line: Int) -> String {
+        guard html.hasPrefix("<"), !html.hasPrefix("</"), !html.hasPrefix("<!") else { return html }
+        var idx = html.index(after: html.startIndex)
+        while idx < html.endIndex, html[idx].isLetter || html[idx].isNumber {
+            idx = html.index(after: idx)
+        }
+        guard idx > html.index(after: html.startIndex) else { return html }
+        return String(html[..<idx]) + " id=\"edmund-l\(line)\"" + String(html[idx...])
     }
 
     /// The last source line at or before `line` (1-indexed) that has non-blank
@@ -764,5 +789,25 @@ struct HTMLRenderer: MarkupVisitor {
         var markerEnd = text.index(after: afterBracket)
         if markerEnd < text.endIndex, text[markerEnd] == " " { markerEnd = text.index(after: markerEnd) }
         return (String(id), text.distance(from: text.startIndex, to: markerEnd))
+    }
+}
+
+/// Start/end source lines (1-indexed) of each top-level block, in document
+/// order — the same blocks that get `id="edmund-l<start>"` anchors in the
+/// rendered HTML. Used to map editor viewport lines to read-mode anchors.
+///
+/// A public wrapper: `HTMLRenderer` itself stays internal (a public struct
+/// would leak its `MarkupVisitor` conformance and rendering internals to
+/// other targets), but callers outside EdmundCore need this line mapping.
+public enum ReadModeAnchors {
+
+    /// Parses `markdown` with the same options `HTMLRenderer.render` uses, so
+    /// the reported spans match the document that's actually rendered.
+    public static func topLevelBlockSpans(for markdown: String) -> [(startLine: Int, endLine: Int)] {
+        let document = Document(parsing: markdown, options: [.disableSmartOpts])
+        return document.children.compactMap { child in
+            guard let range = child.range else { return nil }
+            return (startLine: range.lowerBound.line, endLine: range.upperBound.line)
+        }
     }
 }

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -13,12 +13,25 @@ import AppKit
 // the system appearance flips.
 enum HTMLTheme {
 
+    /// The page background hex for the given appearance — shared by the CSS
+    /// `--bg` variable and `ReadModeWebView.underPageBackgroundColor` so the
+    /// webview's own background can't drift from the page it's about to show.
+    private static func backgroundHex(dark: Bool) -> String {
+        dark ? "#1e1e1e" : "#ffffff"
+    }
+
+    /// `NSColor` form of `backgroundHex`, for `WKWebView.underPageBackgroundColor`.
+    @MainActor
+    static func backgroundColor(dark: Bool) -> NSColor {
+        NSColor(hex: backgroundHex(dark: dark)) ?? .textBackgroundColor
+    }
+
     @MainActor
     static func css(_ theme: EditorTheme,
                     callouts: [String: CalloutStyle],
                     dark: Bool,
                     maxContentWidthPoints: Double = .greatestFiniteMagnitude) -> String {
-        let bg = dark ? "#1e1e1e" : "#ffffff"
+        let bg = backgroundHex(dark: dark)
         let fg = dark ? "#e6e6e6" : "#1a1a1a"
         let faint = dark ? "#9a9a9a" : "#6a6a6a"
         let rule = dark ? "#3a3a3a" : "#e0e0e0"

--- a/Sources/EdmundCore/Export/ReadModeWebView.swift
+++ b/Sources/EdmundCore/Export/ReadModeWebView.swift
@@ -206,7 +206,10 @@ public final class ReadModeWebView: WKWebView {
           var chosen = null;
           for (var i = 0; i < nodes.length; i++) {
             var elTop = nodes[i].getBoundingClientRect().top + top;
-            if (elTop <= top) { chosen = nodes[i]; } else { break; }
+            /* 1px tolerance: setScrollPosition puts the anchor's top exactly at
+               the viewport top; sub-pixel rounding must not flip the pick to
+               the previous block (which would drift the round trip). */
+            if (elTop <= top + 1) { chosen = nodes[i]; } else { break; }
           }
           var fraction;
           if (!chosen) {

--- a/Sources/EdmundCore/Export/ReadModeWebView.swift
+++ b/Sources/EdmundCore/Export/ReadModeWebView.swift
@@ -46,11 +46,32 @@ public final class ReadModeWebView: WKWebView {
     /// destination (e.g. `[text](other.md)`), routed the same way.
     public var onOpenInternalLink: ((String) -> Void)?
 
+    /// Called after a `loadHTMLString` finishes (including any pending scroll
+    /// restore, applied first — see `pendingScrollRestore`).
+    public var onLoadFinished: (() -> Void)?
+
     /// The most recent render inputs, so the view can re-render itself when the
     /// system appearance flips (light ↔ dark) without the document re-driving it.
     private var pending: (markdown: String, theme: EditorTheme,
                           callouts: [String: CalloutStyle], baseURL: URL?,
                           options: ReadRenderOptions)?
+
+    /// A scroll position (source line + fraction into that block) to apply once
+    /// the *next* load finishes. Set either by `reloadHTML()` itself (to carry
+    /// the current scroll position across an appearance-driven re-render) or
+    /// externally via `setPendingScrollRestore` (e.g. an Edit→Read entry point).
+    private var pendingScrollRestore: (line: Int, fraction: Double)?
+
+    /// Guards a `readScrollPosition` capture in flight against a second
+    /// `reloadHTML()` racing ahead of it — the completion only acts if this
+    /// hasn't moved on since it was captured.
+    private var loadGeneration = 0
+
+    /// True once the first `loadHTMLString` has been issued. The very first
+    /// load has nothing on-screen to capture a scroll position from, so
+    /// `reloadHTML()` skips straight to loading instead of awaiting
+    /// `readScrollPosition`.
+    private var hasLoadedOnce = false
 
     /// Renders `markdown` with the given theme; appearance is resolved from the
     /// view itself. `baseURL` is the document's directory (for resolving relative
@@ -64,8 +85,35 @@ public final class ReadModeWebView: WKWebView {
         reloadHTML()
     }
 
+    /// Sets the scroll position to restore on the *next* load, for callers that
+    /// need to drive where a fresh Read-mode render lands (e.g. entering Read
+    /// mode at the Edit-mode caret's position) rather than at the top.
+    public func setPendingScrollRestore(line: Int, fraction: Double) {
+        pendingScrollRestore = (line: line, fraction: fraction)
+    }
+
     func reloadHTML() {
         guard let p = pending else { return }
+        guard hasLoadedOnce else {
+            hasLoadedOnce = true
+            performLoad(p)
+            return
+        }
+        // Capture the current scroll position before we blow it away with a
+        // fresh `loadHTMLString`, so the re-render (appearance flip, settings
+        // change) can restore it once the new document finishes loading.
+        let generation = loadGeneration
+        readScrollPosition { [weak self] restored in
+            guard let self, self.loadGeneration == generation else { return }
+            self.pendingScrollRestore = restored
+            self.loadGeneration += 1
+            self.performLoad(p)
+        }
+    }
+
+    private func performLoad(_ p: (markdown: String, theme: EditorTheme,
+                                   callouts: [String: CalloutStyle], baseURL: URL?,
+                                   options: ReadRenderOptions)) {
         let dark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         let html = DocumentHTML.full(markdown: p.markdown, theme: p.theme,
                                      callouts: p.callouts, dark: dark,
@@ -76,6 +124,93 @@ public final class ReadModeWebView: WKWebView {
     public override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
         reloadHTML()
+    }
+
+    /// Forwarded from the navigation coordinator's `didFinish`. Applies any
+    /// pending scroll restore first, then notifies the owner the load is done.
+    fileprivate func handleDidFinishLoad() {
+        if let restore = pendingScrollRestore {
+            pendingScrollRestore = nil
+            setScrollPosition(line: restore.line, fraction: restore.fraction)
+        }
+        onLoadFinished?()
+    }
+
+    // MARK: - Scroll bridge
+    //
+    // QUIRK: `evaluateJavaScript` still runs even with
+    // `allowsContentJavaScript = false` and the page's `script-src 'none'` CSP
+    // (verified empirically) — those two only govern JS *in the page*;
+    // API-injected JS is a separate, trusted channel. That's load-bearing here:
+    // it's why this bridge can exist while content JS stays fully disabled. All
+    // JS below is a static template with only Swift-computed numeric values
+    // (Int/Double) interpolated — never document content — so nothing user- or
+    // document-controlled ever reaches `evaluateJavaScript`.
+
+    /// Scrolls so the block anchored at source `line` sits at the viewport top,
+    /// offset `fraction` (0–1) into the block's rendered height.
+    public func setScrollPosition(line: Int, fraction: Double) {
+        let clamped = min(max(fraction, 0), 1)
+        // QUIRK: wrapped in an IIFE — each `evaluateJavaScript` runs as a new
+        // program in the page's one global realm, so a top-level `const` here
+        // would throw a redeclaration SyntaxError on the second call without an
+        // intervening reload (and the scroll would silently no-op).
+        let js = """
+        (function() { \
+        var el = document.getElementById('edmund-l\(line)'); \
+        if (el) { var se = document.scrollingElement; \
+        se.scrollTop = el.getBoundingClientRect().top + se.scrollTop + \(String(describing: clamped)) * el.offsetHeight; } \
+        })()
+        """
+        evaluateJavaScript(js, completionHandler: nil)
+    }
+
+    /// Reads the current scroll position as (anchor source line, fraction into
+    /// that block). nil when the document has no anchors or JS fails.
+    public func readScrollPosition(completion: @escaping ((line: Int, fraction: Double)?) -> Void) {
+        let js = """
+        (function() {
+          var nodes = document.querySelectorAll('[id^="edmund-l"]');
+          if (nodes.length === 0) return '';
+          var top = document.scrollingElement.scrollTop;
+          var chosen = null;
+          for (var i = 0; i < nodes.length; i++) {
+            var elTop = nodes[i].getBoundingClientRect().top + top;
+            if (elTop <= top) { chosen = nodes[i]; } else { break; }
+          }
+          var fraction;
+          if (!chosen) {
+            chosen = nodes[0];
+            fraction = 0;
+          } else {
+            var chosenTop = chosen.getBoundingClientRect().top + top;
+            fraction = (top - chosenTop) / Math.max(1, chosen.offsetHeight);
+            if (fraction < 0) fraction = 0;
+            if (fraction > 1) fraction = 1;
+          }
+          return chosen.id.slice(8) + ',' + fraction;
+        })()
+        """
+        evaluateJavaScript(js) { result, error in
+            Task { @MainActor in
+                guard error == nil, let str = result as? String else {
+                    completion(nil)
+                    return
+                }
+                completion(Self.parseScrollPosition(str))
+            }
+        }
+    }
+
+    /// Parses the `"<line>,<fraction>"` string produced by `readScrollPosition`'s
+    /// JS. Extracted as a pure helper so it's unit-testable without a webview.
+    internal static func parseScrollPosition(_ s: String) -> (line: Int, fraction: Double)? {
+        guard !s.isEmpty else { return nil }
+        let parts = s.split(separator: ",", maxSplits: 1)
+        guard parts.count == 2, let line = Int(parts[0]), let fraction = Double(parts[1]) else {
+            return nil
+        }
+        return (line: line, fraction: fraction)
     }
 }
 
@@ -126,6 +261,13 @@ private final class ReadModeNavigationCoordinator: NSObject, WKNavigationDelegat
         case .cancel:
             return .cancel
         }
+    }
+
+    // No completion handler on this one, so — unlike `decidePolicyFor` above —
+    // there's no Swift-6 async/completion-handler selector mismatch to worry
+    // about; the plain delegate method matches the requirement as written.
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        owner?.handleDidFinishLoad()
     }
 }
 

--- a/Sources/EdmundCore/Export/ReadModeWebView.swift
+++ b/Sources/EdmundCore/Export/ReadModeWebView.swift
@@ -92,10 +92,23 @@ public final class ReadModeWebView: WKWebView {
         pendingScrollRestore = (line: line, fraction: fraction)
     }
 
+    /// The HTML from the most recent `loadHTMLString` call, so a re-render that
+    /// produces byte-identical HTML (e.g. a mode-switch re-entry with no
+    /// document change) can skip the reload entirely — instant, no white flash.
+    private var lastLoadedHTML: String?
+
     func reloadHTML() {
         guard let p = pending else { return }
         guard hasLoadedOnce else {
             hasLoadedOnce = true
+            performLoad(p)
+            return
+        }
+        // Externally-set restores (e.g. Edit→Read entry via
+        // `setPendingScrollRestore`) win over self-capture: skip straight to
+        // load rather than clobbering the caller's position with the current
+        // (pre-switch) scroll offset.
+        guard pendingScrollRestore == nil else {
             performLoad(p)
             return
         }
@@ -115,9 +128,19 @@ public final class ReadModeWebView: WKWebView {
                                    callouts: [String: CalloutStyle], baseURL: URL?,
                                    options: ReadRenderOptions)) {
         let dark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        // Kills the white flash between `loadHTMLString` and first paint (most
+        // visible in dark mode): the page background shows immediately instead
+        // of the system default white.
+        underPageBackgroundColor = HTMLTheme.backgroundColor(dark: dark)
         let html = DocumentHTML.full(markdown: p.markdown, theme: p.theme,
                                      callouts: p.callouts, dark: dark,
                                      baseURL: p.baseURL, options: p.options)
+        guard html != lastLoadedHTML else {
+            // Nothing changed — the document on screen is already correct.
+            applyPendingScrollRestoreAndNotify()
+            return
+        }
+        lastLoadedHTML = html
         loadHTMLString(html, baseURL: ReadModeNavigationPolicy.trustedBaseURL)
     }
 
@@ -126,9 +149,16 @@ public final class ReadModeWebView: WKWebView {
         reloadHTML()
     }
 
-    /// Forwarded from the navigation coordinator's `didFinish`. Applies any
-    /// pending scroll restore first, then notifies the owner the load is done.
+    /// Forwarded from the navigation coordinator's `didFinish`.
     fileprivate func handleDidFinishLoad() {
+        applyPendingScrollRestoreAndNotify()
+    }
+
+    /// Applies any pending scroll restore, then notifies the owner the
+    /// document is ready. Shared by a real load's `didFinish` and the
+    /// cache-hit path in `performLoad` (which has nothing to load, so there's
+    /// no `didFinish` to forward from).
+    private func applyPendingScrollRestoreAndNotify() {
         if let restore = pendingScrollRestore {
             pendingScrollRestore = nil
             setScrollPosition(line: restore.line, fraction: restore.fraction)

--- a/Sources/EdmundCore/TextView/EditorTextView+LazyStyling.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+LazyStyling.swift
@@ -186,6 +186,46 @@ extension EditorTextView {
         recomposeDirty(unstyled, cursorInRaw: selectedRange().location)
     }
 
+    /// Synchronously styles every unstyled block from the document start
+    /// through the block containing `offset`. `scrollCharacterToTop` needs the
+    /// heights ABOVE its target to be final before it measures: an unstyled
+    /// block lays out at base-attribute height, and when the drain/promotion
+    /// styles it moments after the scroll, the re-measure slides the whole
+    /// just-anchored viewport (drain invalidation is not scroll-compensated).
+    /// Same per-block body as `drainStylingSlice`, without the time budget —
+    /// callers bound the cost by capping `offset` instead.
+    func ensureBlocksStyled(upTo offset: Int) {
+        guard let ts = textStorage, !isUpdating, !hasMarkedText() else { return }
+        guard let last = blocks.lastIndex(where: { $0.range.location <= offset }) else { return }
+        let unstyled = (0...last).filter { !blocks[$0].isStyled }
+        guard !unstyled.isEmpty else { return }
+        isUpdating = true
+        let nsString = ts.string as NSString
+        let cursor = selectedRange().location
+        autoreleasepool {
+            ts.beginEditing()
+            for idx in unstyled {
+                let cursorInBlock: Int? = (idx == activeBlockIndex)
+                    ? max(0, cursor - blocks[idx].range.location) : nil
+                restyleBlock(idx, cursorInBlock: cursorInBlock)
+                blocks[idx].isStyled = true
+                let sep = blocks[idx].range.upperBound
+                if sep < nsString.length && nsString.character(at: sep) == 0x0A {
+                    ts.setAttributes(baseAttributes, range: NSRange(location: sep, length: 1))
+                }
+            }
+            ts.endEditing()
+        }
+        if let tlm = textLayoutManager {
+            for idx in unstyled where idx < blocks.count {
+                if let range = blockTextRange(blocks[idx].range, tlm) {
+                    tlm.invalidateLayout(for: range)
+                }
+            }
+        }
+        isUpdating = false
+    }
+
     /// Observes clip-view scrolling for promotion. Called from
     /// `viewDidMoveToWindow`.
     func installScrollPromotionObserver() {

--- a/Sources/EdmundCore/TextView/EditorTextView+TypewriterScroll.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+TypewriterScroll.swift
@@ -41,7 +41,12 @@ extension EditorTextView {
         guard let scrollView = enclosingScrollView, let tlm = textLayoutManager else { return nil }
         tlm.textViewportLayoutController.layoutViewport()
         let visible = scrollView.contentView.bounds
-        let topPoint = CGPoint(x: 0, y: visible.minY - textContainerOrigin.y)
+        // +1pt: after `scrollCharacterToTop` the anchor line's top sits exactly
+        // on the viewport top, and sampling the exact boundary (or 1px above,
+        // from settle-loop rounding) picks the fragment *above* — walking the
+        // anchor up a line on every Edit→Read round trip. Sampling just inside
+        // the viewport keeps the round trip fixed-point.
+        let topPoint = CGPoint(x: 0, y: visible.minY + 1 - textContainerOrigin.y)
         guard let frag = tlm.textLayoutFragment(for: topPoint) else { return nil }
         return tlm.offset(from: tlm.documentRange.location, to: frag.rangeInElement.location)
     }
@@ -116,7 +121,21 @@ extension EditorTextView {
     /// first scroll).
     public func scrollCharacterToTop(_ offset: Int) {
         guard let scrollView = enclosingScrollView else { return }
-        guard ensureRegionLaidOut(upTo: offset) else {
+        // The target's absolute Y is only trustworthy once everything ABOVE it
+        // is laid out for real: a Y computed against estimates lands wrong, and
+        // then *keeps shifting* as idle promotion realizes those estimates —
+        // the viewport visibly drifts seconds after the scroll. Lay out from
+        // the document start when that span fits the usual cost cap; only far
+        // targets in huge documents degrade to the viewport-relative path.
+        if let tlm = textLayoutManager, offset <= 60_000,
+           let end = tlm.location(tlm.documentRange.location, offsetBy: offset),
+           let range = NSTextRange(location: tlm.documentRange.location, end: end) {
+            // Style before laying out: an unstyled block's laid-out height is
+            // provisional, and the styling that catches up moments later
+            // re-measures it and slides the just-anchored viewport.
+            ensureBlocksStyled(upTo: offset)
+            tlm.ensureLayout(for: range)
+        } else if !ensureRegionLaidOut(upTo: offset) {
             scrollRangeToVisible(NSRange(location: offset, length: 0)); return
         }
         guard let rect = lineRect(forCharacterAt: offset) else { return }
@@ -130,7 +149,7 @@ extension EditorTextView {
         scrollView.reflectScrolledClipView(scrollView.contentView)
 
         guard let tlm = textLayoutManager else { return }
-        for _ in 0..<3 {
+        for _ in 0..<6 {
             tlm.textViewportLayoutController.layoutViewport()
             guard let settled = lineRect(forCharacterAt: offset) else { return }
             let settledTarget = settled.minY + textContainerOrigin.y

--- a/Sources/EdmundCore/TextView/EditorTextView+TypewriterScroll.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+TypewriterScroll.swift
@@ -20,15 +20,9 @@ extension EditorTextView {
     /// consistent measurement. A mis-measure degrades to no scroll — never a
     /// yank or a jump to the document start.
     func preservingViewportAnchor(_ body: () -> Void) {
-        guard let scrollView = enclosingScrollView, let tlm = textLayoutManager else {
-            body(); return
-        }
-        tlm.textViewportLayoutController.layoutViewport()
+        guard let scrollView = enclosingScrollView else { body(); return }
         let visible = scrollView.contentView.bounds
-        let topPoint = CGPoint(x: 0, y: visible.minY - textContainerOrigin.y)
-        guard let frag = tlm.textLayoutFragment(for: topPoint) else { body(); return }
-        let anchorOffset = tlm.offset(from: tlm.documentRange.location,
-                                      to: frag.rangeInElement.location)
+        guard let anchorOffset = topmostVisibleCharacterOffset() else { body(); return }
         let beforeY = lineRect(forCharacterAt: anchorOffset)?.minY
 
         body()
@@ -39,6 +33,17 @@ extension EditorTextView {
         let newY = max(0, visible.origin.y + delta)
         scrollView.contentView.scroll(to: NSPoint(x: visible.origin.x, y: newY))
         scrollView.reflectScrolledClipView(scrollView.contentView)
+    }
+
+    /// Character offset of the first character of the topmost visible layout
+    /// fragment, or nil when there's no scroll view / layout manager / fragment.
+    public func topmostVisibleCharacterOffset() -> Int? {
+        guard let scrollView = enclosingScrollView, let tlm = textLayoutManager else { return nil }
+        tlm.textViewportLayoutController.layoutViewport()
+        let visible = scrollView.contentView.bounds
+        let topPoint = CGPoint(x: 0, y: visible.minY - textContainerOrigin.y)
+        guard let frag = tlm.textLayoutFragment(for: topPoint) else { return nil }
+        return tlm.offset(from: tlm.documentRange.location, to: frag.rangeInElement.location)
     }
 
     /// Runs a restyle (`body`) while keeping the viewport visually stable: in
@@ -104,26 +109,58 @@ extension EditorTextView {
         }
     }
 
-    /// Lays out the span between the current viewport and the caret so the
-    /// caret's line geometry is real rather than a TextKit 2 estimate. Returns
+    /// Scrolls so the line containing character `offset` sits at the top of
+    /// the viewport (small margin allowed). Does not touch the caret or
+    /// selection. See `centerViewportOnCaret` for why this needs a settle-pass
+    /// loop (TextKit 2 height estimates above the target can throw off the
+    /// first scroll).
+    public func scrollCharacterToTop(_ offset: Int) {
+        guard let scrollView = enclosingScrollView else { return }
+        guard ensureRegionLaidOut(upTo: offset) else {
+            scrollRangeToVisible(NSRange(location: offset, length: 0)); return
+        }
+        guard let rect = lineRect(forCharacterAt: offset) else { return }
+        let targetY = rect.minY + textContainerOrigin.y
+
+        let visibleHeight = scrollView.contentView.bounds.height
+        let maxY = max(0, frame.height - visibleHeight)
+        let clampedY = min(max(0, targetY), maxY)
+
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: clampedY))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+
+        guard let tlm = textLayoutManager else { return }
+        for _ in 0..<3 {
+            tlm.textViewportLayoutController.layoutViewport()
+            guard let settled = lineRect(forCharacterAt: offset) else { return }
+            let settledTarget = settled.minY + textContainerOrigin.y
+            let settledMaxY = max(0, frame.height - visibleHeight)
+            let settledY = min(max(0, settledTarget), settledMaxY)
+            guard abs(settledY - scrollView.contentView.bounds.origin.y) > 1 else { return }
+            scrollView.contentView.scroll(to: NSPoint(x: 0, y: settledY))
+            scrollView.reflectScrolledClipView(scrollView.contentView)
+        }
+    }
+
+    /// Lays out the span between the current viewport and `offset` so that
+    /// offset's line geometry is real rather than a TextKit 2 estimate. Returns
     /// false when that span is too large to lay out cheaply (the caller should
     /// fall back to a plain reveal) — this is the guard that keeps a deep caret
     /// in a 1–2 MB document from triggering the process-killing full-document
     /// layout that motivated the rest of this file.
     @discardableResult
-    func ensureCaretRegionLaidOut() -> Bool {
+    func ensureRegionLaidOut(upTo offset: Int) -> Bool {
         guard let tlm = textLayoutManager else { return false }
-        let caretOffset = selectedRange().location
         tlm.textViewportLayoutController.layoutViewport()
 
         let lo: Int, hi: Int
         if let vp = tlm.textViewportLayoutController.viewportRange {
             let vpStart = tlm.offset(from: tlm.documentRange.location, to: vp.location)
             let vpEnd = tlm.offset(from: tlm.documentRange.location, to: vp.endLocation)
-            lo = min(vpStart, caretOffset); hi = max(vpEnd, caretOffset)
+            lo = min(vpStart, offset); hi = max(vpEnd, offset)
         } else {
             // No viewport yet (first layout): lay out from the document start.
-            lo = 0; hi = caretOffset
+            lo = 0; hi = offset
         }
 
         let cap = 60_000   // ~a few screenfuls; bounds the layout cost
@@ -133,6 +170,13 @@ extension EditorTextView {
               let range = NSTextRange(location: a, end: b) else { return false }
         tlm.ensureLayout(for: range)
         return true
+    }
+
+    /// `ensureRegionLaidOut(upTo:)` anchored at the caret. See that method for
+    /// the layout-cost rationale.
+    @discardableResult
+    func ensureCaretRegionLaidOut() -> Bool {
+        ensureRegionLaidOut(upTo: selectedRange().location)
     }
 
     /// Whether the caret's line fragment lies within the viewport defined by
@@ -234,5 +278,39 @@ extension EditorTextView {
         let clampedY = min(max(0, targetY), maxY)
         scrollView.contentView.scroll(to: NSPoint(x: visible.origin.x, y: clampedY))
         scrollView.reflectScrolledClipView(scrollView.contentView)
+    }
+
+    /// 1-indexed source line containing character `offset` (counts "\n" only —
+    /// matches swift-markdown's SourceLocation convention; no CRLF handling,
+    /// same as the rest of the pipeline).
+    public func line(forOffset offset: Int) -> Int {
+        let utf16 = rawSource.utf16
+        let clamped = min(max(0, offset), utf16.count)
+        var line = 1
+        var i = 0
+        for unit in utf16 {
+            if i >= clamped { break }
+            if unit == 0x000A { line += 1 }
+            i += 1
+        }
+        return line
+    }
+
+    /// Character offset of the start of 1-indexed `line`, clamped to the
+    /// document (line < 1 → 0; past the last line → start of the last line).
+    public func offset(forLine line: Int) -> Int {
+        guard line > 1 else { return 0 }
+        var currentLine = 1
+        var lastLineStart = 0
+        var i = 0
+        for unit in rawSource.utf16 {
+            if currentLine == line { return i }
+            if unit == 0x000A {
+                currentLine += 1
+                lastLineStart = i + 1
+            }
+            i += 1
+        }
+        return currentLine == line ? i : lastLineStart
     }
 }

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -27,6 +27,12 @@ class Document: NSDocument, HeadingNavigable {
     private var containerView: NSView!
     private var readView: ReadModeWebView?
 
+    /// Editor character offset captured when entering Read mode (the topmost
+    /// visible line at the moment of the switch), used to scroll the editor
+    /// back to roughly the same place if leaving Read mode returns no anchor
+    /// (e.g. the rendered document had no top-level blocks).
+    private var lastReadAnchorOffset: Int?
+
     /// Content loaded from disk before the editor window exists.
     /// `nonisolated(unsafe)` because `read(from:ofType:)` may be called
     /// off the main actor, but the value is only consumed on main via `showWindows`.
@@ -404,6 +410,27 @@ class Document: NSDocument, HeadingNavigable {
     private func applyViewMode(_ mode: EditorTextView.ViewMode) {
         guard let containerView else { return }
         if mode == .reading {
+            // Capture the editor's viewport-top anchor BEFORE anything else,
+            // and only when the scroll view is the currently-visible one —
+            // i.e. we're actually switching in from edit/source. If Read mode
+            // is already active (e.g. `applyViewMode(.reading)` re-called
+            // because render options changed), the editor is hidden and its
+            // "visible" viewport is stale, so keep the previous anchor and
+            // let the webview's own scroll-preserving re-render (see
+            // `ReadModeWebView.reloadHTML`) carry the position instead.
+            var pendingRestore: (line: Int, fraction: Double)?
+            if !scrollView.isHidden, let offset = editor.topmostVisibleCharacterOffset() {
+                let visibleLine = editor.line(forOffset: offset)
+                let spans = ReadModeAnchors.topLevelBlockSpans(for: editor.rawSource)
+                if !spans.isEmpty {
+                    let span = spans.last(where: { $0.startLine <= visibleLine }) ?? spans[0]
+                    let fraction = Double(visibleLine - span.startLine)
+                        / Double(max(1, span.endLine - span.startLine + 1))
+                    pendingRestore = (line: span.startLine, fraction: fraction)
+                }
+                lastReadAnchorOffset = offset
+            }
+
             let read = readView ?? {
                 let v = ReadModeWebView()
                 v.frame = scrollView.frame
@@ -415,21 +442,68 @@ class Document: NSDocument, HeadingNavigable {
                 // NSDocumentController) instead of navigating the webview.
                 v.onOpenWikiLink = { [weak self] in self?.editor.followWikiLink($0) }
                 v.onOpenInternalLink = { [weak self] in self?.editor.followLinkDestination($0) }
+                // The ONLY place the Edit→Read view swap happens: the editor
+                // stays on screen (and interactive) until the rendered
+                // document is actually ready, so there's never a blank gap.
+                // Set once, at creation — every later render (re-entry, live
+                // re-render) reuses this same webview and callback.
+                v.onLoadFinished = { [weak self] in
+                    guard let self, self.editor.viewMode == .reading, let read = self.readView else { return }
+                    read.isHidden = false
+                    self.scrollView.isHidden = true
+                    self.editor.window?.makeFirstResponder(read)
+                }
                 readView = v
                 return v
             }()
+
+            if let pendingRestore {
+                read.setPendingScrollRestore(line: pendingRestore.line, fraction: pendingRestore.fraction)
+            }
+            // Cache hit inside the webview (HTML unchanged) fires
+            // `onLoadFinished` synchronously here → instant swap, no reload.
             read.render(markdown: editor.rawSource,
                         theme: editor.theme,
                         callouts: mergedCallouts,
                         baseURL: documentDirectory,
                         options: renderOptions)
-            read.isHidden = false
-            scrollView.isHidden = true
-            editor.window?.makeFirstResponder(read)
         } else {
+            if let read = readView, !read.isHidden {
+                // While the webview is still alive, capture where the user
+                // actually scrolled to in Read mode and map it back onto the
+                // editor's source lines.
+                read.readScrollPosition { [weak self] pos in
+                    // Still in edit/source when this lands? A rapid toggle
+                    // back into Read mode means the editor is hidden again —
+                    // don't scroll it.
+                    guard let self, self.editor.viewMode != .reading else { return }
+                    var targetOffset: Int?
+                    if let pos {
+                        let spans = ReadModeAnchors.topLevelBlockSpans(for: self.editor.rawSource)
+                        let span = spans.first(where: { $0.startLine == pos.line })
+                            ?? spans.last(where: { $0.startLine <= pos.line })
+                        if let span {
+                            let targetLine = span.startLine
+                                + Int(round(pos.fraction * Double(max(0, span.endLine - span.startLine))))
+                            targetOffset = self.editor.offset(forLine: targetLine)
+                        }
+                    }
+                    if let offset = targetOffset ?? self.lastReadAnchorOffset {
+                        self.editor.scrollCharacterToTop(offset)
+                    }
+                }
+            }
+            // Swap views immediately — don't wait for the JS round-trip above.
             readView?.isHidden = true
             scrollView.isHidden = false
             editor.window?.makeFirstResponder(editor)
+            // Nothing else forces TextKit 2 viewport layout/redraw when a
+            // hidden scroll view is unhidden — a click used to supply the
+            // missing event, leaving the editor blank until one arrived. The
+            // async scroll above also forces layout when it lands; this poke
+            // covers the no-anchor path and the gap before the JS returns.
+            editor.textLayoutManager?.textViewportLayoutController.layoutViewport()
+            editor.needsDisplay = true
         }
     }
 

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -400,9 +400,41 @@ class Document: NSDocument, HeadingNavigable {
     }
 
     private func setViewMode(_ mode: EditorTextView.ViewMode) {
+        // Capture the Read-entry anchor BEFORE the `viewMode` setter runs: the
+        // setter's full recompose defers every far-from-viewport block back to
+        // base-height estimates, so a capture taken after it reads collapsed
+        // geometry (~17pt/line instead of styled heights) and lands the read
+        // view ~100+ lines too deep — the "viewport drifts down every toggle"
+        // bug. The pre-setter geometry is exactly what's on screen.
+        if mode == .reading { captureReadEntryAnchor() }
         editor.viewMode = mode
         applyViewMode(mode)
         refreshViewModeButton()
+    }
+
+    /// The Edit→Read entry position, captured by `setViewMode` while the
+    /// editor's on-screen geometry is still settled, consumed by
+    /// `applyViewMode(.reading)`.
+    private var pendingReadEntryRestore: (line: Int, fraction: Double)?
+
+    /// Captures the topmost visible source line (+ fraction into its block)
+    /// while the scroll view is the visible view; no-op when Read mode is
+    /// already showing (re-render case — the webview preserves its own scroll).
+    private func captureReadEntryAnchor() {
+        pendingReadEntryRestore = nil
+        guard !scrollView.isHidden, let offset = editor.topmostVisibleCharacterOffset() else { return }
+        let visibleLine = editor.line(forOffset: offset)
+        let spans = ReadModeAnchors.topLevelBlockSpans(for: editor.rawSource)
+        guard !spans.isEmpty else { return }
+        let span = spans.last(where: { $0.startLine <= visibleLine }) ?? spans[0]
+        // Clamped: `visibleLine` can sit on a blank line *between* blocks
+        // (past `span.endLine`), which would push the raw ratio above 1. Same
+        // denominator as the reverse mapping in `applyViewMode` — the two must
+        // stay exact inverses in line space or every round trip drifts a line.
+        let lineCount = Double(span.endLine - span.startLine + 1)
+        let fraction = min(1, Double(visibleLine - span.startLine) / max(1, lineCount))
+        pendingReadEntryRestore = (line: span.startLine, fraction: fraction)
+        lastReadAnchorOffset = offset
     }
 
     /// Swaps the on-screen view for the mode: Read mode shows the rendered-HTML
@@ -410,26 +442,12 @@ class Document: NSDocument, HeadingNavigable {
     private func applyViewMode(_ mode: EditorTextView.ViewMode) {
         guard let containerView else { return }
         if mode == .reading {
-            // Capture the editor's viewport-top anchor BEFORE anything else,
-            // and only when the scroll view is the currently-visible one —
-            // i.e. we're actually switching in from edit/source. If Read mode
-            // is already active (e.g. `applyViewMode(.reading)` re-called
-            // because render options changed), the editor is hidden and its
-            // "visible" viewport is stale, so keep the previous anchor and
-            // let the webview's own scroll-preserving re-render (see
-            // `ReadModeWebView.reloadHTML`) carry the position instead.
-            var pendingRestore: (line: Int, fraction: Double)?
-            if !scrollView.isHidden, let offset = editor.topmostVisibleCharacterOffset() {
-                let visibleLine = editor.line(forOffset: offset)
-                let spans = ReadModeAnchors.topLevelBlockSpans(for: editor.rawSource)
-                if !spans.isEmpty {
-                    let span = spans.last(where: { $0.startLine <= visibleLine }) ?? spans[0]
-                    let fraction = Double(visibleLine - span.startLine)
-                        / Double(max(1, span.endLine - span.startLine + 1))
-                    pendingRestore = (line: span.startLine, fraction: fraction)
-                }
-                lastReadAnchorOffset = offset
-            }
+            // Entry anchor: captured by `setViewMode` before the `viewMode`
+            // setter's recompose could collapse far geometry to estimates; nil
+            // when Read mode was already showing (re-render case — the
+            // webview's own scroll-preserving reload carries the position).
+            let pendingRestore = pendingReadEntryRestore
+            pendingReadEntryRestore = nil
 
             let read = readView ?? {
                 let v = ReadModeWebView()
@@ -483,8 +501,14 @@ class Document: NSDocument, HeadingNavigable {
                         let span = spans.first(where: { $0.startLine == pos.line })
                             ?? spans.last(where: { $0.startLine <= pos.line })
                         if let span {
-                            let targetLine = span.startLine
-                                + Int(round(pos.fraction * Double(max(0, span.endLine - span.startLine))))
+                            // Exact inverse of the entry mapping above (same
+                            // `lineCount` denominator): an untouched round trip
+                            // returns to the same source line instead of
+                            // drifting. Clamped — fraction ≈ 1 would otherwise
+                            // land on the line after the block.
+                            let lineCount = Double(span.endLine - span.startLine + 1)
+                            let targetLine = min(span.endLine,
+                                span.startLine + Int((pos.fraction * lineCount).rounded()))
                             targetOffset = self.editor.offset(forLine: targetLine)
                         }
                     }

--- a/Sources/edmd/App/ReproScript.swift
+++ b/Sources/edmd/App/ReproScript.swift
@@ -1,6 +1,7 @@
 #if DEBUG
 import AppKit
 import EdmundCore
+import WebKit
 
 /// In-process repro driver: `-debug.reproScript <path>` replays a keystroke
 /// script against the front document through the real AppKit key-event path
@@ -16,6 +17,10 @@ import EdmundCore
 ///   scroll <y>        scroll the clip view to y (bypasses the caret/typewriter
 ///                     recentering, so a block can be driven off-screen)
 ///   logsel            log the current selection
+///   viewmode          toggle Edit ↔ Read via the same action as ⌘E
+///   readscroll <y>    raw-scroll the Read-mode webview to y
+///   logstate          NSLog view-swap state (mode, hidden flags, clip y,
+///                     webview scrollTop) for mode-switch harness debugging
 @MainActor
 enum ReproScript {
 
@@ -175,11 +180,74 @@ enum ReproScript {
                     editor.enclosingScrollView?.reflectScrolledClipView(clipView)
                     Log.info("repro scroll y=\(y) clamped=\(clamped.origin.y)", category: .app)
                 }
+            case "viewmode":
+                // Toggles Edit ↔ Read through the same @objc action the ⌘E
+                // menu item fires, so the switch takes the real code path.
+                scheduleDoc(after: delay) { doc in
+                    doc.toggleViewMode(nil)
+                    Log.info("repro viewmode toggled", category: .app)
+                }
+            case "readscroll":
+                // Raw-scrolls the Read-mode webview to y (simulates the user
+                // scrolling while reading — arbitrary position, independent of
+                // the block anchors the scroll-sync bridge uses).
+                scheduleDoc(after: delay) { doc in
+                    guard let content = doc.windowControllers.first?.window?.contentView,
+                          let web = firstWebView(in: content) else {
+                        Log.info("repro readscroll: no webview", category: .app); return
+                    }
+                    let y = Double(arg) ?? 0
+                    web.evaluateJavaScript("document.scrollingElement.scrollTop = \(y)",
+                                           completionHandler: nil)
+                    Log.info("repro readscroll y=\(y)", category: .app)
+                }
+            case "logstate":
+                // Dumps view-swap state to stdout (shell-visible even when the
+                // file logger is off) for mode-switch harness debugging.
+                scheduleDoc(after: delay) { doc in
+                    let editor = doc.editor!
+                    let sv = editor.enclosingScrollView
+                    let web = doc.windowControllers.first?.window?.contentView
+                        .flatMap { firstWebView(in: $0) }
+                    NSLog("STATE mode=\(editor.viewMode) " +
+                          "scrollHidden=\(sv?.isHidden ?? false) " +
+                          "webHidden=\(web?.isHidden ?? true) webNil=\(web == nil) " +
+                          "clipY=\(sv?.contentView.bounds.origin.y ?? -1) " +
+                          "winKey=\(editor.window?.isKeyWindow ?? false) " +
+                          "occl=\(editor.window?.occlusionState.contains(.visible) ?? false)")
+                    let off = editor.topmostVisibleCharacterOffset()
+                    let line = off.map { editor.line(forOffset: $0) }
+                    let spans = ReadModeAnchors.topLevelBlockSpans(for: editor.rawSource)
+                    let span = line.flatMap { l in spans.last(where: { $0.startLine <= l }) }
+                    NSLog("MAP off=\(off ?? -1) line=\(line ?? -1) span=\(span.map { "\($0.startLine)-\($0.endLine)" } ?? "nil") spans=\(spans.count)")
+                    (web as? ReadModeWebView)?.readScrollPosition { pos in
+                        NSLog("READPOS \(pos.map { "line=\($0.line) f=\($0.fraction)" } ?? "nil")")
+                    }
+                    web?.evaluateJavaScript("document.scrollingElement.scrollTop + ',' + document.body.childElementCount") { v, e in
+                        NSLog("WEBSTATE \(v.map(String.init(describing:)) ?? "nil") err=\(e.map(String.init(describing:)) ?? "none")")
+                    }
+                }
             default:
                 break
             }
             delay += 0.02
         }
+    }
+
+    private static func scheduleDoc(after: TimeInterval,
+                                    _ body: @escaping @MainActor (Document) -> Void) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + after) {
+            guard let doc = NSDocumentController.shared.documents.first as? Document else { return }
+            body(doc)
+        }
+    }
+
+    private static func firstWebView(in view: NSView) -> WKWebView? {
+        if let web = view as? WKWebView { return web }
+        for sub in view.subviews {
+            if let web = firstWebView(in: sub) { return web }
+        }
+        return nil
     }
 
     private static func schedule(after: TimeInterval,

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -17,8 +17,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     var settingsWindowController: SettingsWindowController?
     // startingUpdater: true kicks off the scheduled background check immediately;
     // the "Check for Updates…" menu item targets this controller directly.
+    // `-debug.disableUpdater YES` skips the start entirely: on dev builds the
+    // failed check throws a *modal* "updater failed" alert at launch that
+    // blocks the whole app (no document window until dismissed), which breaks
+    // scripted/automated runs.
     let updaterController = SPUStandardUpdaterController(
-        startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
+        startingUpdater: !UserDefaults.standard.bool(forKey: "debug.disableUpdater"),
+        updaterDelegate: nil, userDriverDelegate: nil)
 
     // MARK: - Typewriter Mode (persisted)
 

--- a/Tests/EdmundTests/DocumentHTMLTests.swift
+++ b/Tests/EdmundTests/DocumentHTMLTests.swift
@@ -16,7 +16,7 @@ struct DocumentHTMLTests {
         let out = doc("# Hi")
         #expect(out.hasPrefix("<!DOCTYPE html>"))
         #expect(out.contains("<style>"))
-        #expect(out.contains("<div class=\"page\"><h1>Hi</h1></div>"))
+        #expect(out.contains("<div class=\"page\"><h1 id=\"edmund-l1\">Hi</h1></div>"))
     }
 
     @Test("Callout icon is an inline (vector) Lucide SVG, not a rasterized SF Symbol")
@@ -51,7 +51,7 @@ struct DocumentHTMLTests {
     @Test("Display math placeholder becomes a centered image")
     func displayMath() {
         let out = doc("$$\nx^2\n$$")
-        #expect(out.contains("<div class=\"math-display\"><img class=\"math\""))
+        #expect(out.contains("<div id=\"edmund-l1\" class=\"math-display\"><img class=\"math\""))
         #expect(out.contains("src=\"data:image/png;base64,"))
     }
 
@@ -67,7 +67,7 @@ struct DocumentHTMLTests {
     @Test("Display environment renders to an image, not the source fallback")
     func displayEnvironmentRenders() {
         let out = doc("$$\n\\begin{aligned} \\pi &= 3 \\\\ e &= 2 \\end{aligned}\n$$")
-        #expect(out.contains("<div class=\"math-display\"><img class=\"math\""))
+        #expect(out.contains("<div id=\"edmund-l1\" class=\"math-display\"><img class=\"math\""))
         #expect(!out.contains("<code>"))
     }
 

--- a/Tests/EdmundTests/HTMLRendererTests.swift
+++ b/Tests/EdmundTests/HTMLRendererTests.swift
@@ -12,34 +12,34 @@ struct HTMLRendererCoreTests {
 
     @Test("Headings render h1…h6")
     func headings() {
-        #expect(html("# Title") == "<h1>Title</h1>")
-        #expect(html("### Sub") == "<h3>Sub</h3>")
-        #expect(html("###### Six") == "<h6>Six</h6>")
+        #expect(html("# Title") == "<h1 id=\"edmund-l1\">Title</h1>")
+        #expect(html("### Sub") == "<h3 id=\"edmund-l1\">Sub</h3>")
+        #expect(html("###### Six") == "<h6 id=\"edmund-l1\">Six</h6>")
     }
 
     @Test("Setext headings render h1/h2")
     func setextHeadings() {
-        #expect(html("Title\n===") == "<h1>Title</h1>")
-        #expect(html("Title\n---") == "<h2>Title</h2>")
+        #expect(html("Title\n===") == "<h1 id=\"edmund-l1\">Title</h1>")
+        #expect(html("Title\n---") == "<h2 id=\"edmund-l1\">Title</h2>")
     }
 
     @Test("Paragraph wraps in <p>")
     func paragraph() {
-        #expect(html("hello world") == "<p>hello world</p>")
+        #expect(html("hello world") == "<p id=\"edmund-l1\">hello world</p>")
     }
 
     @Test("Emphasis, strong, strikethrough, inline code")
     func inlineMarks() {
-        #expect(html("*i*") == "<p><em>i</em></p>")
-        #expect(html("**b**") == "<p><strong>b</strong></p>")
-        #expect(html("~~s~~") == "<p><del>s</del></p>")
-        #expect(html("`x`") == "<p><code>x</code></p>")
+        #expect(html("*i*") == "<p id=\"edmund-l1\"><em>i</em></p>")
+        #expect(html("**b**") == "<p id=\"edmund-l1\"><strong>b</strong></p>")
+        #expect(html("~~s~~") == "<p id=\"edmund-l1\"><del>s</del></p>")
+        #expect(html("`x`") == "<p id=\"edmund-l1\"><code>x</code></p>")
     }
 
     @Test("Fenced code block keeps language class and escapes content")
     func codeBlock() {
         let out = html("```swift\nlet x = a < b && c > d\n```")
-        #expect(out.contains("<pre><code class=\"language-swift\">"))
+        #expect(out.contains("<pre id=\"edmund-l1\"><code class=\"language-swift\">"))
         #expect(out.contains("a &lt; b &amp;&amp; c &gt; d"))
         #expect(!out.contains("a < b"))
     }
@@ -47,9 +47,9 @@ struct HTMLRendererCoreTests {
     @Test("Unordered, ordered, and task lists")
     func lists() {
         // A tight list (GFM §5.3): no <p> wrapper inside items.
-        #expect(html("- a\n- b") == "<ul><li>a</li><li>b</li></ul>")
-        #expect(html("1. a").hasPrefix("<ol>"))
-        #expect(html("3. a\n4. b").hasPrefix("<ol start=\"3\">"))
+        #expect(html("- a\n- b") == "<ul id=\"edmund-l1\"><li>a</li><li>b</li></ul>")
+        #expect(html("1. a").hasPrefix("<ol id=\"edmund-l1\">"))
+        #expect(html("3. a\n4. b").hasPrefix("<ol id=\"edmund-l1\" start=\"3\">"))
         let task = html("- [ ] todo\n- [x] done")
         #expect(task.contains("<li class=\"task\"><span class=\"task-check task-check--unchecked\"><svg"))
         #expect(task.contains("<span class=\"task-check task-check--checked\"><svg"))
@@ -82,7 +82,7 @@ struct HTMLRendererCoreTests {
     @Test("Link title renders as an escaped title attribute")
     func linkTitle() {
         #expect(html("[x](https://example.com \"hi there\")")
-            == "<p><a href=\"https://example.com\" title=\"hi there\">x</a></p>")
+            == "<p id=\"edmund-l1\"><a href=\"https://example.com\" title=\"hi there\">x</a></p>")
         #expect(html("[x](https://example.com \"a & b\")").contains("title=\"a &amp; b\""))
         let internalLink = html("[o](other.md \"note\")")
         #expect(internalLink.contains("<a href=\"x-edmund-link:"))
@@ -92,7 +92,7 @@ struct HTMLRendererCoreTests {
     @Test("Table emits thead/tbody with per-column alignment")
     func table() {
         let out = html("| a | b | c |\n|:--|:-:|--:|\n| 1 | 2 | 3 |")
-        #expect(out.contains("<div class=\"table-wrap\"><table><thead><tr>"))
+        #expect(out.contains("<div id=\"edmund-l1\" class=\"table-wrap\"><table><thead><tr>"))
         #expect(out.contains("</tbody></table></div>"))
         #expect(out.contains("<th style=\"text-align:left\">a</th>"))
         #expect(out.contains("<th style=\"text-align:center\">b</th>"))
@@ -102,12 +102,12 @@ struct HTMLRendererCoreTests {
 
     @Test("Thematic break → <hr>")
     func thematicBreak() {
-        #expect(html("---").contains("<hr>"))
+        #expect(html("---").contains("<hr id=\"edmund-l1\">"))
     }
 
     @Test("External links keep their real href")
     func links() {
-        #expect(html("[text](https://example.com)") == "<p><a href=\"https://example.com\">text</a></p>")
+        #expect(html("[text](https://example.com)") == "<p id=\"edmund-l1\"><a href=\"https://example.com\">text</a></p>")
         #expect(html("[m](mailto:a@b.com)").contains("<a href=\"mailto:a@b.com\">"))
     }
 
@@ -161,7 +161,7 @@ struct HTMLRendererCoreTests {
 
     @Test("Plain block quote stays a blockquote")
     func blockQuote() {
-        #expect(html("> quoted") == "<blockquote><p>quoted</p></blockquote>")
+        #expect(html("> quoted") == "<blockquote id=\"edmund-l1\"><p>quoted</p></blockquote>")
     }
 }
 
@@ -181,7 +181,7 @@ struct HTMLRendererEscapingTests {
     @Test("Raw HTML block passes through with event handlers stripped")
     func blockPassthroughHardened() {
         let out = html("<div onclick=\"x\">hi</div>")
-        #expect(out.contains("<div>hi</div>"))
+        #expect(out.contains("<div id=\"edmund-l1\">hi</div>"))
         #expect(!out.contains("onclick"))
     }
 }
@@ -199,13 +199,13 @@ struct HTMLRendererRawHTMLTests {
         #expect(out.contains("<strong> &lt;title> &lt;style> <em>"))
         #expect(out.contains("&lt;xmp>"))
         #expect(out.contains("&lt;XMP>"))
-        #expect(out.contains("<blockquote>"))
+        #expect(out.contains("<blockquote id=\"edmund-l3\">"))
     }
 
     @Test("HTML block passes through raw; markdown inside is NOT rendered")
     func blockPassthroughRaw() {
         let out = html("<div>\n*hello*\n</div>")
-        #expect(out.contains("<div>\n*hello*\n</div>"))
+        #expect(out.contains("<div id=\"edmund-l1\">\n*hello*\n</div>"))
         #expect(!out.contains("<em>"))
     }
 
@@ -234,14 +234,14 @@ struct HTMLRendererRawHTMLTests {
     @Test("An <img> inside an HTML block becomes the asset-pass placeholder")
     func blockInteriorImg() {
         let out = html("<div><img src=\"cat.png\" alt=\"c\"></div>")
-        #expect(out.contains("<div>"))
+        #expect(out.contains("<div id=\"edmund-l1\">"))
         #expect(out.contains("<img class=\"md-image\" data-src=\"cat.png\""))
     }
 
     @Test("A raw <table> block passes through")
     func tableBlock() {
         let out = html("<table><tr><td>x</td></tr></table>")
-        #expect(out.contains("<table><tr><td>x</td></tr></table>"))
+        #expect(out.contains("<table id=\"edmund-l1\"><tr><td>x</td></tr></table>"))
     }
 
     @Test("A single-quoted <img src> still becomes the asset-pass placeholder")
@@ -270,7 +270,7 @@ struct HTMLRendererInlineTests {
     @Test("Display $$math$$ → math-display div")
     func displayMath() {
         let out = html("$$\n\\int_0^1 x\\,dx\n$$")
-        #expect(out.contains("<div class=\"math-display\" data-tex=\""))
+        #expect(out.contains("<div id=\"edmund-l1\" class=\"math-display\" data-tex=\""))
         #expect(out.contains("\\int_0^1"))
     }
 
@@ -290,7 +290,7 @@ struct HTMLRendererInlineTests {
     @Test("Display environment keeps its `\\\\` row separators in data-tex")
     func displayEnvironmentRowSeparators() {
         let out = html("$$\n\\begin{aligned} \\pi &= 3 \\\\ e &= 2 \\end{aligned}\n$$")
-        #expect(out.contains("<div class=\"math-display\" data-tex=\""))
+        #expect(out.contains("<div id=\"edmund-l1\" class=\"math-display\" data-tex=\""))
         #expect(out.contains("\\begin{aligned}"))
         #expect(out.contains("\\\\ e"))          // the `\\` survived
     }
@@ -391,7 +391,7 @@ struct HTMLRendererFootnoteTests {
         #expect(out.contains("<hr class=\"footnotes-sep\"><ol class=\"footnotes\">"))
         #expect(out.contains("<li id=\"fn-1\">the note text <a href=\"#fnref-1\" class=\"footnote-backref\">↩</a></li>"))
         // The unrelated paragraph after the definition still renders normally.
-        #expect(out.contains("<p>More content.</p>"))
+        #expect(out.contains("<p id=\"edmund-l5\">More content.</p>"))
     }
 
     @Test("Definition body keeps its inline markdown formatting")
@@ -426,14 +426,14 @@ struct HTMLRendererCalloutTests {
     @Test("Known callout type → callout div with title and body")
     func basicCallout() {
         let out = html("> [!note]\n> Body text.")
-        #expect(out.contains("<div class=\"callout callout-note\">"))
+        #expect(out.contains("<div id=\"edmund-l1\" class=\"callout callout-note\">"))
         #expect(out.contains("<div class=\"callout-title\">"))
         // Inline Lucide SVG (note → pencil), tinted by CSS via currentColor.
         #expect(out.contains("<span class=\"callout-icon\"><svg"))
         #expect(out.contains(LucideIcons.geometry["pencil"]!))
         #expect(!out.contains("data-symbol"))
         #expect(out.contains("<span class=\"callout-title-text\">Note</span>"))
-        #expect(out.contains("<div class=\"callout-body\"><p>Body text.</p></div>"))
+        #expect(out.contains("<div class=\"callout-body\"><p id=\"edmund-l1\">Body text.</p></div>"))
     }
 
     @Test("Custom title is used verbatim")
@@ -446,7 +446,7 @@ struct HTMLRendererCalloutTests {
     @Test("Unknown type stays a plain block quote")
     func unknownType() {
         let out = html("> [!bogus]\n> hi")
-        #expect(out.hasPrefix("<blockquote>"))
+        #expect(out.hasPrefix("<blockquote id=\"edmund-l1\">"))
         #expect(!out.contains("callout"))
     }
 
@@ -457,18 +457,18 @@ struct HTMLRendererCalloutTests {
     @Test("A lazy line after a callout renders as a sibling, not in the body")
     func calloutBodyStrict() {
         let out = html("> [!note]\n> body\nlazy")
-        #expect(out.contains("<div class=\"callout-body\"><p>body</p></div>"))
+        #expect(out.contains("<div class=\"callout-body\"><p id=\"edmund-l1\">body</p></div>"))
         // `lazy` sits after the callout div closes, not inside the body.
-        #expect(out.contains("</div></div><p>lazy</p>"))
+        #expect(out.contains("</div></div><p id=\"edmund-l1\">lazy</p>"))
         #expect(!out.contains("body\nlazy"))
     }
 
     @Test("GFM ex.228 tail: `> y` after a lazy line is a sibling quote, not the callout")
     func calloutLazyTailWithQuote() {
         let out = html("> [!note]\n> body\nlazy\n> y")
-        #expect(out.contains("<div class=\"callout-body\"><p>body</p></div>"))
-        #expect(out.contains("<p>lazy</p>"))
-        #expect(out.contains("<blockquote><p>y</p></blockquote>"))
+        #expect(out.contains("<div class=\"callout-body\"><p id=\"edmund-l1\">body</p></div>"))
+        #expect(out.contains("<p id=\"edmund-l1\">lazy</p>"))
+        #expect(out.contains("<blockquote id=\"edmund-l2\"><p>y</p></blockquote>"))
         // Exactly one callout — the second `> y` was not pulled into it.
         #expect(out.components(separatedBy: "class=\"callout ").count == 2)
     }
@@ -476,7 +476,41 @@ struct HTMLRendererCalloutTests {
     @Test("A fully `>`-prefixed callout body is unchanged (no lazy split)")
     func calloutFullyQuotedUnchanged() {
         let out = html("> [!note]\n> a\n> b")
-        #expect(out.contains("<div class=\"callout-body\"><p>a\nb</p></div>"))
+        #expect(out.contains("<div class=\"callout-body\"><p id=\"edmund-l1\">a\nb</p></div>"))
         #expect(!out.contains("</div></div><p>"))
+    }
+}
+
+@Suite("HTMLRenderer — Read-mode source-line anchors")
+struct HTMLRendererAnchorTests {
+
+    private func html(_ md: String, preserveBlankLines: Bool) -> String {
+        HTMLRenderer.render(markdown: md, options: ReadRenderOptions(preserveBlankLines: preserveBlankLines))
+    }
+
+    @Test("Each top-level block gets an id anchored to its starting source line")
+    func topLevelBlocksAnchored() {
+        let md = "# H\n\npara one\nline two\n\n- a\n- b\n"
+        for preserveBlankLines in [true, false] {
+            let out = html(md, preserveBlankLines: preserveBlankLines)
+            #expect(out.contains("<h1 id=\"edmund-l1\">H</h1>"))
+            #expect(out.contains("<p id=\"edmund-l3\">para one\nline two</p>"))
+            #expect(out.contains("<ul id=\"edmund-l6\">"))
+        }
+    }
+
+    @Test("A footnote-definition first block renders empty and doesn't crash; the next block still gets its id")
+    func emptyFirstBlockSkipped() {
+        let out = html("[^1]: note\n\npara\n", preserveBlankLines: true)
+        #expect(out.contains("<p id=\"edmund-l3\">para</p>"))
+    }
+
+    @Test("topLevelBlockSpans reports each block's start/end source line")
+    func topLevelBlockSpans() {
+        let spans = ReadModeAnchors.topLevelBlockSpans(for: "# H\n\npara one\nline two\n\n- a\n- b\n")
+        #expect(spans.count == 3)
+        #expect(spans[0].startLine == 1 && spans[0].endLine == 1)
+        #expect(spans[1].startLine == 3 && spans[1].endLine == 4)
+        #expect(spans[2].startLine == 6 && spans[2].endLine == 7)
     }
 }

--- a/Tests/EdmundTests/ReadModeWebViewTests.swift
+++ b/Tests/EdmundTests/ReadModeWebViewTests.swift
@@ -45,4 +45,16 @@ struct ReadModeWebViewTests {
             for: URL(string: "about:blank")!,
             navigationType: .reload) == .reload)
     }
+
+    @Test("scroll position string parser")
+    func parseScrollPosition() {
+        let parsed = ReadModeWebView.parseScrollPosition("42,0.5")
+        #expect(parsed?.line == 42)
+        #expect(parsed?.fraction == 0.5)
+
+        #expect(ReadModeWebView.parseScrollPosition("") == nil)
+        #expect(ReadModeWebView.parseScrollPosition("notanumber,0.5") == nil)
+        #expect(ReadModeWebView.parseScrollPosition("3,notanumber") == nil)
+        #expect(ReadModeWebView.parseScrollPosition("3") == nil)
+    }
 }

--- a/Tests/EdmundTests/ViewportHelpersTests.swift
+++ b/Tests/EdmundTests/ViewportHelpersTests.swift
@@ -1,0 +1,115 @@
+import Testing
+import AppKit
+@testable import EdmundCore
+
+/// `line(forOffset:)` / `offset(forLine:)` are the character-offset ↔
+/// 1-indexed-line conversions used to sync the read-mode viewport with the
+/// editor. They must agree with swift-markdown's SourceLocation convention
+/// (newline-counted, UTF-16 offsets) since callers cross-reference the two.
+@Suite("Viewport line/offset helpers")
+struct ViewportHelpersTests {
+
+    @Test("Empty document is a single line")
+    @MainActor func emptyDocument() {
+        let editor = makeEditor()
+        editor.loadContent("")
+        #expect(editor.line(forOffset: 0) == 1)
+        #expect(editor.offset(forLine: 1) == 0)
+    }
+
+    @Test("Single line document")
+    @MainActor func singleLine() {
+        let editor = makeEditor()
+        editor.loadContent("hello world")
+        #expect(editor.line(forOffset: 0) == 1)
+        #expect(editor.line(forOffset: 5) == 1)
+        #expect(editor.line(forOffset: 11) == 1)
+        #expect(editor.offset(forLine: 1) == 0)
+    }
+
+    @Test("Multi-line document: offsets at newline boundaries")
+    @MainActor func multiLineBoundaries() {
+        let editor = makeEditor()
+        // Lines:  "aa\n" (0-2, \n@2)  "bbb\n" (3-6, \n@6)  "c" (7)
+        editor.loadContent("aa\nbbb\nc")
+        #expect(editor.line(forOffset: 0) == 1)   // start of "aa"
+        #expect(editor.line(forOffset: 2) == 1)   // the "\n" itself still counts as line 1
+        #expect(editor.line(forOffset: 3) == 2)   // just past the "\n" -> start of "bbb"
+        #expect(editor.line(forOffset: 6) == 2)
+        #expect(editor.line(forOffset: 7) == 3)   // start of "c"
+        #expect(editor.line(forOffset: 8) == 3)   // end of document
+
+        #expect(editor.offset(forLine: 1) == 0)
+        #expect(editor.offset(forLine: 2) == 3)
+        #expect(editor.offset(forLine: 3) == 7)
+    }
+
+    @Test("offset(forLine:) clamps out-of-range input")
+    @MainActor func clamping() {
+        let editor = makeEditor()
+        editor.loadContent("aa\nbbb\nc")
+        #expect(editor.offset(forLine: 0) == 0)
+        #expect(editor.offset(forLine: -5) == 0)
+        #expect(editor.offset(forLine: 100) == 7)  // clamps to start of last line
+    }
+
+    @Test("Non-BMP character before a newline uses UTF-16 offsets")
+    @MainActor func nonBMPCharacter() {
+        let editor = makeEditor()
+        // "a😀\nb": 'a'(1) + 😀(2 UTF-16 units) + '\n'(1) = line 1 spans [0,4);
+        // line 2 ("b") starts at offset 4.
+        editor.loadContent("a😀\nb")
+        let ns = editor.rawSource as NSString
+        #expect(ns.length == 5)
+        #expect(editor.line(forOffset: 0) == 1)   // 'a'
+        #expect(editor.line(forOffset: 1) == 1)   // first UTF-16 unit of the emoji
+        #expect(editor.line(forOffset: 2) == 1)   // second UTF-16 unit of the emoji
+        #expect(editor.line(forOffset: 3) == 1)   // the "\n"
+        #expect(editor.line(forOffset: 4) == 2)   // 'b'
+        #expect(editor.offset(forLine: 2) == 4)
+    }
+}
+
+/// `scrollCharacterToTop` live-geometry check, mirroring the windowed setup
+/// in TypewriterCenteringTests.
+@Suite("scrollCharacterToTop")
+struct ScrollCharacterToTopTests {
+
+    @MainActor
+    private func makeWindowed() -> (EditorTextView, NSScrollView) {
+        let editor = makeEditor()
+        let win = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
+                           styleMask: [.titled], backing: .buffered, defer: false)
+        let scroll = NSScrollView(frame: win.contentLayoutRect)
+        scroll.documentView = editor
+        win.contentView = scroll
+        win.makeFirstResponder(editor)
+        editor.isVerticallyResizable = true
+        editor.minSize = NSSize(width: 0, height: 0)
+        editor.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude,
+                                height: CGFloat.greatestFiniteMagnitude)
+        editor.autoresizingMask = [.width]
+        return (editor, scroll)
+    }
+
+    @Test("Scrolls the target line to the viewport top")
+    @MainActor func scrollsToTop() {
+        let (editor, scroll) = makeWindowed()
+        var doc = ""
+        for i in 1...100 { doc += "Line \(i) content here for the document body.\n" }
+        editor.loadContent(doc)
+        ensureFullLayout(editor); editor.sizeToFit(); editor.layoutSubtreeIfNeeded()
+
+        let off = (editor.rawSource as NSString).range(of: "Line 50 ").location
+        editor.scrollCharacterToTop(off)
+        editor.layoutSubtreeIfNeeded()
+
+        guard let lr = editor.lineRect(forCharacterAt: off) else {
+            Issue.record("no line rect for target offset")
+            return
+        }
+        let docTopY = lr.minY + editor.textContainerOrigin.y
+        let screenTopY = docTopY - scroll.contentView.bounds.origin.y
+        #expect(abs(screenTopY) < 4, "target line landed \(screenTopY)pt from viewport top")
+    }
+}


### PR DESCRIPTION
## What

Switching between Edit and Read mode now keeps the viewport on the same
content, accurate to the source line, in both directions — including
scrolling done inside Read mode — and mode switches no longer flash
blank/white.

- **Anchors**: every top-level block in the read-mode HTML gets
  `id="edmund-l<startLine>"`; `ReadModeAnchors.topLevelBlockSpans(for:)`
  exposes the same line spans to the editor side.
- **Scroll bridge**: `ReadModeWebView` gains `setScrollPosition` /
  `readScrollPosition` via `evaluateJavaScript` — which runs even with
  `allowsContentJavaScript = false` and the `script-src 'none'` CSP, so the
  read-mode sandbox is unchanged (content JS stays fully disabled; the JS is
  static templates interpolating only Swift-computed numbers).
- **Editor helpers**: `topmostVisibleCharacterOffset()`,
  `line(forOffset:)` / `offset(forLine:)`, `scrollCharacterToTop(_:)`.
- **No blank screens**: view swap deferred until the rendered document is
  ready (with an HTML cache making unchanged re-entries instant), themed
  under-page background, and a TextKit 2 viewport poke on return to Edit
  (fixes blank-until-click).
- **Re-renders** (appearance flip, settings change) preserve scroll instead
  of resetting to top.

## Why the drift fix matters

`viewMode`'s didSet recomposes all blocks; far-from-viewport blocks defer to
the styling drain, collapsing their geometry to base-height estimates. An
anchor captured after that read collapsed positions and every round trip
walked the viewport ~100+ lines down the document. Fixes: capture the anchor
before the setter runs; style-then-lay-out everything above a far scroll
target before measuring; keep the entry/exit line↔fraction mappings exact
inverses. Verified as a fixed point with a scripted harness (line 105 → 105 →
105 over three toggles) and confirmed live.

Also adds `-debug.disableUpdater` (Sparkle's failed-check alert is modal at
launch and blocks scripted runs) and ReproScript `viewmode` / `readscroll` /
`logstate` commands used to measure the drift.

## Testing

- `swift test` — 1022 tests pass (new coverage: anchor-id splicing on both
  `preserveBlankLines` settings, `topLevelBlockSpans`, line↔offset helpers
  incl. non-BMP offsets, scroll-position parser, live-geometry
  `scrollCharacterToTop`).
- Scripted live harness with screencaptures + content-space logging; user
  verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)