### PR TITLE
Update site comparison cards and favicon

### DIFF
--- a/site/src/components/ComparisonTable.astro
+++ b/site/src/components/ComparisonTable.astro
@@ -98,9 +98,9 @@ type App = (typeof apps)[number];
 type AppKey = keyof App;
 
 const fields: [string, AppKey][] = [
-  ["Editing Experience", "editing"],
+  ["Editor", "editing"],
   ["Files", "files"],
-  ["Native macOS UI", "native"],
+  ["Native macOS", "native"],
   ["App Size", "size"],
   ["Pricing", "pricing"],
   ["Open Source", "openSource"],
@@ -111,10 +111,7 @@ const fields: [string, AppKey][] = [
     <Card
       title={app.name}
       href={app.url}
-      class:list={[
-        "w-[min(20rem,calc(100vw-3rem))] shrink-0 snap-start",
-        app.name === "Edmund" && "border-primary bg-link-soft/30",
-      ]}
+      class="w-[min(20rem,calc(100vw-3rem))] shrink-0 snap-start"
     >
       <dl class="grid gap-2 text-sm">
         {fields.map(([label, key]) => (
@@ -126,12 +123,10 @@ const fields: [string, AppKey][] = [
                   {app[key] ? (
                     <>
                       <span class="i-lucide-check h-4 w-4 text-green-600"></span>
-                      <span>Yes</span>
                     </>
                   ) : (
                     <>
                       <span class="i-lucide-x h-4 w-4 text-red-600"></span>
-                      <span>No</span>
                     </>
                   )}
                 </span>
@@ -146,6 +141,7 @@ const fields: [string, AppKey][] = [
   ))}
 </div>
 
+<!-- wider screens -->
 <div class="hidden overflow-x-auto md:block">
   <table class="min-w-max border-collapse text-sm font-sans">
     <tbody>
@@ -159,7 +155,7 @@ const fields: [string, AppKey][] = [
             class:list={[
               "px-4 py-3 whitespace-nowrap text-center bg-tertiary-soft",
               app.name === "Edmund" &&
-                "sticky w-36 left-38.5 z-10 bg-tertiary-soft font-semibold",
+                "sticky w-29 left-31.5 z-10 bg-tertiary-soft font-semibold",
             ]}
           >
             <a
@@ -187,7 +183,7 @@ const fields: [string, AppKey][] = [
               class:list={[
                 "px-4 py-3 whitespace-nowrap text-center",
                 app.name === "Edmund" &&
-                  "sticky left-38.5 z-10 bg-background font-semibold",
+                  "sticky left-31.5 z-10 bg-background font-semibold",
               ]}
             >
               {typeof app[key] === "boolean" ? (

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -37,7 +37,7 @@ const base = import.meta.env.BASE_URL.endsWith("/")
         --color-tertiary: #f2f2f7;
         --color-border: #d1d1d6;
         --color-text: #1d1d1f;
-        --color-secondary: #9e9ea0;
+        --color-secondary: #86868b;
         --color-primary: #ff6916; 
         --color-primary-strong: #ee5605;
         --color-link: #007aff;

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -75,7 +75,7 @@ const videoId = "hero-video";
           </a>
         </div>
         <p class="mt-3 text-sm leading-6 text-secondary font-sans">
-          Requires macOS 14 Sonoma or later (<a href="https://github.com/I7T5/Edmund#installation">unnotarized</a>)
+          Requires macOS 14 Sonoma or later. (<a href="https://github.com/I7T5/Edmund#installation">Damaged?</a>)
         </p>
 
         <!-- Animation to scroll here -->
@@ -86,16 +86,17 @@ const videoId = "hero-video";
   <SideSection id="overview" title="Yet another Markdown editor?">
     <div class="space-y-5 text-lg leading-8">
       <p>
-        As far as I know (July 2026), there does not exist a Markdown editor that is 
-        native to macOS, file-based, and has inline WYSIWYG live preview all at the same time.
+        As of July 2026, I have not found a Markdown editor that is 
+        <i>native to macOS</i>, <b>file-based</b>, and has <i><b>inline WYSIWYG live preview</b></i>
+        all at the same time. Which is why I made Edmund.
       </p>
       <p>
-        Whether as a companion alongside your Markdown knowledge base or as a standalone editor, 
-        Edmund aims to blends in with macOS and work seamlessly with your files wherever they are.
+        Edmund aims to just blend in with macOS and your workflow, 
+        whether as a complement to your Markdown knowledge base, or as a standalone editor, or both.
       </p>
       <p>
-        Our goal is to be the <a class="text-link" href="https://coteditor.com/">CotEditor</a> of Markdown editors, i.e. 
-        elegant, powerful, configurable, and native inside out.
+        We hope that Edmund feels so natural that you forget how often you use it every day, 
+        but also beautiful enough that, every once in a while, you pause and appreciate the font antialiasing / color palette / smooth rendering.
       </p>
     </div>
   </SideSection>
@@ -119,7 +120,7 @@ const videoId = "hero-video";
 
   <section class="mt-4 mb-12">
     <h2 class="text-2xl font-semibold mb-1">Comparisons</h2>
-    <p class="text-secondary mb-4">And alternatives, if Edmund's not for you. Scroll for more :D</p>
+    <p class="text-secondary mb-4">And <a href="https://github.com/mundimark/awesome-markdown-editors">alternatives</a>, if Edmund's not for you. Scroll for more :D</p>
     <ComparisonTable />
   </section>
 


### PR DESCRIPTION
## Summary

- make the comparison view usable on mobile with horizontally scrolling cards
- reuse the shared Card component styling and move card body text into the default slot
- update comparison card and overview wording
- add explicit 16x16 and 32x32 PNG favicon assets while keeping the .ico fallback

## Why

The comparison table's sticky desktop layout blocked content on small screens, so mobile now gets a card rail instead of the table. The favicon was only advertised as an .ico, which can be brittle across caches and browsers; explicit PNG sizes make discovery reliable while preserving the existing fallback.

## Validation

- `pnpm --dir site build`
- verified generated HTML includes the favicon PNG, ICO, and Apple touch icon links
- verified generated dist assets include the favicon files

Swift tests intentionally skipped because these are site-only changes.