### PR TITLE
Add /prune-worktrees skill + script

### DIFF
--- a/.claude/commands/prune-worktrees.md
+++ b/.claude/commands/prune-worktrees.md
@@ -1,0 +1,22 @@
+---
+description: Remove git worktrees whose branch is already merged into main (runs scripts/prune-worktrees.sh)
+argument-hint: [go] (omit for a dry run; pass "go" to actually remove)
+allowed-tools: Bash(scripts/prune-worktrees.sh:*)
+---
+
+Run the hardcoded prune script from the repository root and report its output
+verbatim. The logic lives entirely in the script — do not reimplement it.
+
+```
+scripts/prune-worktrees.sh $ARGUMENTS
+```
+
+- No argument ⇒ dry run: prints the plan (which worktrees are prunable and why
+  each other is skipped), changes nothing.
+- `go` ⇒ removes every prunable worktree (auto-unlocking locked ones first) and
+  deletes its merged branch.
+
+The script only removes worktrees whose branch is merged into `origin/main`, are
+clean, and are neither the current nor the main worktree. It never force-removes
+and never deletes an unmerged branch. After running, relay exactly what it
+removed and what it skipped.

--- a/scripts/prune-worktrees.sh
+++ b/scripts/prune-worktrees.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# Prune git worktrees whose branch is already merged into origin/main.
+#
+# Conservative and deterministic. A worktree is removed only when ALL hold:
+#   - it is NOT the main working tree and NOT the worktree this script runs in
+#   - its branch is an ANCESTOR of origin/main (a real merge — squash/rebase
+#     merges are not ancestors and are left alone for manual review)
+#   - its working tree is clean (no uncommitted changes)
+# Locked worktrees that otherwise qualify are auto-unlocked first (the current
+# and main worktrees are never touched, lock or no lock).
+#
+# Usage:
+#   scripts/prune-worktrees.sh          # dry run: print the plan, change nothing
+#   scripts/prune-worktrees.sh go       # actually unlock/remove the prunable ones
+#
+# After removing a worktree, its branch is deleted with `git branch -d` (safe:
+# only deletes if merged). Never force-removes, never touches an unmerged branch.
+set -euo pipefail
+
+MODE="${1:-dry}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+# The worktree this script is executing in — never remove it.
+CURRENT="$REPO_ROOT"
+# The main working tree (first entry of `git worktree list`) — never remove it.
+MAIN_WT="$(git worktree list --porcelain | sed -n 's/^worktree //p' | head -1)"
+
+cd "$MAIN_WT"
+git fetch origin main --quiet
+
+# --- parse `git worktree list --porcelain` into parallel arrays ---
+paths=(); heads=(); branches=(); locks=()
+p=""; h=""; b=""; l="-"
+flush() { [ -n "$p" ] && { paths+=("$p"); heads+=("$h"); branches+=("$b"); locks+=("$l"); }; p=""; h=""; b=""; l="-"; }
+while IFS= read -r line || [ -n "$line" ]; do
+  case "$line" in
+    "worktree "*) flush; p="${line#worktree }" ;;
+    "HEAD "*)     h="${line#HEAD }" ;;
+    "branch "*)   b="${line#refs/heads/}"; b="${b#branch refs/heads/}" ;;
+    "detached")   b="(detached)" ;;
+    "locked"*)    l="LOCKED" ;;
+  esac
+done < <(git worktree list --porcelain)
+flush
+
+printf '%-52s %-42s %s\n' "WORKTREE" "BRANCH" "VERDICT"
+prune_paths=(); prune_branches=(); prune_locked=()
+for i in "${!paths[@]}"; do
+  wp="${paths[$i]}"; wh="${heads[$i]}"; wb="${branches[$i]}"; wl="${locks[$i]}"
+  name="${wp##*/}"
+  if [ "$wp" = "$MAIN_WT" ]; then                                   v="main worktree (skip)"
+  elif [ "$wp" = "$CURRENT" ]; then                                 v="current (skip)"
+  elif [ "$wb" = "(detached)" ]; then                               v="detached HEAD (skip)"
+  elif ! git merge-base --is-ancestor "$wh" origin/main 2>/dev/null; then v="not merged / squash (skip)"
+  elif [ -n "$(git -C "$wp" status --porcelain 2>/dev/null)" ]; then v="dirty (skip)"
+  else
+    v="PRUNABLE"; [ "$wl" = "LOCKED" ] && v="PRUNABLE (auto-unlock)"
+    prune_paths+=("$wp"); prune_branches+=("$wb"); prune_locked+=("$wl")
+  fi
+  printf '%-52s %-42s %s\n' "$name" "$wb" "$v"
+done
+
+echo ""
+echo "Prunable: ${#prune_paths[@]}"
+if [ "${#prune_paths[@]}" -eq 0 ]; then exit 0; fi
+
+if [ "$MODE" != "go" ] && [ "$MODE" != "--force" ]; then
+  echo "(dry run — pass 'go' to remove)"
+  exit 0
+fi
+
+echo "=== removing ==="
+for i in "${!prune_paths[@]}"; do
+  wp="${prune_paths[$i]}"; wb="${prune_branches[$i]}"
+  if [ "${prune_locked[$i]}" = "LOCKED" ]; then
+    git worktree unlock "$wp" && echo "unlocked: ${wp##*/}"
+  fi
+  if git worktree remove "$wp"; then
+    echo "removed worktree: ${wp##*/}"
+    if git branch -d "$wb" >/dev/null 2>&1; then
+      echo "  deleted branch: $wb"
+    else
+      echo "  branch kept (not safe-deletable): $wb"
+    fi
+  else
+    echo "SKIP (remove failed): ${wp##*/}"
+  fi
+done
+git worktree prune
+echo "=== done ==="
+git worktree list


### PR DESCRIPTION
## What

A manually-triggered `/prune-worktrees` command backed by a hardcoded script `scripts/prune-worktrees.sh`.

Removes git worktrees whose branch is already **merged into `origin/main`** and whose tree is **clean**, **auto-unlocking** locked ones first. Never touches the **current** or **main** worktree, never force-removes, never deletes an unmerged branch. **Dry run by default**; `go` executes. Deletes the freed branch with the safe `git branch -d`.

Squash/rebase-merged branches (not ancestors of main) are left for manual review.

## Why

`.claude/worktrees/` accumulates stale merged checkouts. This session cleaned up 16 of them by hand; the script makes it repeatable.

## Files

- `scripts/prune-worktrees.sh` — all logic (parse `git worktree list --porcelain`, classify, unlock+remove).
- `.claude/commands/prune-worktrees.md` — thin `/prune-worktrees` wrapper that runs the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)