### PR TITLE
Obsidian #tag and ^blockid inline syntax (Phase 2, inline pair)

### DIFF
--- a/Sources/EdmundCore/Export/HTMLRenderer.swift
+++ b/Sources/EdmundCore/Export/HTMLRenderer.swift
@@ -694,6 +694,8 @@ struct HTMLRenderer: MarkupVisitor {
             SyntaxHighlighter.parseWikiLinks(s, into: &spans, features: features)
         }
         if features.contains(.inlineComment) { SyntaxHighlighter.parseComments(s, into: &spans) }
+        if features.contains(.tag) { SyntaxHighlighter.parseTag(s, into: &spans) }
+        if features.contains(.blockRef) { SyntaxHighlighter.parseBlockRef(s, into: &spans) }
         if features.contains(.footnote) { SyntaxHighlighter.parseFootnotes(s, into: &spans) }  // references only; a
         // `.footnoteDefinition` match here is a false positive (mid-run text that
         // happens to start with `[^id]:`) since real definitions are handled at
@@ -707,7 +709,7 @@ struct HTMLRenderer: MarkupVisitor {
         let relevant = spans.filter {
             switch $0.kind {
             case .highlight, .math, .wikilink, .comment, .footnoteReference,
-                 .link, .image: return true
+                 .link, .image, .tag, .blockRef: return true
             default: return false
             }
         }.sorted { $0.fullRange.location < $1.fullRange.location }
@@ -779,6 +781,10 @@ struct HTMLRenderer: MarkupVisitor {
                 if let width { dims += " width=\"\(width)\"" }
                 if let height { dims += " height=\"\(height)\"" }
                 out += "<img class=\"md-image\" data-src=\"\(attr(destination))\" alt=\"\"\(dims)>"
+            case .tag(let name):
+                out += "<span class=\"tag\">#\(escape(name))</span>"
+            case .blockRef:
+                break   // hidden in reading, like a comment
             case .comment:
                 break   // hidden in reading, like the editor
             case .link(let destination):

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -187,6 +187,10 @@ enum HTMLTheme {
     .callout-body > blockquote:last-child { margin-bottom: 0; }
     hr { border: none; border-top: 1px solid var(--rule); margin: 1.6em 0; }
     mark { background: rgba(255, 200, 0, 0.3); color: inherit; padding: 0 0.1em; }
+    /* Obsidian #tag: an accent-colored pill. Style only, no navigation. */
+    .tag { color: var(--accent);
+           background: color-mix(in srgb, var(--accent) 14%, transparent);
+           padding: 0.05em 0.5em; border-radius: 0.8em; font-size: 0.88em; white-space: nowrap; }
     /* Whitelisted inline HTML rendered in Read mode (see HTMLRenderer
        sanitizeInlineHTML). <u>/<mark> use the UA underline / the rule above;
        <kbd> matches the editor's inline-key chrome, <sub>/<sup> get the standard

--- a/Sources/EdmundCore/Parsing/SyntaxHighlighter+CustomParsers.swift
+++ b/Sources/EdmundCore/Parsing/SyntaxHighlighter+CustomParsers.swift
@@ -87,6 +87,65 @@ extension SyntaxHighlighter {
         }
     }
 
+    // A tag is `#` (at line start or after whitespace) followed by tag chars
+    // (letters, digits, `_`, `-`, `/`) with at least one non-digit — so `#123`
+    // is not a tag. A space after `#` is an ATX heading and won't match.
+    private static let tagRegex = try! NSRegularExpression(
+        pattern: #"(?:^|(?<=\s))#([A-Za-z0-9_/-]*[A-Za-z_/-][A-Za-z0-9_/-]*)"#)
+
+    /// Parses Obsidian `#tag` tokens (not supported by swift-markdown). The pill
+    /// covers the whole `#tag` (the `#` stays visible). Skips a tag inside a code
+    /// or math span.
+    static func parseTag(_ text: String, into spans: inout [Span]) {
+        let ns = text as NSString
+        for m in tagRegex.matches(in: text, range: NSRange(location: 0, length: ns.length)) {
+            let full = m.range(at: 0)   // includes the leading `#`
+            let overlaps = spans.contains { existing in
+                switch existing.kind {
+                case .code, .codeBlock, .math: break
+                default: return false
+                }
+                return existing.fullRange.location <= full.location
+                    && existing.fullRange.upperBound >= full.upperBound
+            }
+            guard !overlaps else { continue }
+            spans.append(Span(
+                kind: .tag(name: ns.substring(with: m.range(at: 1))),
+                fullRange: full,
+                contentRange: full,        // pill spans `#tag`; no hidden delimiter
+                delimiterRanges: []))
+        }
+    }
+
+    private static let blockRefRegex = try! NSRegularExpression(
+        pattern: #"(?:^|\s)(\^[A-Za-z0-9-]+)\s*$"#)
+
+    /// Parses a trailing Obsidian `^blockid` at the end of a block (not supported
+    /// by swift-markdown). Zero-length content + full-range delimiter ⇒ the whole
+    /// `^id` hides when rendered / dims at the caret, like a comment. No linking.
+    /// Skips a `^id` inside a code or math span.
+    static func parseBlockRef(_ text: String, into spans: inout [Span]) {
+        let ns = text as NSString
+        guard let m = blockRefRegex.firstMatch(
+            in: text, range: NSRange(location: 0, length: ns.length)) else { return }
+        let token = m.range(at: 1)   // the `^id`, without the leading whitespace
+        let overlaps = spans.contains { existing in
+            switch existing.kind {
+            case .code, .codeBlock, .math: break
+            default: return false
+            }
+            return existing.fullRange.location <= token.location
+                && existing.fullRange.upperBound >= token.upperBound
+        }
+        guard !overlaps else { return }
+        spans.append(Span(
+            kind: .blockRef(id: ns.substring(with: NSRange(
+                location: token.location + 1, length: token.length - 1))),  // after `^`
+            fullRange: token,
+            contentRange: NSRange(location: token.location, length: 0),
+            delimiterRanges: [token]))
+    }
+
     private static let htmlCommentRegex =
         try! NSRegularExpression(pattern: "<!--[\\s\\S]*?-->")
 

--- a/Sources/EdmundCore/Parsing/SyntaxHighlighter.swift
+++ b/Sources/EdmundCore/Parsing/SyntaxHighlighter.swift
@@ -76,6 +76,14 @@ public enum SyntaxHighlighter {
             /// tags show colored. `tag` is the lowercased element name; the two
             /// delimiterRanges are the open and close tags.
             case htmlFormat(tag: String)
+            /// An Obsidian `#tag`. `name` is the text after the leading `#`.
+            /// Styled as a pill in Edit and `<span class="tag">` in Read; no
+            /// navigation (style only).
+            case tag(name: String)
+            /// An Obsidian `^blockid` block reference at the end of a block.
+            /// `id` is the text after the `^`. Hidden in reading like a comment,
+            /// dimmed in Edit; no link resolution (style only).
+            case blockRef(id: String)
 
             public enum CheckboxState: Equatable, Sendable {
                 case checked, unchecked
@@ -129,6 +137,11 @@ public enum SyntaxHighlighter {
 
         // [^id] footnote references and [^id]: definition markers.
         if features.contains(.footnote) { parseFootnotes(text, into: &walker.spans) }
+
+        // Obsidian #tag pills and a trailing ^blockid reference. Both skip spans
+        // inside code / math (checked in the parsers).
+        if features.contains(.tag) { parseTag(text, into: &walker.spans) }
+        if features.contains(.blockRef) { parseBlockRef(text, into: &walker.spans) }
 
         // %%comments%% and [[wikilinks]]. Both are opaque: their inner text is
         // a raw note / link target, not markdown — drop any span fully inside

--- a/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
@@ -124,9 +124,11 @@ extension EditorTextView {
              .heading, .blockquote(_), .footnoteReference, .escape:
             return true
         case .listItem, .table, .codeBlock, .thematicBreak, .footnoteDefinition, .comment,
-             .htmlTag, .htmlFormat:
+             .htmlTag, .htmlFormat, .tag, .blockRef:
             // htmlTag: always colored source (brackets dimmed by the generic
             // pass). htmlFormat: handled explicitly in the delimiter loop.
+            // tag: a pill, nothing hides. blockRef: hidden/dimmed like a comment
+            // via its own branch in the delimiter loop.
             return false
         case .wikilink:
             // The `[[`, optional `target|`, and `]]` are hidden when rendered,
@@ -551,6 +553,25 @@ extension EditorTextView {
                     result.addAttribute(.foregroundColor, value: syntaxDimColor, range: span.fullRange)
                 }
 
+            case .tag:
+                guard span.contentRange.upperBound <= result.length else { continue }
+                // Pill: accent text on a faint accent wash over the whole `#tag`.
+                // No delimiter range, so nothing hides — the `#` stays visible.
+                result.addAttribute(.backgroundColor, value: linkColor.withAlphaComponent(0.15),
+                                    range: span.contentRange)
+                result.addAttribute(.foregroundColor, value: linkColor, range: span.contentRange)
+
+            case .blockRef:
+                guard span.fullRange.upperBound <= result.length else { continue }
+                // Like a comment: hidden in reading view, dimmed otherwise. The
+                // delimiter pass repeats this over the token so it wins.
+                if hideComments {
+                    result.addAttribute(.font, value: hiddenFont, range: span.fullRange)
+                    result.addAttribute(.foregroundColor, value: NSColor.clear, range: span.fullRange)
+                } else {
+                    result.addAttribute(.foregroundColor, value: syntaxDimColor, range: span.fullRange)
+                }
+
             case .lineBreak:
                 break  // Delimiter handling done below
 
@@ -639,6 +660,15 @@ extension EditorTextView {
                 } else if case .comment = span.kind {
                     // Comment `%%`: hidden in reading view, dimmed otherwise —
                     // matching the content styling above.
+                    if hideComments {
+                        result.addAttribute(.font, value: hiddenFont, range: dr)
+                        result.addAttribute(.foregroundColor, value: NSColor.clear, range: dr)
+                    } else {
+                        result.addAttribute(.foregroundColor, value: syntaxDimColor, range: dr)
+                    }
+                } else if case .blockRef = span.kind {
+                    // `^id`: hidden in reading view, dimmed otherwise (matches
+                    // the content styling and the comment treatment).
                     if hideComments {
                         result.addAttribute(.font, value: hiddenFont, range: dr)
                         result.addAttribute(.foregroundColor, value: NSColor.clear, range: dr)

--- a/Tests/EdmundTests/SyntaxHighlighterTests.swift
+++ b/Tests/EdmundTests/SyntaxHighlighterTests.swift
@@ -170,7 +170,9 @@ struct HeadingTests {
     @Test("# without space is not a heading")
     func noSpace() {
         let spans = SyntaxHighlighter.parse("#notaheading")
-        #expect(spans.isEmpty)
+        // No space after `#` ⇒ not an ATX heading. (It is an Obsidian `#tag`,
+        // so the span list is not empty — just assert no heading.)
+        #expect(!spans.contains { if case .heading = $0.kind { return true }; return false })
     }
 
     @Test("Setext === underline: content is the first line, delimiter the underline")

--- a/Tests/EdmundTests/TagBlockRefTests.swift
+++ b/Tests/EdmundTests/TagBlockRefTests.swift
@@ -1,0 +1,103 @@
+import Testing
+import AppKit
+@testable import EdmundCore
+
+/// Obsidian `#tag` and `^blockid` (Phase 2, inline pair). Style-only: a pill /
+/// dim, no navigation. Each is gated by its own `MarkdownFeatures` flag.
+@Suite("Tag & block-ref")
+struct TagBlockRefTests {
+
+    private func tagName(_ spans: [SyntaxHighlighter.Span]) -> String? {
+        for s in spans { if case .tag(let n) = s.kind { return n } }
+        return nil
+    }
+    private func blockRefID(_ spans: [SyntaxHighlighter.Span]) -> String? {
+        for s in spans { if case .blockRef(let id) = s.kind { return id } }
+        return nil
+    }
+    private func html(_ src: String, _ features: MarkdownFeatures) -> String {
+        HTMLRenderer.render(markdown: src, options: ReadRenderOptions(features: features))
+    }
+
+    // MARK: - #tag parse
+
+    @Test("#tag parses; the leading # is part of the token, name excludes it")
+    func tagParses() {
+        #expect(tagName(SyntaxHighlighter.parse("a #foo b", features: .all)) == "foo")
+    }
+
+    @Test("Nested #a/b tag keeps the slash in the name")
+    func tagNested() {
+        #expect(tagName(SyntaxHighlighter.parse("#a/b", features: .all)) == "a/b")
+    }
+
+    @Test("'# heading' is not a tag (space after #), and #123 is not (all digits)")
+    func tagNonMatches() {
+        #expect(tagName(SyntaxHighlighter.parse("# heading", features: .all)) == nil)
+        #expect(tagName(SyntaxHighlighter.parse("#123", features: .all)) == nil)
+    }
+
+    @Test("A tag mid-word is not matched (must follow start or whitespace)")
+    func tagRequiresBoundary() {
+        #expect(tagName(SyntaxHighlighter.parse("email#foo", features: .all)) == nil)
+    }
+
+    @Test("#tag not parsed when the flag is cleared")
+    func tagOff() {
+        #expect(tagName(SyntaxHighlighter.parse("#foo", features: MarkdownFeatures.all.subtracting(.tag))) == nil)
+    }
+
+    // MARK: - ^blockid parse
+
+    @Test("Trailing ^blockid parses; id excludes the caret")
+    func blockRefParses() {
+        #expect(blockRefID(SyntaxHighlighter.parse("some text ^abc123", features: .all)) == "abc123")
+    }
+
+    @Test("^id only matches at the end of the block, not mid-text")
+    func blockRefTrailingOnly() {
+        #expect(blockRefID(SyntaxHighlighter.parse("a ^abc more text", features: .all)) == nil)
+    }
+
+    @Test("^blockid not parsed when the flag is cleared")
+    func blockRefOff() {
+        #expect(blockRefID(SyntaxHighlighter.parse("text ^abc", features: MarkdownFeatures.all.subtracting(.blockRef))) == nil)
+    }
+
+    // MARK: - Read HTML
+
+    @Test("Read: #tag emits a .tag span; absent when the flag is off")
+    func readTag() {
+        #expect(html("#foo", .all).contains("class=\"tag\""))
+        #expect(html("#foo", .all).contains(">#foo<"))
+        #expect(!html("#foo", MarkdownFeatures.all.subtracting(.tag)).contains("class=\"tag\""))
+    }
+
+    @Test("Read: ^blockid is hidden (never emitted)")
+    func readBlockRef() {
+        #expect(!html("text ^abc", .all).contains("abc"))
+        // With the flag off it is not a block-ref, so the literal survives.
+        #expect(html("text ^abc", MarkdownFeatures.all.subtracting(.blockRef)).contains("abc"))
+    }
+
+    // MARK: - Edit styling
+
+    @MainActor
+    @Test("Edit: #tag gets a background pill attribute")
+    func editTagPill() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("#foo")
+        #expect(styled.attribute(.backgroundColor, at: 1, effectiveRange: nil) != nil)
+    }
+
+    @MainActor
+    @Test("^blockid hides in reading view, stays visible (dimmed) in edit")
+    func editBlockRefHiding() {
+        let editor = makeEditor()
+        // "some ^abc" → the caret `^` sits at index 5.
+        let reading = editor.styleBlock("some ^abc", cursorPosition: nil, hideComments: true)
+        #expect(isHidden(at: 5, in: reading))
+        let edit = editor.styleBlock("some ^abc", cursorPosition: nil)
+        #expect(!isHidden(at: 5, in: edit))
+    }
+}


### PR DESCRIPTION
## What

Phase 2 of Obsidian-flavored-markdown support — the **inline pair** (`#tag`, `^blockid`). Fills two feature flags that Phase 1 declared and wired to Settings toggles but left as no-ops.

- **`#tag`** — new `.tag(name:)` span. Parsed at line start / after whitespace, requires at least one non-digit (`#123` is not a tag), allows nested `#a/b`; a space after `#` stays an ATX heading. Renders as an accent **pill** in Edit and `<span class="tag">` in Read. Style only — no tag search.
- **`^blockid`** — new `.blockRef(id:)` span. A trailing `^id` at a block's end, matched like the trailing-line-break parser (zero-length content + full-range delimiter). Hidden when the line is rendered / shown dim while editing it; hidden in Read. No link resolution.

Both back-ends gate on the existing `.tag` / `.blockRef` flags, so clearing the Syntax-pane toggle drops each to plain text everywhere. **No new flags or settings UI** — the toggles already ship from Phase 1.

## Scope note

Deferred to a follow-up branch (per the plan): the block-level Phase-2 constructs (YAML front matter, multi-block `%%…%%` comment), which need BlockParser structural changes.

## Verification

- `swift test` — 1074 pass (12 new in `TagBlockRefTests`, covering both directions of each flag: parse, Read HTML, Edit attributes).
- Visual: built the app and `screencapture`-verified — `#tag` / `#a/b` / `#project2024` render as pills, `#123` and `# Heading` stay plain; `^blockid` hidden inactive / revealed while editing its line (Edit), hidden in Read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)