### PR TITLE
Render Mermaid diagrams natively

### DIFF
--- a/LICENSES/beautiful-mermaid-swift.txt
+++ b/LICENSES/beautiful-mermaid-swift.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Craft Docs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSES/elk-swift.txt
+++ b/LICENSES/elk-swift.txt
@@ -1,0 +1,277 @@
+Eclipse Public License - v 2.0
+
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+  a) in the case of the initial Contributor, the initial content
+     Distributed under this Agreement, and
+
+  b) in the case of each subsequent Contributor:
+     i) changes to the Program, and
+     ii) additions to the Program;
+  where such changes and/or additions to the Program originate from
+  and are Distributed by that particular Contributor. A Contribution
+  "originates" from a Contributor if it was added to the Program by
+  such Contributor itself or anyone acting on such Contributor's behalf.
+  Contributions do not include changes or additions to the Program that
+  are not Modified Works.
+
+"Contributor" means any person or entity that Distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which
+are necessarily infringed by the use or sale of its Contribution alone
+or when combined with the Program.
+
+"Program" means the Contributions Distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement
+or any Secondary License (as applicable), including Contributors.
+
+"Derivative Works" shall mean any work, whether in Source Code or other
+form, that is based on (or derived from) the Program and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+
+"Modified Works" shall mean any work in Source Code or other form that
+results from an addition to, deletion from, or modification of the
+contents of the Program, including, for purposes of clarity any new file
+in Source Code form that contains any contents of the Program. Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program solely
+in each case in order to link to, bind by name, or subclass the Program
+or Modified Works thereof.
+
+"Distribute" means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+
+"Source Code" means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+
+"Secondary License" means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including any
+exceptions or additional permissions as identified by the initial
+Contributor.
+
+2. GRANT OF RIGHTS
+
+  a) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free copyright
+  license to reproduce, prepare Derivative Works of, publicly display,
+  publicly perform, Distribute and sublicense the Contribution of such
+  Contributor, if any, and such Derivative Works.
+
+  b) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free patent
+  license under Licensed Patents to make, use, sell, offer to sell,
+  import and otherwise transfer the Contribution of such Contributor,
+  if any, in Source Code or other form. This patent license shall
+  apply to the combination of the Contribution and the Program if, at
+  the time the Contribution is added by the Contributor, such addition
+  of the Contribution causes such combination to be covered by the
+  Licensed Patents. The patent license shall not apply to any other
+  combinations which include the Contribution. No hardware per se is
+  licensed hereunder.
+
+  c) Recipient understands that although each Contributor grants the
+  licenses to its Contributions set forth herein, no assurances are
+  provided by any Contributor that the Program does not infringe the
+  patent or other intellectual property rights of any other entity.
+  Each Contributor disclaims any liability to Recipient for claims
+  brought by any other entity based on infringement of intellectual
+  property rights or otherwise. As a condition to exercising the
+  rights and licenses granted hereunder, each Recipient hereby
+  assumes sole responsibility to secure any other intellectual
+  property rights needed, if any. For example, if a third party
+  patent license is required to allow Recipient to Distribute the
+  Program, it is Recipient's responsibility to acquire that license
+  before distributing the Program.
+
+  d) Each Contributor represents that to its knowledge it has
+  sufficient copyright rights in its Contribution, if any, to grant
+  the copyright license set forth in this Agreement.
+
+  e) Notwithstanding the terms of any Secondary License, no
+  Contributor makes additional grants to any Recipient (other than
+  those set forth in this Agreement) as a result of such Recipient's
+  receipt of the Program under the terms of a Secondary License
+  (if permitted under the terms of Section 3).
+
+3. REQUIREMENTS
+
+3.1 If a Contributor Distributes the Program in any form, then:
+
+  a) the Program must also be made available as Source Code, in
+  accordance with section 3.2, and the Contributor must accompany
+  the Program with a statement that the Source Code for the Program
+  is available under this Agreement, and informs Recipients how to
+  obtain it in a reasonable manner on or through a medium customarily
+  used for software exchange; and
+
+  b) the Contributor may Distribute the Program under a license
+  different than this Agreement, provided that such license:
+     i) effectively disclaims on behalf of all other Contributors all
+     warranties and conditions, express and implied, including
+     warranties or conditions of title and non-infringement, and
+     implied warranties or conditions of merchantability and fitness
+     for a particular purpose;
+
+     ii) effectively excludes on behalf of all other Contributors all
+     liability for damages, including direct, indirect, special,
+     incidental and consequential damages, such as lost profits;
+
+     iii) does not attempt to limit or alter the recipients' rights
+     in the Source Code under section 3.2; and
+
+     iv) requires any subsequent distribution of the Program by any
+     party to be under a license that satisfies the requirements
+     of this section 3.
+
+3.2 When the Program is Distributed as Source Code:
+
+  a) it must be made available under this Agreement, or if the
+  Program (i) is combined with other material in a separate file or
+  files made available under a Secondary License, and (ii) the initial
+  Contributor attached to the Source Code the notice described in
+  Exhibit A of this Agreement, then the Program may be made available
+  under the terms of such Secondary Licenses, and
+
+  b) a copy of this Agreement must be included with each copy of
+  the Program.
+
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability ("notices") contained within the Program from any copy of
+the Program which they Distribute, provided that Contributors may add
+their own appropriate notices.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor includes
+the Program in a commercial product offering, such Contributor
+("Commercial Contributor") hereby agrees to defend and indemnify every
+other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits
+and other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program
+in a commercial product offering. The obligations in this section do not
+apply to any claims or Losses relating to any actual or alleged
+intellectual property infringement. In order to qualify, an Indemnified
+Contributor must: a) promptly notify the Commercial Contributor in
+writing of such claim, and b) allow the Commercial Contributor to control,
+and cooperate with the Commercial Contributor in, the defense and any
+related settlement negotiations. The Indemnified Contributor may
+participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those performance
+claims and warranties, and if a court requires any other Contributor to
+pay any damages as a result, the Commercial Contributor must pay
+those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed to the
+minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other software
+or hardware) infringes such Recipient's patent(s), then such Recipient's
+rights granted under Section 2(b) shall terminate as of the date such
+litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of
+time after becoming aware of such noncompliance. If all Recipient's
+rights under this Agreement terminate, Recipient agrees to cease use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient's obligations under this Agreement and any licenses
+granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions) of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may assign the
+responsibility to serve as the Agreement Steward to a suitable separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always be
+Distributed subject to the version of the Agreement under which it was
+received. In addition, after a new version of the Agreement is published,
+Contributor may elect to Distribute the Program (including its
+Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted
+under this Agreement are reserved. Nothing in this Agreement is intended
+to be enforceable by any entity that is not a Contributor or Recipient.
+No third-party beneficiary rights are created under this Agreement.
+
+Exhibit A - Form of Secondary Licenses Notice
+
+"This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set forth
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}."
+
+  Simply including a copy of this Agreement, including this Exhibit A
+  is not sufficient to license the Source Code under Secondary Licenses.
+
+  If it is not possible or desirable to put the notice in a particular
+  file, then You may include the notice in a location (such as a LICENSE
+  file in a relevant directory) where a recipient would be likely to
+  look for such a notice.
+
+  You may add additional accurate notices of copyright ownership.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,24 @@
 {
-  "originHash" : "a31b21636c19c1fb2661a51b226a2aef490af95e85b9325c822a9c5af1d81190",
+  "originHash" : "964f77339928564758e21222b25f3a246b743df00d94c239682ba66c78fd76b0",
   "pins" : [
+    {
+      "identity" : "beautiful-mermaid-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/lukilabs/beautiful-mermaid-swift",
+      "state" : {
+        "revision" : "6a23a29e91af8f5b3e9fc09945332ca193bd69ec",
+        "version" : "1.0.4"
+      }
+    },
+    {
+      "identity" : "elk-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/lukilabs/elk-swift",
+      "state" : {
+        "revision" : "32f8042e3509a4819f00ff9cd46e829ec2b26da0",
+        "version" : "1.0.2"
+      }
+    },
     {
       "identity" : "sparkle",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -7,14 +7,24 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/swiftlang/swift-markdown.git", from: "0.5.0"),
         .package(url: "https://github.com/mgriebling/SwiftMath.git", from: "1.7.0"),
+        .package(url: "https://github.com/lukilabs/beautiful-mermaid-swift", from: "1.0.4"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.6.0"),
     ],
     targets: [
+        // Keep BeautifulMermaid's API behind a module boundary. It publishes
+        // broad AppKit extensions (including NSColor.init(hex:)); the bridge
+        // keeps those implementation details out of EdmundCore source.
+        .target(
+            name: "EdmundMermaidBridge",
+            dependencies: [
+                .product(name: "BeautifulMermaid", package: "beautiful-mermaid-swift"),
+            ]),
         .target(
             name: "EdmundCore",
             dependencies: [
                 .product(name: "Markdown", package: "swift-markdown"),
                 .product(name: "SwiftMath", package: "SwiftMath"),
+                "EdmundMermaidBridge",
             ],
             resources: [.copy("Resources/Syntaxes")]),
         // The user-facing app is "Edmund" (CFBundleName); the executable target —

--- a/Sources/EdmundCore/Export/DocumentHTML.swift
+++ b/Sources/EdmundCore/Export/DocumentHTML.swift
@@ -1,12 +1,13 @@
 import AppKit
+import EdmundMermaidBridge
 
 // MARK: - DocumentHTML
 //
 // Assembles the full, self-contained HTML document for Read mode and PDF export:
 // the `HTMLRenderer` body, the `HTMLTheme` stylesheet, and a second pass that
-// fills the renderer's placeholder elements with inlined assets (math
-// glyphs and local images) as data URIs. Callout/checkbox icons are inline
-// Lucide SVGs emitted by `HTMLRenderer` (no asset pass needed). Inlining keeps
+// fills the renderer's placeholder elements with inlined assets (Mermaid SVG,
+// math glyphs, and local images). Callout/checkbox icons are inline Lucide SVGs
+// emitted by `HTMLRenderer` (no asset pass needed). Inlining keeps
 // the document self-contained — the webview needs no file/network access.
 // Raw HTML in the markdown passes through per GFM, filtered by
 // `HTMLRenderer.filterRawHTML` (tagfilter + hardening); the page also carries a
@@ -23,6 +24,7 @@ enum DocumentHTML {
                      baseURL: URL? = nil,
                      options: ReadRenderOptions = .default) -> String {
         var body = HTMLRenderer.render(markdown: markdown, options: options)
+        body = fillMermaid(body, theme: theme, dark: dark)
         body = fillMath(body, theme: theme, dark: dark)
         body = fillImages(body, baseURL: baseURL, options: options)
         let css = HTMLTheme.css(theme, callouts: callouts, dark: dark,
@@ -37,6 +39,51 @@ enum DocumentHTML {
         </style></head>
         <body><div class="page">\(body)</div></body></html>
         """
+    }
+
+    // MARK: Mermaid (BeautifulMermaid → inline SVG)
+
+    // Group 1 carries the top-level source-line anchor inserted by
+    // HTMLRenderer.visitDocument; the replacement must retain it.
+    private static let mermaidPattern =
+        "<div( id=\"[^\"]*\")? class=\"mermaid-diagram\" data-source=\"([^\"]*)\"></div>"
+
+    private static func fillMermaid(_ html: String,
+                                    theme: EditorTheme,
+                                    dark: Bool) -> String {
+        let style = MermaidRenderStyle(editorTheme: theme, dark: dark)
+        return replaceMatches(html, pattern: mermaidPattern) { groups in
+            let id = groups[1]
+            guard let data = Data(base64Encoded: groups[2]),
+                  let source = String(data: data, encoding: .utf8),
+                  let svg = try? NativeMermaidRenderer.svg(
+                    source: source, theme: style.theme),
+                  isSafeMermaidSVG(svg) else {
+                let code = HTMLRenderer.escape(
+                    (Data(base64Encoded: groups[2])
+                        .flatMap { String(data: $0, encoding: .utf8) }) ?? "")
+                return "<div\(id) class=\"code-block-wrap\"><pre><code class=\"language-mermaid\">\(code)</code></pre></div>"
+            }
+            return "<div\(id) class=\"mermaid-diagram\" role=\"img\" aria-label=\"Mermaid diagram\">\(svg)</div>"
+        }
+    }
+
+    /// The renderer emits self-contained SVG. Reject active or externally
+    /// referencing SVG constructs before placing it into the read-mode page;
+    /// the CSP's `script-src 'none'` remains a second line of defense.
+    private static func isSafeMermaidSVG(_ svg: String) -> Bool {
+        let trimmed = svg.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("<svg"), trimmed.hasSuffix("</svg>") else { return false }
+        let lower = trimmed.lowercased()
+        let forbidden = [
+            "<script", "<foreignobject", "<iframe", "<object", "<embed",
+            "<image", "javascript:", "data:text/html", "xlink:href=", " href=",
+        ]
+        guard !forbidden.contains(where: lower.contains) else { return false }
+        guard let eventHandler = try? NSRegularExpression(
+            pattern: #"\son[a-z0-9_-]+\s*="#, options: [.caseInsensitive]) else { return false }
+        return eventHandler.firstMatch(
+            in: svg, range: NSRange(location: 0, length: (svg as NSString).length)) == nil
     }
 
     // MARK: Math (active engine → PNG data URI)

--- a/Sources/EdmundCore/Export/HTMLRenderer.swift
+++ b/Sources/EdmundCore/Export/HTMLRenderer.swift
@@ -282,6 +282,13 @@ struct HTMLRenderer: MarkupVisitor {
             .replacingOccurrences(of: "\u{2029}", with: "\n")
         // swift-markdown includes a trailing newline on the block's code.
         let code = raw.hasSuffix("\n") ? String(raw.dropLast()) : raw
+        if options.features.contains(.mermaid),
+           MermaidSyntax.matches(language: codeBlock.language) {
+            // Keep this AST renderer pure: the AppKit-backed native renderer
+            // fills the base64 payload in DocumentHTML's asset pass.
+            let source = Data(code.utf8).base64EncodedString()
+            return "<div class=\"mermaid-diagram\" data-source=\"\(source)\"></div>"
+        }
         let pre = "<pre><code\(lang)>\(Self.highlightCode(code, language: codeBlock.language))</code></pre>"
         return "<div class=\"code-block-wrap\">\(Self.copyButtonHTML(code: code))\(pre)</div>"
     }

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -213,6 +213,8 @@ enum HTMLTheme {
        at rest. */
     .code-copy-icon { opacity: 0; transition: opacity .15s; }
     .code-block-wrap:hover .code-copy-icon { opacity: 1; }
+    .mermaid-diagram { margin: 1em 0; overflow-x: auto; text-align: center; }
+    .mermaid-diagram svg { display: block; width: auto; height: auto; max-width: 100%; margin: 0 auto; }
     /* Dark mode lifts the bar to the marker gray (--rule is nearly invisible
        there); light mode keeps --rule. */
     blockquote { margin: 1em 0; padding: 0.5em 1em; border-left: 3px solid var(--quote-bar); color: var(--faint); }
@@ -407,7 +409,7 @@ enum HTMLTheme {
          keeps them. `print-color-adjust: exact` forces faithful color output
          so callout backgrounds, code blocks, and highlights survive printing. */
       * { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-      .callout, pre, blockquote, .table-wrap, .math-display,
+      .callout, pre, blockquote, .table-wrap, .math-display, .mermaid-diagram,
       .math-display-block { break-inside: avoid; }
       h1, h2, h3, h4, h5, h6 { break-after: avoid; }
       thead { display: table-header-group; }

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -213,7 +213,9 @@ enum HTMLTheme {
        at rest. */
     .code-copy-icon { opacity: 0; transition: opacity .15s; }
     .code-block-wrap:hover .code-copy-icon { opacity: 1; }
-    .mermaid-diagram { margin: 1em 0; overflow-x: auto; text-align: center; }
+    .mermaid-diagram { margin: 1em 0; padding: 14px 16px; overflow-x: auto;
+                       text-align: center; background: var(--code-bg);
+                       border: 1px solid var(--table-border); }
     .mermaid-diagram svg { display: block; width: auto; height: auto; max-width: 100%; margin: 0 auto; }
     /* Dark mode lifts the bar to the marker gray (--rule is nearly invisible
        there); light mode keeps --rule. */

--- a/Sources/EdmundCore/Model/MarkdownFeatures.swift
+++ b/Sources/EdmundCore/Model/MarkdownFeatures.swift
@@ -36,11 +36,14 @@ public struct MarkdownFeatures: OptionSet, Sendable, Equatable {
     /// alerts. Non-GFM: cleared by the master switch, so with it off only the
     /// GFM alert types render as callouts and the rest fall back to plain quotes.
     public static let calloutExtendedTypes = MarkdownFeatures(rawValue: 1 << 13)
+    /// Native rendering for fenced code blocks whose info string starts with
+    /// `mermaid`. The source remains the literal fenced block in text storage.
+    public static let mermaid            = MarkdownFeatures(rawValue: 1 << 14)
 
     /// Every feature enabled — the default.
     public static let all: MarkdownFeatures = [
         .highlight, .inlineComment, .callout, .wikilink, .footnote, .math,
         .frontMatter, .tag, .blockRef, .imageDimensions, .wikilinkEmbed,
-        .collapsibleCallout, .multiBlockComment, .calloutExtendedTypes,
+        .collapsibleCallout, .multiBlockComment, .calloutExtendedTypes, .mermaid,
     ]
 }

--- a/Sources/EdmundCore/Model/MermaidSyntax.swift
+++ b/Sources/EdmundCore/Model/MermaidSyntax.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Shared recognition for Mermaid fenced-code info strings. Mermaid permits
+/// whitespace after the language name, so only the first info-string word
+/// selects the renderer; the complete code body is passed through unchanged.
+enum MermaidSyntax {
+    static func matches(language: String?) -> Bool {
+        language?
+            .split(whereSeparator: \.isWhitespace)
+            .first?
+            .lowercased() == "mermaid"
+    }
+}

--- a/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
@@ -257,13 +257,21 @@ extension EditorTextView {
 
             case .codeBlock(let language):
                 guard span.fullRange.upperBound <= result.length else { continue }
-                // Monospace across the fullRange, fences included: the fence
-                // line keeps its natural (now code-line) height whether shown
-                // dimmed (active) or ink-cleared (rendered, blockquote-style).
-                result.addAttribute(.font, value: codeBlockFont, range: span.fullRange)
-                highlightCodeBlock(result, contentRange: span.contentRange, language: language)
-                if !cursorInToken {
-                    styleCodeBlockBox(result, span: span, language: language)
+                let isMermaid = markdownFeatures.contains(.mermaid)
+                    && MermaidSyntax.matches(language: language)
+                let source = span.contentRange.upperBound <= result.length
+                    ? (markdown as NSString).substring(with: span.contentRange) : ""
+                let renderedMermaid = isMermaid && !cursorInToken
+                    && styleMermaidBlock(result, span: span, source: source)
+                if !renderedMermaid {
+                    // Monospace across the fullRange, fences included: the fence
+                    // line keeps its natural (now code-line) height whether shown
+                    // dimmed (active) or ink-cleared (rendered, blockquote-style).
+                    result.addAttribute(.font, value: codeBlockFont, range: span.fullRange)
+                    highlightCodeBlock(result, contentRange: span.contentRange, language: language)
+                    if !cursorInToken {
+                        styleCodeBlockBox(result, span: span, language: language)
+                    }
                 }
 
             case .strikethrough:

--- a/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+Rendering.swift
@@ -269,7 +269,9 @@ extension EditorTextView {
                     // dimmed (active) or ink-cleared (rendered, blockquote-style).
                     result.addAttribute(.font, value: codeBlockFont, range: span.fullRange)
                     highlightCodeBlock(result, contentRange: span.contentRange, language: language)
-                    if !cursorInToken {
+                    if isMermaid && cursorInToken {
+                        styleActiveMermaidBlock(result, span: span, source: source)
+                    } else if !cursorInToken {
                         styleCodeBlockBox(result, span: span, language: language)
                     }
                 }

--- a/Sources/EdmundCore/Rendering/MermaidRendering.swift
+++ b/Sources/EdmundCore/Rendering/MermaidRendering.swift
@@ -1,0 +1,208 @@
+import AppKit
+import EdmundMermaidBridge
+
+/// A hashable description of the visual inputs sent to BeautifulMermaid. The
+/// native `DiagramTheme` contains AppKit objects and is not itself Hashable, so
+/// this value is the stable cache identity.
+struct MermaidThemeKey: Hashable, Sendable {
+    let dark: Bool
+    let fontName: String
+    let fontSize: CGFloat
+    let standardLigatures: Bool
+    let accentHex: String
+}
+
+struct MermaidRenderStyle: Sendable {
+    let key: MermaidThemeKey
+    let theme: NativeMermaidTheme
+
+    @MainActor
+    init(editorTheme: EditorTheme, dark: Bool) {
+        key = MermaidThemeKey(
+            dark: dark,
+            fontName: editorTheme.fontName,
+            fontSize: editorTheme.fontSize,
+            standardLigatures: editorTheme.standardLigatures,
+            accentHex: editorTheme.linkBlueHex
+        )
+        theme = NativeMermaidTheme(
+            background: NSColor(hex: dark ? "#292929" : "#ffffff") ?? .textBackgroundColor,
+            foreground: NSColor(hex: dark ? "#e6e6e6" : "#1a1a1a") ?? .textColor,
+            accent: NSColor(hex: editorTheme.linkBlueHex) ?? .systemBlue,
+            font: editorTheme.bodyFont
+        )
+    }
+}
+
+private actor MermaidRenderWorker {
+    static let shared = MermaidRenderWorker()
+
+    func image(source: String, theme: NativeMermaidTheme) -> NSImage? {
+        guard !Task.isCancelled else { return nil }
+        return try? NativeMermaidRenderer.image(source: source, theme: theme)
+    }
+}
+
+@MainActor
+private final class WeakMermaidEditor {
+    weak var value: EditorTextView?
+    init(_ value: EditorTextView) { self.value = value }
+}
+
+/// Small, process-wide native-image cache. Rendering stays off the main actor;
+/// a completed render invalidates only blocks containing the same Mermaid body.
+@MainActor
+final class MermaidImageStore {
+    struct Key: Hashable, Sendable {
+        let source: String
+        let theme: MermaidThemeKey
+    }
+
+    static let shared = MermaidImageStore()
+
+    private let capacity = 64
+    private var images: [Key: NSImage] = [:]
+    private var failed: Set<Key> = []
+    private var insertionOrder: [Key] = []
+    private var tasks: [Key: Task<Void, Never>] = [:]
+    private var waiters: [Key: [WeakMermaidEditor]] = [:]
+
+    func image(source: String, style: MermaidRenderStyle,
+               requesting editor: EditorTextView) -> NSImage? {
+        let key = Key(source: source, theme: style.key)
+        if let image = images[key] { return image }
+        guard !failed.contains(key) else { return nil }
+
+        var listeners = waiters[key, default: []]
+        listeners.removeAll { $0.value == nil }
+        if !listeners.contains(where: { $0.value === editor }) {
+            listeners.append(WeakMermaidEditor(editor))
+        }
+        waiters[key] = listeners
+
+        guard tasks[key] == nil else { return nil }
+        tasks[key] = Task { @MainActor [weak self] in
+            let image = await MermaidRenderWorker.shared.image(
+                source: source, theme: style.theme)
+            self?.finish(image: image, for: key)
+        }
+        return nil
+    }
+
+    /// Test/preflight hook that uses the same coalesced cache as editor styling.
+    func prepare(source: String, style: MermaidRenderStyle) async -> NSImage? {
+        let key = Key(source: source, theme: style.key)
+        if let image = images[key] { return image }
+        if failed.contains(key) { return nil }
+        if let task = tasks[key] {
+            await task.value
+            return images[key]
+        }
+
+        tasks[key] = Task { @MainActor [weak self] in
+            let image = await MermaidRenderWorker.shared.image(
+                source: source, theme: style.theme)
+            self?.finish(image: image, for: key)
+        }
+        await tasks[key]?.value
+        return images[key]
+    }
+
+    private func finish(image: NSImage?, for key: Key) {
+        tasks[key] = nil
+        if let image {
+            images[key] = image
+            insertionOrder.append(key)
+            while insertionOrder.count > capacity {
+                let evicted = insertionOrder.removeFirst()
+                images[evicted] = nil
+                failed.remove(evicted)
+            }
+        } else {
+            failed.insert(key)
+        }
+
+        let editors = waiters.removeValue(forKey: key)?
+            .compactMap(\.value) ?? []
+        for editor in editors {
+            editor.mermaidImageDidRender(source: key.source)
+        }
+    }
+}
+
+extension EditorTextView {
+    /// Replaces an inactive Mermaid fence with the cached native image. On a
+    /// cache miss the ordinary code-block box remains visible until the
+    /// background render completes.
+    func styleMermaidBlock(_ result: NSMutableAttributedString,
+                           span: SyntaxHighlighter.Span,
+                           source: String) -> Bool {
+        let style = MermaidRenderStyle(editorTheme: theme, dark: isDarkAppearance)
+        guard let image = MermaidImageStore.shared.image(
+            source: source, style: style, requesting: self),
+              image.size.width > 0, image.size.height > 0 else { return false }
+
+        let maxWidth = max(1, availableContentWidth)
+        let scale = min(1, maxWidth / image.size.width)
+        let width = image.size.width * scale
+        let height = image.size.height * scale
+        let x = max(0, (maxWidth - width) / 2)
+        let overlay = FragmentOverlay(
+            image: image,
+            bounds: CGRect(x: x, y: 0, width: width, height: height)
+        )
+
+        // Every source character remains in storage. Near-zero hidden rows
+        // collapse the code body while the opening-fence paragraph reserves
+        // the diagram's height and carries its overlay.
+        result.addAttribute(.font, value: hiddenFont, range: span.fullRange)
+        result.addAttribute(.foregroundColor, value: NSColor.clear, range: span.fullRange)
+        let collapsed = NSMutableParagraphStyle()
+        collapsed.minimumLineHeight = hiddenFont.pointSize
+        result.addAttribute(.paragraphStyle, value: collapsed, range: span.fullRange)
+
+        let anchor = NSRange(location: span.fullRange.location, length: 1)
+        applyOverlay(overlay, anchor: anchor, in: result)
+        reserveLineHeight(ascent: height, descent: 0,
+                          forOverlayAt: anchor.location, in: result)
+
+        let ns = result.string as NSString
+        let firstLine = NSIntersectionRange(
+            ns.paragraphRange(for: NSRange(location: anchor.location, length: 0)),
+            span.fullRange
+        )
+        if firstLine.length > 0,
+           let base = result.attribute(.paragraphStyle, at: anchor.location,
+                                       effectiveRange: nil) as? NSParagraphStyle {
+            let spaced = base.mutableCopy() as! NSMutableParagraphStyle
+            spaced.paragraphSpacingBefore = 8
+            spaced.paragraphSpacing = 8
+            result.addAttribute(.paragraphStyle, value: spaced, range: firstLine)
+        }
+        return true
+    }
+
+    /// A background render may finish during typing or IME composition. In
+    /// those states the cache is left ready and the normal next styling pass
+    /// picks it up; no asynchronous attribute write is allowed to race the edit.
+    func mermaidImageDidRender(source: String) {
+        guard markdownFeatures.contains(.mermaid),
+              !isUpdating, !hasMarkedText(),
+              (textStorage as? EditorTextStorage)?.pendingEdit == nil else { return }
+
+        var dirty = IndexSet()
+        for index in blocks.indices where blocks[index].content.contains(source) {
+            let content = blocks[index].content
+            let ns = content as NSString
+            let matches = SyntaxHighlighter.parse(content, features: markdownFeatures).contains {
+                guard case .codeBlock(let language) = $0.kind,
+                      MermaidSyntax.matches(language: language),
+                      $0.contentRange.upperBound <= ns.length else { return false }
+                return ns.substring(with: $0.contentRange) == source
+            }
+            if matches { dirty.insert(index) }
+        }
+        guard !dirty.isEmpty else { return }
+        recomposeDirty(dirty, cursorInRaw: currentCursorInRaw())
+    }
+}

--- a/Sources/EdmundCore/Rendering/MermaidRendering.swift
+++ b/Sources/EdmundCore/Rendering/MermaidRendering.swift
@@ -131,30 +131,104 @@ final class MermaidImageStore {
 }
 
 extension EditorTextView {
+    private var mermaidFrameHorizontalPadding: CGFloat { 16 }
+    private var mermaidFrameVerticalPadding: CGFloat { 14 }
+
+    private var mermaidFrameBorderColor: NSColor {
+        isDarkAppearance ? Self.darkRuleGray : .separatorColor
+    }
+
+    private var mermaidSourceParagraphStyle: NSParagraphStyle {
+        let ps = NSMutableParagraphStyle()
+        ps.lineSpacing = bodyParagraphStyle.lineSpacing
+        ps.firstLineHeadIndent = mermaidFrameHorizontalPadding
+        ps.headIndent = mermaidFrameHorizontalPadding
+        ps.tailIndent = -mermaidFrameHorizontalPadding
+        return ps
+    }
+
+    private func mermaidImageAndHeight(source: String,
+                                       result: NSAttributedString,
+                                       span: SyntaxHighlighter.Span)
+        -> (image: NSImage, width: CGFloat, height: CGFloat, frameHeight: CGFloat)? {
+        let style = MermaidRenderStyle(editorTheme: theme, dark: isDarkAppearance)
+        guard let image = MermaidImageStore.shared.image(
+            source: source, style: style, requesting: self),
+              image.size.width > 0, image.size.height > 0 else { return nil }
+
+        let innerWidth = max(1, availableContentWidth - 2 * mermaidFrameHorizontalPadding)
+        let scale = min(1, innerWidth / image.size.width)
+        let width = image.size.width * scale
+        let height = image.size.height * scale
+
+        // Measure the active source with the exact font, line spacing, and
+        // horizontal inset it receives below. This keeps the container height
+        // identical on both sides of the preview/source transition, including
+        // wrapped Mermaid lines.
+        let measured = NSMutableAttributedString(
+            attributedString: result.attributedSubstring(from: span.fullRange))
+        measured.addAttribute(.font, value: codeBlockFont,
+                              range: NSRange(location: 0, length: measured.length))
+        measured.addAttribute(.paragraphStyle, value: mermaidSourceParagraphStyle,
+                              range: NSRange(location: 0, length: measured.length))
+        let sourceHeight = ceil(measured.boundingRect(
+            with: CGSize(width: max(1, availableContentWidth),
+                         height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading]
+        ).height)
+        let frameHeight = max(height, sourceHeight) + 2 * mermaidFrameVerticalPadding
+        return (image, width, height, frameHeight)
+    }
+
+    private func mermaidLineRanges(_ string: NSString,
+                                   in range: NSRange) -> [NSRange] {
+        var lines: [NSRange] = []
+        var location = range.location
+        while location < range.upperBound {
+            let line = NSIntersectionRange(
+                string.lineRange(for: NSRange(location: location, length: 0)),
+                range
+            )
+            guard line.length > 0 else { break }
+            lines.append(line)
+            location = line.upperBound
+        }
+        return lines
+    }
+
+    private func mermaidFrameDecoration(edges: CalloutStyle.Edges,
+                                        bottomPad: CGFloat = 0)
+        -> BlockDecoration {
+        BlockDecoration(.box(
+            background: codeBlockBackground,
+            borderColor: mermaidFrameBorderColor,
+            borderEdges: edges,
+            borderWidth: 1,
+            bottomPad: bottomPad
+        ))
+    }
+
     /// Replaces an inactive Mermaid fence with the cached native image. On a
     /// cache miss the ordinary code-block box remains visible until the
     /// background render completes.
     func styleMermaidBlock(_ result: NSMutableAttributedString,
                            span: SyntaxHighlighter.Span,
                            source: String) -> Bool {
-        let style = MermaidRenderStyle(editorTheme: theme, dark: isDarkAppearance)
-        guard let image = MermaidImageStore.shared.image(
-            source: source, style: style, requesting: self),
-              image.size.width > 0, image.size.height > 0 else { return false }
+        guard let metrics = mermaidImageAndHeight(
+            source: source, result: result, span: span) else { return false }
 
-        let maxWidth = max(1, availableContentWidth)
-        let scale = min(1, maxWidth / image.size.width)
-        let width = image.size.width * scale
-        let height = image.size.height * scale
-        let x = max(0, (maxWidth - width) / 2)
+        let x = max(mermaidFrameHorizontalPadding,
+                    (availableContentWidth - metrics.width) / 2)
+        let y = (metrics.frameHeight - metrics.height) / 2
         let overlay = FragmentOverlay(
-            image: image,
-            bounds: CGRect(x: x, y: 0, width: width, height: height)
+            image: metrics.image,
+            bounds: CGRect(x: x, y: y,
+                           width: metrics.width, height: metrics.height)
         )
 
         // Every source character remains in storage. Near-zero hidden rows
         // collapse the code body while the opening-fence paragraph reserves
-        // the diagram's height and carries its overlay.
+        // the stable frame height and carries its overlay.
         result.addAttribute(.font, value: hiddenFont, range: span.fullRange)
         result.addAttribute(.foregroundColor, value: NSColor.clear, range: span.fullRange)
         let collapsed = NSMutableParagraphStyle()
@@ -163,7 +237,7 @@ extension EditorTextView {
 
         let anchor = NSRange(location: span.fullRange.location, length: 1)
         applyOverlay(overlay, anchor: anchor, in: result)
-        reserveLineHeight(ascent: height, descent: 0,
+        reserveLineHeight(ascent: metrics.frameHeight, descent: 0,
                           forOverlayAt: anchor.location, in: result)
 
         let ns = result.string as NSString
@@ -171,15 +245,70 @@ extension EditorTextView {
             ns.paragraphRange(for: NSRange(location: anchor.location, length: 0)),
             span.fullRange
         )
-        if firstLine.length > 0,
-           let base = result.attribute(.paragraphStyle, at: anchor.location,
-                                       effectiveRange: nil) as? NSParagraphStyle {
-            let spaced = base.mutableCopy() as! NSMutableParagraphStyle
-            spaced.paragraphSpacingBefore = 8
-            spaced.paragraphSpacing = 8
-            result.addAttribute(.paragraphStyle, value: spaced, range: firstLine)
+        if firstLine.length > 0 {
+            result.addAttribute(.blockDecoration,
+                                value: mermaidFrameDecoration(edges: .all),
+                                range: firstLine)
         }
         return true
+    }
+
+    /// Keeps the editable source inside the same framed height as its preview.
+    /// Source lines retain their natural metrics; only the last fragment grows
+    /// to absorb the unused part of the frame, so caret placement and selection
+    /// hit-testing remain ordinary TextKit behavior.
+    func styleActiveMermaidBlock(_ result: NSMutableAttributedString,
+                                 span: SyntaxHighlighter.Span,
+                                 source: String) {
+        guard let metrics = mermaidImageAndHeight(
+            source: source, result: result, span: span) else { return }
+
+        let ns = result.string as NSString
+        let lines = mermaidLineRanges(ns, in: span.fullRange)
+        guard !lines.isEmpty else { return }
+
+        result.addAttribute(.paragraphStyle, value: mermaidSourceParagraphStyle,
+                            range: span.fullRange)
+
+        let firstStyle = mermaidSourceParagraphStyle.mutableCopy()
+            as! NSMutableParagraphStyle
+        firstStyle.paragraphSpacingBefore = mermaidFrameVerticalPadding
+        result.addAttribute(.paragraphStyle, value: firstStyle, range: lines[0])
+
+        let measured = NSMutableAttributedString(
+            attributedString: result.attributedSubstring(from: span.fullRange))
+        // The active source already includes its top inset. The remaining
+        // height belongs below the final line; the decoration grows that
+        // fragment directly, keeping the space painted and clickable.
+        let activeHeight = ceil(measured.boundingRect(
+            with: CGSize(width: max(1, availableContentWidth),
+                         height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading]
+        ).height)
+        // NSString drawing omits the final line's trailing lineSpacing while
+        // TextKit includes it in the fragment stack. Account for that and the
+        // explicit top inset before assigning the remainder to the last line.
+        let bottomPad = max(
+            0,
+            metrics.frameHeight - activeHeight
+                - mermaidFrameVerticalPadding
+                - mermaidSourceParagraphStyle.lineSpacing
+        )
+
+        for (index, line) in lines.enumerated() {
+            var edges: CalloutStyle.Edges = [.left, .right]
+            if index == lines.startIndex { edges.insert(.top) }
+            if index == lines.index(before: lines.endIndex) { edges.insert(.bottom) }
+            result.addAttribute(
+                .blockDecoration,
+                value: mermaidFrameDecoration(
+                    edges: edges,
+                    bottomPad: index == lines.index(before: lines.endIndex)
+                        ? bottomPad : 0
+                ),
+                range: line
+            )
+        }
     }
 
     /// A background render may finish during typing or IME composition. In

--- a/Sources/EdmundMermaidBridge/NativeMermaidRenderer.swift
+++ b/Sources/EdmundMermaidBridge/NativeMermaidRenderer.swift
@@ -1,0 +1,79 @@
+import AppKit
+internal import BeautifulMermaid
+
+/// Edmund-facing theme value that keeps BeautifulMermaid's public AppKit
+/// extensions behind this target's module boundary.
+public struct NativeMermaidTheme: @unchecked Sendable {
+    fileprivate let background: NSColor
+    fileprivate let foreground: NSColor
+    fileprivate let accent: NSColor
+    fileprivate let font: NSFont
+
+    public init(background: NSColor,
+                foreground: NSColor,
+                accent: NSColor,
+                font: NSFont) {
+        self.background = background
+        self.foreground = foreground
+        self.accent = accent
+        self.font = font
+    }
+
+    fileprivate var diagramTheme: DiagramTheme {
+        DiagramTheme(background: background, foreground: foreground,
+                     accent: accent, font: font)
+    }
+}
+
+/// Serialized native rendering. BeautifulMermaid shares one ELK instance, so
+/// bitmap work and SVG work must not enter it concurrently.
+public enum NativeMermaidRenderer {
+    private static let lock = NSLock()
+
+    public static func image(source: String,
+                             theme: NativeMermaidTheme) throws -> NSImage? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let image = try MermaidRenderer.renderImage(
+            source: source, theme: theme.diagramTheme, scale: 2)
+        else { return nil }
+        // BeautifulMermaid's AppKit bitmap currently has top-down diagram
+        // coordinates in a bottom-up CGContext, so its pixels arrive vertically
+        // inverted. Correct the pixel orientation once at the bridge boundary;
+        // keeping the package's direct bitmap also preserves its resolved theme
+        // colors (AppKit's SVG decoder does not resolve the emitted CSS vars).
+        return verticallyFlipped(image)
+    }
+
+    public static func svg(source: String,
+                           theme: NativeMermaidTheme) throws -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        return try MermaidRenderer.renderSVG(
+            source: source, theme: theme.diagramTheme)
+    }
+
+    private static func verticallyFlipped(_ image: NSImage) -> NSImage? {
+        guard let source = image.cgImage(
+            forProposedRect: nil, context: nil, hints: nil) else { return nil }
+        let width = source.width
+        let height = source.height
+        guard width > 0, height > 0,
+              let context = CGContext(
+                data: nil,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: 0,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+                    | CGBitmapInfo.byteOrder32Big.rawValue
+              ) else { return nil }
+        context.translateBy(x: 0, y: CGFloat(height))
+        context.scaleBy(x: 1, y: -1)
+        context.draw(source, in: CGRect(x: 0, y: 0,
+                                       width: width, height: height))
+        guard let corrected = context.makeImage() else { return nil }
+        return NSImage(cgImage: corrected, size: image.size)
+    }
+}

--- a/Sources/EdmundMermaidBridge/NativeMermaidRenderer.swift
+++ b/Sources/EdmundMermaidBridge/NativeMermaidRenderer.swift
@@ -49,8 +49,23 @@ public enum NativeMermaidRenderer {
                            theme: NativeMermaidTheme) throws -> String {
         lock.lock()
         defer { lock.unlock() }
-        return try MermaidRenderer.renderSVG(
-            source: source, theme: theme.diagramTheme)
+        let diagramTheme = theme.diagramTheme
+        let options = RenderOptions(
+            bg: diagramTheme.background.hexString,
+            fg: diagramTheme.foreground.hexString,
+            line: diagramTheme.effectiveLine().hexString,
+            accent: diagramTheme.effectiveAccent().hexString,
+            muted: diagramTheme.effectiveMuted().hexString,
+            surface: diagramTheme.effectiveSurface().hexString,
+            border: diagramTheme.effectiveBorder().hexString,
+            font: theme.font.fontName,
+            transparent: false
+        )
+        // BeautifulMermaid 1.0.4's convenience SVG path tries to flatten
+        // nested CSS fallbacks and can produce invalid paint values such as
+        // `#F8F8F8 3%, #FFFFFF))`. WKWebView supports the renderer's original
+        // SVG variables, so retain that valid vector output at our boundary.
+        return try renderMermaidSVG(source, options)
     }
 
     private static func verticallyFlipped(_ image: NSImage) -> NSImage? {

--- a/Sources/edmd/Settings/AppSettings.swift
+++ b/Sources/edmd/Settings/AppSettings.swift
@@ -106,6 +106,7 @@ enum AppSettings {
         static let enableNonGFM      = "settings.syntax.enableNonGFM"
         static let synFrontMatter    = "settings.syntax.frontMatter"
         static let synMath           = "settings.syntax.math"
+        static let synMermaid        = "settings.syntax.mermaid"
         static let synHighlight      = "settings.syntax.highlight"
         static let synComment        = "settings.syntax.comment"
         static let synWikilink       = "settings.syntax.wikilink"
@@ -175,11 +176,12 @@ enum AppSettings {
         // ordinary image dimensions `![alt|200](url)` aren't tied to any grid item.
         f.insert(.imageDimensions)
 
-        // The 5x2 grid. Related sub-syntaxes fold into their grid toggle:
+        // The feature grid. Related sub-syntaxes fold into their grid toggle:
         // wikilink image embeds under Wikilink, collapsible under the Obsidian
         // callout, multi-block comments under Comment.
         if boolDefaultTrue(Key.synFrontMatter)    { f.insert(.frontMatter) }
         if boolDefaultTrue(Key.synMath)           { f.insert(.math) }
+        if boolDefaultTrue(Key.synMermaid)        { f.insert(.mermaid) }
         if boolDefaultTrue(Key.synHighlight)      { f.insert(.highlight) }
         if boolDefaultTrue(Key.synComment)        { f.formUnion([.inlineComment, .multiBlockComment]) }
         if boolDefaultTrue(Key.synWikilink)       { f.formUnion([.wikilink, .wikilinkEmbed]) }

--- a/Sources/edmd/Settings/SyntaxSettingsView.swift
+++ b/Sources/edmd/Settings/SyntaxSettingsView.swift
@@ -12,6 +12,7 @@ struct SyntaxSettingsView: View {
     @AppStorage(AppSettings.Key.enableNonGFM)       private var enableNonGFM = true
     @AppStorage(AppSettings.Key.synFrontMatter)     private var frontMatter = true
     @AppStorage(AppSettings.Key.synMath)            private var math = true
+    @AppStorage(AppSettings.Key.synMermaid)         private var mermaid = true
     @AppStorage(AppSettings.Key.synHighlight)       private var highlight = true
     @AppStorage(AppSettings.Key.synComment)         private var comment = true
     @AppStorage(AppSettings.Key.synWikilink)        private var wikilink = true
@@ -178,8 +179,8 @@ struct SyntaxSettingsView: View {
                 cell("Block ^1", $blockRef)
             }
             GridRow {
+                cell("Mermaid diagrams", $mermaid)
                 cell("Obsidian callout > [!note]", $obsidianCallout)
-                    .gridCellColumns(2)
             }
         }
     }

--- a/Tests/EdmundTests/MermaidRenderingTests.swift
+++ b/Tests/EdmundTests/MermaidRenderingTests.swift
@@ -12,6 +12,18 @@ struct MermaidRenderingTests {
         ```
         """
 
+    private func preparePreview(for editor: EditorTextView) async -> String? {
+        guard let span = SyntaxHighlighter.parse(markdown).first(where: {
+            if case .codeBlock = $0.kind { return true }
+            return false
+        }) else { return nil }
+        let source = (markdown as NSString).substring(with: span.contentRange)
+        let style = MermaidRenderStyle(editorTheme: editor.theme, dark: false)
+        guard await MermaidImageStore.shared.prepare(source: source, style: style) != nil
+        else { return nil }
+        return source
+    }
+
     @Test("Info-string recognition is case-insensitive and uses its first word")
     func languageRecognition() {
         #expect(MermaidSyntax.matches(language: "mermaid"))
@@ -47,6 +59,11 @@ struct MermaidRenderingTests {
             "<div id=\"edmund-l1\" class=\"mermaid-diagram\" role=\"img\""))
         #expect(html.contains("<svg xmlns=\"http://www.w3.org/2000/svg\""))
         #expect(html.contains(".mermaid-diagram svg"))
+        #expect(html.contains("background: var(--code-bg)"))
+        #expect(html.contains("border: 1px solid var(--table-border)"))
+        #expect(html.contains("fill=\"var(--_node-fill)\""))
+        #expect(!html.contains(#/fill="#[0-9A-Fa-f]{6} [0-9]+%/#))
+        #expect(!html.contains(#/stroke="#[0-9A-Fa-f]{6} [0-9]+%/#))
         #expect(!html.lowercased().contains("<script"))
     }
 
@@ -78,23 +95,65 @@ struct MermaidRenderingTests {
         #expect(span != nil)
         guard let span else { return }
         let source = (markdown as NSString).substring(with: span.contentRange)
-        let style = MermaidRenderStyle(editorTheme: editor.theme, dark: false)
-        #expect(await MermaidImageStore.shared.prepare(source: source, style: style) != nil)
+        #expect(await preparePreview(for: editor) == source)
 
         let styled = editor.styleBlock(markdown)
         #expect(styled.string == markdown)
         #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil)
                 is FragmentOverlay)
+        guard let decoration = blockDecoration(at: 0, in: styled),
+              case .box(_, let border, let edges, let width, _) = decoration.kind else {
+            Issue.record("Mermaid preview has no frame")
+            return
+        }
+        #expect(border != nil)
+        #expect(edges == .all)
+        #expect(width == 1)
     }
 
     @Test("Active editor fence remains editable raw source")
     func activeEditorSource() async {
         let editor = makeEditor()
+        #expect(await preparePreview(for: editor) != nil)
         let styled = editor.styleBlock(markdown, cursorPosition: 20)
         #expect(styled.string == markdown)
         #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) == nil)
         let body = (markdown as NSString).range(of: "graph TD")
         let font = styled.attribute(.font, at: body.location, effectiveRange: nil) as? NSFont
         #expect(font?.pointSize == editor.codeBlockFont.pointSize)
+        #expect(blockDecoration(at: 0, in: styled) != nil)
+        #expect(blockDecoration(at: styled.length - 1, in: styled) != nil)
+    }
+
+    @Test("Preview and editable source keep the same framed height")
+    func stableEditorHeight() async {
+        let editor = makeEditor()
+        #expect(await preparePreview(for: editor) != nil)
+        let document = "lead paragraph\n\n\(markdown)\n\nREFERENCE LINE\n"
+        editor.loadContent(document)
+        ensureFullLayout(editor)
+
+        let ns = document as NSString
+        let lead = ns.range(of: "lead paragraph").location
+        let source = ns.range(of: "graph TD").location
+        let reference = ns.range(of: "REFERENCE LINE").location
+
+        editor.setSelectedRange(NSRange(location: lead, length: 0))
+        editor.recomposeIncremental(cursorInRaw: lead)
+        ensureFullLayout(editor)
+        let renderedY = editor.lineRect(forCharacterAt: reference)?.minY
+
+        editor.setSelectedRange(NSRange(location: source, length: 0))
+        editor.recomposeIncremental(cursorInRaw: source)
+        ensureFullLayout(editor)
+        let activeY = editor.lineRect(forCharacterAt: reference)?.minY
+
+        #expect(renderedY != nil)
+        #expect(activeY != nil)
+        if let renderedY, let activeY {
+            #expect(abs(activeY - renderedY) < 1,
+                    "Mermaid frame shifted by \(activeY - renderedY)pt")
+        }
+        #expect(editor.rawSource == editor.string)
     }
 }

--- a/Tests/EdmundTests/MermaidRenderingTests.swift
+++ b/Tests/EdmundTests/MermaidRenderingTests.swift
@@ -1,0 +1,100 @@
+import AppKit
+import Testing
+@testable import EdmundCore
+
+@Suite("Mermaid — native rendering", .serialized)
+@MainActor
+struct MermaidRenderingTests {
+    private let markdown = """
+        ```mermaid
+        graph TD
+          A[Write] --> B[Preview]
+        ```
+        """
+
+    @Test("Info-string recognition is case-insensitive and uses its first word")
+    func languageRecognition() {
+        #expect(MermaidSyntax.matches(language: "mermaid"))
+        #expect(MermaidSyntax.matches(language: "MERMAID title=Example"))
+        #expect(!MermaidSyntax.matches(language: "swift"))
+        #expect(!MermaidSyntax.matches(language: nil))
+    }
+
+    @Test("HTML renderer emits an asset placeholder only while Mermaid is enabled")
+    func htmlFeatureGate() {
+        let on = HTMLRenderer.render(markdown: markdown)
+        #expect(on.contains(
+            "<div id=\"edmund-l1\" class=\"mermaid-diagram\" data-source=\""))
+        #expect(!on.contains("<code class=\"language-mermaid\">"))
+
+        let options = ReadRenderOptions(
+            features: MarkdownFeatures.all.subtracting(.mermaid))
+        let off = HTMLRenderer.render(markdown: markdown, options: options)
+        #expect(!off.contains("data-source="))
+        #expect(off.contains("<code class=\"language-mermaid\">"))
+    }
+
+    @Test("Read/PDF document contains safe inline SVG and preserves its source anchor")
+    func documentSVG() {
+        let html = DocumentHTML.full(
+            markdown: markdown,
+            theme: .default,
+            callouts: Callout.defaultStyles,
+            dark: false
+        )
+        #expect(!html.contains("data-source="))
+        #expect(html.contains(
+            "<div id=\"edmund-l1\" class=\"mermaid-diagram\" role=\"img\""))
+        #expect(html.contains("<svg xmlns=\"http://www.w3.org/2000/svg\""))
+        #expect(html.contains(".mermaid-diagram svg"))
+        #expect(!html.lowercased().contains("<script"))
+    }
+
+    @Test("An unsupported diagram falls back to escaped source code")
+    func unsupportedFallback() {
+        let source = """
+            ```mermaid
+            this is not a diagram
+            ```
+            """
+        let html = DocumentHTML.full(
+            markdown: source,
+            theme: .default,
+            callouts: Callout.defaultStyles,
+            dark: false
+        )
+        #expect(!html.contains("data-source="))
+        #expect(html.contains("<code class=\"language-mermaid\">"))
+        #expect(html.contains("this is not a diagram"))
+    }
+
+    @Test("Inactive editor fence draws a native overlay without changing its string")
+    func editorOverlay() async {
+        let editor = makeEditor()
+        let span = SyntaxHighlighter.parse(markdown).first {
+            if case .codeBlock = $0.kind { return true }
+            return false
+        }
+        #expect(span != nil)
+        guard let span else { return }
+        let source = (markdown as NSString).substring(with: span.contentRange)
+        let style = MermaidRenderStyle(editorTheme: editor.theme, dark: false)
+        #expect(await MermaidImageStore.shared.prepare(source: source, style: style) != nil)
+
+        let styled = editor.styleBlock(markdown)
+        #expect(styled.string == markdown)
+        #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil)
+                is FragmentOverlay)
+    }
+
+    @Test("Active editor fence remains editable raw source")
+    func activeEditorSource() async {
+        let editor = makeEditor()
+        let styled = editor.styleBlock(markdown, cursorPosition: 20)
+        #expect(styled.string == markdown)
+        #expect(styled.attribute(.fragmentOverlay, at: 0, effectiveRange: nil) == nil)
+        let body = (markdown as NSString).range(of: "graph TD")
+        let font = styled.attribute(.font, at: body.location, effectiveRange: nil) as? NSFont
+        #expect(font?.pointSize == editor.codeBlockFont.pointSize)
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -175,7 +175,12 @@ rawSource ─BlockParser─▶ [Block] ─SyntaxHighlighter─▶ spans ─style
   serialized background actor, caches the native image, hides/collapses the
   remaining raw fence rows, and invalidates only matching blocks on completion.
   The opening fence is a single-line fragment, so it stays outside the image
-  overlay wrapping wedge above. Active fences remain ordinary editable code.
+  overlay wrapping wedge above. Preview and active source share one full-column
+  framed height: the frame takes the larger of the scaled image and measured
+  source, and the active form grows only its final fragment to consume the
+  remainder. This keeps ordinary source-line/caret metrics while preventing
+  content below from jumping when the block activates. Read/PDF uses the same
+  framed surface around its inline SVG.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,7 +33,8 @@ Two SPM targets (`Package.swift`):
   window setup.
 
 Dependencies: `swift-markdown` (CommonMark/GFM), `SwiftMath` (LaTeX),
-`Sparkle` (auto-update).
+`beautiful-mermaid-swift` + its `elk-swift` layout dependency (native Mermaid
+diagrams), `Sparkle` (auto-update).
 
 ---
 
@@ -78,7 +79,7 @@ rawSource ─BlockParser─▶ [Block] ─SyntaxHighlighter─▶ spans ─style
   autolinks.
 - **`styleBlock(_:cursorPosition:)`** (`Rendering/EditorTextView+Rendering.swift`)
   renders ONE block. Each feature has a `Rendering/` extension: Callout,
-  Code, Image, List, ListMarker, Math, Table, WikiLinks.
+  Code, Image, List, ListMarker, Math, Mermaid, Table, WikiLinks.
 - **Recompose** (`TextView/EditorTextView+Composition.swift`) drives styling:
   - `recompose(cursorInRaw:)` — full: replace storage with rawSource, restyle
     all blocks (load, undo, indent).
@@ -169,6 +170,12 @@ rawSource ─BlockParser─▶ [Block] ─SyntaxHighlighter─▶ spans ─style
   equality paired with constant-by-kind/count hashes turns Foundation's global
   attribute-dictionary interner into a collision chain and makes styling
   superlinear. Hash every field used by equality whenever the value permits it.
+- **Mermaid fences use the opening-fence fragment as their overlay anchor.**
+  `MermaidRendering.swift` renders inactive ```` ```mermaid ```` bodies on a
+  serialized background actor, caches the native image, hides/collapses the
+  remaining raw fence rows, and invalidates only matching blocks on completion.
+  The opening fence is a single-line fragment, so it stays outside the image
+  overlay wrapping wedge above. Active fences remain ordinary editable code.
 
 ---
 
@@ -181,13 +188,13 @@ rawSource ─BlockParser─▶ [Block] ─SyntaxHighlighter─▶ spans ─style
 | Code-fence highlighting | A pluggable seam, not a hardcoded scanner. `CodeHighlighter` is the facade: it resolves the effective language, then hands `(code, language)` to the active `CodeSyntaxBackend`. `BuiltinSyntaxBackend` is the default — one single-pass O(n) char scanner driven by a declarative `LanguageDefinition` (keywords, comment/string delimiters) rather than per-language code. `SyntaxDefinitionStore` loads those definitions from two places: the bundled JSON in `EdmundCore/Resources/Syntaxes/` and the user's Application Support dir, so **users can add a language without a rebuild**. Settings ▸ Syntax picks the fallback language (`settings.syntax.defaultCodeSyntax`). |
 | Block model | `Model/Block.swift`, `Callout.swift`, `EditorTheme.swift`, `ListIndentState.swift`, `LinkDefinitionState.swift` (incremental index of `[label]: dest` reference-link definitions, which resolve across blocks — so a definition edit dirties the blocks that cite it), `LineEnding.swift` (buffer is always LF internally so `BlockParser`'s `\n` split stays clean; the file's original CRLF/CR style is remembered and written back on save), `StatusBarPrefs.swift`, `SVGPath.swift` (minimal SVG→`CGPath` for the vendored Lucide geometry — §5's wrapping-callout icon) |
 | Text storage | `TextView/EditorTextStorage.swift` — `NSTextStorage` subclass whose `fixAttributes` does **font substitution only**. The editor manages every attribute on every character (incl. custom keys like `.blockDecoration`/`.fragmentOverlay`), so AppKit's usual attribute fixing would fight it. Also carries the `pendingEdit` that drives incremental reparse (§4) and the bypassed-edit heal (§8). |
-| Markdown feature toggles | `Model/MarkdownFeatures.swift` — one `OptionSet` (`.all` default) gating each extension (highlight, `%%`comment, callout, wikilink, footnote, math, image dimensions `\|WxH`, `![[embed]]`, collapsible callouts `[!x]-/+`, plus Phase-2 front-matter/tag/blockRef/multi-block-comment). Threaded into `SyntaxHighlighter.parse(features:)` (gates each custom-parser pass; callout gated at render via `calloutInfo`), `EditorTextView.markdownFeatures` (didSet recompose), and `ReadRenderOptions.features` (→ `HTMLRenderer`). Assembled from per-feature UserDefaults toggles by `AppSettings.markdownFeatures`; Settings ▸ Syntax pane. A cleared flag renders the syntax as plain text in **both** back-ends. |
-| Rendering | `Rendering/EditorTextView+*Rendering.swift` (Callout, Code, Image, List, Math, Table, WikiLinks) |
+| Markdown feature toggles | `Model/MarkdownFeatures.swift` — one `OptionSet` (`.all` default) gating each extension (highlight, `%%`comment, callout, wikilink, footnote, math, Mermaid fences, image dimensions `\|WxH`, `![[embed]]`, collapsible callouts `[!x]-/+`, plus Phase-2 front-matter/tag/blockRef/multi-block-comment). Threaded into `SyntaxHighlighter.parse(features:)` (gates each custom-parser pass; callout and Mermaid are gated at render), `EditorTextView.markdownFeatures` (didSet recompose), and `ReadRenderOptions.features` (→ `HTMLRenderer`). Assembled from per-feature UserDefaults toggles by `AppSettings.markdownFeatures`; Settings ▸ Syntax pane. A cleared flag renders the syntax as plain text in **both** back-ends. |
+| Rendering | `Rendering/EditorTextView+*Rendering.swift` (Callout, Code, Image, List, Math, Mermaid, Table, WikiLinks) |
 | Invisible characters | `TextView/EditorTextView+Invisibles.swift` — faint marks (· → ¬ ␣ ▯) overdrawn on laid-out whitespace, riding `DecoratedTextLayoutFragment.draw`. Pure display overlay: no characters inserted, TextKit 2 only. `EditorTextView.invisibles` ← `AppSettings.invisiblesConfig`; Settings ▸ Edit. Mechanism: [`architecture/editor-affordances.md`](architecture/editor-affordances.md). |
 | List indent guides | Faint vertical hairlines on list items: one per *ancestor* level spanning the item, plus the item's own column beside its wrapped continuation lines. Offsets from `listGuideOffsets(depth:slotWidth:)` (`Rendering/EditorTextView+ListRendering.swift`), written to `.listGuides` **whether or not the setting is on** — the fragment gates the drawing, so toggling is a re-vend, never a restyle. `EditorTextView.showListIndentGuides`; Settings ▸ Edit. Geometry traps (container-relative offsets, `lineFragmentPadding`): [`architecture/editor-affordances.md`](architecture/editor-affordances.md). |
 | Line numbers | `TextView/EditorTextView+LineNumbers.swift` — source line numbers (Settings ▸ Edit ▸ Lines, off by default), `EditorTextView.showLineNumbers`. **Two placements over one walk**, and the placement is **not** a setting: it follows whether the margin can hold them (beside the content by default, a `LineNumberRulerView` at the window edge otherwise). Also home to `line(forOffset:)`/`offset(forLine:)`, binary-searching the cached `lineStarts`. Editor-only; never printed. Placement rules, the macOS 14 SIGSEGV, draw rules and the tabular-figure face: [`architecture/editor-affordances.md`](architecture/editor-affordances.md). |
 | Focus mode | `TextView/EditorTextView+FocusMode.swift` — dims all but the lines the selection touches (Settings ▸ Edit ▸ Editor, Edit ▸ Focus Mode; off by default), `EditorTextView.focusMode`. **One transparency layer around `DecoratedTextLayoutFragment.draw`**, so text and its decorations fade as one composite; it cannot be a scrim (NSTextView composites fragments *after* `draw(_:)` returns). Editor-only. Why, and the measurements: [`architecture/editor-affordances.md`](architecture/editor-affordances.md). |
-| Read mode / Export | `Export/` — `HTMLRenderer` (MarkupVisitor → HTML; callout/checkbox icons are inline Lucide SVGs from `LucideIcons`), `HTMLTheme` (EditorTheme → CSS), `DocumentHTML` (assembly + asset inlining: math + local images → data URIs), `ReadModeWebView`, `MarkdownPrinter` (PDF/Print). `Document.refreshReadView()` keeps an open Read view in sync with edits and theme changes. |
+| Read mode / Export | `Export/` — `HTMLRenderer` (MarkupVisitor → HTML; callout/checkbox icons are inline Lucide SVGs from `LucideIcons`; Mermaid emits an asset placeholder), `HTMLTheme` (EditorTheme → CSS), `DocumentHTML` (assembly + asset inlining: Mermaid → sanitized inline SVG, math + local images → data URIs), `ReadModeWebView`, `MarkdownPrinter` (PDF/Print). `Document.refreshReadView()` keeps an open Read view in sync with edits and theme changes. |
 | Icons | `Model/LucideIcons.swift` — vendored [Lucide](https://lucide.dev) SVGs (ISC, `LICENSES/lucide.txt`). Callout headers use them in **both** modes: Read inlines the SVG (CSS-tinted via `currentColor`); Edit rasterizes to a tinted `NSImage` overlay. SF Symbols can't ship in exported PDFs (license); app-chrome SF Symbols are fine (in-app UI). Edit-mode task checkboxes still use SF Symbols (on-screen only); Read-mode checkboxes are a composed Lucide SVG. |
 | Edit behaviors | `Editing/EditorTextView+{List,Blockquote}Continuation.swift`, `+Indentation.swift`, `+AutoPairs.swift`, `+ListRenumbering.swift` |
 | Hard wrap | `Editing/HardWrap.swift` (pure `wrap`/`unwrap`) + `Editing/EditorTextView+HardWrap.swift` (Edit ▸ Hard Wrap Paragraphs). Settings ▸ Edit ▸ Document, off by default; read at **load/save time in `Document`**, not pushed onto the editor. Treated as a property of the *file*: opening a wrapped file joins its paragraphs, save re-wraps, and **only files that arrived wrapped are wrapped** (`wasHardWrapped`). The column is **derived from the file's own existing breaks**, not guessed. Requires strict line breaks. Full rules, GFM constraints and perf numbers: [`architecture/hard-wrap.md`](architecture/hard-wrap.md). |
@@ -312,7 +319,8 @@ Notable subsystems:
   Element", with WebKit's own duplicate removed.
   **Export as PDF… / Print… (⌘P)** run the same HTML through
   `WKWebView.printOperation` (`MarkdownPrinter`; vector text, math is
-  high-DPI PNG). Full spec: `docs/architecture/reader-and-export.md`.
+  high-DPI PNG, Mermaid is SVG). Full spec:
+  `docs/architecture/reader-and-export.md`.
 - **Find & Replace** (in-document, ⌘F / ⌥⌘F / ⌘G / ⇧⌘G): **not**
   `NSTextFinder` — it renders the system bar rather than the Notes look, and
   its highlighting drives `NSLayoutManager`, which the TextKit 2 tripwire
@@ -1056,6 +1064,8 @@ Dependencies and prior art worth consulting before designing something new:
   CommonMark/GFM parser both back-ends walk (§3, §6).
 - [SwiftMath](https://github.com/mgriebling/SwiftMath) — LaTeX rendering
   (raster only; no SVG output yet — why exported math is PNG, §6).
+- [beautiful-mermaid-swift](https://github.com/lukilabs/beautiful-mermaid-swift)
+  — native Mermaid parsing, ELK layout, bitmap, and SVG rendering.
 - [Sparkle](https://sparkle-project.org) — auto-update (§8, §13 for the
   signing/appcast quirks).
 - [Lucide](https://lucide.dev) — vendored icon SVGs (ISC),

--- a/docs/architecture/reader-and-export.md
+++ b/docs/architecture/reader-and-export.md
@@ -34,15 +34,17 @@ flowchart LR
 | --- | --- |
 | `HTMLRenderer.swift` | `MarkupVisitor` → HTML; raw-HTML filtering; line anchors |
 | `HTMLTheme.swift` | `EditorTheme` → CSS |
-| `DocumentHTML.swift` | Page assembly, CSP meta, asset inlining (math + local images → data URIs), the image-policy chokepoint |
+| `DocumentHTML.swift` | Page assembly, CSP meta, asset inlining (Mermaid → sanitized inline SVG; math + local images → data URIs), the image-policy chokepoint |
 | `ReadModeWebView.swift` | The sandboxed webview + scroll-position mapping |
 | `MarkdownPrinter.swift` | Same HTML through `WKWebView.printOperation` — real vector (selectable) text |
 
 `Document.refreshReadView()` keeps an open Read view in sync with edits and
 theme changes. Code blocks are syntax-colored by the same `CodeHighlighter`
-+ `CodeSyntaxPalette` as Edit mode. Callout/checkbox icons are inline
-Lucide SVG (vector); math glyphs are high-DPI PNG (SwiftMath has no SVG
-output yet) — in PDF export, everything else is vector.
++ `CodeSyntaxPalette` as Edit mode. A Mermaid-tagged fence is handed to
+`beautiful-mermaid-swift`; `DocumentHTML` validates and inlines its SVG, so
+the diagram remains vector in PDF output. Callout/checkbox icons are also
+inline Lucide SVG; math glyphs are high-DPI PNG (SwiftMath has no SVG output
+yet).
 
 Math classing (classing agrees with Edit mode via the shared
 `parseDisplayMath`): a `$$…$$` that is a whole paragraph is a block
@@ -64,8 +66,9 @@ The webview needs no file or network reach:
 - JavaScript disabled (`allowsContentJavaScript = false`); the page carries
   a `script-src 'none'` CSP meta (`DocumentHTML.full` — Read and Print/PDF
   both consume it); loaded against `baseURL: nil` / explicit `about:blank`.
-- Every asset is inlined: math and icons as data URIs; local images as data
-  URIs via a `baseURL` (the document's directory) threaded through
+- Every asset is inlined: Mermaid diagrams and icons as SVG, math as a data
+  URI, and local images as data URIs via a `baseURL` (the document's
+  directory) threaded through
   `DocumentHTML`/`ReadModeWebView`/`MarkdownPrinter`. Remote images are off
   by default (`ReadRenderOptions.allowRemoteImages`).
 - External `http`/`https`/`mailto` links open in the default browser;


### PR DESCRIPTION
> **Status — 2026-09-16:** The Read-mode and export work requested in this PR's review has been merged into `main` through [#320](https://github.com/I7T5/Edmund/pull/320) on 2026-09-15. That implementation uses the runtime-downloaded, SHA-256-verified `beautiful-mermaid` JavaScript payload, the **Mermaid** extension switch, and no additional SwiftPM dependencies. It preserves code-block fallbacks and scroll anchors, and allows local SVG fragment references for arrowheads. Its required `test` check passed.
>
> #320 credits this PR's fence recognition, placeholder/fill pipeline, SVG filtering, and diagram CSS in the code history and architecture documentation. Edit-mode diagrams remain a separate follow-up; this PR's original Swift/ELK implementation is preserved below for reference.

## Summary

- integrate `beautiful-mermaid-swift` behind an Edmund bridge target
- render inactive Mermaid fences as native Edit-mode previews while preserving raw Markdown storage
- emit safe inline vector SVG for Read mode and PDF export
- keep preview and editable source in one framed, stable-height block to prevent focus-induced layout jumps
- expose Mermaid rendering as a Markdown feature toggle and document the dependency/license
- preserve the package’s valid original SVG CSS in WebKit, avoiding malformed paint values from its convenience SVG flattener

## Validation

- `swift test` — 1,124 tests in 163 suites passed
- release app build completed
- Edit preview/source and Read mode visually verified in light and dark appearances
- regression test asserts less than 1 pt movement below the block when switching between preview and source