### PR TITLE
YAML front matter & multi-block %% comments (Phase 2 complete)

### DIFF
--- a/Sources/EdmundCore/Diagnostics/Log.swift
+++ b/Sources/EdmundCore/Diagnostics/Log.swift
@@ -129,6 +129,8 @@ public enum Log {
             case .thematicBreak:          return "hr·\(c)c"
             case .htmlBlock:              return "htmlBlock·\(c)c"
             case .blank:                  return "blank·\(c)c"
+            case .frontMatter:            return "frontMatter·\(c)c"
+            case .multiBlockComment:      return "comment·\(c)c"
             }
         }
         LogStore.shared.write(level: .debug, category: category,

--- a/Sources/EdmundCore/Editing/EditorTextView+FormattingCore.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+FormattingCore.swift
@@ -39,7 +39,7 @@ extension EditorTextView {
         rawSource = ns.replacingCharacters(in: clamped, with: replacement)
         rebuildListIndentState()
         rebuildLinkDefState()
-        blocks = BlockParser.parse(rawSource, previous: blocks)
+        blocks = BlockParser.parse(rawSource, previous: blocks, features: markdownFeatures)
 
         // The replaced region grew/shrank by `delta`; the new block-aligned span
         // is the old span plus that delta. Its text is the storage replacement.
@@ -76,7 +76,7 @@ extension EditorTextView {
         rawSource = newRawSource
         rebuildListIndentState()
         rebuildLinkDefState()
-        blocks = BlockParser.parse(rawSource, previous: blocks)
+        blocks = BlockParser.parse(rawSource, previous: blocks, features: markdownFeatures)
 
         let len = (rawSource as NSString).length
         let loc = min(select.location, len)

--- a/Sources/EdmundCore/Editing/EditorTextView+Indentation.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+Indentation.swift
@@ -106,7 +106,7 @@ extension EditorTextView {
         let newRawStart = rawStart + indentLen
         let newRawEnd = rawEnd + indentLen * (endBlock - startBlock + 1)
 
-        blocks = BlockParser.parse(rawSource, previous: blocks)
+        blocks = BlockParser.parse(rawSource, previous: blocks, features: markdownFeatures)
 
         let selInRaw = sel.length > 0
             ? NSRange(location: newRawStart, length: newRawEnd - newRawStart) : nil
@@ -204,7 +204,7 @@ extension EditorTextView {
         let endOff = rawEnd - blocks[endBlock].range.location
         let newRawEnd = endBlockNewStart + max(0, endOff - removed[endBlock])
 
-        blocks = BlockParser.parse(rawSource, previous: blocks)
+        blocks = BlockParser.parse(rawSource, previous: blocks, features: markdownFeatures)
 
         let selInRaw = sel.length > 0
             ? NSRange(location: newRawStart, length: max(0, newRawEnd - newRawStart)) : nil

--- a/Sources/EdmundCore/Editing/EditorTextView+ListRenumbering.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+ListRenumbering.swift
@@ -164,7 +164,7 @@ extension EditorTextView {
         let caretAfter = max(0, caretBefore + netDelta)
 
         rawSource = (rawSource as NSString).replacingCharacters(in: oldSpan, with: newText)
-        blocks = BlockParser.parse(rawSource, previous: blocks)
+        blocks = BlockParser.parse(rawSource, previous: blocks, features: markdownFeatures)
 
         // `recomposeReplacing` wipes the whole replaced span to base
         // attributes before restyling only the dirty blocks — every block in

--- a/Sources/EdmundCore/Export/HTMLRenderer.swift
+++ b/Sources/EdmundCore/Export/HTMLRenderer.swift
@@ -61,10 +61,57 @@ struct HTMLRenderer: MarkupVisitor {
     /// Parses `markdown` and returns the rendered HTML body (no `<html>`/`<head>`
     /// wrapper — `DocumentHTML` adds that).
     static func render(markdown: String, options: ReadRenderOptions = .default) -> String {
-        var r = HTMLRenderer(source: markdown, options: options)
-        let doc = Document(parsing: markdown, options: [.disableSmartOpts])
+        // Strip block constructs swift-markdown can't hide for us before it
+        // parses (front matter, block-spanning `%%…%%`). `source` and `doc`
+        // must see the same text so range-based raw-text recovery stays aligned.
+        let prepared = preprocess(markdown, options: options)
+        var r = HTMLRenderer(source: prepared, options: options)
+        let doc = Document(parsing: prepared, options: [.disableSmartOpts])
         let body = r.visit(doc)
         return body + r.renderFootnotesSection()
+    }
+
+    /// Removes constructs that must be gone before swift-markdown parses:
+    /// leading YAML front matter (hidden in Read) and block-spanning `%%…%%`
+    /// comments (swift-markdown splits them at blank lines, so the per-node
+    /// inline `.comment` pass can't catch them). Each gated by its flag.
+    private static func preprocess(_ markdown: String, options: ReadRenderOptions) -> String {
+        var s = markdown
+        if options.features.contains(.frontMatter) { s = stripFrontMatter(s) }
+        if options.features.contains(.multiBlockComment) { s = stripMultiBlockComments(s) }
+        return s
+    }
+
+    /// Drops a leading `---`…`---` YAML block (and one following blank line).
+    /// No leading `---`, or no closing `---`, ⇒ unchanged.
+    private static func stripFrontMatter(_ md: String) -> String {
+        let lines = md.components(separatedBy: "\n")
+        guard let first = lines.first,
+              first.trimmingCharacters(in: .whitespaces) == "---" else { return md }
+        for k in 1..<lines.count where lines[k].trimmingCharacters(in: .whitespaces) == "---" {
+            var rest = Array(lines[(k + 1)...])
+            if rest.first == "" { rest.removeFirst() }   // one blank separator
+            return rest.joined(separator: "\n")
+        }
+        return md   // unclosed: not front matter
+    }
+
+    private static let multiBlockCommentRegex =
+        try! NSRegularExpression(pattern: "%%[\\s\\S]*?%%")
+
+    /// Removes `%%…%%` comments that span lines (the block-level case). A
+    /// single-line `%%x%%` is left to the inline `.comment` pass.
+    private static func stripMultiBlockComments(_ md: String) -> String {
+        let ns = md as NSString
+        let matches = multiBlockCommentRegex.matches(
+            in: md, range: NSRange(location: 0, length: ns.length))
+        guard !matches.isEmpty else { return md }
+        let result = NSMutableString(string: md)
+        // Replace from the end so earlier match ranges stay valid.
+        for m in matches.reversed() where ns.substring(with: m.range).contains("\n") {
+            result.replaceCharacters(in: m.range, with: "")
+        }
+        return result as String
     }
 
     /// `[^id]: body` definitions render at the bottom of the page as a `<hr>` +

--- a/Sources/EdmundCore/Model/Block.swift
+++ b/Sources/EdmundCore/Model/Block.swift
@@ -17,6 +17,12 @@ public enum BlockKind: Equatable, Sendable {
     case thematicBreak
     case htmlBlock
     case blank
+    /// A YAML `---`…`---` fence at the very start of the document (Obsidian
+    /// front matter). Dim monospace in Edit, hidden in Read.
+    case frontMatter
+    /// An Obsidian `%%…%%` comment whose fences sit on different lines, merged
+    /// into one block so the inline `.comment` styling can span it.
+    case multiBlockComment
 }
 
 /// A Block is one paragraph of markdown — the unit of rendering.

--- a/Sources/EdmundCore/Parsing/BlockParser.swift
+++ b/Sources/EdmundCore/Parsing/BlockParser.swift
@@ -15,17 +15,18 @@ import Markdown
 ///      the recompose engine restyles.
 public enum BlockParser {
 
-    public static func parse(_ text: String, previous: [Block] = []) -> [Block] {
-        parseWithDiff(text, previous: previous).blocks
+    public static func parse(_ text: String, previous: [Block] = [],
+                             features: MarkdownFeatures = .all) -> [Block] {
+        parseWithDiff(text, previous: previous, features: features).blocks
     }
 
     /// Parses `text` and returns the blocks plus the changed window: the range
     /// of indices (in the new list) outside the unchanged prefix/suffix.
     public static func parseWithDiff(
-        _ text: String, previous: [Block] = []
+        _ text: String, previous: [Block] = [], features: MarkdownFeatures = .all
     ) -> (blocks: [Block], changed: Range<Int>) {
         let nsText = text as NSString
-        let paragraphs = splitParagraphs(text)
+        let paragraphs = splitParagraphs(text, features: features)
 
         var blocks: [Block] = []
         blocks.reserveCapacity(paragraphs.count)
@@ -68,13 +69,27 @@ public enum BlockParser {
         text: String,
         old: [Block],
         editedOldRange: NSRange,
-        delta: Int
+        delta: Int,
+        features: MarkdownFeatures = .all
     ) -> (blocks: [Block], changed: Range<Int>)? {
         guard !old.isEmpty else { return nil }
         let newLength = (text as NSString).length
         let oldLength = newLength - delta
         guard editedOldRange.location >= 0,
               editedOldRange.upperBound <= oldLength else { return nil }
+
+        // Front matter is anchored at the document start (`i == 0`) yet its
+        // extent depends on a closing `---` that can sit anywhere below — so an
+        // edit far from the top can form, dissolve, or resize it, which the
+        // incremental splice can't track without stranding a stale block-0 kind.
+        // Whenever front matter is in play (the doc now starts with a `---`
+        // opener, or block 0 was front matter) fall back to the full parse. It's
+        // cheap and rare — only documents that begin with `---`.
+        if features.contains(.frontMatter),
+           firstLine(of: text).trimmingCharacters(in: .whitespaces) == "---"
+            || old.first?.kind == .frontMatter {
+            return nil
+        }
 
         guard let firstAffected = blockIndex(in: old, forOffset: editedOldRange.location)
         else { return nil }
@@ -127,7 +142,8 @@ public enum BlockParser {
             }
 
             guard let (content, kind, next) = consumeBlock(&buf, at: lineIndex,
-                                                           prevLine: prevLine) else {
+                                                           prevLine: prevLine,
+                                                           features: features) else {
                 break   // end of document: the window runs to the end
             }
             let length = (content as NSString).length
@@ -267,9 +283,33 @@ public enum BlockParser {
     /// start) — the only backward context any rule uses: an indented code
     /// block may start only after a blank line. Returns the block's
     /// content/kind and the index of the line after it.
-    static func consumeBlock(_ buf: inout LineBuffer, at i: Int, prevLine: String?)
+    static func consumeBlock(_ buf: inout LineBuffer, at i: Int, prevLine: String?,
+                             features: MarkdownFeatures = .all)
         -> (content: String, kind: BlockKind, next: Int)? {
         guard let first = buf.line(at: i) else { return nil }
+
+        // YAML front matter: a `---`…`---` fence pair at the very start of the
+        // document (`i == 0 && prevLine == nil` is the doc start in both the
+        // full and incremental parse paths). Checked before the setext and
+        // thematic-break classification below so a leading `---` opens front
+        // matter instead of becoming a rule. Requires a *closing* `---`, so a
+        // lone `---` (or `---` followed by non-front-matter) falls through to a
+        // thematic break.
+        if features.contains(.frontMatter), i == 0, prevLine == nil,
+           first.trimmingCharacters(in: .whitespaces) == "---" {
+            var merged = [first]
+            var j = i + 1
+            var closed = false
+            while let line = buf.line(at: j) {
+                merged.append(line)
+                j += 1
+                if line.trimmingCharacters(in: .whitespaces) == "---" { closed = true; break }
+            }
+            if closed {
+                return (merged.joined(separator: "\n"), .frontMatter, j)
+            }
+            // No closing fence: not front matter — fall through to normal handling.
+        }
 
         // Detect opening code fence
         if let fence = codeFenceInfo(first) {
@@ -318,6 +358,24 @@ public enum BlockParser {
                 if line.contains("$$") { break }
             }
             return (merged.joined(separator: "\n"), .listItem, j)
+        }
+
+        // Obsidian multi-line `%%…%%` comment: a line that starts with `%%` and
+        // is not closed by a second `%%` on the same line opens a comment that
+        // spans following blocks. Merge forward to the line that closes it.
+        // A single-line `%%x%%` closes on its own line and is left to the inline
+        // `.comment` pass. Placed after the fence/math branches (which may hold
+        // a literal `%%`) and before the quote/paragraph handling.
+        if features.contains(.multiBlockComment),
+           let closedOnSameLine = multiBlockCommentOpener(first), !closedOnSameLine {
+            var merged = [first]
+            var j = i + 1
+            while let line = buf.line(at: j) {
+                merged.append(line)
+                j += 1
+                if line.contains("%%") { break }
+            }
+            return (merged.joined(separator: "\n"), .multiBlockComment, j)
         }
 
         // Merge block-quote lines into one block (the editor's styling /
@@ -477,14 +535,17 @@ public enum BlockParser {
     /// Splits text into paragraphs on single newlines, merging fenced code blocks
     /// and table rows into single multi-line blocks. Each paragraph is tagged
     /// with its `BlockKind`.
-    private static func splitParagraphs(_ text: String) -> [(content: String, kind: BlockKind)] {
+    private static func splitParagraphs(_ text: String,
+                                        features: MarkdownFeatures = .all)
+        -> [(content: String, kind: BlockKind)] {
         if text.isEmpty { return [("", .blank)] }
 
         var buf = LineBuffer(text)
         var result: [(content: String, kind: BlockKind)] = []
         var i = 0
         var prevLine: String? = nil
-        while let (content, kind, next) = consumeBlock(&buf, at: i, prevLine: prevLine) {
+        while let (content, kind, next) = consumeBlock(&buf, at: i, prevLine: prevLine,
+                                                       features: features) {
             result.append((content, kind))
             i = next
             prevLine = lastLine(of: content)
@@ -675,6 +736,16 @@ public enum BlockParser {
         let trimmed = line.drop(while: { $0 == " " })
         guard trimmed.hasPrefix("$$") else { return nil }
         return trimmed.dropFirst(2).contains("$$")
+    }
+
+    /// If the line (after optional leading whitespace) starts with `%%`, returns
+    /// whether a second `%%` also appears on the same line (a one-line `%%…%%`
+    /// comment, left to the inline pass). Returns nil when the line is not a
+    /// `%%` opener.
+    private static func multiBlockCommentOpener(_ line: String) -> Bool? {
+        let trimmed = line.drop(while: { $0 == " " })
+        guard trimmed.hasPrefix("%%") else { return nil }
+        return trimmed.dropFirst(2).contains("%%")
     }
 
     /// Returns true if the line is a block-quote line (optional leading spaces

--- a/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
@@ -750,6 +750,19 @@ extension EditorTextView {
         }
     }
 
+    /// Dim monospaced styling for a YAML front-matter block: like `sourceStyled`
+    /// but faint, and — crucially — the YAML text is never parsed as markdown.
+    func styleFrontMatter(_ markdown: String) -> NSAttributedString {
+        let mono = theme.monospaceFont(ofSize: bodyFont.pointSize)
+        let ps = NSMutableParagraphStyle()
+        ps.lineSpacing = theme.lineSpacing
+        return NSAttributedString(string: markdown, attributes: [
+            .font: mono,
+            .foregroundColor: syntaxDimColor,
+            .paragraphStyle: ps,
+        ])
+    }
+
     /// Plain monospaced styling for source mode: the raw markdown with no
     /// markup interpretation (no hidden delimiters, overlays, or decorations).
     func sourceStyled(_ markdown: String) -> NSAttributedString {
@@ -776,10 +789,17 @@ extension EditorTextView {
         guard block.range.upperBound <= ts.length else { return }
 
         let styled: NSAttributedString
-        switch viewMode {
-        case .edit:    styled = styleBlock(block.content, cursorPosition: cursorInBlock)
-        case .reading: styled = styleBlock(block.content, cursorPosition: nil, hideComments: true)
-        case .source:  styled = sourceStyled(block.content)
+        if case .frontMatter = block.kind, viewMode != .source {
+            // YAML front matter: flat dim monospace. Never run YAML through the
+            // markdown span parser — a `- x` line would list-style and `#x`
+            // would tag-style. (Source mode still shows plain raw mono below.)
+            styled = styleFrontMatter(block.content)
+        } else {
+            switch viewMode {
+            case .edit:    styled = styleBlock(block.content, cursorPosition: cursorInBlock)
+            case .reading: styled = styleBlock(block.content, cursorPosition: nil, hideComments: true)
+            case .source:  styled = sourceStyled(block.content)
+            }
         }
         let offset = block.range.location
 

--- a/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
@@ -753,7 +753,7 @@ extension EditorTextView {
     /// Dim monospaced styling for a YAML front-matter block: like `sourceStyled`
     /// but faint, and — crucially — the YAML text is never parsed as markdown.
     func styleFrontMatter(_ markdown: String) -> NSAttributedString {
-        let mono = theme.monospaceFont(ofSize: bodyFont.pointSize)
+        let mono = theme.monospaceFont()   // the mono font + size recorded in settings
         let ps = NSMutableParagraphStyle()
         ps.lineSpacing = theme.lineSpacing
         return NSAttributedString(string: markdown, attributes: [

--- a/Sources/EdmundCore/TextView/EditorTextView+EditFlow.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+EditFlow.swift
@@ -166,7 +166,8 @@ extension EditorTextView {
            let incremental = BlockParser.incrementalParse(text: rawSource,
                                                           old: blocks,
                                                           editedOldRange: pending.oldRange,
-                                                          delta: pending.delta) {
+                                                          delta: pending.delta,
+                                                          features: markdownFeatures) {
             (newBlocks, changed) = incremental
             #if DEBUG
             verifyIncrementalParse(newBlocks)
@@ -187,7 +188,8 @@ extension EditorTextView {
             listIndentUnit = listIndentState.unit
             defsChanged = linkDefState != oldDefState
         } else {
-            (newBlocks, changed) = BlockParser.parseWithDiff(rawSource, previous: blocks)
+            (newBlocks, changed) = BlockParser.parseWithDiff(rawSource, previous: blocks,
+                                                             features: markdownFeatures)
             let oldDefState = linkDefState
             rebuildListIndentState()
             rebuildLinkDefState()
@@ -261,7 +263,7 @@ extension EditorTextView {
     /// to differ). Skipped under MD_PERF so measurements stay representative.
     private func verifyIncrementalParse(_ incremental: [Block]) {
         guard ProcessInfo.processInfo.environment["MD_PERF"] == nil else { return }
-        let reference = BlockParser.parse(rawSource)
+        let reference = BlockParser.parse(rawSource, features: markdownFeatures)
         guard incremental.count == reference.count else {
             assertionFailure("""
             incremental parse diverged: \(incremental.count) blocks \

--- a/Sources/EdmundCore/TextView/EditorTextView+Undo.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+Undo.swift
@@ -107,7 +107,8 @@ extension EditorTextView {
         rawSource = snapshot.rawSource
         rebuildListIndentState()
         rebuildLinkDefState()
-        let (newBlocks, changed) = BlockParser.parseWithDiff(rawSource, previous: blocks)
+        let (newBlocks, changed) = BlockParser.parseWithDiff(rawSource, previous: blocks,
+                                                             features: markdownFeatures)
         blocks = newBlocks
 
         var dirty = IndexSet(integersIn: changed)

--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -316,7 +316,7 @@ public class EditorTextView: NSTextView {
         rawSource = ""
         rebuildListIndentState()
         rebuildLinkDefState()
-        blocks = BlockParser.parse(rawSource)
+        blocks = BlockParser.parse(rawSource, features: markdownFeatures)
         recompose(cursorInRaw: 0)
 
         // Vend decoration-drawing layout fragments (TextKit 2).
@@ -522,7 +522,7 @@ public class EditorTextView: NSTextView {
         rawSource = ts.string
         rebuildListIndentState()
         rebuildLinkDefState()
-        blocks = BlockParser.parse(rawSource, previous: blocks)
+        blocks = BlockParser.parse(rawSource, previous: blocks, features: markdownFeatures)
         recompose(cursorInRaw: min(selectedRange().location, (rawSource as NSString).length))
     }
 
@@ -580,7 +580,7 @@ public class EditorTextView: NSTextView {
             rawSource = LineEnding.normalize(content)
             rebuildListIndentState()
             rebuildLinkDefState()
-            blocks = BlockParser.parse(rawSource)
+            blocks = BlockParser.parse(rawSource, features: markdownFeatures)
             Log.blockStructure(blocks)
             undoStack.removeAll()
             redoStack.removeAll()

--- a/Tests/EdmundTests/BlockSyntaxTests.swift
+++ b/Tests/EdmundTests/BlockSyntaxTests.swift
@@ -1,0 +1,101 @@
+import Testing
+import AppKit
+@testable import EdmundCore
+
+/// Block-level Phase-2 syntax: YAML front matter and multi-block `%%…%%`
+/// comments. Both are structural (`BlockParser`) and gated by their flag —
+/// cleared, `---` / `%%` fall back to their existing classification.
+@Suite("Block syntax (front matter & multi-block comment)")
+struct BlockSyntaxTests {
+
+    private func kinds(_ src: String, _ features: MarkdownFeatures) -> [BlockKind] {
+        BlockParser.parse(src, features: features).map(\.kind)
+    }
+    private func html(_ src: String, _ features: MarkdownFeatures) -> String {
+        HTMLRenderer.render(markdown: src, options: ReadRenderOptions(features: features))
+    }
+
+    // MARK: - Front matter
+
+    @Test("Leading ---…--- is one frontMatter block; body follows")
+    func frontMatterParses() {
+        let ks = kinds("---\ntitle: x\ntags: [a]\n---\n\nbody", .all)
+        #expect(ks.first == .frontMatter)
+        // Exactly one front-matter block, and the body is still there.
+        #expect(ks.filter { $0 == .frontMatter }.count == 1)
+        #expect(ks.contains { if case .paragraph = $0 { return true }; return false })
+    }
+
+    @Test("With the flag cleared, leading --- is a thematic break, not front matter")
+    func frontMatterOff() {
+        let ks = kinds("---\ntitle: x\n---\n\nbody", MarkdownFeatures.all.subtracting(.frontMatter))
+        #expect(!ks.contains(.frontMatter))
+        #expect(ks.first == .thematicBreak)
+    }
+
+    @Test("A lone --- (no closing fence) stays a thematic break")
+    func frontMatterNeedsClose() {
+        #expect(kinds("---\n# Heading", .all).first == .thematicBreak)
+        #expect(kinds("---", .all).first == .thematicBreak)
+    }
+
+    @Test("A mid-document ---…--- is not front matter")
+    func frontMatterOnlyAtStart() {
+        let ks = kinds("intro\n\n---\na: b\n---\n\nbody", .all)
+        #expect(!ks.contains(.frontMatter))
+    }
+
+    @Test("Read: front matter is omitted when on, rendered as <hr> when off")
+    func readFrontMatter() {
+        let on = html("---\ntitle: x\n---\n\nbody", .all)
+        #expect(!on.contains("title") && on.contains("body"))
+        let off = html("---\ntitle: x\n---\n\nbody", MarkdownFeatures.all.subtracting(.frontMatter))
+        #expect(off.contains("<hr"))
+    }
+
+    @MainActor
+    @Test("Edit: a front-matter block is dim monospace, YAML not markdown-parsed")
+    func editFrontMatter() {
+        let editor = makeEditor()
+        paste("---\n- notalist\n---\n\nbody", into: editor)
+        editor.setSelectedRange(NSRange(location: 0, length: 0))
+        editor.recomposeAllDirty()
+        guard let ts = editor.textStorage else { Issue.record("no storage"); return }
+        // The `- notalist` inside front matter must NOT become a list marker;
+        // the whole fence is dim + monospace. Check the `t` of "title"/"-".
+        let font = ts.attribute(.font, at: 4, effectiveRange: nil) as? NSFont
+        #expect(font?.fontName.contains("Mono") == true || font!.isFixedPitch)
+        let fg = ts.attribute(.foregroundColor, at: 4, effectiveRange: nil) as? NSColor
+        #expect(fg == editor.syntaxDimColor)
+    }
+
+    // MARK: - Multi-block comment
+
+    @Test("A %%…%% spanning a blank line merges to one multiBlockComment block")
+    func multiBlockMerges() {
+        let ks = kinds("%%\nhidden\n\nstill hidden\n%%\n\nvisible", .all)
+        #expect(ks.first == .multiBlockComment)
+        #expect(ks.filter { $0 == .multiBlockComment }.count == 1)
+    }
+
+    @Test("With the flag cleared, the %% lines are not merged into a comment block")
+    func multiBlockOff() {
+        let ks = kinds("%%\nhidden\n\nstill\n%%", MarkdownFeatures.all.subtracting(.multiBlockComment))
+        #expect(!ks.contains(.multiBlockComment))
+    }
+
+    @Test("A single-line %%x%% is left alone (inline comment, not a block)")
+    func singleLineCommentUnaffected() {
+        let ks = kinds("%%just inline%%", .all)
+        #expect(!ks.contains(.multiBlockComment))
+    }
+
+    @Test("Read: a block-spanning %% comment body is dropped when on")
+    func readMultiBlockComment() {
+        let on = html("%%\nsecret note\n\nmore secret\n%%\n\nvisible", .all)
+        #expect(!on.contains("secret") && on.contains("visible"))
+        // Off: the comment isn't stripped, so its text survives in some form.
+        let off = html("%%\nsecret note\n%%\n\nvisible", MarkdownFeatures.all.subtracting(.multiBlockComment))
+        #expect(off.contains("visible"))
+    }
+}

--- a/Tests/EdmundTests/TestHelpers.swift
+++ b/Tests/EdmundTests/TestHelpers.swift
@@ -192,7 +192,14 @@ func expectedFullComposition(for editor: EditorTextView) -> NSAttributedString {
         guard block.range.upperBound <= composed.length, block.isStyled else { continue }
         let cursorInBlock: Int? = (i == editor.activeBlockIndex)
             ? max(0, cursorInRaw - block.range.location) : nil
-        let styled = editor.styleBlock(block.content, cursorPosition: cursorInBlock)
+        // Mirror restyleBlock: a front-matter block is styled dim-mono, not
+        // parsed as markdown.
+        let styled: NSAttributedString
+        if case .frontMatter = block.kind {
+            styled = editor.styleFrontMatter(block.content)
+        } else {
+            styled = editor.styleBlock(block.content, cursorPosition: cursorInBlock)
+        }
         styled.enumerateAttributes(
             in: NSRange(location: 0, length: styled.length), options: []
         ) { attrs, range, _ in


### PR DESCRIPTION
## What

Completes Phase 2 of Obsidian-flavored-markdown support — the two remaining **block-level** constructs. Their flags were declared and settings-mapped in Phase 1 (PR #225); this makes them functional. Follows the inline pair (PR #226).

- **YAML front matter** — a `---`…`---` fence at document start (new `.frontMatter` BlockKind). Requires a *closing* `---`, else the leading `---` stays a thematic break. **Edit:** dim monospace, and the YAML is never run through the markdown span parser (a `- x` line must not become a list). **Read:** stripped before swift-markdown parses. Gate: `.frontMatter`.
- **Multi-block `%%…%%` comment** — a `%%` opener not closed on its own line merges following blocks to the closing `%%` (new `.multiBlockComment` BlockKind). **Edit styling is free**: once merged, the existing inline `.comment` span covers it. **Read:** multi-line `%%…%%` stripped from source (single-line `%%x%%` stays to the inline pass). Gate: `.multiBlockComment`.

**No new flags or settings UI** — the `synFrontMatter` / `synComment` toggles already ship.

## Notable

`MarkdownFeatures` is now threaded into `BlockParser` (`parse`/`parseWithDiff`/`incrementalParse`/`consumeBlock`) and passed from every `EditorTextView` call site; the `.all` default keeps other callers unchanged. Front matter is anchored at the document start yet its extent depends on a far-away closing `---`, which the incremental splice can't track — so `incrementalParse` falls back to a full parse whenever the document starts with `---` or block 0 was front matter (cheap, rare). The full-recompose test oracle was updated to mirror the new front-matter styling.

## Verification

- `swift test` — 1084 pass, including the incremental-parse fuzz (all seeds) which caught and now guards the front-matter forward-dependency, plus 10 new `BlockSyntaxTests`.
- Visual: built the app and `screencapture`-verified — front matter dim monospace in Edit / absent in Read; a `%%` comment spanning a blank line hidden in both; YAML body not markdown-parsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)