### PR TITLE
Hide the Read→Edit reposition hop by deferring the view swap

### DIFF
--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -489,11 +489,17 @@ class Document: NSDocument, HeadingNavigable {
             if let read = readView, !read.isHidden {
                 // While the webview is still alive, capture where the user
                 // actually scrolled to in Read mode and map it back onto the
-                // editor's source lines.
+                // editor's source lines. The view swap waits for this
+                // completion: swapping immediately showed the editor at its
+                // stale position for a few frames before the scroll landed —
+                // a visible up-then-down hop. Positioning while hidden and
+                // swapping after keeps the hop off-screen; the JS round trip
+                // is a few ms, and the completion fires exactly once even on
+                // error, so the swap can't be dropped.
                 read.readScrollPosition { [weak self] pos in
                     // Still in edit/source when this lands? A rapid toggle
                     // back into Read mode means the editor is hidden again —
-                    // don't scroll it.
+                    // don't scroll it (or swap).
                     guard let self, self.editor.viewMode != .reading else { return }
                     var targetOffset: Int?
                     if let pos {
@@ -515,20 +521,24 @@ class Document: NSDocument, HeadingNavigable {
                     if let offset = targetOffset ?? self.lastReadAnchorOffset {
                         self.editor.scrollCharacterToTop(offset)
                     }
+                    self.swapToEditor()
                 }
+            } else {
+                swapToEditor()
             }
-            // Swap views immediately — don't wait for the JS round-trip above.
-            readView?.isHidden = true
-            scrollView.isHidden = false
-            editor.window?.makeFirstResponder(editor)
-            // Nothing else forces TextKit 2 viewport layout/redraw when a
-            // hidden scroll view is unhidden — a click used to supply the
-            // missing event, leaving the editor blank until one arrived. The
-            // async scroll above also forces layout when it lands; this poke
-            // covers the no-anchor path and the gap before the JS returns.
-            editor.textLayoutManager?.textViewportLayoutController.layoutViewport()
-            editor.needsDisplay = true
         }
+    }
+
+    /// Reveals the editor's scroll view (hiding any read view) and repairs
+    /// TextKit 2 state: nothing else forces viewport layout/redraw when a
+    /// hidden scroll view is unhidden — a click used to supply the missing
+    /// event, leaving the editor blank until one arrived.
+    private func swapToEditor() {
+        readView?.isHidden = true
+        scrollView.isHidden = false
+        editor.window?.makeFirstResponder(editor)
+        editor.textLayoutManager?.textViewportLayoutController.layoutViewport()
+        editor.needsDisplay = true
     }
 
     /// Re-renders an open Read view from the editor's current source + theme.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -225,6 +225,27 @@ relative markdown links use private URL schemes (`x-edmund-wiki:`,
 `x-edmund-link:`) in the rendered HTML so the nav coordinator can intercept
 them and route through the app's document graph without JavaScript.
 
+**Mode-switch viewport sync** (Edit ↔ Read, line-accurate both directions):
+every top-level block in the read HTML carries `id="edmund-l<startLine>"`
+(spliced in `HTMLRenderer.visitDocument`; `ReadModeAnchors.topLevelBlockSpans`
+exposes the same 1-indexed line spans to callers). `ReadModeWebView` reads and
+sets its scroll position as (anchor line, fraction-into-block) via
+`evaluateJavaScript` — which runs even with `allowsContentJavaScript = false`
+and the `script-src 'none'` CSP (both gate only *page content* JS; API-injected
+JS is a separate trusted channel), so the sandbox above is unchanged. The JS is
+static templates interpolating only Swift-computed numbers. `Document` maps the
+editor side with `topmostVisibleCharacterOffset()` / `line(forOffset:)` /
+`offset(forLine:)` / `scrollCharacterToTop(_:)`; entry and exit mappings use
+the same `lineCount` denominator so an untouched round trip is a fixed point.
+Both swap directions are deferred so no intermediate frame is visible: Edit→Read
+swaps in `onLoadFinished` (with an HTML cache making unchanged re-entries
+instant and skipping the reload), Read→Edit swaps in `readScrollPosition`'s
+completion after the editor is positioned while still hidden. Re-renders
+(appearance flip, settings) self-capture and restore their scroll. Two gotchas
+this feature learned the hard way (see also §8): the anchor must be captured
+*before* the `viewMode` setter runs, and far scrolls must style-then-lay-out
+everything above the target before measuring.
+
 ---
 
 ## 7. Settings & persistence
@@ -388,10 +409,25 @@ them and route through the app's document graph without JavaScript.
   fixup synchronously): use the in-process repro driver — DEBUG builds accept
   `-debug.reproScript <path>` (`Sources/edmd/App/ReproScript.swift`) and replay
   keystroke scripts (`caret` / `type` / `backspace` / `bypassdelete` /
-  `assertcaret` / `logsel`) through the real `window.sendEvent` key path — no
-  Accessibility/TCC needed, works with the window on an invisible Space. Full
-  chronicle: `docs/investigations/delete-drift-investigation.md` round 6; step-by-step method
-  for producing such repros: `docs/dev-guides/live-repro-guide.md`.
+  `assertcaret` / `logsel` / `scroll` / `viewmode` / `readscroll` / `logstate`)
+  through the real `window.sendEvent` key path — no Accessibility/TCC needed,
+  works with the window on an invisible Space. Pass `-debug.disableUpdater YES`
+  alongside it: Sparkle's failed-update alert on dev builds is **modal at
+  launch** and blocks everything (no document window, no script) until
+  dismissed. Full chronicle: `docs/investigations/delete-drift-investigation.md`
+  round 6; step-by-step method for producing such repros:
+  `docs/dev-guides/live-repro-guide.md`.
+- **The `viewMode` setter recomposes every block, collapsing far geometry to
+  estimates.** `recomposeDirty` on a large dirty set styles only the viewport
+  synchronously and defers the rest to the idle drain, so right after a mode
+  toggle everything far from the viewport is laid out at base-attribute height
+  (~17pt/line vs ~27pt styled). Two consequences (the read-mode viewport-drift
+  bug): capture any viewport anchor **before** `editor.viewMode = mode` runs
+  (`Document.setViewMode` does), and a far `scrollCharacterToTop` must
+  style-then-lay-out everything above its target before measuring
+  (`ensureBlocksStyled(upTo:)` + `ensureLayout`) — the drain's later layout
+  invalidation is *not* scroll-compensated, so landing first and letting
+  styling catch up slides the just-anchored viewport.
 - **A custom toolbar item can't win a right-click from a view-level handler.**
   With `NSToolbar.allowsUserCustomization = true`, the toolbar turns any
   secondary (right / control) click over the toolbar — *including* a custom item


### PR DESCRIPTION
## What

After switching Read → Edit, the editor appeared at its stale scroll
position for a few frames, then hopped to the synced position when the
async `readScrollPosition` completion landed — a small visible
up-then-down glitch (final position was already correct).

The editor is now positioned **while still hidden** and the view swap
happens in the completion, mirroring the Edit→Read deferred swap from
#213. The JS round trip is a few milliseconds, and the completion fires
exactly once even on error, so the swap can't be dropped. Rapid-toggle
and never-loaded-webview paths keep their guards.

Also documents the mode-switch scroll sync (§6) and its two hard-won
gotchas (§8: capture anchors before the `viewMode` setter's recompose;
style-then-lay-out above far scroll targets) in ARCHITECTURE.md.

## Testing

- `swift test` — 1022 tests pass.
- Scripted harness regression: Edit→Read→Edit round trip remains a fixed
  point (topmost line 105 → 105 → 105 over three toggles) with the
  deferred swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)