### PR TITLE
fix: dark-mode background #292929, more Read-mode vertical spacing

### DIFF
--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -17,7 +17,7 @@ enum HTMLTheme {
     /// `--bg` variable and `ReadModeWebView.underPageBackgroundColor` so the
     /// webview's own background can't drift from the page it's about to show.
     private static func backgroundHex(dark: Bool) -> String {
-        dark ? "#1e1e1e" : "#ffffff"
+        dark ? "#292929" : "#ffffff"
     }
 
     /// `NSColor` form of `backgroundHex`, for `WKWebView.underPageBackgroundColor`.
@@ -149,7 +149,7 @@ enum HTMLTheme {
        room, so the cadence feels like a clean, readable version of Edit mode
        rather than a collapsed publication layout. */
     p { margin: 0 0 1em; }
-    h1, h2, h3, h4, h5, h6 { line-height: 1.25; font-weight: 600; margin: 1.4em 0 0.5em; }
+    h1, h2, h3, h4, h5, h6 { line-height: 1.25; font-weight: 600; margin: 1.7em 0 0.7em; }
     h1 { font-size: 1.9em; } h2 { font-size: 1.55em; } h3 { font-size: 1.3em; }
     h4 { font-size: 1.1em; } h5 { font-size: 1em; } h6 { font-size: 0.9em; color: var(--faint); }
     :is(h1, h2, h3, h4, h5, h6):first-child { margin-top: 0; }
@@ -198,10 +198,10 @@ enum HTMLTheme {
        items stay at 0 margin — otherwise each level compounds to large gaps. */
     ul, ol { margin: 0; padding-left: 1.25em; }
     .page > ul, .page > ol,
-    .callout-body > ul, .callout-body > ol { margin: 1em 0; padding-left: 2.25em; }
+    .callout-body > ul, .callout-body > ol { margin: 1.3em 0; padding-left: 2.25em; }
     li > ul, li > ol { margin: 0; }
     ul { list-style-type: disc; }
-    li { margin: 0.2em 0; }
+    li { margin: 0.35em 0; }
     li::marker { color: var(--marker); font-size: 0.85em; }
     li > p { margin: 0; }
     /* Task items: float the checkbox into the marker slot so the label and

--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -198,9 +198,17 @@ public class EditorTextView: NSTextView {
     /// as warm amber rather than tracking the (potentially red) brand accent.
     var selectionHighlightColor: NSColor { .systemOrange.withAlphaComponent(0.3) }
 
-    /// Background color for the editor surface. `.textBackgroundColor` is the
-    /// standard semantic color for text-editing backgrounds (white / dark gray).
-    private var editorBackgroundColor: NSColor { .textBackgroundColor }
+    /// Background color for the editor surface. Light appearance keeps the
+    /// standard `.textBackgroundColor` semantic; dark appearance uses `#292929`,
+    /// matching Read mode's page background. Built with `srgbRed:` rather than
+    /// the shared `NSColor(hex:)` helper (which uses `calibratedRed:`) — the
+    /// calibrated color space renders visibly lighter than the sRGB hex value
+    /// once composited on screen.
+    private var editorBackgroundColor: NSColor {
+        let dark = effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+        guard dark else { return .textBackgroundColor }
+        return NSColor(srgbRed: 0x29 / 255.0, green: 0x29 / 255.0, blue: 0x29 / 255.0, alpha: 1.0)
+    }
 
     // MARK: - Font & Paragraph Style (derived from theme)
 

--- a/Tests/EdmundTests/EditorFeatureTests.swift
+++ b/Tests/EdmundTests/EditorFeatureTests.swift
@@ -302,10 +302,17 @@ struct AppearanceIntegrationTests {
         #expect(editor.typewriterModeEnabled == false)
     }
 
-    @Test("Editor background uses textBackgroundColor")
+    @Test("Editor background uses textBackgroundColor in light, #292929 in dark")
     @MainActor func editorBackground() {
         let editor = makeEditor()
+
+        editor.appearance = NSAppearance(named: .aqua)
+        editor.viewDidChangeEffectiveAppearance()
         #expect(editor.backgroundColor == NSColor.textBackgroundColor)
+
+        editor.appearance = NSAppearance(named: .darkAqua)
+        editor.viewDidChangeEffectiveAppearance()
+        #expect(editor.backgroundColor == NSColor(srgbRed: 0x29 / 255.0, green: 0x29 / 255.0, blue: 0x29 / 255.0, alpha: 1.0))
     }
 
     @Test("Insertion point uses the accent color")

--- a/Tests/EdmundTests/HTMLThemeTests.swift
+++ b/Tests/EdmundTests/HTMLThemeTests.swift
@@ -52,7 +52,7 @@ struct HTMLThemeTests {
         // 'caution' has darkColorHex #F85149.
         #expect(css(dark: true).contains("--c-accent: #F85149;"))
         #expect(css(dark: false).contains("--c-accent: #CF222E;"))
-        #expect(css(dark: true).contains("--bg: #1e1e1e;"))
+        #expect(css(dark: true).contains("--bg: #292929;"))
     }
 
     @Test("Wide tables scroll horizontally instead of wrapping cell text")


### PR DESCRIPTION
## Summary
- Dark-mode background now #292929 in both Edit mode (AppKit editor) and Read mode (WKWebView CSS), replacing the old #1e1e1e.
- Edit mode builds the color via `NSColor(srgbRed:)` instead of the shared `NSColor(hex:)` helper — that helper uses `calibratedRed:`, whose color space renders visibly lighter than the literal sRGB hex once composited on screen. Left the shared helper untouched to avoid affecting unrelated colors (links, code, math).
- Read-mode heading and list-item vertical margins widened for breathing room. Horizontal indent (`padding-left`) is unchanged, per explicit request.

## Test plan
- [x] `swift test` — 1022 tests pass
- [x] Built `Edmund.app`, screencapture-verified + pixel-sampled: Edit mode dark bg = (41,41,41) = #292929
- [x] Same verification for Read mode dark bg = (41,41,41) = #292929
- [x] Visual check of increased heading/list vertical spacing in Read mode