### PR TITLE
Fix test.md rendering bugs and dark-mode chrome palette

### DIFF
--- a/Sources/EdmundCore/Editing/EditorTextView+FormattingCommands.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+FormattingCommands.swift
@@ -67,7 +67,7 @@ extension EditorTextView {
     @objc public func formatCode(_ sender: Any?)          { toggleInlineWrap(open: "`", close: "`", expandToWord: true) }
     @objc public func formatInlineMath(_ sender: Any?)    { toggleInlineWrap(open: "$", close: "$", expandToWord: true) }
     @objc public func formatKeyboard(_ sender: Any?)      { toggleInlineWrap(open: "<kbd>", close: "</kbd>", expandToWord: true) }
-    @objc public func formatComment(_ sender: Any?)       { toggleInlineWrap(open: "%%", close: "%%", expandToWord: true) }
+    @objc public func formatComment(_ sender: Any?)       { toggleInlineWrap(open: "<!-- ", close: " -->", expandToWord: true) }
 
     // MARK: - Inline links
     // Link / Image: caret in `()` so URL can be typed next.
@@ -104,6 +104,29 @@ extension EditorTextView {
         applyCalloutType(type)
     }
 
+    // MARK: - Context menu
+
+    /// Builds the editor's right-click Font submenu, replacing the system one.
+    /// Set by the app (edmd) at menu setup so EdmundCore doesn't depend on the
+    /// Format-menu command table. nil → keep the system Font submenu.
+    public static var contextFontMenuProvider: (() -> NSMenu)?
+
+    /// Swap the system "Font" submenu (Show Fonts, Bold, Bigger, …) for our
+    /// Markdown Font menu (Bold, Italic, Highlight, Comments, …) so right-click
+    /// offers the same commands as Format ▸ Font.
+    public override func menu(for event: NSEvent) -> NSMenu? {
+        guard let menu = super.menu(for: event) else { return nil }
+        if let provider = Self.contextFontMenuProvider,
+           let fontItem = menu.items.first(where: { item in
+               item.submenu?.items.contains {
+                   $0.action == #selector(NSFontManager.orderFrontFontPanel(_:))
+               } == true
+           }) {
+            fontItem.submenu = provider()
+        }
+        return menu
+    }
+
     // MARK: - Menu validation
     // Formatting actions are disabled in Reading mode (the editor is read-only).
 
@@ -130,7 +153,8 @@ extension EditorTextView {
                                 representedObject: Any?) -> MarkdownFeatures? {
         switch action {
         case #selector(formatHighlight(_:)): return .highlight
-        case #selector(formatComment(_:)):   return .inlineComment
+        // formatComment inserts an HTML `<!-- -->` comment, which is always
+        // recognized (parseHTMLComments is not feature-gated) — so no gate.
         case #selector(formatWikilink(_:)):  return .wikilink
         case #selector(formatFootnote(_:)):  return .footnote
         case #selector(formatInlineMath(_:)), #selector(formatMathBlock(_:)): return .math

--- a/Sources/EdmundCore/Export/DocumentHTML.swift
+++ b/Sources/EdmundCore/Export/DocumentHTML.swift
@@ -79,13 +79,17 @@ enum DocumentHTML {
         }
         out = replaceMatches(out, pattern: displayInlineMathPattern) { groups in
             let tex = unescapeAttr(groups[1])
+            // Display math embedded in a prose line still gets its own centered
+            // block (a `<span>` promoted to display:block, since the placeholder
+            // sits inside a `<p>` where a `<div>` would be invalid). The
+            // paragraph's text keeps flowing above and below it.
             guard let r = mathImage(latex: tex, display: true,
                                     fontSize: theme.fontSize, color: color),
                   let data = pngData(r.image, scale: 2) else {
-                return "<code>\(HTMLRenderer.escape(tex))</code>"
+                return "<span class=\"math-display-block\"><code>\(HTMLRenderer.escape(tex))</code></span>"
             }
             let uri = "data:image/png;base64,\(data.base64EncodedString())"
-            return "<img class=\"math math-inline\" style=\"height:\(fmt(r.image.size.height))px; vertical-align:\(fmt(-r.descent))px\" src=\"\(uri)\" alt=\"\(HTMLRenderer.attr(tex))\">"
+            return "<span class=\"math-display-block\"><img class=\"math\" style=\"height:\(fmt(r.image.size.height))px\" src=\"\(uri)\" alt=\"\(HTMLRenderer.attr(tex))\"></span>"
         }
         return out
     }

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -274,6 +274,9 @@ enum HTMLTheme {
     img { max-width: 100%; }
     img.math { vertical-align: middle; }
     .math-display { text-align: center; margin: 1em 0; }
+    /* `$$…$$` embedded in a prose line: same centered block treatment, but as
+       a span (it lives inside the paragraph's <p>, where a <div> is invalid). */
+    .math-display-block { display: block; text-align: center; margin: 1em 0; }
     /* Stand-in for a plain-http image, which never loads under ATS. */
     .md-image-blocked { display: inline-flex; align-items: center; gap: 0.4em;
                         color: var(--faint); background: var(--code-bg);
@@ -342,7 +345,8 @@ enum HTMLTheme {
          keeps them. `print-color-adjust: exact` forces faithful color output
          so callout backgrounds, code blocks, and highlights survive printing. */
       * { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-      .callout, pre, blockquote, .table-wrap, .math-display { break-inside: avoid; }
+      .callout, pre, blockquote, .table-wrap, .math-display,
+      .math-display-block { break-inside: avoid; }
       h1, h2, h3, h4, h5, h6 { break-after: avoid; }
       thead { display: table-header-group; }
     }

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -35,6 +35,9 @@ enum HTMLTheme {
         let fg = dark ? "#e6e6e6" : "#1a1a1a"
         let faint = dark ? "#9a9a9a" : "#6a6a6a"
         let rule = dark ? "#3a3a3a" : "#e0e0e0"
+        // Markers, rules and table borders in dark mode: the same gray the editor
+        // draws them at (EditorTextView.darkChromeGray, 0.41 white).
+        let darkChrome = "#696969"
         let codeBg = dark ? "#2a2a2a" : "#f4f4f4"
 
         // line-height: editor `NSParagraphStyle.lineSpacing` adds extra points
@@ -62,9 +65,10 @@ enum HTMLTheme {
           --faint: \(faint);
           --rule: \(rule);
           --code-bg: \(codeBg);
-          --marker: \(resolvedRGBA(dark ? .secondaryLabelColor : .tertiaryLabelColor, dark: dark));
-          --table-border: \(resolvedRGBA(.secondaryLabelColor, dark: dark));
-          --hr: \(dark ? resolvedRGBA(.tertiaryLabelColor, dark: dark) : rule);
+          --marker: \(dark ? darkChrome : resolvedRGBA(.tertiaryLabelColor, dark: dark));
+          --table-border: \(dark ? darkChrome : rule);
+          --hr: \(dark ? darkChrome : rule);
+          --quote-bar: \(dark ? darkChrome : rule);
           --check-fill: \(resolvedRGBA(.controlAccentColor, dark: dark));
           --line-height: \(trim(lineHeight));
           --para-space: \(trim(max(theme.paragraphSpacingBefore, 0)))px;
@@ -180,9 +184,9 @@ enum HTMLTheme {
        at rest. */
     .code-copy-icon { opacity: 0; transition: opacity .15s; }
     .code-block-wrap:hover .code-copy-icon { opacity: 1; }
-    /* Bar color matches Edit mode's quote bar (tertiaryLabelColor, = --marker);
-       --rule was too faint to read as a quote marker. */
-    blockquote { margin: 1em 0; padding: 0.5em 1em; border-left: 3px solid var(--marker); color: var(--faint); }
+    /* Dark mode lifts the bar to the marker gray (--rule is nearly invisible
+       there); light mode keeps --rule. */
+    blockquote { margin: 1em 0; padding: 0.5em 1em; border-left: 3px solid var(--quote-bar); color: var(--faint); }
     /* Without this, the 1em bottom margin on the last <p> inside a blockquote
        creates asymmetric vertical padding — the blockquote looks heavier at the
        bottom than at the top. Reset it so padding alone controls the spacing. */

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -62,7 +62,9 @@ enum HTMLTheme {
           --faint: \(faint);
           --rule: \(rule);
           --code-bg: \(codeBg);
-          --marker: \(resolvedRGBA(.tertiaryLabelColor, dark: dark));
+          --marker: \(resolvedRGBA(dark ? .secondaryLabelColor : .tertiaryLabelColor, dark: dark));
+          --table-border: \(resolvedRGBA(.secondaryLabelColor, dark: dark));
+          --hr: \(dark ? resolvedRGBA(.tertiaryLabelColor, dark: dark) : rule);
           --check-fill: \(resolvedRGBA(.controlAccentColor, dark: dark));
           --line-height: \(trim(lineHeight));
           --para-space: \(trim(max(theme.paragraphSpacingBefore, 0)))px;
@@ -178,7 +180,9 @@ enum HTMLTheme {
        at rest. */
     .code-copy-icon { opacity: 0; transition: opacity .15s; }
     .code-block-wrap:hover .code-copy-icon { opacity: 1; }
-    blockquote { margin: 1em 0; padding: 0.5em 1em; border-left: 3px solid var(--rule); color: var(--faint); }
+    /* Bar color matches Edit mode's quote bar (tertiaryLabelColor, = --marker);
+       --rule was too faint to read as a quote marker. */
+    blockquote { margin: 1em 0; padding: 0.5em 1em; border-left: 3px solid var(--marker); color: var(--faint); }
     /* Without this, the 1em bottom margin on the last <p> inside a blockquote
        creates asymmetric vertical padding — the blockquote looks heavier at the
        bottom than at the top. Reset it so padding alone controls the spacing. */
@@ -188,7 +192,7 @@ enum HTMLTheme {
        the parent's padding. Collapse it. */
     blockquote > blockquote:last-child,
     .callout-body > blockquote:last-child { margin-bottom: 0; }
-    hr { border: none; border-top: 1px solid var(--rule); margin: 1.6em 0; }
+    hr { border: none; border-top: 1px solid var(--hr); margin: 1.6em 0; }
     mark { background: rgba(255, 200, 0, 0.3); color: inherit; padding: 0 0.1em; }
     /* Obsidian #tag: an accent-colored pill. Style only, no navigation. */
     .tag { color: var(--accent);
@@ -225,6 +229,9 @@ enum HTMLTheme {
     ul { list-style-type: disc; }
     li { margin: 0.35em 0; }
     li::marker { color: var(--marker); font-size: 0.85em; }
+    /* Numbers read as text, not as a glyph: keep them at the item's own size so
+       Read mode matches Edit mode, where the "N." keeps the body font. */
+    ol > li::marker { font-size: 1em; }
     li > p { margin: 0; }
     /* Task items: float the checkbox into the marker slot so the label and
        wrapped lines sit at the same content edge as bullet/number text. The
@@ -269,7 +276,7 @@ enum HTMLTheme {
        wrap — same idiom as `pre`'s overflow-x below. */
     .table-wrap { overflow-x: auto; margin: 1em 0; }
     table { border-collapse: collapse; }
-    th, td { border: 1px solid var(--rule); padding: 6px 10px; }
+    th, td { border: 1px solid var(--table-border); padding: 6px 10px; }
     thead th { background: var(--code-bg); }
     img { max-width: 100%; }
     img.math { vertical-align: middle; }

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -74,7 +74,7 @@ enum HTMLTheme {
           --inline-code-bg: \(dark ? "#3c3c3c" : codeBg);
           --marker: \(dark ? darkChrome : resolvedRGBA(.tertiaryLabelColor, dark: dark));
           --table-border: \(dark ? darkRule : rule);
-          --hr: \(dark ? darkRule : rule);
+          --hr: \(dark ? "#4a4a4a" : rule);
           --quote-bar: \(dark ? darkChrome : rule);
           --check-fill: \(resolvedRGBA(.controlAccentColor, dark: dark));
           --line-height: \(trim(lineHeight));
@@ -170,7 +170,9 @@ enum HTMLTheme {
     h4 { font-size: 1.1em; } h5 { font-size: 1em; } h6 { font-size: 0.9em; color: var(--faint); }
     :is(h1, h2, h3, h4, h5, h6):first-child { margin-top: 0; }
     a { color: var(--accent); text-decoration: underline; }
-    code { font-family: var(--mono-font); font-size: 0.92em; color: var(--code);
+    /* Body color, not --code: the editor draws inline code in the body color
+       too, and the two views must agree. --code still tints block code. */
+    code { font-family: var(--mono-font); font-size: 0.92em; color: var(--fg);
            background: var(--inline-code-bg); padding: 0.1em 0.35em; border-radius: 4px; }
     pre { background: var(--code-bg); padding: 12px 14px; border-radius: 8px; overflow-x: auto;
           /* tab-size: browsers default to 8; match the common editor convention of 4. */
@@ -203,7 +205,7 @@ enum HTMLTheme {
        the parent's padding. Collapse it. */
     blockquote > blockquote:last-child,
     .callout-body > blockquote:last-child { margin-bottom: 0; }
-    hr { border: none; border-top: 1px solid var(--hr); margin: 1.6em 0; }
+    hr { border: none; border-top: 1.5px solid var(--hr); margin: 1.6em 0; }
     mark { background: rgba(255, 200, 0, 0.3); color: inherit; padding: 0 0.1em; }
     /* Obsidian #tag: an accent-colored pill. Style only, no navigation. */
     .tag { color: var(--accent);

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -40,7 +40,9 @@ enum HTMLTheme {
         let darkChrome = "#696969"
         // Rules and table borders sit a step dimmer (EditorTextView.darkRuleGray).
         let darkRule = "#555555"
-        let codeBg = dark ? "#2a2a2a" : "#f4f4f4"
+        // #2a2a2a sat one level above the #292929 page background — code blocks
+        // and table header rows had no visible tint at all in dark mode.
+        let codeBg = dark ? "#333333" : "#f4f4f4"
 
         // line-height: editor `NSParagraphStyle.lineSpacing` adds extra points
         // *between* lines on top of the font's natural leading (~1.2×). The CSS
@@ -67,6 +69,9 @@ enum HTMLTheme {
           --faint: \(faint);
           --rule: \(rule);
           --code-bg: \(codeBg);
+          /* Inline code sits directly on --bg, where the block --code-bg is only
+             one level lighter and reads as nothing; dark mode needs its own step. */
+          --inline-code-bg: \(dark ? "#3c3c3c" : codeBg);
           --marker: \(dark ? darkChrome : resolvedRGBA(.tertiaryLabelColor, dark: dark));
           --table-border: \(dark ? darkRule : rule);
           --hr: \(dark ? darkRule : rule);
@@ -166,7 +171,7 @@ enum HTMLTheme {
     :is(h1, h2, h3, h4, h5, h6):first-child { margin-top: 0; }
     a { color: var(--accent); text-decoration: underline; }
     code { font-family: var(--mono-font); font-size: 0.92em; color: var(--code);
-           background: var(--code-bg); padding: 0.1em 0.35em; border-radius: 4px; }
+           background: var(--inline-code-bg); padding: 0.1em 0.35em; border-radius: 4px; }
     pre { background: var(--code-bg); padding: 12px 14px; border-radius: 8px; overflow-x: auto;
           /* tab-size: browsers default to 8; match the common editor convention of 4. */
           tab-size: 4; -moz-tab-size: 4; }

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -38,6 +38,8 @@ enum HTMLTheme {
         // Markers, rules and table borders in dark mode: the same gray the editor
         // draws them at (EditorTextView.darkChromeGray, 0.41 white).
         let darkChrome = "#696969"
+        // Rules and table borders sit a step dimmer (EditorTextView.darkRuleGray).
+        let darkRule = "#555555"
         let codeBg = dark ? "#2a2a2a" : "#f4f4f4"
 
         // line-height: editor `NSParagraphStyle.lineSpacing` adds extra points
@@ -66,8 +68,8 @@ enum HTMLTheme {
           --rule: \(rule);
           --code-bg: \(codeBg);
           --marker: \(dark ? darkChrome : resolvedRGBA(.tertiaryLabelColor, dark: dark));
-          --table-border: \(dark ? darkChrome : rule);
-          --hr: \(dark ? darkChrome : rule);
+          --table-border: \(dark ? darkRule : rule);
+          --hr: \(dark ? darkRule : rule);
           --quote-bar: \(dark ? darkChrome : rule);
           --check-fill: \(resolvedRGBA(.controlAccentColor, dark: dark));
           --line-height: \(trim(lineHeight));

--- a/Sources/EdmundCore/Export/ReadModeWebView.swift
+++ b/Sources/EdmundCore/Export/ReadModeWebView.swift
@@ -212,12 +212,16 @@ public final class ReadModeWebView: WKWebView {
         webInspector?.perform(Selector(("hide")))
     }
 
-    /// Append "Inspect Reader" (⌥⌘I) to the web view's right-click menu,
-    /// mirroring the View-menu item. Already in Read mode here, so the item is
-    /// a plain open/close toggle of the inspector.
+    /// Append "Inspect Element" (⌥⌘I) to the web view's right-click menu.
+    /// Already in Read mode here, so the item is a plain open/close toggle of
+    /// the inspector. WebKit's own "Inspect Element" item is dropped first —
+    /// it does the same job without the toggle and without the shortcut, so
+    /// keeping both would just be a duplicate entry.
     public override func willOpenMenu(_ menu: NSMenu, with event: NSEvent) {
         super.willOpenMenu(menu, with: event)
-        let item = NSMenuItem(title: "Inspect Reader",
+        menu.items.filter { $0.identifier?.rawValue.contains("InspectElement") == true }
+            .forEach(menu.removeItem)
+        let item = NSMenuItem(title: "Inspect Element",
                               action: isWebInspectorVisible
                                   ? #selector(hideWebInspector(_:))
                                   : #selector(showWebInspector(_:)),

--- a/Sources/EdmundCore/Export/ReadModeWebView.swift
+++ b/Sources/EdmundCore/Export/ReadModeWebView.swift
@@ -191,15 +191,41 @@ public final class ReadModeWebView: WKWebView {
 
     // MARK: - Web Inspector (⌥⌘I)
 
+    /// The private `_WKInspector` backing this web view. A standalone WKWebView,
+    /// unlike Safari, doesn't bind ⌥⌘I on its own; `isInspectable` /
+    /// `developerExtrasEnabled` enable the inspector but never open it.
+    private var webInspector: NSObject? { value(forKey: "_inspector") as? NSObject }
+
+    /// Whether the Web Inspector is currently showing for this read view.
+    public var isWebInspectorVisible: Bool {
+        (webInspector?.value(forKey: "isVisible") as? Bool) ?? false
+    }
+
     /// Opens the Web Inspector on this read view. Wired to the View-menu item
-    /// ("Inspect Read View", ⌥⌘I), which routes here through the responder chain
-    /// while Read mode is first responder — so the item is auto-disabled in Edit
-    /// mode. A standalone WKWebView, unlike Safari, doesn't bind ⌥⌘I on its own;
-    /// `isInspectable`/`developerExtrasEnabled` enable the inspector but don't
-    /// open it. `_inspector` is a private `_WKInspector` exposing `show`.
+    /// ("Inspect Reader", ⌥⌘I) via `Document.toggleReaderInspector`.
     @objc public func showWebInspector(_ sender: Any?) {
-        guard let inspector = value(forKey: "_inspector") as? NSObject else { return }
-        inspector.perform(Selector(("show")))
+        webInspector?.perform(Selector(("show")))
+    }
+
+    /// Closes the Web Inspector, leaving the read view in place.
+    @objc public func hideWebInspector(_ sender: Any?) {
+        webInspector?.perform(Selector(("hide")))
+    }
+
+    /// Append "Inspect Reader" (⌥⌘I) to the web view's right-click menu,
+    /// mirroring the View-menu item. Already in Read mode here, so the item is
+    /// a plain open/close toggle of the inspector.
+    public override func willOpenMenu(_ menu: NSMenu, with event: NSEvent) {
+        super.willOpenMenu(menu, with: event)
+        let item = NSMenuItem(title: "Inspect Reader",
+                              action: isWebInspectorVisible
+                                  ? #selector(hideWebInspector(_:))
+                                  : #selector(showWebInspector(_:)),
+                              keyEquivalent: "i")
+        item.keyEquivalentModifierMask = [.command, .option]
+        item.target = self
+        menu.addItem(.separator())
+        menu.addItem(item)
     }
 
     /// Forwarded from the navigation coordinator's `didFinish`.

--- a/Sources/EdmundCore/Export/ReadModeWebView.swift
+++ b/Sources/EdmundCore/Export/ReadModeWebView.swift
@@ -189,6 +189,19 @@ public final class ReadModeWebView: WKWebView {
         reloadHTML()
     }
 
+    // MARK: - Web Inspector (⌥⌘I)
+
+    /// Opens the Web Inspector on this read view. Wired to the View-menu item
+    /// ("Inspect Read View", ⌥⌘I), which routes here through the responder chain
+    /// while Read mode is first responder — so the item is auto-disabled in Edit
+    /// mode. A standalone WKWebView, unlike Safari, doesn't bind ⌥⌘I on its own;
+    /// `isInspectable`/`developerExtrasEnabled` enable the inspector but don't
+    /// open it. `_inspector` is a private `_WKInspector` exposing `show`.
+    @objc public func showWebInspector(_ sender: Any?) {
+        guard let inspector = value(forKey: "_inspector") as? NSObject else { return }
+        inspector.perform(Selector(("show")))
+    }
+
     /// Forwarded from the navigation coordinator's `didFinish`.
     fileprivate func handleDidFinishLoad() {
         applyPendingScrollRestoreAndNotify()

--- a/Sources/EdmundCore/Parsing/SyntaxHighlighter+Walker.swift
+++ b/Sources/EdmundCore/Parsing/SyntaxHighlighter+Walker.swift
@@ -175,6 +175,26 @@ extension SyntaxHighlighter {
             let cLen = max(0, full.length - openDelimLen)
             var delimiterRanges = [NSRange(location: full.location, length: openDelimLen)]
 
+            // CommonMark allows up to 3 spaces of indent before the `#`, and
+            // cmark's range starts at the `#` — so that whitespace stayed visible
+            // at heading size and pushed the title right of every other block.
+            // Hide it with the opener.
+            let src = source as NSString
+            var indentStart = full.location
+            while indentStart > 0 {
+                let c = src.character(at: indentStart - 1)
+                guard c == 0x20 || c == 0x09 else { break }
+                indentStart -= 1
+            }
+            // Only when that whitespace is the start of the line — otherwise the
+            // run belongs to an enclosing marker (`> # x`), whose own styling
+            // owns it.
+            let atLineStart = indentStart == 0 || src.character(at: indentStart - 1) == 0x0A
+            if indentStart < full.location, atLineStart {
+                delimiterRanges[0] = NSRange(location: indentStart,
+                                             length: openDelimLen + full.location - indentStart)
+            }
+
             // Whatever raw text follows `full` to the end of this
             // single-line block is exactly what cmark trimmed as the
             // closing sequence (its required separating whitespace, the

--- a/Sources/EdmundCore/Parsing/SyntaxHighlighter.swift
+++ b/Sources/EdmundCore/Parsing/SyntaxHighlighter.swift
@@ -118,7 +118,23 @@ public enum SyntaxHighlighter {
         var walker = SpanCollector(source: parseText, features: features)
         walker.visit(doc)
         if !linkDefinitions.isEmpty {
-            walker.spans.removeAll { $0.fullRange.upperBound > textLen }
+            // A block-level node can legitimately run past the block into the
+            // appended region: an indented code block swallows the blank
+            // separator line, so its span ends at textLen+2. Dropping those
+            // left the block unstyled (serif, no mono). Clamp spans that START
+            // inside the block; drop only what begins in the appended region.
+            walker.spans = walker.spans.compactMap { span in
+                guard span.fullRange.location < textLen else { return nil }
+                guard span.fullRange.upperBound > textLen else { return span }
+                func clamp(_ r: NSRange) -> NSRange {
+                    NSRange(location: min(r.location, textLen),
+                            length: max(0, min(r.upperBound, textLen) - min(r.location, textLen)))
+                }
+                return Span(kind: span.kind,
+                            fullRange: clamp(span.fullRange),
+                            contentRange: clamp(span.contentRange),
+                            delimiterRanges: span.delimiterRanges.map(clamp).filter { $0.length > 0 })
+            }
         }
 
         // Each custom pass below is gated by its feature flag: a cleared flag

--- a/Sources/EdmundCore/Rendering/EditorTextView+CalloutRendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+CalloutRendering.swift
@@ -377,7 +377,7 @@ extension EditorTextView {
 
     // MARK: Colors (appearance-aware)
 
-    private var isDarkAppearance: Bool {
+    var isDarkAppearance: Bool {
         effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
     }
 

--- a/Sources/EdmundCore/Rendering/EditorTextView+CodeBlockRendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+CodeBlockRendering.swift
@@ -18,8 +18,11 @@ extension EditorTextView {
     /// Background tint for a code block's box. Matches Read mode's
     /// `--code-bg` (HTMLTheme.swift) so Edit and Read mode agree.
     var codeBlockBackground: NSColor {
-        effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
-            ? (NSColor(hex: "#2a2a2a") ?? NSColor(calibratedWhite: 0.16, alpha: 1))
+        // sRGB, not the calibrated `NSColor(hex:)` helper — same reason as
+        // `editorBackgroundColor`: calibrated renders visibly lighter, and this
+        // has to land exactly on Read mode's --code-bg.
+        isDarkAppearance
+            ? NSColor(srgbRed: 0x33 / 255.0, green: 0x33 / 255.0, blue: 0x33 / 255.0, alpha: 1)
             : (NSColor(hex: "#f4f4f4") ?? NSColor(calibratedWhite: 0.96, alpha: 1))
     }
 

--- a/Sources/EdmundCore/Rendering/EditorTextView+ListRendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+ListRendering.swift
@@ -44,6 +44,15 @@ extension EditorTextView {
 
     // MARK: Marker Icons
 
+    /// Ink for every list marker (dot, checkbox circle, ordered "N."), shared so
+    /// the three marker kinds always read at the same weight. Tertiary is ~25%
+    /// white in dark mode — markers all but vanish against the dark background —
+    /// so dark mode steps up to secondary. Read mode's `--marker` matches.
+    var listMarkerColor: NSColor {
+        effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+            ? .secondaryLabelColor : .tertiaryLabelColor
+    }
+
     /// Creates a fragment overlay with an SF Symbol for checkbox rendering.
     /// Unchecked: dim outlined `circle`. Checked: filled `checkmark.circle.fill`.
     private func checkboxOverlay(checked: Bool) -> FragmentOverlay {
@@ -51,11 +60,7 @@ extension EditorTextView {
         let symbolName = checked ? "checkmark.circle.fill" : "circle"
         // Checked: white checkmark knocked out of an accent-tinted circle (two
         // palette layers — checkmark first, circle second). Unchecked: dim outline.
-        // Tertiary is ~25% white in dark mode — the outline all but disappears
-        // against the dark background, so bump it to secondary there.
-        let dark = effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
-        let palette: [NSColor] = checked ? [.white, accentColor]
-                                         : [dark ? .secondaryLabelColor : .tertiaryLabelColor]
+        let palette: [NSColor] = checked ? [.white, accentColor] : [listMarkerColor]
         let config = NSImage.SymbolConfiguration(pointSize: fontSize, weight: .regular)
             .applying(NSImage.SymbolConfiguration(paletteColors: palette))
 
@@ -84,11 +89,11 @@ extension EditorTextView {
     /// share one indentation (Apple Notes style).
     private func bulletOverlay() -> FragmentOverlay {
         let fontSize = bodyFont.pointSize
+        let dotColor = listMarkerColor
         let image = NSImage(size: NSSize(width: fontSize, height: fontSize), flipped: true) { bounds in
             let r = fontSize * 0.13                 // small dot
             let dot = NSRect(x: bounds.midX - r, y: bounds.midY - r, width: 2 * r, height: 2 * r)
-            // Match the dim used for numbered-list markers (syntaxDimColor).
-            NSColor.tertiaryLabelColor.setFill()
+            dotColor.setFill()
             NSBezierPath(ovalIn: dot).fill()
             return true
         }
@@ -124,7 +129,7 @@ extension EditorTextView {
                 result.addAttribute(.foregroundColor, value: NSColor.clear, range: before)
             }
             let numStart = dr.location + wsLen
-            result.addAttribute(.foregroundColor, value: syntaxDimColor,
+            result.addAttribute(.foregroundColor, value: listMarkerColor,
                                 range: NSRange(location: numStart, length: dr.upperBound - numStart))
             return
         }

--- a/Sources/EdmundCore/Rendering/EditorTextView+ListRendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+ListRendering.swift
@@ -64,12 +64,10 @@ extension EditorTextView {
         NSColor(srgbRed: 85 / 255, green: 85 / 255, blue: 85 / 255, alpha: 1)
     }
 
-    /// Ink for every list marker (dot, checkbox circle, ordered "N."), shared so
-    /// the three marker kinds always read at the same weight. Light mode keeps
-    /// the original `tertiaryLabelColor`.
-    var listMarkerColor: NSColor {
-        isDarkAppearance ? Self.darkChromeGray : .tertiaryLabelColor
-    }
+    /// Ink for every list marker (dot, checkbox circle, ordered "N."). Markers
+    /// are part of the dim tier, so this is `syntaxDimColor` under a name that
+    /// says what it is at the call sites.
+    var listMarkerColor: NSColor { syntaxDimColor }
 
     /// Creates a fragment overlay with an SF Symbol for checkbox rendering.
     /// Unchecked: dim outlined `circle`. Checked: filled `checkmark.circle.fill`.

--- a/Sources/EdmundCore/Rendering/EditorTextView+ListRendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+ListRendering.swift
@@ -56,6 +56,14 @@ extension EditorTextView {
         NSColor(srgbRed: 105 / 255, green: 105 / 255, blue: 105 / 255, alpha: 1)
     }
 
+    /// Dark-mode ink for the `---` hairline and table borders. They cover far
+    /// more pixels than a marker glyph does, so at the marker gray they read as
+    /// heavy furniture; a step dimmer keeps them structural. Read mode's `--hr`
+    /// and `--table-border` carry the same value.
+    nonisolated static var darkRuleGray: NSColor {
+        NSColor(srgbRed: 85 / 255, green: 85 / 255, blue: 85 / 255, alpha: 1)
+    }
+
     /// Ink for every list marker (dot, checkbox circle, ordered "N."), shared so
     /// the three marker kinds always read at the same weight. Light mode keeps
     /// the original `tertiaryLabelColor`.

--- a/Sources/EdmundCore/Rendering/EditorTextView+ListRendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+ListRendering.swift
@@ -51,7 +51,11 @@ extension EditorTextView {
         let symbolName = checked ? "checkmark.circle.fill" : "circle"
         // Checked: white checkmark knocked out of an accent-tinted circle (two
         // palette layers — checkmark first, circle second). Unchecked: dim outline.
-        let palette: [NSColor] = checked ? [.white, accentColor] : [.tertiaryLabelColor]
+        // Tertiary is ~25% white in dark mode — the outline all but disappears
+        // against the dark background, so bump it to secondary there.
+        let dark = effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+        let palette: [NSColor] = checked ? [.white, accentColor]
+                                         : [dark ? .secondaryLabelColor : .tertiaryLabelColor]
         let config = NSImage.SymbolConfiguration(pointSize: fontSize, weight: .regular)
             .applying(NSImage.SymbolConfiguration(paletteColors: palette))
 

--- a/Sources/EdmundCore/Rendering/EditorTextView+ListRendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+ListRendering.swift
@@ -44,13 +44,23 @@ extension EditorTextView {
 
     // MARK: Marker Icons
 
+    /// Dark-mode ink for markers, rules and table borders: the gray the
+    /// unchecked checkbox circle renders at, which reads clearly against the
+    /// dark background without shouting. `secondaryLabelColor` (0.55 white ≈
+    /// #9f9f9f) was too hot; `tertiaryLabelColor` (0.25) too dim. Fixed gray
+    /// rather than a dynamic color — it is only ever used on the dark side.
+    /// Read mode's `--marker` carries the same value.
+    /// sRGB, not `calibratedWhite`: the gamma difference between the two puts
+    /// the same 0.41 on screen as #7c7c7c instead of the #696969 wanted here.
+    nonisolated static var darkChromeGray: NSColor {
+        NSColor(srgbRed: 105 / 255, green: 105 / 255, blue: 105 / 255, alpha: 1)
+    }
+
     /// Ink for every list marker (dot, checkbox circle, ordered "N."), shared so
-    /// the three marker kinds always read at the same weight. Tertiary is ~25%
-    /// white in dark mode — markers all but vanish against the dark background —
-    /// so dark mode steps up to secondary. Read mode's `--marker` matches.
+    /// the three marker kinds always read at the same weight. Light mode keeps
+    /// the original `tertiaryLabelColor`.
     var listMarkerColor: NSColor {
-        effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
-            ? .secondaryLabelColor : .tertiaryLabelColor
+        isDarkAppearance ? Self.darkChromeGray : .tertiaryLabelColor
     }
 
     /// Creates a fragment overlay with an SF Symbol for checkbox rendering.

--- a/Sources/EdmundCore/Rendering/EditorTextView+ListRendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+ListRendering.swift
@@ -64,6 +64,13 @@ extension EditorTextView {
         NSColor(srgbRed: 85 / 255, green: 85 / 255, blue: 85 / 255, alpha: 1)
     }
 
+    /// Dark-mode ink for the `---` hairline specifically. It is thicker than a
+    /// table border (3 device pixels), so it needs a dimmer gray to carry the
+    /// same visual weight. Read mode's `--hr` matches.
+    nonisolated static var darkHRuleGray: NSColor {
+        NSColor(srgbRed: 74 / 255, green: 74 / 255, blue: 74 / 255, alpha: 1)
+    }
+
     /// Ink for every list marker (dot, checkbox circle, ordered "N."). Markers
     /// are part of the dim tier, so this is `syntaxDimColor` under a name that
     /// says what it is at the call sites.

--- a/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
@@ -37,8 +37,14 @@ extension NSAttributedString.Key {
 
 extension EditorTextView {
 
-    /// Color for dimmed syntax delimiters (*, **, `, #, etc.)
-    var syntaxDimColor: NSColor { .tertiaryLabelColor }
+    /// Color for dimmed syntax delimiters (*, **, `, #, …) and for the ink of
+    /// syntax that stays visible but recedes (%%comments%%, ^blockrefs). In dark
+    /// mode `tertiaryLabelColor` (0.25 white) sits too close to the background,
+    /// so the whole dim tier moves to the marker gray — one tertiary substitute
+    /// for every dimmed thing on the dark side. Light mode is untouched.
+    var syntaxDimColor: NSColor {
+        isDarkAppearance ? Self.darkChromeGray : .tertiaryLabelColor
+    }
 
     /// Color for links and wikilinks — always the theme's accent blue, independent of
     /// the system accent so links stay consistently blue across user accent preferences.
@@ -373,7 +379,7 @@ extension EditorTextView {
                                             length: paraRange.upperBound - firstLineEnd)
                     for (range, hugs) in [(firstRange, true), (restRange, false)] {
                         guard range.length > 0 else { continue }
-                        let ownBar = BlockDecoration(.leftBar(color: .tertiaryLabelColor, width: 2),
+                        let ownBar = BlockDecoration(.leftBar(color: syntaxDimColor, width: 2),
                                                      inset: CGFloat(depth) * quoteMarkerWidth,
                                                      hugsTextTop: hugs)
                         if depth == 0 {

--- a/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
@@ -105,7 +105,7 @@ extension EditorTextView {
     /// invisible on the dark background, so dark mode uses the shared marker
     /// gray instead; light mode keeps `separatorColor`. Read mode's `--hr` matches.
     var thematicBreakColor: NSColor {
-        isDarkAppearance ? Self.darkRuleGray : .separatorColor
+        isDarkAppearance ? Self.darkHRuleGray : .separatorColor
     }
 
     /// Width of the `> ` quote marker in body text. Used as the hanging indent

--- a/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
@@ -63,9 +63,12 @@ extension EditorTextView {
     /// Monospaced font for inline code spans.
     var inlineCodeFont: NSFont { theme.monospaceFont() }
 
-    /// Subtle background color for inline code spans.
+    /// Subtle background color for inline code spans. The 10% wash reads fine
+    /// on white but nearly disappears on the dark background (it lands ~4 levels
+    /// above it), so dark mode more than doubles the alpha to hold the same
+    /// visible step as Read mode's --inline-code-bg.
     var inlineCodeBackground: NSColor {
-        NSColor(calibratedWhite: 0.5, alpha: 0.1)
+        NSColor(calibratedWhite: 0.5, alpha: isDarkAppearance ? 0.22 : 0.1)
     }
 
     /// Paragraph style for thematic breaks. The raw dashes are hidden with a

--- a/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
@@ -92,6 +92,14 @@ extension EditorTextView {
     /// against rendered output (see RenderingRegressionTests / screencapture).
     var thematicBreakCenterOffset: CGFloat { bodyFont.pointSize * 0.3 }
 
+    /// Ink for the `---` hairline. `separatorColor` sits at ~10% and is nearly
+    /// invisible on the dark background, so dark mode uses the list-marker
+    /// tertiary/secondary step instead. Read mode's `--hr` matches.
+    var thematicBreakColor: NSColor {
+        effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+            ? .tertiaryLabelColor : .separatorColor
+    }
+
     /// Width of the `> ` quote marker in body text. Used as the hanging indent
     /// for blockquotes and callouts so wrapped/continuation lines align after
     /// the marker (like list items) rather than under the `>`. The marker is
@@ -425,7 +433,7 @@ extension EditorTextView {
                     // Non-active: horizontal hairline decoration, hide raw text
                     result.addAttribute(.paragraphStyle, value: thematicBreakParagraphStyle(), range: span.fullRange)
                     result.addAttribute(.blockDecoration,
-                                        value: BlockDecoration(.horizontalRule(color: .separatorColor,
+                                        value: BlockDecoration(.horizontalRule(color: thematicBreakColor,
                                                                                centerOffset: thematicBreakCenterOffset)),
                                         range: span.fullRange)
                     result.addAttribute(.font, value: hiddenFont, range: span.fullRange)

--- a/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
@@ -96,7 +96,7 @@ extension EditorTextView {
     /// invisible on the dark background, so dark mode uses the shared marker
     /// gray instead; light mode keeps `separatorColor`. Read mode's `--hr` matches.
     var thematicBreakColor: NSColor {
-        isDarkAppearance ? Self.darkChromeGray : .separatorColor
+        isDarkAppearance ? Self.darkRuleGray : .separatorColor
     }
 
     /// Width of the `> ` quote marker in body text. Used as the hanging indent

--- a/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
@@ -93,11 +93,10 @@ extension EditorTextView {
     var thematicBreakCenterOffset: CGFloat { bodyFont.pointSize * 0.3 }
 
     /// Ink for the `---` hairline. `separatorColor` sits at ~10% and is nearly
-    /// invisible on the dark background, so dark mode uses the list-marker
-    /// tertiary/secondary step instead. Read mode's `--hr` matches.
+    /// invisible on the dark background, so dark mode uses the shared marker
+    /// gray instead; light mode keeps `separatorColor`. Read mode's `--hr` matches.
     var thematicBreakColor: NSColor {
-        effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
-            ? .tertiaryLabelColor : .separatorColor
+        isDarkAppearance ? Self.darkChromeGray : .separatorColor
     }
 
     /// Width of the `> ` quote marker in body text. Used as the hanging indent

--- a/Sources/EdmundCore/Rendering/EditorTextView+TableRendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+TableRendering.swift
@@ -151,7 +151,10 @@ extension EditorTextView {
                                                      width: totalWidth,
                                                      leftInset: cellHPad,
                                                      separator: i == 1,
-                                                     bottomBorder: i > 1)),
+                                                     // No rule under the last row: the
+                                                     // table's bottom edge is open, like
+                                                     // its left and right edges.
+                                                     bottomBorder: i > 1 && i < lines.count - 1)),
                     range: lineRange)
 
                 // Cells whose styled width exceeds their column's (clamped)

--- a/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
@@ -659,12 +659,15 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
             context.strokePath()
 
         case .horizontalRule(let color, let centerOffset):
-            context.setStrokeColor(color.cgColor)
-            context.setLineWidth(1)
-            let y = round(point.y + frame.height / 2 + centerOffset) + 0.5
-            context.move(to: CGPoint(x: columnRect.minX, y: y))
-            context.addLine(to: CGPoint(x: columnRect.maxX, y: y))
-            context.strokePath()
+            // Filled at a fixed 3 device pixels (1.5pt on Retina) rather than
+            // stroked at 1pt: a section divider wants a little more presence
+            // than a table gridline, and filling keeps the edges crisp.
+            let scale = max(1, abs(context.convertToDeviceSpace(CGSize(width: 1, height: 1)).width))
+            let thickness = 3 / scale
+            let y = ((point.y + frame.height / 2 + centerOffset) * scale).rounded() / scale
+            context.setFillColor(color.cgColor)
+            context.fill(CGRect(x: columnRect.minX, y: y,
+                                width: columnRect.maxX - columnRect.minX, height: thickness))
         }
     }
 }

--- a/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
@@ -628,7 +628,7 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
             // separatorColor. Read mode's --table-border matches.
             let darkChrome = NSAppearance.currentDrawing()
                 .bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
-            context.setStrokeColor((darkChrome ? EditorTextView.darkChromeGray
+            context.setStrokeColor((darkChrome ? EditorTextView.darkRuleGray
                                                : NSColor.separatorColor).cgColor)
             context.setLineWidth(1)
             for x in xOffsets {

--- a/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
@@ -623,7 +623,9 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
 
         case .tableRow(let xOffsets, let width, let leftInset, let separator, let bottomBorder):
             // Offsets are text-relative; the fragment's origin is the text start.
-            context.setStrokeColor(NSColor.separatorColor.cgColor)
+            // secondaryLabelColor, not separatorColor: the latter is ~10% ink and
+            // the grid all but vanished. Read mode uses the same color (--table-border).
+            context.setStrokeColor(NSColor.secondaryLabelColor.cgColor)
             context.setLineWidth(1)
             for x in xOffsets {
                 let lineX = round(point.x + x) + 0.5

--- a/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
@@ -628,13 +628,23 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
             // separatorColor. Read mode's --table-border matches.
             let darkChrome = NSAppearance.currentDrawing()
                 .bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
-            context.setStrokeColor((darkChrome ? EditorTextView.darkRuleGray
-                                               : NSColor.separatorColor).cgColor)
+            let borderColor = (darkChrome ? EditorTextView.darkRuleGray
+                                          : NSColor.separatorColor)
+            context.setStrokeColor(borderColor.cgColor)
             context.setLineWidth(1)
+            // Column borders are FILLED at exactly one device pixel rather than
+            // stroked: a 1pt stroke straddling a pixel boundary lands on two
+            // device rows on a Retina display, which made the verticals read
+            // twice as heavy as the row rules beside them.
+            // `ctm.a` reports the user-space transform only (1 even on Retina);
+            // converting a unit size into device space gives the real backing scale.
+            let scale = max(1, abs(context.convertToDeviceSpace(CGSize(width: 1, height: 1)).width))
+            let hairline = 1 / scale
+            context.setFillColor(borderColor.cgColor)
             for x in xOffsets {
-                let lineX = round(point.x + x) + 0.5
-                context.move(to: CGPoint(x: lineX, y: point.y))
-                context.addLine(to: CGPoint(x: lineX, y: point.y + frame.height))
+                let lineX = (((point.x + x) * scale).rounded()) / scale
+                context.fill(CGRect(x: lineX, y: point.y,
+                                    width: hairline, height: frame.height))
             }
             if separator {
                 let y = round(point.y + frame.height / 2) + 0.5

--- a/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
@@ -623,9 +623,13 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
 
         case .tableRow(let xOffsets, let width, let leftInset, let separator, let bottomBorder):
             // Offsets are text-relative; the fragment's origin is the text start.
-            // secondaryLabelColor, not separatorColor: the latter is ~10% ink and
-            // the grid all but vanished. Read mode uses the same color (--table-border).
-            context.setStrokeColor(NSColor.secondaryLabelColor.cgColor)
+            // In dark mode `separatorColor` is ~10% ink and the grid all but
+            // vanishes, so use the shared marker gray there; light mode keeps
+            // separatorColor. Read mode's --table-border matches.
+            let darkChrome = NSAppearance.currentDrawing()
+                .bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+            context.setStrokeColor((darkChrome ? EditorTextView.darkChromeGray
+                                               : NSColor.separatorColor).cgColor)
             context.setLineWidth(1)
             for x in xOffsets {
                 let lineX = round(point.x + x) + 0.5

--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -218,7 +218,14 @@ public class EditorTextView: NSTextView {
 
     /// Foreground color for all body text. Uses the system text color so it
     /// flips automatically between near-black (light) and near-white (dark).
-    var foregroundColor: NSColor { .textColor }
+    /// Body text. `textColor` is pure white in dark mode, which glares against
+    /// the near-black background; soften it to the same #e6e6e6 Read mode has
+    /// always used (--fg). Light mode keeps the system color.
+    var foregroundColor: NSColor {
+        isDarkAppearance ? NSColor(srgbRed: 230 / 255, green: 230 / 255,
+                                   blue: 230 / 255, alpha: 1)
+                         : .textColor
+    }
 
     /// Background tint for text selection. Uses system orange so selections read
     /// as warm amber rather than tracking the (potentially red) brand accent.

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -540,6 +540,9 @@ class Document: NSDocument, HeadingNavigable {
     /// hidden scroll view is unhidden — a click used to supply the missing
     /// event, leaving the editor blank until one arrived.
     private func swapToEditor() {
+        // The inspector inspects the read view; leaving it up over the editor
+        // would show a document that is no longer on screen.
+        readView?.hideWebInspector(nil)
         readView?.isHidden = true
         scrollView.isHidden = false
         editor.window?.makeFirstResponder(editor)
@@ -635,6 +638,21 @@ class Document: NSDocument, HeadingNavigable {
     /// Source ↔ Read; otherwise Edit ↔ Read.
     @objc func toggleViewMode(_ sender: Any?) {
         setViewMode(editor.viewMode == .reading ? editingMode : .reading)
+    }
+
+    /// "Inspect Reader" (⌥⌘I) — a semi-toggle, so one shortcut always gets you
+    /// to "reading with the inspector open": from Edit (or from Read with the
+    /// inspector closed) it lands in Read mode with the inspector up; pressed
+    /// again in that state it closes the inspector and leaves you in Read mode.
+    @objc func toggleReaderInspector(_ sender: Any?) {
+        if editor.viewMode == .reading, readView?.isWebInspectorVisible == true {
+            readView?.hideWebInspector(nil)
+            return
+        }
+        if editor.viewMode != .reading { setViewMode(.reading) }
+        // The read view is created (and its HTML rendered) by `setViewMode`, so
+        // by here `readView` exists even on the first entry into Read mode.
+        readView?.showWebInspector(nil)
     }
 
     /// One mode menu item: icon + title, checked when `on`.

--- a/Sources/edmd/App/FormatMenu.swift
+++ b/Sources/edmd/App/FormatMenu.swift
@@ -181,9 +181,16 @@ enum FormatMenu {
 
     private static func fontSubmenuItem() -> NSMenuItem {
         let item = NSMenuItem(title: "Font", action: nil, keyEquivalent: "")
+        item.submenu = fontMenu()
+        return item
+    }
+
+    /// A fresh Font submenu built from `fontCommands` (Bold, Italic, …). Also
+    /// used to replace the system Font submenu in the editor's right-click menu
+    /// (see `EditorTextView.contextFontMenuProvider`).
+    static func fontMenu() -> NSMenu {
         let menu = NSMenu(title: "Font")
         for cmd in fontCommands { menu.addItem(cmd.makeItem()) }
-        item.submenu = menu
-        return item
+        return menu
     }
 }

--- a/Sources/edmd/App/ViewMenu.swift
+++ b/Sources/edmd/App/ViewMenu.swift
@@ -33,11 +33,12 @@ enum ViewMenu {
                          action: #selector(Document.toggleSourceMode(_:)),
                          keyEquivalent: "")
 
-        // Web Inspector for Read mode (⌥⌘I). nil target → routes through the
-        // responder chain to the ReadModeWebView, which is first responder in
-        // Read mode; auto-disabled in Edit/Source mode.
-        let inspectItem = viewMenu.addItem(withTitle: "Inspect Read View",
-                         action: #selector(ReadModeWebView.showWebInspector(_:)),
+        // Web Inspector (⌥⌘I). nil target → routes through the responder chain
+        // to the key window's Document, so it works from Edit mode too: it
+        // switches to Read mode and opens the inspector, and toggles the
+        // inspector back off when it's already up.
+        let inspectItem = viewMenu.addItem(withTitle: "Inspect Reader",
+                         action: #selector(Document.toggleReaderInspector(_:)),
                          keyEquivalent: "i")
         inspectItem.keyEquivalentModifierMask = [.command, .option]
         viewMenu.addItem(.separator())

--- a/Sources/edmd/App/ViewMenu.swift
+++ b/Sources/edmd/App/ViewMenu.swift
@@ -32,6 +32,14 @@ enum ViewMenu {
         viewMenu.addItem(withTitle: "Show Source in Editor",
                          action: #selector(Document.toggleSourceMode(_:)),
                          keyEquivalent: "")
+
+        // Web Inspector for Read mode (⌥⌘I). nil target → routes through the
+        // responder chain to the ReadModeWebView, which is first responder in
+        // Read mode; auto-disabled in Edit/Source mode.
+        let inspectItem = viewMenu.addItem(withTitle: "Inspect Read View",
+                         action: #selector(ReadModeWebView.showWebInspector(_:)),
+                         keyEquivalent: "i")
+        inspectItem.keyEquivalentModifierMask = [.command, .option]
         viewMenu.addItem(.separator())
 
         // Zoom (font size + max content width, scaled together). Target nil

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -275,6 +275,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         // Format menu — built from the declarative command registry.
         mainMenu.addItem(FormatMenu.build())
 
+        // Editor right-click Font submenu mirrors Format ▸ Font.
+        EditorTextView.contextFontMenuProvider = { FormatMenu.fontMenu() }
+
         // View menu — built in its own file (ViewMenu.swift).
         mainMenu.addItem(ViewMenu.build())
 

--- a/Tests/EdmundTests/BlockStylingTests.swift
+++ b/Tests/EdmundTests/BlockStylingTests.swift
@@ -276,7 +276,7 @@ struct BlockStylingNonActiveTests {
         let text = displayText(for: 0, in: editor)
         #expect(text == "1. first")
         let numColor = fgColor(at: 0, in: editor)
-        #expect(numColor == NSColor.tertiaryLabelColor)
+        #expect(numColor == editor.listMarkerColor)
     }
 
     // MARK: - Todo Lists

--- a/Tests/EdmundTests/BlockStylingTests.swift
+++ b/Tests/EdmundTests/BlockStylingTests.swift
@@ -52,7 +52,7 @@ struct BlockStylingActiveTests {
         activateBlock(0, in: editor)
 
         let delimColor = fgColor(at: 0, in: editor)
-        #expect(delimColor == NSColor.tertiaryLabelColor)
+        #expect(delimColor == expectedDimColor)
     }
 
     // MARK: - Bullet Lists
@@ -88,7 +88,7 @@ struct BlockStylingActiveTests {
         activateBlock(0, in: editor)
 
         let delimColor = fgColor(at: 0, in: editor)
-        #expect(delimColor == NSColor.tertiaryLabelColor)
+        #expect(delimColor == expectedDimColor)
     }
 
     // MARK: - Numbered Lists
@@ -128,7 +128,7 @@ struct BlockStylingActiveTests {
         activateBlock(0, in: editor)
 
         let delimColor = fgColor(at: 0, in: editor)
-        #expect(delimColor == NSColor.tertiaryLabelColor)
+        #expect(delimColor == expectedDimColor)
     }
 
     @Test("Active blockquote shows its raw text")
@@ -453,7 +453,7 @@ struct TableActiveTests {
         activateBlock(0, in: editor)
 
         let color = fgColor(at: 0, in: editor)
-        #expect(color == NSColor.tertiaryLabelColor)
+        #expect(color == expectedDimColor)
     }
 }
 
@@ -517,7 +517,7 @@ struct CodeBlockActiveTests {
         activateBlock(0, in: editor)
 
         let color = fgColor(at: 0, in: editor)
-        #expect(color == NSColor.tertiaryLabelColor)
+        #expect(color == expectedDimColor)
     }
 
     @Test("Active code block content has monospace font")
@@ -600,7 +600,7 @@ struct BlockTransitionTests {
         // Block 0 active: ** delimiters dimmed (visible)
         activateBlock(0, in: editor)
         let dimColor = fgColor(at: 0, in: editor)
-        #expect(dimColor == NSColor.tertiaryLabelColor)
+        #expect(dimColor == expectedDimColor)
 
         // Switch to block 1: block 0's ** delimiters become hidden
         activateBlock(1, in: editor)
@@ -641,7 +641,7 @@ struct ThematicBreakActiveTests {
         activateBlock(0, in: editor)
 
         let color = fgColor(at: 0, in: editor)
-        #expect(color == NSColor.tertiaryLabelColor)
+        #expect(color == expectedDimColor)
     }
 
     @Test("Active *** is dimmed")
@@ -651,7 +651,7 @@ struct ThematicBreakActiveTests {
         activateBlock(0, in: editor)
 
         let color = fgColor(at: 0, in: editor)
-        #expect(color == NSColor.tertiaryLabelColor)
+        #expect(color == expectedDimColor)
     }
 
     @Test("Active --- shows raw markdown text")
@@ -735,7 +735,7 @@ struct ImageActiveTests {
         activateBlock(0, in: editor)
 
         let delimColor = fgColor(at: 0, in: editor)
-        #expect(delimColor == NSColor.tertiaryLabelColor)
+        #expect(delimColor == expectedDimColor)
     }
 }
 
@@ -809,7 +809,7 @@ struct LineBreakActiveTests {
         editor.recompose(cursorInRaw: 5)
 
         let color = fgColor(at: 5, in: editor)
-        #expect(color == NSColor.tertiaryLabelColor)
+        #expect(color == expectedDimColor)
     }
 }
 

--- a/Tests/EdmundTests/DocumentHTMLTests.swift
+++ b/Tests/EdmundTests/DocumentHTMLTests.swift
@@ -55,6 +55,19 @@ struct DocumentHTMLTests {
         #expect(out.contains("src=\"data:image/png;base64,"))
     }
 
+    // `$$…$$` inside a prose line gets its own centered block (as a span, since
+    // the placeholder sits inside the paragraph's <p>); the prose keeps flowing
+    // above and below it.
+    @Test("Display math amid prose becomes a centered block, not an inline image")
+    func displayMathAmidProseIsBlock() {
+        let out = doc("before $$x^2$$ after")
+        #expect(out.contains("<span class=\"math-display-block\"><img class=\"math\""))
+        #expect(!out.contains("math-display-inline"))   // placeholder was filled
+        #expect(out.contains("before"))
+        #expect(out.contains("after"))
+        #expect(out.contains(".math-display-block { display: block;"))   // CSS shipped
+    }
+
     @Test("Unparseable math falls back to showing the source")
     func mathFallback() {
         let out = doc("bad $\\frac{$ math")

--- a/Tests/EdmundTests/EditorFeatureTests.swift
+++ b/Tests/EdmundTests/EditorFeatureTests.swift
@@ -390,7 +390,7 @@ struct AppearanceIntegrationTests {
         activateBlock(0, in: editor)
 
         // Cursor at 0 → inside bold token. Bold delimiters dimmed.
-        #expect(fgColor(at: 0, in: editor) == NSColor.tertiaryLabelColor)
+        #expect(fgColor(at: 0, in: editor) == expectedDimColor)
         // Italic and code delimiters hidden (cursor not inside those tokens)
         #expect(fgColor(at: 9, in: editor) == NSColor.clear)
         #expect(fgColor(at: 18, in: editor) == NSColor.clear)

--- a/Tests/EdmundTests/EditorRenderingTests.swift
+++ b/Tests/EdmundTests/EditorRenderingTests.swift
@@ -906,7 +906,7 @@ struct EditorRecomposeTests {
         let ts = editor.textStorage!
         // ** at position 0 should be dimmed (visible), not hidden
         let color = ts.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
-        #expect(color == NSColor.tertiaryLabelColor)
+        #expect(color == expectedDimColor)
         let f = ts.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
         #expect(f != nil)
         #expect(f!.pointSize > 1.0)  // Not hidden

--- a/Tests/EdmundTests/EditorRenderingTests.swift
+++ b/Tests/EdmundTests/EditorRenderingTests.swift
@@ -534,7 +534,8 @@ struct EditorStylingTests {
         let editor = makeEditor()
         let styled = editor.styleBlock("1. hello")
         #expect(styled.string == "1. hello")
-        #expect(isDimmed(at: 0, in: styled))
+        #expect(styled.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+                == editor.listMarkerColor)
     }
 
     @Test("Indented list (4 spaces) has wider hanging indent than top-level")

--- a/Tests/EdmundTests/FormattingTests.swift
+++ b/Tests/EdmundTests/FormattingTests.swift
@@ -76,7 +76,7 @@ private func mk(_ content: String, _ sel: NSRange) -> EditorTextView {
         #expect(wrap("`", "`") { $0.formatCode(nil) } == "`x`")
         #expect(wrap("$", "$") { $0.formatInlineMath(nil) } == "$x$")
         #expect(wrap("<kbd>", "</kbd>") { $0.formatKeyboard(nil) } == "<kbd>x</kbd>")
-        #expect(wrap("%%", "%%") { $0.formatComment(nil) } == "%%x%%")
+        #expect(wrap("<!-- ", " -->") { $0.formatComment(nil) } == "<!-- x -->")
     }
 
     @Test func emptyInlineCaretCentersForMultiCharDelimiter() {

--- a/Tests/EdmundTests/HTMLRendererTests.swift
+++ b/Tests/EdmundTests/HTMLRendererTests.swift
@@ -290,6 +290,15 @@ struct HTMLRendererInlineTests {
         #expect(out.contains("\\int_0^1"))
     }
 
+
+    // Single-line `$$…$$` owning its paragraph — the shape used in test.md.
+    @Test("Single-line $$math$$ paragraph → math-display div, not inline span")
+    func singleLineDisplayMath() {
+        let out = html("$$f(x)=a_nx^n+a_1x+a_0$$")
+        #expect(out.contains("class=\"math-display\""))
+        #expect(!out.contains("math-display-inline"))
+    }
+
     // Read-mode parity with the editor's list-item block math: a `$$…$$` that is
     // the whole content of a list item renders as a display-math block inside the
     // <li> (swift-markdown lazy-continues the item's following lines into one

--- a/Tests/EdmundTests/InlineStylingTests.swift
+++ b/Tests/EdmundTests/InlineStylingTests.swift
@@ -23,9 +23,9 @@ struct InlineStylingActiveTests {
 
         // Delimiters should be dimmed
         let delimColor = fgColor(at: 0, in: editor)
-        #expect(delimColor == NSColor.tertiaryLabelColor)
+        #expect(delimColor == expectedDimColor)
         let endDelimColor = fgColor(at: 7, in: editor)
-        #expect(endDelimColor == NSColor.tertiaryLabelColor)
+        #expect(endDelimColor == expectedDimColor)
     }
 
     @Test("Active __bold__ with underscores has bold font")
@@ -50,7 +50,7 @@ struct InlineStylingActiveTests {
         #expect(NSFontManager.shared.traits(of: contentFont).contains(.italicFontMask))
 
         let delimColor = fgColor(at: 0, in: editor)
-        #expect(delimColor == NSColor.tertiaryLabelColor)
+        #expect(delimColor == expectedDimColor)
     }
 
     @Test("Active _italic_ with underscores has italic font")
@@ -101,7 +101,7 @@ struct InlineStylingActiveTests {
         #expect(contentColor == editor.foregroundColor)
 
         let delimColor = fgColor(at: 0, in: editor)
-        #expect(delimColor == NSColor.tertiaryLabelColor)
+        #expect(delimColor == expectedDimColor)
     }
 
     // MARK: - Strikethrough
@@ -144,7 +144,7 @@ struct InlineStylingActiveTests {
 
         // Delimiter "[" should be dimmed
         let delimColor = fgColor(at: 0, in: editor)
-        #expect(delimColor == NSColor.tertiaryLabelColor)
+        #expect(delimColor == expectedDimColor)
     }
 
     // MARK: - Combinations

--- a/Tests/EdmundTests/InlineStylingTests.swift
+++ b/Tests/EdmundTests/InlineStylingTests.swift
@@ -407,3 +407,22 @@ struct InlineStylingInactiveTests {
         #expect(text == "*hi**")
     }
 }
+
+// MARK: - Indented headings
+
+@Suite("Heading indent")
+struct HeadingIndentTests {
+
+    // CommonMark allows up to 3 spaces before the `#`. cmark's heading range
+    // starts at the `#`, so that whitespace used to keep the heading font and
+    // push the title right of every other block (test.md's " # Edmund").
+    @Test("Leading spaces before # are hidden with the opener")
+    @MainActor func leadingSpaceHidden() {
+        let editor = makeEditor()
+        let styled = editor.styleBlock("  # Title")
+        #expect(isHidden(at: 0, in: styled))   // first indent space
+        #expect(isHidden(at: 1, in: styled))   // second indent space
+        #expect(isHidden(at: 2, in: styled))   // the `#`
+        #expect(!isHidden(at: 4, in: styled))  // "T" of the title
+    }
+}

--- a/Tests/EdmundTests/ListRenumberingTests.swift
+++ b/Tests/EdmundTests/ListRenumberingTests.swift
@@ -93,7 +93,7 @@ struct ListRenumberingTests {
         // The caret (and thus the active, intentionally-undimmed block) sits
         // at the deletion point, on "2. c" — "1. a" stays inactive throughout.
         #expect(editor.blocks[0].content == "1. a")
-        #expect(fgColor(at: editor.blocks[0].range.location, in: editor) == NSColor.tertiaryLabelColor)
+        #expect(fgColor(at: editor.blocks[0].range.location, in: editor) == editor.listMarkerColor)
     }
 
     @Test("Enter on an empty item leaves a blank line but still renumbers across it")

--- a/Tests/EdmundTests/MarkdownFeaturesTests.swift
+++ b/Tests/EdmundTests/MarkdownFeaturesTests.swift
@@ -189,7 +189,9 @@ struct MarkdownFeaturesTests {
         #expect(EditorTextView.requiredFeature(forAction: #selector(EditorTextView.formatHighlight(_:)), representedObject: nil) == .highlight)
         #expect(EditorTextView.requiredFeature(forAction: #selector(EditorTextView.formatWikilink(_:)), representedObject: nil) == .wikilink)
         #expect(EditorTextView.requiredFeature(forAction: #selector(EditorTextView.formatFootnote(_:)), representedObject: nil) == .footnote)
-        #expect(EditorTextView.requiredFeature(forAction: #selector(EditorTextView.formatComment(_:)), representedObject: nil) == .inlineComment)
+        // formatComment inserts an HTML `<!-- -->` comment, which is always
+        // recognized (parseHTMLComments is not feature-gated) — no flag needed.
+        #expect(EditorTextView.requiredFeature(forAction: #selector(EditorTextView.formatComment(_:)), representedObject: nil) == nil)
         // Callout split by type.
         #expect(EditorTextView.requiredFeature(forAction: #selector(EditorTextView.formatCallout(_:)), representedObject: "NOTE") == .callout)
         #expect(EditorTextView.requiredFeature(forAction: #selector(EditorTextView.formatCallout(_:)), representedObject: "info") == .calloutExtendedTypes)

--- a/Tests/EdmundTests/ReferenceLinkTests.swift
+++ b/Tests/EdmundTests/ReferenceLinkTests.swift
@@ -68,6 +68,18 @@ struct ReferenceLinkTests {
         let spans = SyntaxHighlighter.parse(text, linkDefinitions: "[foo]: https://f.com")
         #expect(spans.allSatisfy { $0.fullRange.upperBound <= (text as NSString).length })
     }
+
+    // An indented code block's node range runs past the block over the blank
+    // separator line the append adds; the span must be clamped, not dropped,
+    // or the block loses its monospace font (test.md "\tIndented").
+    @Test("Indented code keeps its span when definitions are appended")
+    func indentedCodeSurvivesAppend() {
+        let text = "\tIndented"
+        let spans = SyntaxHighlighter.parse(text, linkDefinitions: "[foo]: https://f.com")
+        #expect(spans.contains { if case .codeBlock = $0.kind {
+            return $0.fullRange == NSRange(location: 0, length: 9)
+        }; return false })
+    }
 }
 
 // MARK: - LinkDefinitionState

--- a/Tests/EdmundTests/TableWrapRenderingTests.swift
+++ b/Tests/EdmundTests/TableWrapRenderingTests.swift
@@ -84,7 +84,7 @@ struct TableWrapRenderingTests {
         #expect(offsetsPerRow.dropFirst().allSatisfy { $0 == offsetsPerRow[0] })
     }
 
-    @Test("Every data row gets a bottom grid line; header and separator rows don't")
+    @Test("Interior data rows get a bottom grid line; header, separator and last row don't")
     func bottomBorderOnDataRowsOnly() {
         let editor = makeEditor()
         let styled = editor.styleBlock("| a | b |\n|---|---|\n| x | y |\n| p | q |", cursorPosition: nil)
@@ -100,8 +100,9 @@ struct TableWrapRenderingTests {
             guard nl.location != NSNotFound else { break }
             lineStart = nl.upperBound
         }
-        // Rows: header, separator, "x | y", "p | q".
-        #expect(bottoms == [false, false, true, true])
+        // Rows: header, separator, "x | y", "p | q". The last row draws no
+        // bottom rule — the table's bottom edge is open.
+        #expect(bottoms == [false, false, true, false])
     }
 
     @Test("distributeColumnWidths keeps under-fair-share columns, clamps the rest")

--- a/Tests/EdmundTests/TestHelpers.swift
+++ b/Tests/EdmundTests/TestHelpers.swift
@@ -159,13 +159,23 @@ func isInvisible(at offset: Int, in result: NSAttributedString) -> Bool {
     return true
 }
 
-/// Returns true if the character at `offset` is dimmed (tertiary label color).
+/// The dim-syntax ink for the appearance the tests are running under — dark
+/// mode substitutes its own gray for `tertiaryLabelColor` (see
+/// `EditorTextView.syntaxDimColor`), so asserting the constant directly makes a
+/// test pass or fail depending on the machine's appearance.
+@MainActor
+var expectedDimColor: NSColor {
+    NSApp.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+        ? EditorTextView.darkChromeGray : .tertiaryLabelColor
+}
+
+/// Returns true if the character at `offset` is dimmed (syntax-dim color).
 @MainActor
 func isDimmed(at offset: Int, in result: NSAttributedString) -> Bool {
     guard offset < result.length else { return false }
     let a = result.attributes(at: offset, effectiveRange: nil)
     guard let c = a[.foregroundColor] as? NSColor else { return false }
-    return c == NSColor.tertiaryLabelColor
+    return c == expectedDimColor
 }
 
 // MARK: - Full-Recompose Oracle

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -135,6 +135,24 @@ rawSource ─BlockParser─▶ [Block] ─SyntaxHighlighter─▶ spans ─style
     drawing's advance width (same trick as the table renderer).
 - **Hiding** text = `hiddenFont` (≈0.01pt) + clear `foregroundColor` — how
   delimiters and in-source markers vanish without changing the string.
+- **Dark-mode chrome palette** (`+ListRendering.swift`): the system semantic
+  colors are too faint on the `#292929` background, so dark mode substitutes
+  fixed sRGB grays and Read mode's CSS vars carry the same values, so the two
+  views match pixel-for-pixel. `syntaxDimColor` (the whole dim tier —
+  delimiters, `%%comments%%`, `^blockrefs`, list markers, quote bars) →
+  `darkChromeGray` #696969 = `--marker`; table borders → `darkRuleGray`
+  #555555 = `--table-border`; the `---` rule → `darkHRuleGray` #4a4a4a =
+  `--hr`; body text → #e6e6e6 = `--fg`; code backgrounds #333333 = `--code-bg`
+  with inline code a step above at #3c3c3c = `--inline-code-bg`. Light mode
+  keeps the semantic colors. Build these with `srgbRed:`, **not**
+  `NSColor(hex:)` or `calibratedWhite:` — the calibrated space renders visibly
+  lighter than the hex it was given (same trap as `editorBackgroundColor`).
+- **Hairlines are filled, not stroked.** A 1pt stroke straddles a pixel
+  boundary and covers *two* device rows on Retina, so stroked table verticals
+  read twice as heavy as the row rules beside them. Table column borders fill
+  exactly one device pixel and the `---` rule fills three. The backing scale
+  comes from `context.convertToDeviceSpace(CGSize(width: 1, height: 1))` —
+  `context.ctm.a` reports 1 even at 2x.
 - **Image overlays only work on single-line fragments.** An *image* on a
   *multi-line* (wrapping) fragment re-triggers a layout pass that wedges it
   to one line; a *shape* does not. So the wrapping callout custom title's
@@ -208,6 +226,11 @@ Notable subsystems:
   `http`/`https`/`mailto` links open in the browser, `file:`/unknown
   schemes cancelled; wikilinks/relative links use private
   `x-edmund-wiki:`/`x-edmund-link:` schemes the nav coordinator intercepts.
+  **Inspect Reader (⌥⌘I)** is a semi-toggle on `Document`, not on the web
+  view, so it works from Edit too: it switches to Read and opens WebKit's
+  private `_inspector`, and closes it when already up; entering Edit always
+  hides it. The read view's context menu carries the same item as "Inspect
+  Element", with WebKit's own duplicate removed.
   **Export as PDF… / Print… (⌘P)** run the same HTML through
   `WKWebView.printOperation` (`MarkdownPrinter`; vector text, math is
   high-DPI PNG). Full spec: `docs/architecture/reader-and-export.md`.
@@ -456,9 +479,10 @@ Notable subsystems:
   only wraps a whole paragraph at the container edge and has no per-cell
   flow region (that's NSTextTable/NSTextBlock, banned per §2).
   Click-to-caret inside a wrapped, non-active cell is approximate as a
-  result. Every data row draws a full-width bottom grid line (`.tableRow`'s
+  result. Interior data rows draw a full-width bottom grid line (`.tableRow`'s
   `bottomBorder`) — the header/body boundary already gets its line from
-  `separator`, so only rows after the separator set it.
+  `separator`, and the last row draws none, so the table's bottom edge is open
+  like its left and right edges.
 - *(Track larger roadmap items in README/ROADMAP; track code-debt here.)*
 
 ---

--- a/docs/architecture/reader-and-export.md
+++ b/docs/architecture/reader-and-export.md
@@ -44,10 +44,16 @@ theme changes. Code blocks are syntax-colored by the same `CodeHighlighter`
 Lucide SVG (vector); math glyphs are high-DPI PNG (SwiftMath has no SVG
 output yet) — in PDF export, everything else is vector.
 
-Math classing (agrees with Edit mode via the shared `parseDisplayMath`): a
-`$$…$$` that is a whole paragraph is a block (`math-display`); one embedded in
-a prose line is display-mode math flowed inline (`math-display-inline`); a `$$`
-inside code stays literal.
+Math classing (classing agrees with Edit mode via the shared
+`parseDisplayMath`): a `$$…$$` that is a whole paragraph is a block
+(`math-display`); one embedded in a prose line is `math-display-inline`, which
+`DocumentHTML.fillMath` fills as a `display:block` span
+(`.math-display-block`) so it gets its own centered line with the prose
+flowing above and below — a `<span>`, not a `<div>`, because the placeholder
+sits inside the paragraph's `<p>`. **This is a deliberate divergence**: Edit
+mode still flows that case inline, because breaking the line around the run
+needs a line break where the source has no break character, which
+storage==rawSource forbids. A `$$` inside code stays literal.
 
 ## 3. Specs
 


### PR DESCRIPTION
## What

A batch of rendering fixes found while going through `test-files/test.md`, plus the dark-mode color pass that followed.

**Bugs**
- **Indented code blocks lost their monospace font** whenever the document contained a reference or footnote definition. `SyntaxHighlighter.parse` appends those definitions after the block, and an indented code block's node range runs *past* the block over the blank separator line the append itself adds — so the post-parse filter dropped the `codeBlock` span entirely and the block fell back to `baseAttributes` (serif). Spans that start inside the block are now clamped instead of dropped.
- **Headings written with a leading space rendered unflushed.** CommonMark allows up to 3 spaces before the `#`, and cmark's heading range starts at the `#`, so that whitespace kept the heading font and pushed the title right of every other block (test.md's ` # Edmund`). It is now hidden with the opener — only when it starts the line, so an enclosing marker's whitespace (`> # x`) is left to its own styling.
- **`$$…$$` embedded in a prose line** now gets its own centered block in Read mode instead of flowing inline. Edit mode still flows it inline: breaking the line there needs a line break where the source has no break character, which the storage==rawSource invariant forbids. Documented as a deliberate divergence.
- **Tables** no longer draw a rule under the last row — the bottom edge is open, like the left and right edges.

**Dark mode**
- One chrome palette, matched between the editor and Read mode's CSS vars: the dim tier (delimiters, `%%comments%%`, `^blockrefs`, list markers, quote bars) at `#696969`, table borders `#555555`, the `---` rule `#4a4a4a`, body text `#e6e6e6`. The system semantics were too faint against `#292929`. Light mode is unchanged.
- Code backgrounds were invisible: `--code-bg` sat at `#2a2a2a` against a `#292929` page, so code blocks and table header rows had no tint at all. Now `#333333`, with inline code a step above at `#3c3c3c`.
- Hairlines are filled rather than stroked — a 1pt stroke covers two device rows on Retina, so table verticals read twice as heavy as the row rules beside them.
- Read-mode inline code takes the body color instead of `--code`, matching the editor.

**Menus**
- `Inspect Read View` → **Inspect Reader** (⌥⌘I), moved onto `Document` as a semi-toggle so it works from Edit mode: it switches to Read and opens the inspector, closes it when already up, and hides it whenever you enter Edit. The read view's context menu carries the same item as "Inspect Element", with WebKit's duplicate removed.
- Format ▸ Font ▸ Comments inserts `<!-- … -->`; the right-click Font submenu is Edmund's own.

## Verification

`swift test` — 1103/1103 green. Every visual change was checked against live captures in both appearances and both view modes, with pixel sampling rather than eyeballing (the colors above are measured values, not intended ones).

Two bugs from the original list did **not** reproduce on a correct build and are left alone: list markers rendering unstyled, and a code-block language label clipping after the block above is re-laid-out (four live repro attempts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)