### PR TITLE
Find & Replace within the current document

### DIFF
--- a/.claude/skills/edmund-live-repro-and-diagnostics/SKILL.md
+++ b/.claude/skills/edmund-live-repro-and-diagnostics/SKILL.md
@@ -210,18 +210,66 @@ Caveats (all hit in practice):
 **Visual judgments are measured, not eyeballed** — when the task says "balance
 padding" or "align the icon", capture the window and measure pixels.
 
-`scripts/capture-window.sh <window-title-substring> out.png` finds the window id
-(JXA → `CGWindowListCopyWindowInfo`) and runs `screencapture -x -o -l<id>`.
-Notes:
-- Capture **by window id**, reliable even when not frontmost.
+`scripts/capture-window.sh <window-title-substring> out.png` resolves the window
+id (via `winid.swift`) and runs `screencapture -x -o -l<id>`. Notes:
+- Capture **by window id**, reliable even when not frontmost — and **never
+  raise the window to do it**. Stealing focus takes the machine away from the
+  user mid-session; `screencapture -l<id>` does not need the window in front.
 - **Crop by the detected window bounds** — the desktop wallpaper defeats
   screencapture's brightness-based auto-crop.
-- Measure padding/alignment from the PNG (e.g. a short Python/PIL pixel scan for
-  the first/last colored row of a callout box). Report the pixel numbers, not an
-  impression.
+- Captures are Retina: **2 device px = 1 point.** Report both.
+- Measure padding/alignment from the PNG with `scripts/ui-measure.py` (below).
+  Report the pixel numbers, not an impression.
 - Window-server state can glitch (tiny windows, restoration) after many rapid
   launch/kill cycles: `rm -rf ~/Library/"Saved Application State"/com.i7t5.edmund.savedState`
   and relaunch.
+
+---
+
+## 5a. The UI-chrome harness — build the pipeline, then keep it
+
+Any task phrased as "align it / balance the padding / match the native control"
+turns into the same loop: launch, put the UI into a specific state, capture,
+measure, tweak, repeat — a dozen times or more. **Write that loop as a script on
+the first iteration, not the tenth.** The scripts below started as one-off
+shell in a scratch directory during the find-bar work and were rebuilt from
+memory several times before being made permanent; that rebuilding was the single
+largest waste in the task.
+
+**These tools are fixtures, not scratch work. Do not delete them when the task
+ends, and do not apologise for leaving them behind.** The cleanup instinct is
+wrong here: the next visual task pays the full setup cost again. Extend them
+instead — a new subcommand for a new surface is a two-line addition.
+
+```bash
+S=.claude/skills/edmund-live-repro-and-diagnostics/scripts
+$S/ui-harness.sh launch notes.md dark    # force appearance per-launch
+$S/ui-harness.sh replace on              # find bar → replace row showing
+$S/ui-harness.sh capture /tmp/shot.png   # by window id, no focus steal
+$S/ui-measure.py box /tmp/shot.png 30 80 100 165     # ink bbox + centre
+$S/ui-measure.py runs /tmp/shot.png 2400 3024 100 165 # control gaps
+```
+
+`ui-harness.sh state` reports `closed | find | replace` off the AX tree.
+**Drive control flow off that, never off a screenshot** — it is the only signal
+that says whether the UI actually changed, and it makes the flaky steps
+(below) self-correcting instead of silently producing a screenshot of the wrong
+state.
+
+Traps this harness already encodes — each one cost a debugging cycle, so read
+before "simplifying" it:
+
+| Trap | What happens | What to do |
+|---|---|---|
+| `pgrep -f "$PATH"` | Takes a **regex**; a worktree path like `feat+find-replace-in-doc` contains `+`, so it matches **nothing** | Exact-match the path field (`pgrep -lf` + awk). macOS `pgrep -a` prints bare pids, no args |
+| JXA `CGWindowListCopyWindowInfo` | `deepUnwrap` returns a value with no `.length` — reports nothing, never errors | Use `winid.swift` |
+| `.optionOnScreenOnly` | A launched-but-never-activated app looks **windowless** | `.optionAll` |
+| `click at {x, y}` | Does not reliably land on the control even at its own AX frame | Click via Accessibility (`click (checkbox 1 of window "…")`) |
+| AppleScript errors | Error text starts with a line number (`87:129: …`), so a glob like `[2-9]*` reads it as a **count** | Match `^[0-9]+$` strictly |
+| AX window queries after launch | System Events cannot enumerate windows until the app is activated **once** | `raise` before the first AX query |
+| First `⌘F` after launch | Regularly swallowed | Retry until `state` agrees |
+| Flipping **system** appearance | Slow to repaint, takes over the user's machine, and Edmund reads its **own** stored `settings.appearance.mode` anyway — so it may stay light regardless | Force per-launch: `-settings.appearance.mode dark` (NSArgumentDomain beats the stored default) |
+| `.git` inside a worktree | It is a **file**, not a directory | `git rev-parse --git-dir` |
 
 ---
 
@@ -251,12 +299,17 @@ mechanism.
 |---|---|---|
 | `check-live-instance.sh` | Report running `edmd`, exit 2 if any; never kills | logic verified; safe by construction |
 | `grep-trace.sh [date]` | Surface suspect patterns in today's log | logic verified |
-| `capture-window.sh <needle> <out.png>` | Screenshot a window by id + report bounds | **verify on first use** (JXA CGWindowList lookup not executed this session) |
+| `winid.swift <pid> [title]` | CGWindow ids for a process | **exercised** 2026-07-26 |
+| `capture-window.sh <needle> <out.png>` | Screenshot a window by id + report bounds | **exercised** 2026-07-26 (its old JXA lookup never worked — see §5) |
+| `ui-harness.sh <subcommand>` | Launch / raise / read find-bar state / toggle replace / capture, appearance per-launch | **every subcommand exercised** 2026-07-26 |
+| `ui-measure.py box\|runs\|rows` | Ink bounding box, control gaps, colour transitions | **exercised** 2026-07-26 |
 | `launch-debug.sh <file.md> [script.repro]` | Build + assemble EdmundDbg.app + direct-exec with flags | **verify on first use** (assumes arm64 debug triple; guards user instance) |
 
-All four pass `bash -n`. The two "verify on first use" scripts depend on live
-system state (window server, build layout) that couldn't be exercised while
-authoring; read the header comment before first run.
+All pass `bash -n`. One caveat on `launch-debug.sh`: its header claims a bare
+`.build/debug/edmd` "never makes a window". That is **not true** — the find-bar
+work drove the bare debug binary for a whole session and it windows fine, which
+is what `ui-harness.sh launch` does. The EdmundDbg bundle is still the right
+choice when you need Info.plist-dependent behaviour.
 
 ---
 

--- a/.claude/skills/edmund-live-repro-and-diagnostics/scripts/capture-window.sh
+++ b/.claude/skills/edmund-live-repro-and-diagnostics/scripts/capture-window.sh
@@ -1,46 +1,34 @@
 #!/usr/bin/env bash
 # capture-window.sh <window-name-substring> <out.png>
-# Screenshot a specific window by id (reliable even when not frontmost).
+# Screenshot a window by id — reliable even when the window is not frontmost,
+# and without stealing focus.
 #
-# Mechanism: osascript(JXA) enumerates on-screen windows via the ObjC bridge
-# to CGWindowListCopyWindowInfo, finds the first whose kCGWindowName contains
-# the substring, prints "<id> <x> <y> <w> <h>", then `screencapture -x -o
-# -l<id>` grabs it. We crop by the detected window bounds (the desktop
-# wallpaper defeats screencapture's brightness-based auto-crop).
+# This used to do the window lookup in JXA. That never worked: under osascript,
+# `ObjC.deepUnwrap($.CGWindowListCopyWindowInfo(...))` returns a value with no
+# `.length`, so the loop silently found nothing and the script reported "no
+# window" for windows that were plainly on screen. Verified broken 2026-07-26;
+# the lookup now goes through `winid.swift`, which is exercised routinely.
 #
-# VERIFY ON FIRST USE: JXA ObjC bridging + the CGWindowList key names are
-# stable AppKit API, but this script has not been executed in this session.
-# If the JXA lookup prints nothing, the window title didn't match or Screen
-# Recording permission is missing (it is granted for this project per
-# CLAUDE.md — do NOT request Computer Access to "fix" it).
+# For driving Edmund's own UI (open the find bar, toggle the replace row,
+# force light/dark), use `ui-harness.sh` — it wraps this plus the AX driving.
 set -euo pipefail
 
 needle="${1:?usage: capture-window.sh <window-name-substring> <out.png>}"
 out="${2:?usage: capture-window.sh <window-name-substring> <out.png>}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-read -r wid x y w h < <(osascript -l JavaScript <<JXA || true
-ObjC.import('CoreGraphics');
-ObjC.import('Foundation');
-const info = \$.CGWindowListCopyWindowInfo(
-  \$.kCGWindowListOptionOnScreenOnly | \$.kCGWindowListExcludeDesktopElements,
-  \$.kCGNullWindowID);
-const arr = ObjC.deepUnwrap(info);
-const needle = "$needle";
-for (const win of arr) {
-  const name = win.kCGWindowName || "";
-  if (name.indexOf(needle) !== -1) {
-    const b = win.kCGWindowBounds;
-    console.log([win.kCGWindowNumber, b.X, b.Y, b.Width, b.Height].join(" "));
-    break;
-  }
-}
-JXA
-)
+# Scan every edmd process for a window whose title contains the needle.
+line=""
+for pid in $(pgrep -x edmd 2>/dev/null || true); do
+  line="$(swift "$HERE/winid.swift" "$pid" | grep -F "name=" | grep -F "$needle" | head -1 || true)"
+  [[ -n "$line" ]] && break
+done
 
-if [[ -z "${wid:-}" ]]; then
-  echo "No on-screen window title contains: $needle" >&2
+if [[ -z "$line" ]]; then
+  echo "No window title contains: $needle" >&2
   exit 1
 fi
 
+wid="${line#id=}"; wid="${wid%% *}"
 screencapture -x -o -l"$wid" "$out"
-echo "Captured window $wid ($needle) -> $out  bounds=${x},${y} ${w}x${h}"
+echo "Captured window $wid -> $out  ($line)"

--- a/.claude/skills/edmund-live-repro-and-diagnostics/scripts/ui-harness.sh
+++ b/.claude/skills/edmund-live-repro-and-diagnostics/scripts/ui-harness.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# ui-harness.sh — drive Edmund's UI chrome so visual work can be measured
+# instead of eyeballed. Every subcommand here was executed against a live app
+# while authoring (2026-07-26); none are "verify on first use".
+#
+#   ui-harness.sh launch <file.md> [light|dark]   # kill only OUR debug build, relaunch
+#   ui-harness.sh raise                   # activate + AXRaise the document window
+#   ui-harness.sh winid                   # print the document window's CGWindow id
+#   ui-harness.sh state                   # closed | find | replace  (find bar state)
+#   ui-harness.sh open-find               # Cmd-F, retried until `state` agrees
+#   ui-harness.sh replace on|off          # toggle the Replace row via the checkbox
+#   ui-harness.sh capture <out.png>       # screencapture the window by id (no focus steal)
+#   ui-harness.sh shot <out.png>          # open-find + capture, one call
+#
+# Why each mechanism — all learned by watching the obvious version fail, so do
+# not "simplify" them:
+#   * Window lookup goes through winid.swift. JXA cannot do it: under osascript
+#     `ObjC.deepUnwrap($.CGWindowListCopyWindowInfo(...))` yields a value with no
+#     `.length`, so the JS route silently reports nothing rather than erroring.
+#   * That lookup uses .optionAll, never .optionOnScreenOnly — a freshly
+#     launched app that has not been activated yet owns windows the on-screen
+#     filter omits, making it look windowless.
+#   * `capture` never raises. `screencapture -l<id>` grabs a background window
+#     fine, and stealing focus takes the machine away from the user.
+#   * Controls are clicked through Accessibility, never `click at {x,y}`:
+#     System Events coordinate clicks do not reliably land on the control even
+#     when the coordinates match the control's own AX frame.
+#   * Our process is found by exact-matching the binary path field. Not
+#     `pgrep -f "$BIN"`: that takes a REGEX, and a worktree path like
+#     `feat+find-replace-in-doc` contains `+`, which silently matches nothing.
+#     macOS `pgrep -a` prints bare pids with no args, so `-lf` is the flag that
+#     carries the command line.
+#   * `state` (AX tree) is the ground truth for "did the UI change"; screenshots
+#     are for measuring, never for control flow.
+#   * Light/dark is forced per-launch through `-settings.appearance.mode`
+#     (NSArgumentDomain beats the stored default), NOT by flipping the system
+#     appearance. Flipping the system takes the user's machine away from them,
+#     and it does not even work here: the app shares the user's UserDefaults, so
+#     a stored Light preference keeps it light whatever the system is doing.
+#
+# Env: DOC_TITLE overrides the window title to target (default: basename of the
+# doc passed to `launch`, remembered under the repo's git dir).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE" && git rev-parse --show-toplevel)"
+cd "$ROOT"
+BIN="$ROOT/.build/debug/edmd"
+# `git rev-parse --git-dir`, not "$ROOT/.git" — in a worktree .git is a *file*.
+STATE_FILE="$(git rev-parse --git-dir)/edmund-ui-harness-doc"
+
+title() {
+  if [[ -n "${DOC_TITLE:-}" ]]; then echo "$DOC_TITLE"
+  elif [[ -f "$STATE_FILE" ]]; then cat "$STATE_FILE"
+  else echo "Untitled"; fi
+}
+
+# Our own instance only — the user's daily driver is also called `edmd`.
+# awk on an exact field match, not `grep -F "$BIN"`: a grep for the path also
+# matches the grep process's own command line.
+our_pid() { pgrep -lf edmd 2>/dev/null | awk -v b="$BIN" '$2 == b { print $1; exit }'; }
+
+kill_ours() {
+  local pid
+  while pid="$(our_pid)"; [[ -n "$pid" ]]; do kill "$pid" 2>/dev/null || break; sleep 1; done
+}
+
+require_pid() {
+  local pid; pid="$(our_pid || true)"
+  [[ -n "$pid" ]] || { echo "No debug edmd running; run: ui-harness.sh launch <file.md>" >&2; exit 1; }
+  echo "$pid"
+}
+
+ax() {  # ax <applescript predicate applied to our process>
+  local pid; pid="$(require_pid)"
+  osascript -e "tell application \"System Events\" to tell (first process whose unix id is $pid) to $1" 2>&1
+}
+
+cmd_launch() {
+  local doc="${1:?usage: ui-harness.sh launch <file.md> [light|dark]}"
+  local mode="${2:-}"
+  [[ -x "$BIN" ]] || { echo "Missing $BIN — run: swift build" >&2; exit 1; }
+  kill_ours
+  basename "$doc" > "$STATE_FILE"
+  local args=( "$doc" )
+  [[ -n "$mode" ]] && args+=( -settings.appearance.mode "$mode" )
+  "$BIN" "${args[@]}" >/dev/null 2>&1 &
+  sleep 4
+  echo "pid=$(our_pid)${mode:+ appearance=$mode}"
+}
+
+cmd_raise() {
+  local pid; pid="$(require_pid)"
+  osascript >/dev/null 2>&1 <<AS || true
+tell application "System Events"
+  tell (first process whose unix id is $pid)
+    set frontmost to true
+    try
+      perform action "AXRaise" of (first window whose title is "$(title)")
+    end try
+  end tell
+end tell
+AS
+  sleep 1
+}
+
+cmd_winid() {
+  local pid; pid="$(require_pid)"
+  swift "$HERE/winid.swift" "$pid" "$(title)"
+}
+
+# closed | find | replace — counted off the AX tree, the only reliable signal.
+#
+# Two traps: (1) System Events cannot enumerate a process's windows until the
+# app has been activated at least once, so this reads `closed` on a
+# just-launched app — `open-find` raises first, which fixes it. (2) The failure
+# mode is an *error string*, and AppleScript error text starts with a line
+# number ("87:129: execution error…"), so a substring/glob test happily reads
+# it as a count. Only a strict all-digits match is safe.
+cmd_state() {
+  local n; n="$(ax "get count of text fields of window \"$(title)\"" || true)"
+  if [[ "$n" =~ ^[0-9]+$ ]]; then
+    (( n >= 2 )) && echo replace || { (( n == 1 )) && echo find || echo closed; }
+  else
+    echo closed
+  fi
+}
+
+cmd_open_find() {
+  cmd_raise   # also makes the window AX-visible for the first time
+  for _ in 1 2 3; do
+    [[ "$(cmd_state)" == closed ]] || break
+    cmd_raise
+    osascript -e 'tell application "System Events" to keystroke "f" using command down' >/dev/null 2>&1
+    sleep 2
+  done
+  cmd_state
+}
+
+cmd_replace() {
+  local want="${1:?usage: ui-harness.sh replace on|off}" now
+  now="$(cmd_open_find)"
+  if { [[ "$want" == on ]] && [[ "$now" == find ]]; } ||
+     { [[ "$want" == off ]] && [[ "$now" == replace ]]; }; then
+    ax "click (checkbox 1 of window \"$(title)\")" >/dev/null || true
+    sleep 2
+  fi
+  cmd_state
+}
+
+cmd_capture() {
+  local out="${1:?usage: ui-harness.sh capture <out.png>}" id
+  id="$(cmd_winid)"
+  [[ -n "$id" ]] || { echo "No window id for \"$(title)\"" >&2; exit 1; }
+  screencapture -x -o -l"$id" "$out"
+  echo "$out"
+}
+
+cmd_shot() {
+  local out="${1:?usage: ui-harness.sh shot <out.png>}"
+  cmd_open_find >/dev/null
+  cmd_capture "$out"
+}
+
+case "${1:?see header for usage}" in
+  launch)     shift; cmd_launch "$@" ;;
+  raise)      cmd_raise ;;
+  winid)      cmd_winid ;;
+  state)      cmd_state ;;
+  open-find)  cmd_open_find ;;
+  replace)    shift; cmd_replace "$@" ;;
+  capture)    shift; cmd_capture "$@" ;;
+  shot)       shift; cmd_shot "$@" ;;
+  *) echo "Unknown subcommand: $1 (see header)" >&2; exit 64 ;;
+esac

--- a/.claude/skills/edmund-live-repro-and-diagnostics/scripts/ui-measure.py
+++ b/.claude/skills/edmund-live-repro-and-diagnostics/scripts/ui-measure.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""ui-measure.py — pixel measurements off a window screenshot.
+
+Turns "is the icon centred / is the padding balanced" into numbers. Captures
+are Retina, so **2 device px = 1 point**; every command reports both.
+
+    ui-measure.py box   <png> X0 X1 Y0 Y1     # ink bounding box in a region
+    ui-measure.py runs  <png> X0 X1 Y0 Y1     # control runs + the gaps between
+    ui-measure.py rows  <png> X Y0 Y1         # colour transitions down a column
+
+Coordinates are device pixels in the PNG. Region args are inclusive-exclusive.
+
+`box` is the workhorse: it reports the tight bounding box of "ink" (dark on
+light, light on dark — pass --dark) plus its centre, which is what you compare
+against a control's centre to prove an icon is or is not centred.
+
+`runs` finds horizontal spans of control-fill colour and prints the gaps
+between them — the way to check that button spacing is even without eyeballing.
+
+`rows` dumps where colours change down a single column: use it to find a
+field's bezel and focus-ring boundaries before measuring anything inside it.
+"""
+import sys
+
+import numpy as np
+from PIL import Image
+
+
+def load(path):
+    return np.array(Image.open(path).convert("RGB")).astype(int)
+
+
+def ink_mask(sub, dark_mode=False):
+    """Ink = clearly darker (light mode) or lighter (dark mode) than the local
+    background, with blue-dominant pixels excluded so a focus ring or text
+    caret is never mistaken for glyph ink."""
+    lum = sub.mean(axis=2)
+    bg = np.median(lum)
+    not_blue = (sub[:, :, 2] - sub[:, :, 0]) < 40
+    return ((lum > bg + 30) if dark_mode else (lum < bg - 30)) & not_blue
+
+
+def cmd_box(png, x0, x1, y0, y1, dark_mode=False):
+    a = load(png)
+    m = ink_mask(a[y0:y1, x0:x1], dark_mode)
+    if not m.any():
+        print("no ink found in region")
+        return
+    rs, cs = np.where(m.any(axis=1))[0], np.where(m.any(axis=0))[0]
+    top, bot, left, right = rs.min() + y0, rs.max() + y0, cs.min() + x0, cs.max() + x0
+    print(f"x {left}..{right} ({(right - left + 1) / 2:.2f} pt wide)")
+    print(f"y {top}..{bot} ({(bot - top + 1) / 2:.2f} pt tall)")
+    print(f"centre x={(left + right) / 2:.1f} y={(top + bot) / 2:.1f} (device px)")
+
+
+def cmd_runs(png, x0, x1, y0, y1):
+    a = load(png)
+    sub = a[y0:y1, x0:x1]
+    # Control fill: mid greys, plus anything strongly blue (a checked checkbox).
+    fill = (((sub[:, :, 0] > 215) & (sub[:, :, 0] < 242)) |
+            ((sub[:, :, 2] - sub[:, :, 0]) > 60)).sum(axis=0)
+    runs, start = [], None
+    for i, v in enumerate(fill):
+        on = v > 15
+        if on and start is None:
+            start = i
+        if not on and start is not None:
+            runs.append((start + x0, i - 1 + x0))
+            start = None
+    if start is not None:
+        runs.append((start + x0, len(fill) - 1 + x0))
+    runs = [r for r in runs if r[1] - r[0] > 3]
+    print("runs:", runs)
+    for i in range(len(runs) - 1):
+        gap = runs[i + 1][0] - runs[i][1] - 1
+        print(f"  gap {runs[i][1]}..{runs[i + 1][0]} = {gap} px = {gap / 2:.1f} pt")
+
+
+def cmd_rows(png, x, y0, y1):
+    a = load(png)
+    prev = None
+    for y in range(y0, y1):
+        cur = tuple(a[y, x])
+        if cur != prev:
+            print(y, cur)
+            prev = cur
+
+
+def main(argv):
+    if len(argv) < 2:
+        print(__doc__)
+        return 64
+    cmd, png, rest = argv[0], argv[1], [int(v) for v in argv[2:] if v != "--dark"]
+    dark = "--dark" in argv
+    if cmd == "box":
+        cmd_box(png, *rest[:4], dark_mode=dark)
+    elif cmd == "runs":
+        cmd_runs(png, *rest[:4])
+    elif cmd == "rows":
+        cmd_rows(png, *rest[:3])
+    else:
+        print(__doc__)
+        return 64
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.claude/skills/edmund-live-repro-and-diagnostics/scripts/winid.swift
+++ b/.claude/skills/edmund-live-repro-and-diagnostics/scripts/winid.swift
@@ -1,0 +1,37 @@
+// winid.swift — print CGWindow ids for a process, newest first.
+//
+//   swift winid.swift <pid> [title]
+//
+// With a title, prints just that window's id; without, prints
+// "id=<n> name=<title> X= Y= W= H=" for every window the pid owns.
+//
+// Why Swift and not JXA: `ObjC.deepUnwrap($.CGWindowListCopyWindowInfo(...))`
+// returns something with no `.length` under osascript — the CoreGraphics
+// bridge does not carry this call, so the JS route reports nothing at all
+// rather than failing loudly. Verified broken 2026-07-26.
+//
+// Uses .optionAll, NOT .optionOnScreenOnly: a freshly launched app that has
+// not been activated yet owns windows that onScreenOnly omits entirely, so
+// the on-screen filter makes a just-launched app look windowless.
+import CoreGraphics
+import Foundation
+
+let args = CommandLine.arguments
+guard args.count > 1, let pid = Int32(args[1]) else {
+    FileHandle.standardError.write("usage: swift winid.swift <pid> [title]\n".data(using: .utf8)!)
+    exit(64)
+}
+let wanted: String? = args.count > 2 ? args[2] : nil
+
+let list = CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as? [[String: Any]] ?? []
+for w in list {
+    guard (w[kCGWindowOwnerPID as String] as? Int32) == pid else { continue }
+    let id = w[kCGWindowNumber as String] as? Int ?? -1
+    let name = w[kCGWindowName as String] as? String ?? ""
+    if let wanted {
+        if name == wanted { print(id); exit(0) }
+        continue
+    }
+    let b = w[kCGWindowBounds as String] as? [String: Any] ?? [:]
+    print("id=\(id) name=\(name) X=\(b["X"] ?? "") Y=\(b["Y"] ?? "") W=\(b["Width"] ?? "") H=\(b["Height"] ?? "")")
+}

--- a/Sources/EdmundCore/Find/FindEngine.swift
+++ b/Sources/EdmundCore/Find/FindEngine.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Pure text search over a document's raw source. No UI, no state — given a
+/// needle and the haystack, returns the character ranges of every match.
+///
+/// The ranges are `NSRange` over the string's UTF-16 view, which is exactly the
+/// index space the text storage uses (storage == rawSource, identity offsets),
+/// so a match range maps straight onto the editor with no offset translation.
+public enum FindEngine {
+
+    /// Non-overlapping matches of `needle` in `haystack`, left to right.
+    ///
+    /// - `caseSensitive`: false (default) folds case via `.caseInsensitive`.
+    /// - `wholeWord`: keeps only hits whose neighbouring characters are not
+    ///   alphanumeric, so "cat" does not match inside "category".
+    ///
+    /// Empty needle → no matches.
+    // ponytail: linear rescan of the whole document on every keystroke. Fine to
+    // ~10⁵ chars; if large docs lag, debounce or search incrementally around the
+    // viewport.
+    public static func matches(of needle: String,
+                               in haystack: String,
+                               caseSensitive: Bool = false,
+                               wholeWord: Bool = false) -> [NSRange] {
+        guard !needle.isEmpty else { return [] }
+
+        let hay = haystack as NSString
+        let opts: NSString.CompareOptions = caseSensitive ? [] : [.caseInsensitive]
+        var results: [NSRange] = []
+        var searchStart = 0
+
+        while searchStart < hay.length {
+            let searchRange = NSRange(location: searchStart, length: hay.length - searchStart)
+            let hit = hay.range(of: needle, options: opts, range: searchRange)
+            if hit.location == NSNotFound { break }
+
+            if !wholeWord || isWholeWord(hit, in: hay) {
+                results.append(hit)
+            }
+            // Advance past this hit's start (by 1, not by length) so adjacent and
+            // rejected-whole-word hits are still found; matches themselves never
+            // overlap because the next accepted hit starts at or after hit.end.
+            searchStart = max(hit.location + 1, hit.location + hit.length)
+        }
+        return results
+    }
+
+    /// A hit is a whole word when the characters immediately before and after it
+    /// are not alphanumeric (or the hit sits at a document edge).
+    private static func isWholeWord(_ hit: NSRange, in hay: NSString) -> Bool {
+        let alnum = CharacterSet.alphanumerics
+        if hit.location > 0 {
+            let before = hay.substring(with: NSRange(location: hit.location - 1, length: 1))
+            if before.rangeOfCharacter(from: alnum) != nil { return false }
+        }
+        let afterIndex = hit.location + hit.length
+        if afterIndex < hay.length {
+            let after = hay.substring(with: NSRange(location: afterIndex, length: 1))
+            if after.rangeOfCharacter(from: alnum) != nil { return false }
+        }
+        return true
+    }
+}

--- a/Sources/EdmundCore/TextView/EditorTextView+Find.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+Find.swift
@@ -11,6 +11,14 @@ import AppKit
     func editorHideFind()
 }
 
+private extension NSRect {
+    /// Scales the rect about its own centre.
+    func scaled(by s: CGFloat) -> NSRect {
+        NSRect(x: midX - width * s / 2, y: midY - height * s / 2,
+               width: width * s, height: height * s)
+    }
+}
+
 extension EditorTextView {
 
     // MARK: - Match state
@@ -80,15 +88,18 @@ extension EditorTextView {
             }
         }
 
-        // Pop box over the emphasised match: holds at full yellow, then swells
-        // outward and fades out. `emphasisProgress` runs 0…1 over the whole
-        // duration; the first `holdFraction` of it is the steady hold.
+        // Pop box over the emphasised match (Preview-style): springs in from a
+        // larger scale with a bouncy overshoot, holds, then fades out. The box
+        // hugs the match text, so it's naturally variable-length.
         guard let em = emphasisRange, emphasisProgress < 1,
               let tr = blockTextRange(em, tlm) else { return }
-        let holdFraction = CGFloat(Self.emphasisHold / Self.emphasisDuration)
-        let fade = max(0, (emphasisProgress - holdFraction) / (1 - holdFraction))
-        let grow = 2 + fade * 4                       // 2 → 6pt beyond the text box
-        let alpha = 1 - fade                          // fade to transparent
+        let elapsed = emphasisProgress * Self.emphasisDuration
+        let scale = elapsed < Self.emphasisSpring
+            ? Self.startScale + (1 - Self.startScale) * easeOutBack(elapsed / Self.emphasisSpring)
+            : 1
+        let alpha = elapsed < Self.emphasisHold
+            ? 1
+            : max(0, 1 - (elapsed - Self.emphasisHold) / Self.emphasisFade)
 
         NSGraphicsContext.saveGraphicsState()
         let shadow = NSShadow()
@@ -98,7 +109,9 @@ extension EditorTextView {
         shadow.set()
         NSColor.findHighlightColor.withAlphaComponent(alpha).setFill()
         tlm.enumerateTextSegments(in: tr, type: .highlight, options: []) { _, frame, _, _ in
-            let box = frame.offsetBy(dx: origin.x, dy: origin.y).insetBy(dx: -grow, dy: -grow)
+            // Base box hugs the text (2pt padding); scale it about its centre.
+            let base = frame.offsetBy(dx: origin.x, dy: origin.y).insetBy(dx: -2, dy: -2)
+            let box = base.scaled(by: scale)
             if box.intersects(rect) {
                 NSBezierPath(roundedRect: box, xRadius: 4, yRadius: 4).fill()
             }
@@ -107,12 +120,22 @@ extension EditorTextView {
         NSGraphicsContext.restoreGraphicsState()
     }
 
+    /// Overshooting ease (0→1, briefly passing 1) — the source of the bounce.
+    private func easeOutBack(_ t: CGFloat) -> CGFloat {
+        let c1: CGFloat = 1.70158, c3 = c1 + 1
+        let u = t - 1
+        return 1 + c3 * u * u * u + c1 * u * u
+    }
+
     // MARK: - Pop animation
 
-    /// Full yellow is held for `emphasisHold`, then swells + fades over
-    /// `emphasisFade`.
-    private static let emphasisHold: CFTimeInterval = 1.0
-    private static let emphasisFade: CFTimeInterval = 0.2
+    /// The box springs in over `emphasisSpring` (from `startScale` down to 1,
+    /// overshooting for the bounce), stays full until `emphasisHold`, then fades
+    /// over `emphasisFade`. `emphasisSpring` must be ≤ `emphasisHold`.
+    private static let emphasisSpring: CFTimeInterval = 0.35
+    private static let emphasisHold: CFTimeInterval = 0.6
+    private static let emphasisFade: CFTimeInterval = 0.1
+    private static let startScale: CGFloat = 1.6
     private static var emphasisDuration: CFTimeInterval { emphasisHold + emphasisFade }
 
     /// Starts (or restarts) the pop on `range`, driven by a display link so it

--- a/Sources/EdmundCore/TextView/EditorTextView+Find.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+Find.swift
@@ -31,7 +31,7 @@ extension EditorTextView {
         findMatches = []
         currentMatchIndex = nil
         findActive = false
-        findDimActive = false
+        stopEmphasis()
         needsDisplay = true
     }
 
@@ -39,6 +39,7 @@ extension EditorTextView {
     /// would trigger the active-block-renders-raw recompose). Already-visible
     /// matches don't move the viewport; otherwise the match's line goes to the
     /// top, so a document jump lands the hit predictably rather than at an edge.
+    /// Also fires the pop animation on the freshly-focused match.
     public func revealFindMatch(_ index: Int) {
         guard findMatches.indices.contains(index) else { return }
         let range = findMatches[index]
@@ -46,24 +47,28 @@ extension EditorTextView {
         if !rangeIsVisible(range, forViewportOrigin: origin) {
             scrollCharacterToTop(range.location)
         }
+        emphasize(range)
     }
 
     // MARK: - Highlight drawing
 
-    /// Paints the match highlights behind the glyphs, using the system find
-    /// colour. Runs on the normal background-draw pass (so scrolling repaints
-    /// exposed matches for free) and is bounded to matches intersecting the
-    /// laid-out viewport, so a document with many scattered hits doesn't force
+    /// Paints a grey background behind every match (CotEditor-style), plus a
+    /// yellow→grey settle animation on the match just navigated to. Draw-only,
+    /// on the background pass so scrolling repaints exposed matches for free and
+    /// bounded to the laid-out viewport, so many scattered hits don't force
     /// whole-document layout on every frame.
     public override func drawBackground(in rect: NSRect) {
         super.drawBackground(in: rect)
         guard findActive, !findMatches.isEmpty, let tlm = textLayoutManager else { return }
 
         let visible = viewportCharRange(tlm)
-        // All matches read equal weight; the "current" one is distinguished by
-        // the viewport revealing it, not by colour. Emphasis now comes from the
-        // dimmed document behind them (see `draw(_:)`).
-        NSColor.findHighlightColor.setFill()
+        let rest = NSColor.unemphasizedSelectedTextBackgroundColor   // grey for unfocused hits
+        // The emphasised hit starts at find-yellow and blends to grey as the pop
+        // settles. sRGB-convert both first: catalog colours won't blend directly.
+        let hot = NSColor.findHighlightColor.usingColorSpace(.sRGB)
+        let cool = rest.usingColorSpace(.sRGB)
+        let emphasised = (hot != nil && cool != nil)
+            ? (hot!.blended(withFraction: emphasisProgress, of: cool!) ?? rest) : rest
         // Layout-fragment frames are in text-container space; the view offsets
         // them by textContainerOrigin (which also carries the content-width
         // centering). Translate to draw in view coordinates.
@@ -72,6 +77,8 @@ extension EditorTextView {
         for match in findMatches {
             if let visible, NSIntersectionRange(visible, match).length == 0 { continue }
             guard let tr = blockTextRange(match, tlm) else { continue }
+            let isEmphasised = emphasisRange.map { NSEqualRanges($0, match) } ?? false
+            (isEmphasised ? emphasised : rest).setFill()
             tlm.enumerateTextSegments(in: tr, type: .highlight, options: []) { _, frame, _, _ in
                 let r = frame.offsetBy(dx: origin.x, dy: origin.y)
                 if r.intersects(rect) { r.fill() }
@@ -80,32 +87,35 @@ extension EditorTextView {
         }
     }
 
-    /// Paints the Notes-style dim veil *over* the glyphs while the find bar holds
-    /// focus, punching a hole around every match so the highlighted hits stay
-    /// bright and the rest of the page recedes. Draw-only, no storage touch.
-    /// Cleared when focus returns to the editor (`findDimActive`).
-    public override func draw(_ dirtyRect: NSRect) {
-        super.draw(dirtyRect)
-        guard findActive, findDimActive, let tlm = textLayoutManager else { return }
+    // MARK: - Pop animation
 
-        // Full dirty area, minus a rect per visible match → even-odd fill leaves
-        // the matches undimmed.
-        let veil = NSBezierPath(rect: dirtyRect)
-        let visible = viewportCharRange(tlm)
-        let origin = textContainerOrigin
-        for match in findMatches {
-            if let visible, NSIntersectionRange(visible, match).length == 0 { continue }
-            guard let tr = blockTextRange(match, tlm) else { continue }
-            tlm.enumerateTextSegments(in: tr, type: .highlight, options: []) { _, frame, _, _ in
-                let r = frame.offsetBy(dx: origin.x, dy: origin.y).insetBy(dx: -1.5, dy: -1.5)
-                if r.intersects(dirtyRect) { veil.appendRect(r) }
-                return true
-            }
-        }
-        veil.windingRule = .evenOdd
-        let dark = effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
-        NSColor.black.withAlphaComponent(dark ? 0.45 : 0.12).setFill()
-        veil.fill()
+    private static let emphasisDuration: CFTimeInterval = 0.45
+
+    /// Starts (or restarts) the yellow→grey settle on `range`, driven by a
+    /// display link so it stays smooth without a manual timer.
+    private func emphasize(_ range: NSRange) {
+        emphasisLink?.invalidate()
+        emphasisRange = range
+        emphasisProgress = 0
+        let link = displayLink(target: self, selector: #selector(stepEmphasis))
+        link.add(to: .main, forMode: .common)
+        emphasisLink = link
+        needsDisplay = true
+    }
+
+    private func stopEmphasis() {
+        emphasisLink?.invalidate()
+        emphasisLink = nil
+        emphasisRange = nil
+        emphasisProgress = 0
+    }
+
+    @objc private func stepEmphasis(_ link: CADisplayLink) {
+        // targetTimestamp - duration ≈ link start on the first tick; use the
+        // link's own clock so pauses/dropped frames stay in sync.
+        emphasisProgress = min(1, emphasisProgress + CGFloat(link.duration / Self.emphasisDuration))
+        needsDisplay = true
+        if emphasisProgress >= 1 { stopEmphasis(); needsDisplay = true }
     }
 
     /// The character range currently laid out in the viewport, or nil if

--- a/Sources/EdmundCore/TextView/EditorTextView+Find.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+Find.swift
@@ -31,6 +31,7 @@ extension EditorTextView {
         findMatches = []
         currentMatchIndex = nil
         findActive = false
+        findDimActive = false
         needsDisplay = true
     }
 
@@ -59,26 +60,52 @@ extension EditorTextView {
         guard findActive, !findMatches.isEmpty, let tlm = textLayoutManager else { return }
 
         let visible = viewportCharRange(tlm)
-        let current = NSColor.findHighlightColor
-        // Non-current matches are dimmer, and dimmer still in light mode where
-        // the yellow reads stronger against the white page.
-        let dark = effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
-        let other = current.withAlphaComponent(dark ? 0.55 : 0.3)
+        // All matches read equal weight; the "current" one is distinguished by
+        // the viewport revealing it, not by colour. Emphasis now comes from the
+        // dimmed document behind them (see `draw(_:)`).
+        NSColor.findHighlightColor.setFill()
         // Layout-fragment frames are in text-container space; the view offsets
         // them by textContainerOrigin (which also carries the content-width
         // centering). Translate to draw in view coordinates.
         let origin = textContainerOrigin
 
-        for (i, match) in findMatches.enumerated() {
+        for match in findMatches {
             if let visible, NSIntersectionRange(visible, match).length == 0 { continue }
             guard let tr = blockTextRange(match, tlm) else { continue }
-            (i == currentMatchIndex ? current : other).setFill()
             tlm.enumerateTextSegments(in: tr, type: .highlight, options: []) { _, frame, _, _ in
                 let r = frame.offsetBy(dx: origin.x, dy: origin.y)
                 if r.intersects(rect) { r.fill() }
                 return true
             }
         }
+    }
+
+    /// Paints the Notes-style dim veil *over* the glyphs while the find bar holds
+    /// focus, punching a hole around every match so the highlighted hits stay
+    /// bright and the rest of the page recedes. Draw-only, no storage touch.
+    /// Cleared when focus returns to the editor (`findDimActive`).
+    public override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        guard findActive, findDimActive, let tlm = textLayoutManager else { return }
+
+        // Full dirty area, minus a rect per visible match → even-odd fill leaves
+        // the matches undimmed.
+        let veil = NSBezierPath(rect: dirtyRect)
+        let visible = viewportCharRange(tlm)
+        let origin = textContainerOrigin
+        for match in findMatches {
+            if let visible, NSIntersectionRange(visible, match).length == 0 { continue }
+            guard let tr = blockTextRange(match, tlm) else { continue }
+            tlm.enumerateTextSegments(in: tr, type: .highlight, options: []) { _, frame, _, _ in
+                let r = frame.offsetBy(dx: origin.x, dy: origin.y).insetBy(dx: -1.5, dy: -1.5)
+                if r.intersects(dirtyRect) { veil.appendRect(r) }
+                return true
+            }
+        }
+        veil.windingRule = .evenOdd
+        let dark = effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+        NSColor.black.withAlphaComponent(dark ? 0.45 : 0.12).setFill()
+        veil.fill()
     }
 
     /// The character range currently laid out in the viewport, or nil if

--- a/Sources/EdmundCore/TextView/EditorTextView+Find.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+Find.swift
@@ -53,46 +53,70 @@ extension EditorTextView {
     // MARK: - Highlight drawing
 
     /// Paints a grey background behind every match (CotEditor-style), plus a
-    /// yellow→grey settle animation on the match just navigated to. Draw-only,
-    /// on the background pass so scrolling repaints exposed matches for free and
-    /// bounded to the laid-out viewport, so many scattered hits don't force
-    /// whole-document layout on every frame.
+    /// yellow "pop" box on the match just navigated to: a rounded rect a touch
+    /// larger than the text that swells slightly and fades out. Draw-only, on the
+    /// background pass (behind the glyphs, so the text stays legible through the
+    /// pop) and bounded to the laid-out viewport so many scattered hits don't
+    /// force whole-document layout on every frame.
     public override func drawBackground(in rect: NSRect) {
         super.drawBackground(in: rect)
         guard findActive, !findMatches.isEmpty, let tlm = textLayoutManager else { return }
 
         let visible = viewportCharRange(tlm)
-        let rest = NSColor.unemphasizedSelectedTextBackgroundColor   // grey for unfocused hits
-        // The emphasised hit starts at find-yellow and blends to grey as the pop
-        // settles. sRGB-convert both first: catalog colours won't blend directly.
-        let hot = NSColor.findHighlightColor.usingColorSpace(.sRGB)
-        let cool = rest.usingColorSpace(.sRGB)
-        let emphasised = (hot != nil && cool != nil)
-            ? (hot!.blended(withFraction: emphasisProgress, of: cool!) ?? rest) : rest
         // Layout-fragment frames are in text-container space; the view offsets
         // them by textContainerOrigin (which also carries the content-width
         // centering). Translate to draw in view coordinates.
         let origin = textContainerOrigin
 
+        // Grey resting background for every visible match.
+        NSColor.unemphasizedSelectedTextBackgroundColor.setFill()
         for match in findMatches {
             if let visible, NSIntersectionRange(visible, match).length == 0 { continue }
             guard let tr = blockTextRange(match, tlm) else { continue }
-            let isEmphasised = emphasisRange.map { NSEqualRanges($0, match) } ?? false
-            (isEmphasised ? emphasised : rest).setFill()
             tlm.enumerateTextSegments(in: tr, type: .highlight, options: []) { _, frame, _, _ in
                 let r = frame.offsetBy(dx: origin.x, dy: origin.y)
                 if r.intersects(rect) { r.fill() }
                 return true
             }
         }
+
+        // Pop box over the emphasised match: holds at full yellow, then swells
+        // outward and fades out. `emphasisProgress` runs 0…1 over the whole
+        // duration; the first `holdFraction` of it is the steady hold.
+        guard let em = emphasisRange, emphasisProgress < 1,
+              let tr = blockTextRange(em, tlm) else { return }
+        let holdFraction = CGFloat(Self.emphasisHold / Self.emphasisDuration)
+        let fade = max(0, (emphasisProgress - holdFraction) / (1 - holdFraction))
+        let grow = 2 + fade * 4                       // 2 → 6pt beyond the text box
+        let alpha = 1 - fade                          // fade to transparent
+
+        NSGraphicsContext.saveGraphicsState()
+        let shadow = NSShadow()
+        shadow.shadowColor = NSColor.black.withAlphaComponent(0.35 * alpha)   // fades with the box
+        shadow.shadowOffset = NSSize(width: 0, height: -1.5)                   // flipped view: downward
+        shadow.shadowBlurRadius = 4
+        shadow.set()
+        NSColor.findHighlightColor.withAlphaComponent(alpha).setFill()
+        tlm.enumerateTextSegments(in: tr, type: .highlight, options: []) { _, frame, _, _ in
+            let box = frame.offsetBy(dx: origin.x, dy: origin.y).insetBy(dx: -grow, dy: -grow)
+            if box.intersects(rect) {
+                NSBezierPath(roundedRect: box, xRadius: 4, yRadius: 4).fill()
+            }
+            return true
+        }
+        NSGraphicsContext.restoreGraphicsState()
     }
 
     // MARK: - Pop animation
 
-    private static let emphasisDuration: CFTimeInterval = 0.45
+    /// Full yellow is held for `emphasisHold`, then swells + fades over
+    /// `emphasisFade`.
+    private static let emphasisHold: CFTimeInterval = 1.0
+    private static let emphasisFade: CFTimeInterval = 0.2
+    private static var emphasisDuration: CFTimeInterval { emphasisHold + emphasisFade }
 
-    /// Starts (or restarts) the yellow→grey settle on `range`, driven by a
-    /// display link so it stays smooth without a manual timer.
+    /// Starts (or restarts) the pop on `range`, driven by a display link so it
+    /// stays smooth without a manual timer.
     private func emphasize(_ range: NSRange) {
         emphasisLink?.invalidate()
         emphasisRange = range

--- a/Sources/EdmundCore/TextView/EditorTextView+Find.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+Find.swift
@@ -1,0 +1,95 @@
+import AppKit
+
+/// Implemented by the app-side find controller (edmd's FindController). The
+/// editor forwards menu/keyboard find commands here so EdmundCore stays
+/// unaware of the concrete controller — same decoupling as
+/// `contextFontMenuProvider`.
+@MainActor public protocol EditorFindHandling: AnyObject {
+    func editorShowFind(replace: Bool)
+    func editorFindNext()
+    func editorFindPrevious()
+    func editorHideFind()
+}
+
+extension EditorTextView {
+
+    // MARK: - Match state
+
+    /// Replaces the current match set and requests a redraw. Draw-only — never
+    /// touches storage or the selection, so it can't perturb the edit/recompose
+    /// pipeline or the storage == rawSource invariant.
+    public func setFindMatches(_ matches: [NSRange], current: Int?) {
+        findMatches = matches
+        currentMatchIndex = current
+        findActive = true
+        needsDisplay = true
+    }
+
+    /// Clears find highlighting (bar closed).
+    public func clearFindMatches() {
+        guard findActive || !findMatches.isEmpty else { return }
+        findMatches = []
+        currentMatchIndex = nil
+        findActive = false
+        needsDisplay = true
+    }
+
+    /// Scrolls the match at `index` into view without moving the caret (a
+    /// selection change would trigger the active-block-renders-raw recompose).
+    public func scrollFindMatchToVisible(_ index: Int) {
+        guard findMatches.indices.contains(index) else { return }
+        scrollRangeToVisible(findMatches[index])
+    }
+
+    // MARK: - Highlight drawing
+
+    /// Paints the match highlights behind the glyphs, using the system find
+    /// colour. Runs on the normal background-draw pass (so scrolling repaints
+    /// exposed matches for free) and is bounded to matches intersecting the
+    /// laid-out viewport, so a document with many scattered hits doesn't force
+    /// whole-document layout on every frame.
+    public override func drawBackground(in rect: NSRect) {
+        super.drawBackground(in: rect)
+        guard findActive, !findMatches.isEmpty, let tlm = textLayoutManager else { return }
+
+        let visible = viewportCharRange(tlm)
+        let current = NSColor.findHighlightColor
+        let other = current.withAlphaComponent(0.5)
+        // Layout-fragment frames are in text-container space; the view offsets
+        // them by textContainerOrigin (which also carries the content-width
+        // centering). Translate to draw in view coordinates.
+        let origin = textContainerOrigin
+
+        for (i, match) in findMatches.enumerated() {
+            if let visible, NSIntersectionRange(visible, match).length == 0 { continue }
+            guard let tr = blockTextRange(match, tlm) else { continue }
+            (i == currentMatchIndex ? current : other).setFill()
+            tlm.enumerateTextSegments(in: tr, type: .highlight, options: []) { _, frame, _, _ in
+                let r = frame.offsetBy(dx: origin.x, dy: origin.y)
+                if r.intersects(rect) { r.fill() }
+                return true
+            }
+        }
+    }
+
+    /// The character range currently laid out in the viewport, or nil if
+    /// unavailable (fall back to enumerating all matches).
+    private func viewportCharRange(_ tlm: NSTextLayoutManager) -> NSRange? {
+        guard let vp = tlm.textViewportLayoutController.viewportRange else { return nil }
+        let docStart = tlm.documentRange.location
+        let lo = tlm.offset(from: docStart, to: vp.location)
+        let hi = tlm.offset(from: docStart, to: vp.endLocation)
+        guard lo >= 0, hi >= lo else { return nil }
+        return NSRange(location: lo, length: hi - lo)
+    }
+
+    // MARK: - Menu / keyboard actions
+    // Only implemented here, so in Reading mode (webview is first responder)
+    // these gray out automatically — no explicit validation needed.
+
+    @objc public func showFindBar(_ sender: Any?)      { findHandler?.editorShowFind(replace: false) }
+    @objc public func showFindReplaceBar(_ sender: Any?) { findHandler?.editorShowFind(replace: true) }
+    @objc public func findNext(_ sender: Any?)         { findHandler?.editorFindNext() }
+    @objc public func findPrevious(_ sender: Any?)     { findHandler?.editorFindPrevious() }
+    @objc public func hideFindBar(_ sender: Any?)      { findHandler?.editorHideFind() }
+}

--- a/Sources/EdmundCore/TextView/EditorTextView+Find.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+Find.swift
@@ -34,11 +34,17 @@ extension EditorTextView {
         needsDisplay = true
     }
 
-    /// Scrolls the match at `index` into view without moving the caret (a
-    /// selection change would trigger the active-block-renders-raw recompose).
-    public func scrollFindMatchToVisible(_ index: Int) {
+    /// Reveals the match at `index` without moving the caret (a selection change
+    /// would trigger the active-block-renders-raw recompose). Already-visible
+    /// matches don't move the viewport; otherwise the match's line goes to the
+    /// top, so a document jump lands the hit predictably rather than at an edge.
+    public func revealFindMatch(_ index: Int) {
         guard findMatches.indices.contains(index) else { return }
-        scrollRangeToVisible(findMatches[index])
+        let range = findMatches[index]
+        let origin = enclosingScrollView?.contentView.bounds.origin ?? .zero
+        if !rangeIsVisible(range, forViewportOrigin: origin) {
+            scrollCharacterToTop(range.location)
+        }
     }
 
     // MARK: - Highlight drawing
@@ -54,7 +60,10 @@ extension EditorTextView {
 
         let visible = viewportCharRange(tlm)
         let current = NSColor.findHighlightColor
-        let other = current.withAlphaComponent(0.5)
+        // Non-current matches are dimmer, and dimmer still in light mode where
+        // the yellow reads stronger against the white page.
+        let dark = effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+        let other = current.withAlphaComponent(dark ? 0.55 : 0.3)
         // Layout-fragment frames are in text-container space; the view offsets
         // them by textContainerOrigin (which also carries the content-width
         // centering). Translate to draw in view coordinates.

--- a/Sources/EdmundCore/TextView/EditorTextView+Find.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+Find.swift
@@ -5,7 +5,9 @@ import AppKit
 /// unaware of the concrete controller — same decoupling as
 /// `contextFontMenuProvider`.
 @MainActor public protocol EditorFindHandling: AnyObject {
-    func editorShowFind(replace: Bool)
+    /// ⌘F / ⌥⌘F. Both *toggle*: the requested bar opens, or closes if it is
+    /// already the one showing.
+    func editorToggleFind(replace: Bool)
     func editorFindNext()
     func editorFindPrevious()
     func editorHideFind()
@@ -180,8 +182,8 @@ extension EditorTextView {
     // Only implemented here, so in Reading mode (webview is first responder)
     // these gray out automatically — no explicit validation needed.
 
-    @objc public func showFindBar(_ sender: Any?)      { findHandler?.editorShowFind(replace: false) }
-    @objc public func showFindReplaceBar(_ sender: Any?) { findHandler?.editorShowFind(replace: true) }
+    @objc public func showFindBar(_ sender: Any?)      { findHandler?.editorToggleFind(replace: false) }
+    @objc public func showFindReplaceBar(_ sender: Any?) { findHandler?.editorToggleFind(replace: true) }
     @objc public func findNext(_ sender: Any?)         { findHandler?.editorFindNext() }
     @objc public func findPrevious(_ sender: Any?)     { findHandler?.editorFindPrevious() }
     @objc public func hideFindBar(_ sender: Any?)      { findHandler?.editorHideFind() }

--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -32,6 +32,22 @@ public class EditorTextView: NSTextView {
     /// Set by Document.makeWindowControllers(). Not available in unit tests.
     public weak var document: NSDocument?
 
+    // MARK: - Find
+
+    /// Character ranges of the current search's matches, in raw/display index
+    /// space (identity). Drawn as highlights by `drawBackground(in:)` while
+    /// `findActive`. Never written into storage — draw-only, to hold the
+    /// storage == rawSource invariant. See EditorTextView+Find.
+    public var findMatches: [NSRange] = []
+    /// Index into `findMatches` of the current match (drawn stronger), or nil.
+    public var currentMatchIndex: Int?
+    /// True while the find bar is open; gates highlight drawing.
+    public var findActive = false
+    /// Routes menu/keyboard find commands to the app-side find controller.
+    /// Weak; mirrors the module decoupling of `contextFontMenuProvider` so
+    /// EdmundCore need not know about edmd's FindController.
+    public weak var findHandler: EditorFindHandling?
+
     // MARK: - State (internal for @testable import)
 
     public var rawSource: String = ""

--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -43,10 +43,12 @@ public class EditorTextView: NSTextView {
     public var currentMatchIndex: Int?
     /// True while the find bar is open; gates highlight drawing.
     public var findActive = false
-    /// Dims the document (Notes-style) while the find bar holds focus, so the
-    /// bright matches pop. Cleared the moment focus returns to the editor
-    /// (a click into the text) — see `becomeFirstResponder`.
-    public var findDimActive = false
+    /// The match currently being emphasised (the newly-navigated hit), and how
+    /// far its yellow→grey settle animation has progressed (0…1). Drives the
+    /// CotEditor-style pop; nil when nothing is animating. See EditorTextView+Find.
+    var emphasisRange: NSRange?
+    var emphasisProgress: CGFloat = 0
+    var emphasisLink: CADisplayLink?
     /// Routes menu/keyboard find commands to the app-side find controller.
     /// Weak; mirrors the module decoupling of `contextFontMenuProvider` so
     /// EdmundCore need not know about edmd's FindController.
@@ -561,11 +563,7 @@ public class EditorTextView: NSTextView {
     /// This formalizes the focus-switch recovery users already stumble into.
     public override func becomeFirstResponder() -> Bool {
         let became = super.becomeFirstResponder()
-        if became {
-            recoverFromStrandedCompositionIfNeeded()
-            // Clicking/typing into the editor lifts the find dim (matches stay).
-            if findDimActive { findDimActive = false; needsDisplay = true }
-        }
+        if became { recoverFromStrandedCompositionIfNeeded() }
         return became
     }
 

--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -43,6 +43,10 @@ public class EditorTextView: NSTextView {
     public var currentMatchIndex: Int?
     /// True while the find bar is open; gates highlight drawing.
     public var findActive = false
+    /// Dims the document (Notes-style) while the find bar holds focus, so the
+    /// bright matches pop. Cleared the moment focus returns to the editor
+    /// (a click into the text) — see `becomeFirstResponder`.
+    public var findDimActive = false
     /// Routes menu/keyboard find commands to the app-side find controller.
     /// Weak; mirrors the module decoupling of `contextFontMenuProvider` so
     /// EdmundCore need not know about edmd's FindController.
@@ -557,7 +561,11 @@ public class EditorTextView: NSTextView {
     /// This formalizes the focus-switch recovery users already stumble into.
     public override func becomeFirstResponder() -> Bool {
         let became = super.becomeFirstResponder()
-        if became { recoverFromStrandedCompositionIfNeeded() }
+        if became {
+            recoverFromStrandedCompositionIfNeeded()
+            // Clicking/typing into the editor lifts the find dim (matches stay).
+            if findDimActive { findDimActive = false; needsDisplay = true }
+        }
         return became
     }
 

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -25,6 +25,7 @@ class Document: NSDocument, HeadingNavigable {
     /// editor out for a `ReadModeWebView` (created lazily on first read).
     private var scrollView: NSScrollView!
     private var containerView: NSView!
+    private var findController: FindController!
     private var readView: ReadModeWebView?
 
     /// Editor character offset captured when entering Read mode (the topmost
@@ -183,6 +184,9 @@ class Document: NSDocument, HeadingNavigable {
         containerView.addSubview(statusBar)   // overlay, on top of the text
 
         window.contentView = containerView
+
+        findController = FindController(editor: editor, scrollView: scrollView,
+                                       container: containerView, statusBar: statusBar)
 
         NotificationCenter.default.addObserver(
             self, selector: #selector(editorDidChange(_:)),

--- a/Sources/edmd/App/FindController.swift
+++ b/Sources/edmd/App/FindController.swift
@@ -68,7 +68,6 @@ final class FindController: NSObject, EditorFindHandling {
             if !picked.contains("\n") { bar.searchField.stringValue = picked }
         }
         editor.window?.makeFirstResponder(bar.searchField)
-        editor.findDimActive = true   // dim the page until focus returns to it
         runSearch(resetToFirst: true)
     }
 

--- a/Sources/edmd/App/FindController.swift
+++ b/Sources/edmd/App/FindController.swift
@@ -41,6 +41,7 @@ final class FindController: NSObject, EditorFindHandling {
         bar.onToggleReplace = { [weak self] _ in self?.layoutBar() }
         bar.onReplace = { [weak self] in self?.replaceCurrent() }
         bar.onReplaceAll = { [weak self] in self?.replaceAll() }
+        bar.onToggleFindBar = { [weak self] replace in self?.editorToggleFind(replace: replace) }
 
         // Live edits while the bar is open: re-run so the count/highlights track.
         NotificationCenter.default.addObserver(
@@ -50,7 +51,18 @@ final class FindController: NSObject, EditorFindHandling {
 
     // MARK: - EditorFindHandling
 
-    func editorShowFind(replace: Bool) {
+    /// ⌘F and ⌥⌘F both toggle. Pressing the shortcut for the bar that is already
+    /// up closes it; pressing the other one switches to it, so ⌘F from the
+    /// replace bar drops the replace row rather than closing outright.
+    func editorToggleFind(replace: Bool) {
+        if isShowing && bar.showsReplaceRow == replace {
+            editorHideFind()
+        } else {
+            editorShowFind(replace: replace)
+        }
+    }
+
+    private func editorShowFind(replace: Bool) {
         guard let editor else { return }
         let firstShow = !isShowing
         if firstShow {

--- a/Sources/edmd/App/FindController.swift
+++ b/Sources/edmd/App/FindController.swift
@@ -52,14 +52,19 @@ final class FindController: NSObject, EditorFindHandling {
 
     func editorShowFind(replace: Bool) {
         guard let editor else { return }
-        if !isShowing {
+        let firstShow = !isShowing
+        if firstShow {
             savedTopInset = scrollView?.contentInsets.top ?? 0
             scrollView?.automaticallyAdjustsContentInsets = false
             isShowing = true
-            bar.isHidden = false
         }
         bar.showsReplaceRow = replace
         layoutBar()
+        // Finish the bar's internal layout *before* revealing it, otherwise the
+        // first painted frame is pre-layout and controls (the search field's
+        // magnifier) visibly settle a pass later.
+        bar.layoutSubtreeIfNeeded()
+        if firstShow { bar.isHidden = false }
 
         // Seed from the current selection when it's a single line of text.
         let sel = editor.selectedRange()
@@ -119,14 +124,15 @@ final class FindController: NSObject, EditorFindHandling {
         matches = FindEngine.matches(of: needle, in: editor.rawSource,
                                      caseSensitive: bar.caseSensitive,
                                      wholeWord: bar.wholeWord)
-        bar.setCount(matches.count)
 
         guard !matches.isEmpty else {
+            bar.setCount(current: nil, total: 0)
             editor.setFindMatches([], current: nil)
             return
         }
         let caret = editor.selectedRange().location
         let current = matches.firstIndex { $0.location >= caret } ?? 0
+        bar.setCount(current: current, total: matches.count)
         editor.setFindMatches(matches, current: current)
         if resetToFirst { editor.revealFindMatch(current) }
     }
@@ -135,6 +141,7 @@ final class FindController: NSObject, EditorFindHandling {
         guard let editor, !matches.isEmpty,
               let current = editor.currentMatchIndex else { return }
         let next = (current + delta + matches.count) % matches.count
+        bar.setCount(current: next, total: matches.count)
         editor.setFindMatches(matches, current: next)
         editor.revealFindMatch(next)
     }

--- a/Sources/edmd/App/FindController.swift
+++ b/Sources/edmd/App/FindController.swift
@@ -68,6 +68,7 @@ final class FindController: NSObject, EditorFindHandling {
             if !picked.contains("\n") { bar.searchField.stringValue = picked }
         }
         editor.window?.makeFirstResponder(bar.searchField)
+        editor.findDimActive = true   // dim the page until focus returns to it
         runSearch(resetToFirst: true)
     }
 

--- a/Sources/edmd/App/FindController.swift
+++ b/Sources/edmd/App/FindController.swift
@@ -1,0 +1,179 @@
+import AppKit
+import EdmundCore
+
+/// Owns the find bar and drives search/replace against one document's editor.
+/// Created by `Document` after the editor/scroll/container views exist.
+///
+/// Search is draw-only (highlights via `EditorTextView.setFindMatches`); the
+/// only text mutation is Replace / Replace All, done through the editor's
+/// sanctioned edit cycle so undo, recompose and storage == rawSource all hold.
+@MainActor
+final class FindController: NSObject, EditorFindHandling {
+
+    private weak var editor: EditorTextView?
+    private weak var scrollView: NSScrollView?
+    private weak var container: NSView?
+    private let bar = FindBarView()
+
+    /// The scroll view's top content inset before we pushed content down for the
+    /// bar (usually the toolbar overlap). Restored on hide.
+    private var savedTopInset: CGFloat = 0
+    private var isShowing = false
+
+    init(editor: EditorTextView, scrollView: NSScrollView, container: NSView, statusBar: NSView) {
+        self.editor = editor
+        self.scrollView = scrollView
+        self.container = container
+        super.init()
+
+        editor.findHandler = self
+
+        bar.isHidden = true
+        bar.autoresizingMask = [.width, .minYMargin]   // pinned to the top edge
+        // Below the floating status bar so counts stay on top.
+        container.addSubview(bar, positioned: .below, relativeTo: statusBar)
+
+        bar.onSearchChanged = { [weak self] in self?.runSearch(resetToFirst: true) }
+        bar.onOptionsChanged = { [weak self] in self?.runSearch(resetToFirst: true) }
+        bar.onNext = { [weak self] in self?.step(+1) }
+        bar.onPrevious = { [weak self] in self?.step(-1) }
+        bar.onDone = { [weak self] in self?.editorHideFind() }
+        bar.onToggleReplace = { [weak self] _ in self?.layoutBar() }
+        bar.onReplace = { [weak self] in self?.replaceCurrent() }
+        bar.onReplaceAll = { [weak self] in self?.replaceAll() }
+
+        // Live edits while the bar is open: re-run so the count/highlights track.
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(editorTextChanged),
+            name: NSText.didChangeNotification, object: editor)
+    }
+
+    // MARK: - EditorFindHandling
+
+    func editorShowFind(replace: Bool) {
+        guard let editor else { return }
+        if !isShowing {
+            savedTopInset = scrollView?.contentInsets.top ?? 0
+            scrollView?.automaticallyAdjustsContentInsets = false
+            isShowing = true
+            bar.isHidden = false
+        }
+        bar.showsReplaceRow = replace
+        layoutBar()
+
+        // Seed from the current selection when it's a single line of text.
+        let sel = editor.selectedRange()
+        if sel.length > 0 {
+            let picked = (editor.string as NSString).substring(with: sel)
+            if !picked.contains("\n") { bar.searchField.stringValue = picked }
+        }
+        editor.window?.makeFirstResponder(bar.searchField)
+        runSearch(resetToFirst: true)
+    }
+
+    func editorHideFind() {
+        guard isShowing else { return }
+        isShowing = false
+        bar.isHidden = true
+        editor?.clearFindMatches()
+        scrollView?.automaticallyAdjustsContentInsets = true
+        editor?.window?.makeFirstResponder(editor)
+    }
+
+    func editorFindNext() {
+        if isShowing { step(+1) } else { editorShowFind(replace: false) }
+    }
+
+    func editorFindPrevious() {
+        if isShowing { step(-1) } else { editorShowFind(replace: false) }
+    }
+
+    // MARK: - Layout
+
+    /// Positions the bar under the toolbar and pushes the document content down
+    /// by the bar's height (varies with the replace row).
+    private func layoutBar() {
+        guard let container, let scrollView else { return }
+        let h = bar.preferredHeight
+        bar.frame = NSRect(x: 0,
+                           y: container.bounds.height - savedTopInset - h,
+                           width: container.bounds.width, height: h)
+        scrollView.contentInsets.top = savedTopInset + h
+    }
+
+    // MARK: - Search
+
+    private var matches: [NSRange] = []
+
+    @objc private func editorTextChanged() {
+        guard isShowing else { return }
+        runSearch(resetToFirst: false)
+    }
+
+    /// Recomputes matches from the current source. `resetToFirst` picks the first
+    /// match at/after the caret (new search); otherwise keeps the closest index
+    /// so a live edit doesn't jump the selection around.
+    private func runSearch(resetToFirst: Bool) {
+        guard let editor else { return }
+        let needle = bar.searchField.stringValue
+        matches = FindEngine.matches(of: needle, in: editor.rawSource,
+                                     caseSensitive: bar.caseSensitive,
+                                     wholeWord: bar.wholeWord)
+        bar.setCount(matches.count)
+
+        guard !matches.isEmpty else {
+            editor.setFindMatches([], current: nil)
+            return
+        }
+        let caret = editor.selectedRange().location
+        let current = matches.firstIndex { $0.location >= caret } ?? 0
+        editor.setFindMatches(matches, current: current)
+        if resetToFirst { editor.scrollFindMatchToVisible(current) }
+    }
+
+    private func step(_ delta: Int) {
+        guard let editor, !matches.isEmpty,
+              let current = editor.currentMatchIndex else { return }
+        let next = (current + delta + matches.count) % matches.count
+        editor.setFindMatches(matches, current: next)
+        editor.scrollFindMatchToVisible(next)
+    }
+
+    // MARK: - Replace
+    // Both paths go through shouldChangeText → replaceCharacters → didChangeText,
+    // the editor's own edit cycle: one undo snapshot each, rawSource re-synced,
+    // recompose triggered. Never mutate storage outside this cycle.
+
+    private func replaceCurrent() {
+        guard let editor, let idx = editor.currentMatchIndex,
+              matches.indices.contains(idx) else { return }
+        let range = matches[idx]
+        let replacement = bar.replaceField.stringValue
+        applyEdit(range: range, replacement: replacement, in: editor)
+        // The document changed; recompute and advance to the next hit.
+        runSearch(resetToFirst: false)
+    }
+
+    private func replaceAll() {
+        guard let editor, !matches.isEmpty else { return }
+        let replacement = bar.replaceField.stringValue
+        // Rebuild the whole source once (back-to-front so earlier offsets stay
+        // valid) and apply it as a single edit → a single undo step.
+        let source = editor.rawSource as NSString
+        let result = NSMutableString(string: source)
+        for range in matches.reversed() {
+            result.replaceCharacters(in: range, with: replacement)
+        }
+        applyEdit(range: NSRange(location: 0, length: source.length),
+                  replacement: result as String, in: editor)
+        runSearch(resetToFirst: false)
+    }
+
+    private func applyEdit(range: NSRange, replacement: String, in editor: EditorTextView) {
+        guard editor.shouldChangeText(in: range, replacementString: replacement) else { return }
+        editor.textStorage?.replaceCharacters(in: range, with: replacement)
+        let caret = range.location + (replacement as NSString).length
+        editor.setSelectedRange(NSRange(location: min(caret, (editor.string as NSString).length), length: 0))
+        editor.didChangeText()
+    }
+}

--- a/Sources/edmd/App/FindController.swift
+++ b/Sources/edmd/App/FindController.swift
@@ -128,7 +128,7 @@ final class FindController: NSObject, EditorFindHandling {
         let caret = editor.selectedRange().location
         let current = matches.firstIndex { $0.location >= caret } ?? 0
         editor.setFindMatches(matches, current: current)
-        if resetToFirst { editor.scrollFindMatchToVisible(current) }
+        if resetToFirst { editor.revealFindMatch(current) }
     }
 
     private func step(_ delta: Int) {
@@ -136,7 +136,7 @@ final class FindController: NSObject, EditorFindHandling {
               let current = editor.currentMatchIndex else { return }
         let next = (current + delta + matches.count) % matches.count
         editor.setFindMatches(matches, current: next)
-        editor.scrollFindMatchToVisible(next)
+        editor.revealFindMatch(next)
     }
 
     // MARK: - Replace

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -297,6 +297,64 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         findMenuItem.title = "Find"
         editMenu.addItem(findMenuItem)
 
+        // The standard text submenus, same first-responder routing as Find.
+        // NSTextView supplies the actions *and* the checkmark state for the
+        // toggles (our validateMenuItem override falls through to super for
+        // anything that isn't a formatting command).
+        //
+        // In Reading mode the editing commands gray out — measured: all of
+        // Transformations, plus Show Spelling and Check Document Now. The two
+        // spell-checking toggles and Start Speaking stay live, because the web
+        // view answers those selectors itself; both are harmless there (they
+        // act on the rendered view, not the source).
+        //
+        // Substitutions is deliberately absent: smart quotes/dashes, text
+        // replacement and autocorrect are switched off in
+        // `EditorTextView.commonInit()` on purpose — they rewrite typed Markdown
+        // and the completion machinery can strand marked text, breaking the
+        // storage == rawSource invariant. Same reason "Correct Spelling
+        // Automatically" is left out of Spelling and Grammar below.
+        let spellingMenu = NSMenu(title: "Spelling and Grammar")
+        spellingMenu.addItem(withTitle: "Show Spelling and Grammar",
+                             action: #selector(NSText.showGuessPanel(_:)),
+                             keyEquivalent: ":")
+        spellingMenu.addItem(withTitle: "Check Document Now",
+                             action: #selector(NSText.checkSpelling(_:)),
+                             keyEquivalent: ";")
+        spellingMenu.addItem(.separator())
+        spellingMenu.addItem(withTitle: "Check Spelling While Typing",
+                             action: #selector(NSTextView.toggleContinuousSpellChecking(_:)),
+                             keyEquivalent: "")
+        spellingMenu.addItem(withTitle: "Check Grammar With Spelling",
+                             action: #selector(NSTextView.toggleGrammarChecking(_:)),
+                             keyEquivalent: "")
+        let spellingItem = NSMenuItem()
+        spellingItem.title = "Spelling and Grammar"
+        spellingItem.submenu = spellingMenu
+        editMenu.addItem(spellingItem)
+
+        let transformMenu = NSMenu(title: "Transformations")
+        transformMenu.addItem(withTitle: "Make Upper Case",
+                              action: #selector(NSResponder.uppercaseWord(_:)), keyEquivalent: "")
+        transformMenu.addItem(withTitle: "Make Lower Case",
+                              action: #selector(NSResponder.lowercaseWord(_:)), keyEquivalent: "")
+        transformMenu.addItem(withTitle: "Capitalize",
+                              action: #selector(NSResponder.capitalizeWord(_:)), keyEquivalent: "")
+        let transformItem = NSMenuItem()
+        transformItem.title = "Transformations"
+        transformItem.submenu = transformMenu
+        editMenu.addItem(transformItem)
+
+        let speechMenu = NSMenu(title: "Speech")
+        speechMenu.addItem(withTitle: "Start Speaking",
+                           action: #selector(NSTextView.startSpeaking(_:)), keyEquivalent: "")
+        speechMenu.addItem(withTitle: "Stop Speaking",
+                           action: #selector(NSTextView.stopSpeaking(_:)), keyEquivalent: "")
+        let speechItem = NSMenuItem()
+        speechItem.title = "Speech"
+        speechItem.submenu = speechMenu
+        editMenu.addItem(speechItem)
+
         editMenuItem.submenu = editMenu
         mainMenu.addItem(editMenuItem)
 

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -274,6 +274,29 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
                          action: #selector(NSText.selectAll(_:)),
                          keyEquivalent: "a")
 
+        editMenu.addItem(NSMenuItem.separator())
+
+        // Find submenu — routes to first-responder actions on EditorTextView,
+        // which forward to the document's FindController. Grays out in Reading
+        // mode (the web view is first responder and implements none of these).
+        let findMenuItem = NSMenuItem()
+        let findMenu = NSMenu(title: "Find")
+        findMenu.addItem(withTitle: "Find…",
+                         action: #selector(EditorTextView.showFindBar(_:)),
+                         keyEquivalent: "f")
+        findMenu.addItem(withTitle: "Find and Replace…",
+                         action: #selector(EditorTextView.showFindReplaceBar(_:)),
+                         keyEquivalent: "f").keyEquivalentModifierMask = [.command, .option]
+        findMenu.addItem(withTitle: "Find Next",
+                         action: #selector(EditorTextView.findNext(_:)),
+                         keyEquivalent: "g")
+        findMenu.addItem(withTitle: "Find Previous",
+                         action: #selector(EditorTextView.findPrevious(_:)),
+                         keyEquivalent: "g").keyEquivalentModifierMask = [.command, .shift]
+        findMenuItem.submenu = findMenu
+        findMenuItem.title = "Find"
+        editMenu.addItem(findMenuItem)
+
         editMenuItem.submenu = editMenu
         mainMenu.addItem(editMenuItem)
 

--- a/Sources/edmd/Views/FindBarView.swift
+++ b/Sources/edmd/Views/FindBarView.swift
@@ -1,0 +1,179 @@
+import AppKit
+
+/// The in-document find/replace bar, styled after Apple Notes: a full-width
+/// strip under the toolbar with a magnifier search field (case / whole-word
+/// options in its menu), a live match count, prev/next arrows, a Done button,
+/// and a Replace toggle that reveals the replace row.
+///
+/// This view is dumb: it owns the controls and reports events through closures.
+/// All search/replace logic lives in `FindController`.
+final class FindBarView: NSVisualEffectView {
+
+    static let findRowHeight: CGFloat = 32
+    static let replaceRowHeight: CGFloat = 30
+
+    let searchField = NSSearchField()
+    let replaceField = NSTextField()
+    private let countLabel = NSTextField(labelWithString: "0")
+    private let nav = NSSegmentedControl(
+        images: [NSImage(systemSymbolName: "chevron.left", accessibilityDescription: "Previous")!,
+                 NSImage(systemSymbolName: "chevron.right", accessibilityDescription: "Next")!],
+        trackingMode: .momentary, target: nil, action: nil)
+    private let replaceToggle = NSButton(checkboxWithTitle: "Replace", target: nil, action: nil)
+    private let replaceRow = NSStackView()
+
+    // Event callbacks, wired by the controller.
+    var onSearchChanged: (() -> Void)?
+    var onNext: (() -> Void)?
+    var onPrevious: (() -> Void)?
+    var onDone: (() -> Void)?
+    var onToggleReplace: ((Bool) -> Void)?
+    var onReplace: (() -> Void)?
+    var onReplaceAll: (() -> Void)?
+    var onOptionsChanged: (() -> Void)?
+
+    var caseSensitive = false { didSet { syncOptionMenu() } }
+    var wholeWord = false { didSet { syncOptionMenu() } }
+
+    var showsReplaceRow: Bool {
+        get { replaceToggle.state == .on }
+        set {
+            replaceToggle.state = newValue ? .on : .off
+            replaceRow.isHidden = !newValue
+        }
+    }
+
+    /// The bar's current height for the active replace state.
+    var preferredHeight: CGFloat {
+        Self.findRowHeight + (showsReplaceRow ? Self.replaceRowHeight : 0)
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        material = .titlebar
+        blendingMode = .withinWindow
+        state = .active
+        buildUI()
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    // MARK: - Build
+
+    private func buildUI() {
+        searchField.placeholderString = "Find"
+        searchField.sendsWholeSearchString = false          // fire per keystroke
+        searchField.sendsSearchStringImmediately = true
+        searchField.target = self
+        searchField.action = #selector(searchChanged)
+        searchField.searchMenuTemplate = optionsMenu()
+
+        countLabel.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+        countLabel.textColor = .secondaryLabelColor
+        countLabel.alignment = .right
+        countLabel.setContentHuggingPriority(.required, for: .horizontal)
+
+        nav.target = self
+        nav.action = #selector(navClicked)
+        nav.setContentHuggingPriority(.required, for: .horizontal)
+
+        let done = NSButton(title: "Done", target: self, action: #selector(doneClicked))
+        done.bezelStyle = .rounded
+        done.setContentHuggingPriority(.required, for: .horizontal)
+
+        replaceToggle.target = self
+        replaceToggle.action = #selector(replaceToggled)
+        replaceToggle.setContentHuggingPriority(.required, for: .horizontal)
+
+        let findRow = NSStackView(views: [searchField, countLabel, nav, done, replaceToggle])
+        findRow.orientation = .horizontal
+        findRow.spacing = 8
+        findRow.alignment = .centerY
+        findRow.edgeInsets = NSEdgeInsets(top: 0, left: 12, bottom: 0, right: 12)
+        searchField.setContentHuggingPriority(.defaultLow, for: .horizontal) // takes slack
+
+        // Replace row.
+        replaceField.placeholderString = "Replace"
+        replaceField.target = self
+        replaceField.action = #selector(replaceReturn)
+        let replaceBtn = NSButton(title: "Replace", target: self, action: #selector(replaceClicked))
+        replaceBtn.bezelStyle = .rounded
+        let replaceAllBtn = NSButton(title: "Replace All", target: self, action: #selector(replaceAllClicked))
+        replaceAllBtn.bezelStyle = .rounded
+        for b in [replaceBtn, replaceAllBtn] { b.setContentHuggingPriority(.required, for: .horizontal) }
+
+        replaceRow.setViews([replaceField, replaceBtn, replaceAllBtn], in: .leading)
+        replaceRow.orientation = .horizontal
+        replaceRow.spacing = 8
+        replaceRow.alignment = .centerY
+        replaceRow.edgeInsets = NSEdgeInsets(top: 0, left: 12, bottom: 0, right: 12)
+        replaceRow.isHidden = true
+
+        let column = NSStackView(views: [findRow, replaceRow])
+        column.orientation = .vertical
+        column.spacing = 0
+        column.alignment = .leading
+        column.distribution = .fill
+        column.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(column)
+        NSLayoutConstraint.activate([
+            column.leadingAnchor.constraint(equalTo: leadingAnchor),
+            column.trailingAnchor.constraint(equalTo: trailingAnchor),
+            column.topAnchor.constraint(equalTo: topAnchor),
+            findRow.heightAnchor.constraint(equalToConstant: Self.findRowHeight),
+            replaceRow.heightAnchor.constraint(equalToConstant: Self.replaceRowHeight),
+            findRow.widthAnchor.constraint(equalTo: column.widthAnchor),
+            replaceRow.widthAnchor.constraint(equalTo: column.widthAnchor),
+        ])
+    }
+
+    private func optionsMenu() -> NSMenu {
+        let menu = NSMenu()
+        let cs = NSMenuItem(title: "Case Sensitive", action: #selector(toggleCase), keyEquivalent: "")
+        cs.target = self
+        let ww = NSMenuItem(title: "Whole Words", action: #selector(toggleWholeWord), keyEquivalent: "")
+        ww.target = self
+        menu.addItem(cs); menu.addItem(ww)
+        return menu
+    }
+
+    private func syncOptionMenu() {
+        guard let menu = searchField.searchMenuTemplate else { return }
+        menu.items.first { $0.action == #selector(toggleCase) }?.state = caseSensitive ? .on : .off
+        menu.items.first { $0.action == #selector(toggleWholeWord) }?.state = wholeWord ? .on : .off
+    }
+
+    // MARK: - Display
+
+    func setCount(_ count: Int) {
+        countLabel.stringValue = "\(count)"
+    }
+
+    // MARK: - Actions
+
+    @objc private func searchChanged() { onSearchChanged?() }
+    @objc private func doneClicked() { onDone?() }
+    @objc private func replaceClicked() { onReplace?() }
+    @objc private func replaceReturn() { onReplace?() }
+    @objc private func replaceAllClicked() { onReplaceAll?() }
+
+    @objc private func navClicked() {
+        if nav.selectedSegment == 0 { onPrevious?() } else { onNext?() }
+    }
+
+    @objc private func replaceToggled() {
+        let on = replaceToggle.state == .on
+        replaceRow.isHidden = !on
+        onToggleReplace?(on)
+    }
+
+    @objc private func toggleCase() {
+        caseSensitive.toggle()
+        onOptionsChanged?()
+    }
+
+    @objc private func toggleWholeWord() {
+        wholeWord.toggle()
+        onOptionsChanged?()
+    }
+}

--- a/Sources/edmd/Views/FindBarView.swift
+++ b/Sources/edmd/Views/FindBarView.swift
@@ -88,8 +88,6 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
     private let doneBottom = NSButton(title: "Done", target: nil, action: nil)
     /// Row-0 trailing cell: Done (find-only) + the Replace checkbox.
     private let trailing0 = NSStackView()
-    /// Row-1 trailing cell: Replace|All group butted up against Done (no gap).
-    private let trailing1 = NSStackView()
 
     private var grid: NSGridView!
 
@@ -170,13 +168,12 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
         trailing0.spacing = 8
         trailing0.setViews([doneTop, replaceToggle], in: .leading)
 
-        trailing1.orientation = .horizontal
-        trailing1.spacing = 6   // Replace|All butted up against Done, per the reference
-        trailing1.setViews([replaceGroup, doneBottom], in: .leading)
-
+        // ‹›/Replace|All share col1's left edge; ☑Replace/Done share col2 (trailing,
+        // far right) — the reference grid. Done lands under the Replace checkbox
+        // with a small gap after Replace|All, driven by the column widths.
         grid = NSGridView(views: [
             [searchField, nav, trailing0],
-            [replaceField, NSGridCell.emptyContentView, trailing1],
+            [replaceField, replaceGroup, doneBottom],
         ])
         grid.columnSpacing = 8
         grid.rowSpacing = 5

--- a/Sources/edmd/Views/FindBarView.swift
+++ b/Sources/edmd/Views/FindBarView.swift
@@ -1,26 +1,95 @@
 import AppKit
 
-/// The in-document find/replace bar, styled after Apple Notes: a full-width
-/// strip under the toolbar with a magnifier search field (case / whole-word
-/// options in its menu), a live match count, prev/next arrows, a Done button,
-/// and a Replace toggle that reveals the replace row.
+// MARK: - Search field with an inline match count
+
+/// Reserves room on the right of the search text for the count label so the
+/// typed text never runs under it.
+private final class CountingSearchFieldCell: NSSearchFieldCell {
+    var countWidth: CGFloat = 0
+    override func searchTextRect(forBounds rect: NSRect) -> NSRect {
+        var r = super.searchTextRect(forBounds: rect)
+        r.size.width = max(0, r.width - countWidth)
+        return r
+    }
+}
+
+/// An `NSSearchField` that shows the match count inside the field, just left of
+/// the cancel (✕) button — the Notes placement.
+final class CountingSearchField: NSSearchField {
+    private let countLabel = NSTextField(labelWithString: "")
+
+    override class var cellClass: AnyClass? {
+        get { CountingSearchFieldCell.self }
+        set { }
+    }
+
+    /// nil or an empty query hides the count.
+    var matchCount: Int? { didSet { updateCount() } }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        countLabel.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+        countLabel.textColor = .secondaryLabelColor
+        countLabel.isHidden = true
+        addSubview(countLabel)
+    }
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private func updateCount() {
+        if let c = matchCount, !stringValue.isEmpty {
+            countLabel.stringValue = "\(c)"
+            countLabel.sizeToFit()
+            countLabel.isHidden = false
+            (cell as? CountingSearchFieldCell)?.countWidth = countLabel.frame.width + 10
+        } else {
+            countLabel.isHidden = true
+            (cell as? CountingSearchFieldCell)?.countWidth = 0
+        }
+        needsLayout = true
+    }
+
+    override func layout() {
+        super.layout()
+        guard !countLabel.isHidden else { return }
+        let cancel = (cell as? NSSearchFieldCell)?.cancelButtonRect(forBounds: bounds) ?? .zero
+        let rightEdge = cancel.width > 0 ? cancel.minX : bounds.maxX - 6
+        let w = countLabel.frame.width
+        countLabel.frame = NSRect(x: rightEdge - w - 4,
+                                  y: (bounds.height - countLabel.frame.height) / 2,
+                                  width: w, height: countLabel.frame.height)
+    }
+}
+
+// MARK: - Find bar
+
+/// The in-document find/replace bar, styled after Apple Notes. Laid out on an
+/// `NSGridView` so the search/replace fields share a left edge and the `‹ ›` /
+/// `Replace|All` control groups share a left edge. Find-only is one row; toggling
+/// Replace reveals a second row and moves **Done** down onto it.
 ///
-/// This view is dumb: it owns the controls and reports events through closures.
-/// All search/replace logic lives in `FindController`.
-final class FindBarView: NSVisualEffectView {
+/// Dumb view: owns the controls, reports events through closures. All logic is
+/// in `FindController`.
+final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
 
-    static let findRowHeight: CGFloat = 32
-    static let replaceRowHeight: CGFloat = 30
-
-    let searchField = NSSearchField()
+    let searchField = CountingSearchField()
     let replaceField = NSTextField()
-    private let countLabel = NSTextField(labelWithString: "0")
+
     private let nav = NSSegmentedControl(
         images: [NSImage(systemSymbolName: "chevron.left", accessibilityDescription: "Previous")!,
                  NSImage(systemSymbolName: "chevron.right", accessibilityDescription: "Next")!],
         trackingMode: .momentary, target: nil, action: nil)
     private let replaceToggle = NSButton(checkboxWithTitle: "Replace", target: nil, action: nil)
-    private let replaceRow = NSStackView()
+    private let replaceGroup = NSSegmentedControl(
+        labels: ["Replace", "All"], trackingMode: .momentary, target: nil, action: nil)
+    // Two Done buttons — one per row — toggled by visibility. Simpler and more
+    // robust than moving a single button between grid cells (which failed to
+    // render). find-only shows the top one; replace shows the bottom one.
+    private let doneTop = NSButton(title: "Done", target: nil, action: nil)
+    private let doneBottom = NSButton(title: "Done", target: nil, action: nil)
+    /// Row-0 trailing cell: Done (find-only) + the Replace checkbox.
+    private let trailing0 = NSStackView()
+
+    private var grid: NSGridView!
 
     // Event callbacks, wired by the controller.
     var onSearchChanged: (() -> Void)?
@@ -39,13 +108,16 @@ final class FindBarView: NSVisualEffectView {
         get { replaceToggle.state == .on }
         set {
             replaceToggle.state = newValue ? .on : .off
-            replaceRow.isHidden = !newValue
+            grid.row(at: 1).isHidden = !newValue   // hides replace field + group + doneBottom
+            doneTop.isHidden = newValue            // Done only on the visible row
+            needsLayout = true
         }
     }
 
-    /// The bar's current height for the active replace state.
+    /// The bar's height for the active replace state (drives the content inset).
     var preferredHeight: CGFloat {
-        Self.findRowHeight + (showsReplaceRow ? Self.replaceRowHeight : 0)
+        grid.layoutSubtreeIfNeeded()
+        return grid.fittingSize.height + 12
     }
 
     override init(frame frameRect: NSRect) {
@@ -54,76 +126,64 @@ final class FindBarView: NSVisualEffectView {
         blendingMode = .withinWindow
         state = .active
         buildUI()
+        showsReplaceRow = false
     }
-
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
     // MARK: - Build
 
     private func buildUI() {
         searchField.placeholderString = "Find"
-        searchField.sendsWholeSearchString = false          // fire per keystroke
+        searchField.sendsWholeSearchString = false
         searchField.sendsSearchStringImmediately = true
         searchField.target = self
         searchField.action = #selector(searchChanged)
+        searchField.delegate = self
         searchField.searchMenuTemplate = optionsMenu()
+        searchField.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
-        countLabel.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
-        countLabel.textColor = .secondaryLabelColor
-        countLabel.alignment = .right
-        countLabel.setContentHuggingPriority(.required, for: .horizontal)
-
-        nav.target = self
-        nav.action = #selector(navClicked)
-        nav.setContentHuggingPriority(.required, for: .horizontal)
-
-        let done = NSButton(title: "Done", target: self, action: #selector(doneClicked))
-        done.bezelStyle = .rounded
-        done.setContentHuggingPriority(.required, for: .horizontal)
-
-        replaceToggle.target = self
-        replaceToggle.action = #selector(replaceToggled)
-        replaceToggle.setContentHuggingPriority(.required, for: .horizontal)
-
-        let findRow = NSStackView(views: [searchField, countLabel, nav, done, replaceToggle])
-        findRow.orientation = .horizontal
-        findRow.spacing = 8
-        findRow.alignment = .centerY
-        findRow.edgeInsets = NSEdgeInsets(top: 0, left: 12, bottom: 0, right: 12)
-        searchField.setContentHuggingPriority(.defaultLow, for: .horizontal) // takes slack
-
-        // Replace row.
         replaceField.placeholderString = "Replace"
         replaceField.target = self
         replaceField.action = #selector(replaceReturn)
-        let replaceBtn = NSButton(title: "Replace", target: self, action: #selector(replaceClicked))
-        replaceBtn.bezelStyle = .rounded
-        let replaceAllBtn = NSButton(title: "Replace All", target: self, action: #selector(replaceAllClicked))
-        replaceAllBtn.bezelStyle = .rounded
-        for b in [replaceBtn, replaceAllBtn] { b.setContentHuggingPriority(.required, for: .horizontal) }
+        replaceField.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
-        replaceRow.setViews([replaceField, replaceBtn, replaceAllBtn], in: .leading)
-        replaceRow.orientation = .horizontal
-        replaceRow.spacing = 8
-        replaceRow.alignment = .centerY
-        replaceRow.edgeInsets = NSEdgeInsets(top: 0, left: 12, bottom: 0, right: 12)
-        replaceRow.isHidden = true
+        nav.target = self
+        nav.action = #selector(navClicked)
 
-        let column = NSStackView(views: [findRow, replaceRow])
-        column.orientation = .vertical
-        column.spacing = 0
-        column.alignment = .leading
-        column.distribution = .fill
-        column.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(column)
+        replaceGroup.target = self
+        replaceGroup.action = #selector(replaceGroupClicked)
+        replaceGroup.segmentDistribution = .fit
+
+        for done in [doneTop, doneBottom] {
+            done.bezelStyle = .rounded
+            done.target = self
+            done.action = #selector(doneClicked)
+        }
+
+        replaceToggle.target = self
+        replaceToggle.action = #selector(replaceToggled)
+
+        trailing0.orientation = .horizontal
+        trailing0.spacing = 8
+        trailing0.setViews([doneTop, replaceToggle], in: .leading)
+
+        grid = NSGridView(views: [
+            [searchField, nav, trailing0],
+            [replaceField, replaceGroup, doneBottom],
+        ])
+        grid.columnSpacing = 8
+        grid.rowSpacing = 5
+        grid.column(at: 0).xPlacement = .fill        // fields absorb slack
+        grid.column(at: 1).xPlacement = .leading      // ‹›/Replace|All share a left edge
+        grid.column(at: 2).xPlacement = .trailing
+        for r in 0..<grid.numberOfRows { grid.row(at: r).yPlacement = .center }
+
+        grid.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(grid)
         NSLayoutConstraint.activate([
-            column.leadingAnchor.constraint(equalTo: leadingAnchor),
-            column.trailingAnchor.constraint(equalTo: trailingAnchor),
-            column.topAnchor.constraint(equalTo: topAnchor),
-            findRow.heightAnchor.constraint(equalToConstant: Self.findRowHeight),
-            replaceRow.heightAnchor.constraint(equalToConstant: Self.replaceRowHeight),
-            findRow.widthAnchor.constraint(equalTo: column.widthAnchor),
-            replaceRow.widthAnchor.constraint(equalTo: column.widthAnchor),
+            grid.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            grid.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+            grid.topAnchor.constraint(equalTo: topAnchor, constant: 6),
         ])
     }
 
@@ -145,35 +205,35 @@ final class FindBarView: NSVisualEffectView {
 
     // MARK: - Display
 
-    func setCount(_ count: Int) {
-        countLabel.stringValue = "\(count)"
+    func setCount(_ count: Int) { searchField.matchCount = count }
+
+    // MARK: - Search-field Return → find next
+
+    func control(_ control: NSControl, textView: NSTextView, doCommandBy selector: Selector) -> Bool {
+        guard control === searchField else { return false }
+        if selector == #selector(NSResponder.insertNewline(_:)) { onNext?(); return true }
+        return false
     }
 
     // MARK: - Actions
 
     @objc private func searchChanged() { onSearchChanged?() }
     @objc private func doneClicked() { onDone?() }
-    @objc private func replaceClicked() { onReplace?() }
     @objc private func replaceReturn() { onReplace?() }
-    @objc private func replaceAllClicked() { onReplaceAll?() }
 
     @objc private func navClicked() {
         if nav.selectedSegment == 0 { onPrevious?() } else { onNext?() }
     }
 
+    @objc private func replaceGroupClicked() {
+        if replaceGroup.selectedSegment == 0 { onReplace?() } else { onReplaceAll?() }
+    }
+
     @objc private func replaceToggled() {
-        let on = replaceToggle.state == .on
-        replaceRow.isHidden = !on
-        onToggleReplace?(on)
+        showsReplaceRow = replaceToggle.state == .on
+        onToggleReplace?(showsReplaceRow)
     }
 
-    @objc private func toggleCase() {
-        caseSensitive.toggle()
-        onOptionsChanged?()
-    }
-
-    @objc private func toggleWholeWord() {
-        wholeWord.toggle()
-        onOptionsChanged?()
-    }
+    @objc private func toggleCase() { caseSensitive.toggle(); onOptionsChanged?() }
+    @objc private func toggleWholeWord() { wholeWord.toggle(); onOptionsChanged?() }
 }

--- a/Sources/edmd/Views/FindBarView.swift
+++ b/Sources/edmd/Views/FindBarView.swift
@@ -204,6 +204,68 @@ final class CountingSearchField: NSSearchField {
     }
 }
 
+// MARK: - Segmented control whose segments are individually Tab-reachable
+
+/// AppKit already focuses segments one at a time — it draws the focus ring
+/// around a single segment and moves it with ← / → — but Tab always leaves the
+/// whole control, so a trailing segment (`›`, `All`) can never be reached by
+/// Tab. This translates Tab into AppKit's own arrow handling until the last
+/// segment, then releases it to the key-view loop.
+///
+/// The focused segment has no public accessor, so it is mirrored here: seeded
+/// on focus, advanced when we forward an arrow, and kept in sync by watching
+/// the user's own ← / → presses.
+private final class SegmentTabbingControl: NSSegmentedControl {
+    private var focusedSegment = 0
+
+    override func becomeFirstResponder() -> Bool {
+        let accepted = super.becomeFirstResponder()
+        // AppKit enters on the leading segment going forwards and the *trailing*
+        // one coming back via Shift-Tab; seed the mirror to match, or the first
+        // Shift-Tab inside the control leaves it a segment early.
+        if accepted { focusedSegment = enteringBackwards ? segmentCount - 1 : 0 }
+        return accepted
+    }
+
+    private var enteringBackwards: Bool {
+        guard let event = NSApp.currentEvent, event.type == .keyDown else { return false }
+        return Int(event.keyCode) == 48 && event.modifierFlags.contains(.shift)
+    }
+
+    override func keyDown(with event: NSEvent) {
+        let shift = event.modifierFlags.contains(.shift)
+        switch Int(event.keyCode) {
+        case 48:                                    // Tab / Shift-Tab
+            let step = shift ? -1 : 1
+            let next = focusedSegment + step
+            if (0..<segmentCount).contains(next) {
+                focusedSegment = next
+                super.keyDown(with: arrowEvent(right: !shift, like: event))
+            } else if shift {
+                window?.selectPreviousKeyView(self)
+            } else {
+                window?.selectNextKeyView(self)
+            }
+        case 123, 124:                              // ← / → — mirror AppKit's move
+            focusedSegment = max(0, min(segmentCount - 1,
+                                        focusedSegment + (event.keyCode == 124 ? 1 : -1)))
+            super.keyDown(with: event)
+        default:
+            super.keyDown(with: event)
+        }
+    }
+
+    private func arrowEvent(right: Bool, like event: NSEvent) -> NSEvent {
+        let key = right ? NSRightArrowFunctionKey : NSLeftArrowFunctionKey
+        let chars = String(UnicodeScalar(key)!)
+        return NSEvent.keyEvent(with: .keyDown, location: event.locationInWindow,
+                                modifierFlags: [], timestamp: event.timestamp,
+                                windowNumber: event.windowNumber, context: nil,
+                                characters: chars, charactersIgnoringModifiers: chars,
+                                isARepeat: false, keyCode: right ? 124 : 123) ?? event
+    }
+}
+
 // MARK: - Find bar
 
 /// The in-document find/replace bar, styled after Apple Notes. Laid out on an
@@ -218,12 +280,12 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
     let searchField = CountingSearchField()
     let replaceField = NSTextField()
 
-    private let nav = NSSegmentedControl(
+    private let nav = SegmentTabbingControl(
         images: [NSImage(systemSymbolName: "chevron.left", accessibilityDescription: "Previous")!,
                  NSImage(systemSymbolName: "chevron.right", accessibilityDescription: "Next")!],
         trackingMode: .momentary, target: nil, action: nil)
     private let replaceToggle = NSButton(checkboxWithTitle: "Replace", target: nil, action: nil)
-    private let replaceGroup = NSSegmentedControl(
+    private let replaceGroup = SegmentTabbingControl(
         labels: ["Replace", "All"], trackingMode: .momentary, target: nil, action: nil)
     // Two Done buttons — one per row — toggled by visibility. Simpler and more
     // robust than moving a single button between grid cells (which failed to

--- a/Sources/edmd/Views/FindBarView.swift
+++ b/Sources/edmd/Views/FindBarView.swift
@@ -307,6 +307,8 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
     var onReplace: (() -> Void)?
     var onReplaceAll: (() -> Void)?
     var onOptionsChanged: (() -> Void)?
+    /// ⌘F / ⌥⌘F pressed while the bar has focus; the flag is `replace`.
+    var onToggleFindBar: ((Bool) -> Void)?
 
     var caseSensitive = false { didSet { syncOptionMenu() } }
     var wholeWord = false { didSet { syncOptionMenu() } }
@@ -478,13 +480,34 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
         searchField.matchInfo = (current, total)
     }
 
-    // MARK: - Search-field Return → find next
+    // MARK: - Search-field Return → find next / ⇧Return → find previous
 
     func control(_ control: NSControl, textView: NSTextView, doCommandBy selector: Selector) -> Bool {
         guard control === searchField else { return false }
-        if selector == #selector(NSResponder.insertNewline(_:)) { onNext?(); return true }
-        return false
+        // ⇧Return arrives as either selector depending on the field's state, and
+        // only the originating event carries the modifier.
+        switch selector {
+        case #selector(NSResponder.insertNewline(_:)), #selector(NSResponder.insertLineBreak(_:)):
+            let backwards = NSApp.currentEvent?.modifierFlags.contains(.shift) ?? false
+            if backwards { onPrevious?() } else { onNext?() }
+            return true
+        default:
+            return false
+        }
     }
+
+    // MARK: - Find commands while the bar has focus
+    //
+    // The Edit ▸ Find items target the first responder, and route to
+    // `EditorTextView`. With focus inside the bar the editor is not in the
+    // responder chain — the bar is — so ⌘F / ⌥⌘F / ⌘G / ⇧⌘G would grey out
+    // exactly while you're typing a query. Same selectors here pick them up.
+
+    @objc func showFindBar(_ sender: Any?) { onToggleFindBar?(false) }
+    @objc func showFindReplaceBar(_ sender: Any?) { onToggleFindBar?(true) }
+    @objc func findNext(_ sender: Any?) { onNext?() }
+    @objc func findPrevious(_ sender: Any?) { onPrevious?() }
+    @objc func hideFindBar(_ sender: Any?) { onDone?() }
 
     // MARK: - Actions
 

--- a/Sources/edmd/Views/FindBarView.swift
+++ b/Sources/edmd/Views/FindBarView.swift
@@ -260,8 +260,38 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
             // is nothing to absorb, so the cell hugs its content instead.
             topSpacer.isHidden = !newValue
             grid.cell(atColumnIndex: 1, rowIndex: 0).xPlacement = newValue ? .fill : .leading
+            refreshKeyViewLoop()
             needsLayout = true
             invalidateIntrinsicContentSize()
+        }
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        // AppKit rebuilds the window's key-view loop from view geometry whenever
+        // the view tree changes, wiping any `nextKeyView` we set — Tab then fell
+        // straight out of the bar. Opt the window out so our chain survives.
+        window?.autorecalculatesKeyViewLoop = false
+        refreshKeyViewLoop()
+    }
+
+    /// Chains the bar's controls into a closed Tab loop in visual order, so Tab
+    /// walks the bar instead of escaping to the editor. Rebuilt whenever the
+    /// replace row appears or hides, because that changes both the membership
+    /// (the replace row joins) and which **Done** is live.
+    ///
+    /// The loop is declared in full, including the buttons: AppKit skips links
+    /// whose view can't become a key view, so with macOS "Keyboard navigation"
+    /// off — the default — Tab moves between the two text fields only, and the
+    /// same chain lights up the buttons for users who switch it on. Nothing here
+    /// can force that; a control's `refusesFirstResponder` doesn't override the
+    /// system setting.
+    private func refreshKeyViewLoop() {
+        let chain: [NSView] = showsReplaceRow
+            ? [searchField, nav, replaceToggle, replaceField, replaceGroup, doneBottom]
+            : [searchField, nav, doneTop, replaceToggle]
+        for (view, next) in zip(chain, chain.dropFirst() + [chain[0]]) {
+            view.nextKeyView = next
         }
     }
 

--- a/Sources/edmd/Views/FindBarView.swift
+++ b/Sources/edmd/Views/FindBarView.swift
@@ -2,6 +2,23 @@ import AppKit
 
 // MARK: - Search field with an inline match count
 
+/// Suppresses the stock magnifier ▾ glyph so the field can draw it centred
+/// itself — see `CountingSearchField.draw(_:)`.
+///
+/// AppKit draws the glyph ~3.75pt below the field's centre (the image is 21×15,
+/// the button rect the field's full 22pt height) and there is no built-in way to
+/// move it: `searchButtonRect(forBounds:)` is only a sizing probe (it's called
+/// with a 40000×40000 bounds), `drawInterior(withFrame:in:)` is bypassed by the
+/// search field's private draw path, and the cell ignores a replacement image
+/// (the Big Sur `NSSearchField` regression, FB8913004). `imageRect(forBounds:)`
+/// *is* honoured, but the drawing is clipped to a fixed band, so shifting or
+/// growing the rect only chops the top off the glyph. Zeroing it draws nothing,
+/// which is the one thing we can use. The cell still handles the click, so the
+/// search-options menu keeps working.
+private final class BlankSearchButtonCell: NSButtonCell {
+    override func imageRect(forBounds rect: NSRect) -> NSRect { .zero }
+}
+
 /// Reserves room on the right of the search text for the count label so the
 /// typed text never runs under it.
 private final class CountingSearchFieldCell: NSSearchFieldCell {
@@ -33,6 +50,57 @@ final class CountingSearchField: NSSearchField {
         countLabel.textColor = .secondaryLabelColor
         countLabel.isHidden = true
         addSubview(countLabel)
+        recentreSearchButton()
+    }
+
+    /// Blank the search button cell, keeping its target/action so the
+    /// search-options menu still opens; `draw(_:)` renders the glyph instead.
+    private func recentreSearchButton() {
+        guard let sfCell = cell as? NSSearchFieldCell,
+              let old = sfCell.searchButtonCell else { return }
+        let blank = BlankSearchButtonCell()
+        blank.title = ""              // NSButtonCell defaults to drawing "Button"
+        blank.imagePosition = .imageOnly
+        blank.isBordered = old.isBordered
+        blank.isTransparent = old.isTransparent
+        blank.target = old.target
+        blank.action = old.action
+        sfCell.searchButtonCell = blank
+    }
+
+    /// Draws the magnifier (and the ▾ search-menu affordance, when there is a
+    /// menu) centred on the button rect, matching the stock glyph's geometry.
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        guard let sfCell = cell as? NSSearchFieldCell, let magnifier = Self.magnifier else { return }
+        let button = sfCell.searchButtonRect(forBounds: bounds)
+        var x = button.minX + 2
+        func place(_ image: NSImage) {
+            let s = image.size
+            tint(image).draw(in: NSRect(x: x, y: button.midY - s.height / 2,
+                                        width: s.width, height: s.height))
+            x += s.width
+        }
+        place(magnifier)
+        if searchMenuTemplate != nil, let chevron = Self.menuChevron { place(chevron) }
+    }
+
+    private static let magnifier = NSImage(systemSymbolName: "magnifyingglass",
+                                           accessibilityDescription: "Search")?
+        .withSymbolConfiguration(NSImage.SymbolConfiguration(pointSize: 11, weight: .regular))
+    private static let menuChevron = NSImage(systemSymbolName: "chevron.down",
+                                             accessibilityDescription: "Search options")?
+        .withSymbolConfiguration(NSImage.SymbolConfiguration(pointSize: 7, weight: .semibold))
+
+    /// Template images render flat black when drawn by hand; tint per draw so the
+    /// glyph follows light/dark.
+    private func tint(_ image: NSImage) -> NSImage {
+        NSImage(size: image.size, flipped: false) { rect in
+            image.draw(in: rect)
+            NSColor.secondaryLabelColor.set()
+            rect.fill(using: .sourceAtop)
+            return true
+        }
     }
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
@@ -116,9 +184,11 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
     }
 
     /// The bar's height for the active replace state (drives the content inset).
+    /// `fittingSize` already carries the grid's top/bottom insets, so no padding
+    /// is added here — adding more would stretch the grid and unbalance the rows.
     var preferredHeight: CGFloat {
         layoutSubtreeIfNeeded()
-        return fittingSize.height + 12
+        return fittingSize.height
     }
 
     override init(frame frameRect: NSRect) {
@@ -192,7 +262,7 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
             [replaceField, bottomRightStack],
         ])
         grid.columnSpacing = 8
-        grid.rowSpacing = 5
+        grid.rowSpacing = 3          // tight gap between the find and replace rows
         grid.column(at: 0).xPlacement = .fill        // fields stretch to fill
         grid.column(at: 1).xPlacement = .leading      // col1 hugs content (driven by the wider cluster)
         grid.cell(atColumnIndex: 1, rowIndex: 0).xPlacement = .fill   // top cluster fills col1 so its spacer expands

--- a/Sources/edmd/Views/FindBarView.swift
+++ b/Sources/edmd/Views/FindBarView.swift
@@ -23,8 +23,9 @@ final class CountingSearchField: NSSearchField {
         set { }
     }
 
-    /// nil or an empty query hides the count.
-    var matchCount: Int? { didSet { updateCount() } }
+    /// Current match (0-based) and total; shown as "k of n". nil total or an
+    /// empty query hides the count.
+    var matchInfo: (current: Int?, total: Int)? { didSet { updateCount() } }
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -36,8 +37,8 @@ final class CountingSearchField: NSSearchField {
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
     private func updateCount() {
-        if let c = matchCount, !stringValue.isEmpty {
-            countLabel.stringValue = "\(c)"
+        if let info = matchInfo, info.total > 0, !stringValue.isEmpty {
+            countLabel.stringValue = info.current.map { "\($0 + 1) of \(info.total)" } ?? "\(info.total)"
             countLabel.sizeToFit()
             countLabel.isHidden = false
             (cell as? CountingSearchFieldCell)?.countWidth = countLabel.frame.width + 10
@@ -168,9 +169,13 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
         // A 2×2 grid: column 0 holds the two fields (stretch to fill), column 1
         // the two right-hand clusters. Row 1 (replace) is hidden in find-only.
 
-        // Top cluster: nav, Done (find-only), Replace — leading, no spacer.
-        // doneTop detaches when the replace row appears.
-        let topRight = NSStackView(views: [nav, doneTop, replaceToggle])
+        // Top cluster: nav — spacer — Done (find-only), Replace. The spacer
+        // pushes Replace to the trailing edge (aligned with Done below), with
+        // nav on the leading edge. doneTop detaches when the replace row appears.
+        let topSpacer = NSView()
+        topSpacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        topSpacer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        let topRight = NSStackView(views: [nav, topSpacer, doneTop, replaceToggle])
         topRight.orientation = .horizontal
         topRight.spacing = 8
         topRight.alignment = .centerY
@@ -189,7 +194,8 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
         grid.columnSpacing = 8
         grid.rowSpacing = 5
         grid.column(at: 0).xPlacement = .fill        // fields stretch to fill
-        grid.column(at: 1).xPlacement = .leading      // both clusters leading; col1 hugs content
+        grid.column(at: 1).xPlacement = .leading      // col1 hugs content (driven by the wider cluster)
+        grid.cell(atColumnIndex: 1, rowIndex: 0).xPlacement = .fill   // top cluster fills col1 so its spacer expands
         grid.row(at: 0).yPlacement = .center
         grid.row(at: 1).yPlacement = .center
 
@@ -224,7 +230,9 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
 
     // MARK: - Display
 
-    func setCount(_ count: Int) { searchField.matchCount = count }
+    func setCount(current: Int?, total: Int) {
+        searchField.matchInfo = (current, total)
+    }
 
     // MARK: - Search-field Return → find next
 

--- a/Sources/edmd/Views/FindBarView.swift
+++ b/Sources/edmd/Views/FindBarView.swift
@@ -1,5 +1,11 @@
 import AppKit
 
+/// How far the find bar's fields inset their leading content: the search
+/// field's magnifier glyph and the replace field's text both start here, so the
+/// two rows line up. AppKit's own insets differ per control (3.5pt for the
+/// search button, 12pt for a rounded-bezel text field), so both are overridden.
+private let fieldContentInset: CGFloat = 6
+
 // MARK: - Search field with an inline match count
 
 /// Suppresses the stock magnifier ▾ glyph so the field can draw it centred
@@ -17,6 +23,29 @@ import AppKit
 /// search-options menu keeps working.
 private final class BlankSearchButtonCell: NSButtonCell {
     override func imageRect(forBounds rect: NSRect) -> NSRect { .zero }
+}
+
+/// A text field whose text starts at `fieldContentInset`, lining the replace
+/// row up with the search field's magnifier.
+final class PaddedTextField: NSTextField {
+    override class var cellClass: AnyClass? {
+        get { PaddedTextFieldCell.self }
+        set { }
+    }
+}
+
+private final class PaddedTextFieldCell: NSTextFieldCell {
+    /// AppKit insets the drawn text this much further inside `drawingRect`
+    /// (measured), so the rect must start that much before the inset we want.
+    private static let textInsetInsideDrawingRect: CGFloat = 3
+
+    override func drawingRect(forBounds rect: NSRect) -> NSRect {
+        var r = super.drawingRect(forBounds: rect)
+        let shift = rect.minX + fieldContentInset - Self.textInsetInsideDrawingRect - r.minX
+        r.origin.x += shift
+        r.size.width -= shift
+        return r
+    }
 }
 
 /// Reserves room on the right of the search text for the count label so the
@@ -68,13 +97,14 @@ final class CountingSearchField: NSSearchField {
         sfCell.searchButtonCell = blank
     }
 
-    // Ink geometry of the stock glyph, measured off a screenshot of the native
-    // search field (device pixels ÷ 2), stated as an offset from the button
-    // rect's leading edge. The magnifier and the ▾ are both centred on the
-    // composite, so centring each on the button rect keeps their relationship
-    // while lifting the whole glyph onto the field's centre.
-    private static let magnifierInk = (x: CGFloat(1.5), size: NSSize(width: 12.5, height: 12.5))
-    private static let chevronInk = (x: CGFloat(14.0), size: NSSize(width: 6.1, height: 4.3))
+    // Ink sizes of the stock glyph, measured off a screenshot of the native
+    // search field (device pixels ÷ 2). The magnifier and the ▾ are both centred
+    // on the composite, so centring each on the button rect keeps their
+    // relationship while lifting the whole glyph onto the field's centre. Their
+    // leading edge is `fieldContentInset` rather than AppKit's own 3.5pt.
+    private static let magnifierInkSize = NSSize(width: 12.5, height: 12.5)
+    private static let chevronInkSize = NSSize(width: 6.1, height: 4.3)
+    private static let chevronGap: CGFloat = 0.25   // measured, magnifier ink → ▾ ink
 
     /// Draws the magnifier — and the ▾ search-menu affordance, when there is a
     /// menu — replicating the stock glyph, but centred on the button rect
@@ -84,24 +114,26 @@ final class CountingSearchField: NSSearchField {
         guard let sfCell = cell as? NSSearchFieldCell else { return }
         let button = sfCell.searchButtonRect(forBounds: bounds)
         if let magnifier = Self.magnifier {
-            draw(magnifier, inkAt: Self.magnifierInk.x, size: Self.magnifierInk.size, in: button)
+            draw(magnifier, inkAt: fieldContentInset, size: Self.magnifierInkSize, in: button)
         }
         if searchMenuTemplate != nil, let chevron = Self.menuChevron {
-            draw(chevron, inkAt: Self.chevronInk.x, size: Self.chevronInk.size, in: button)
+            draw(chevron, inkAt: fieldContentInset + Self.magnifierInkSize.width + Self.chevronGap,
+                 size: Self.chevronInkSize, in: button)
         }
     }
 
     /// Scales and offsets `glyph` so its *ink* — not its padded image bounds —
-    /// lands `x` points in from the button rect's leading edge, `size` big, and
-    /// centred on the rect. SF Symbol images carry internal padding that varies
-    /// with the symbol, so placing them by image bounds would miss the stock
-    /// geometry; going through the ink makes the measured numbers exact.
+    /// lands `x` points in from the *field's* leading edge, `size` big, and
+    /// centred vertically on the button rect. SF Symbol images carry internal
+    /// padding that varies with the symbol, so placing them by image bounds
+    /// would miss the stock geometry; going through the ink makes the measured
+    /// numbers exact.
     private func draw(_ glyph: (image: NSImage, ink: NSRect), inkAt x: CGFloat,
                       size: NSSize, in button: NSRect) {
         guard glyph.ink.width > 0, glyph.ink.height > 0 else { return }
         let sx = size.width / glyph.ink.width, sy = size.height / glyph.ink.height
         tint(glyph.image).draw(in: NSRect(
-            x: button.minX + x - glyph.ink.minX * sx,
+            x: bounds.minX + x - glyph.ink.minX * sx,
             y: button.midY - size.height / 2 - glyph.ink.minY * sy,
             width: glyph.image.size.width * sx, height: glyph.image.size.height * sy))
     }
@@ -205,7 +237,7 @@ final class CountingSearchField: NSSearchField {
 final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
 
     let searchField = CountingSearchField()
-    let replaceField = NSTextField()
+    let replaceField = PaddedTextField()
 
     private let nav = NSSegmentedControl(
         images: [NSImage(systemSymbolName: "chevron.left", accessibilityDescription: "Previous")!,

--- a/Sources/edmd/Views/FindBarView.swift
+++ b/Sources/edmd/Views/FindBarView.swift
@@ -80,6 +80,10 @@ final class CountingSearchField: NSSearchField {
     private static let magnifierInkSize = NSSize(width: 12.5, height: 12.5)
     private static let chevronInkSize = NSSize(width: 6.1, height: 4.3)
     private static let chevronGap: CGFloat = 0.25   // measured, magnifier ink → ▾ ink
+    /// Raises the glyph off the button rect's dead centre, which reads slightly
+    /// low next to the text's x-height. Subtracted, because the field's
+    /// coordinate space is flipped — smaller y is higher.
+    private static let glyphLift: CGFloat = 0.5
 
     /// Draws the magnifier — and the ▾ search-menu affordance, when there is a
     /// menu — replicating the stock glyph, but centred on the button rect
@@ -109,7 +113,7 @@ final class CountingSearchField: NSSearchField {
         let sx = size.width / glyph.ink.width, sy = size.height / glyph.ink.height
         tint(glyph.image).draw(in: NSRect(
             x: bounds.minX + x - glyph.ink.minX * sx,
-            y: button.midY - size.height / 2 - glyph.ink.minY * sy,
+            y: button.midY - size.height / 2 - glyph.ink.minY * sy - Self.glyphLift,
             width: glyph.image.size.width * sx, height: glyph.image.size.height * sy))
     }
 

--- a/Sources/edmd/Views/FindBarView.swift
+++ b/Sources/edmd/Views/FindBarView.swift
@@ -221,6 +221,8 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
     private let doneBottom = NSButton(title: "Done", target: nil, action: nil)
     /// Row-1 right cluster: Replace|All — spacer — Done.
     private let bottomRightStack = NSStackView()
+    /// Row-0 slack, live only in replace mode — see `showsReplaceRow`.
+    private let topSpacer = NSView()
     private var grid: NSGridView!
 
     // Event callbacks, wired by the controller.
@@ -242,6 +244,11 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
             replaceToggle.state = newValue ? .on : .off
             grid.row(at: 1).isHidden = !newValue   // hides the replace field + right cluster
             doneTop.isHidden = newValue            // Done lives on the visible row only
+            // With Done gone the top row has slack: let the spacer take it so
+            // Replace lands on the trailing edge, above Done. In find-only there
+            // is nothing to absorb, so the cell hugs its content instead.
+            topSpacer.isHidden = !newValue
+            grid.cell(atColumnIndex: 1, rowIndex: 0).xPlacement = newValue ? .fill : .leading
             needsLayout = true
             invalidateIntrinsicContentSize()
         }
@@ -303,10 +310,14 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
         // A 2×2 grid: column 0 holds the two fields (stretch to fill), column 1
         // the two right-hand clusters. Row 1 (replace) is hidden in find-only.
 
-        // Top cluster: nav, Done (find-only), Replace — evenly spaced, leading,
-        // so nav shares its left edge with Replace|All below. doneTop detaches
-        // when the replace row appears.
-        let topRight = NSStackView(views: [nav, doneTop, replaceToggle])
+        // Top cluster: nav, spacer, Done (find-only), Replace. nav is leading, so
+        // it shares its left edge with Replace|All below. The spacer is hidden in
+        // find-only — there the three controls are evenly spaced — and shown once
+        // doneTop detaches for the replace row, pushing Replace out to the
+        // trailing edge above Done.
+        topSpacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        topSpacer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        let topRight = NSStackView(views: [nav, topSpacer, doneTop, replaceToggle])
         topRight.orientation = .horizontal
         topRight.spacing = 8
         topRight.alignment = .centerY
@@ -326,7 +337,6 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
         grid.rowSpacing = 3          // tight gap between the find and replace rows
         grid.column(at: 0).xPlacement = .fill        // fields stretch to fill
         grid.column(at: 1).xPlacement = .leading      // col1 hugs content (driven by the wider cluster)
-        grid.cell(atColumnIndex: 1, rowIndex: 0).xPlacement = .leading
         grid.row(at: 0).yPlacement = .center
         grid.row(at: 1).yPlacement = .center
 

--- a/Sources/edmd/Views/FindBarView.swift
+++ b/Sources/edmd/Views/FindBarView.swift
@@ -1,9 +1,7 @@
 import AppKit
 
-/// How far the find bar's fields inset their leading content: the search
-/// field's magnifier glyph and the replace field's text both start here, so the
-/// two rows line up. AppKit's own insets differ per control (3.5pt for the
-/// search button, 12pt for a rounded-bezel text field), so both are overridden.
+/// How far the search field insets its magnifier glyph from its leading edge —
+/// AppKit's own inset is a tighter 3.5pt.
 private let fieldContentInset: CGFloat = 6
 
 // MARK: - Search field with an inline match count
@@ -23,29 +21,6 @@ private let fieldContentInset: CGFloat = 6
 /// search-options menu keeps working.
 private final class BlankSearchButtonCell: NSButtonCell {
     override func imageRect(forBounds rect: NSRect) -> NSRect { .zero }
-}
-
-/// A text field whose text starts at `fieldContentInset`, lining the replace
-/// row up with the search field's magnifier.
-final class PaddedTextField: NSTextField {
-    override class var cellClass: AnyClass? {
-        get { PaddedTextFieldCell.self }
-        set { }
-    }
-}
-
-private final class PaddedTextFieldCell: NSTextFieldCell {
-    /// AppKit insets the drawn text this much further inside `drawingRect`
-    /// (measured), so the rect must start that much before the inset we want.
-    private static let textInsetInsideDrawingRect: CGFloat = 3
-
-    override func drawingRect(forBounds rect: NSRect) -> NSRect {
-        var r = super.drawingRect(forBounds: rect)
-        let shift = rect.minX + fieldContentInset - Self.textInsetInsideDrawingRect - r.minX
-        r.origin.x += shift
-        r.size.width -= shift
-        return r
-    }
 }
 
 /// Reserves room on the right of the search text for the count label so the
@@ -237,7 +212,7 @@ final class CountingSearchField: NSSearchField {
 final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
 
     let searchField = CountingSearchField()
-    let replaceField = PaddedTextField()
+    let replaceField = NSTextField()
 
     private let nav = NSSegmentedControl(
         images: [NSImage(systemSymbolName: "chevron.left", accessibilityDescription: "Previous")!,

--- a/Sources/edmd/Views/FindBarView.swift
+++ b/Sources/edmd/Views/FindBarView.swift
@@ -296,6 +296,12 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
     private let bottomRightStack = NSStackView()
     /// Row-0 slack, live only in replace mode — see `showsReplaceRow`.
     private let topSpacer = NSView()
+    /// Hairline along the bottom edge, matching the toolbar's separator so the
+    /// bar reads as window chrome. A subview, not a `draw(_:)` override:
+    /// `NSVisualEffectView` renders its material through layers and never calls
+    /// through to a custom `draw`. Pinned to the bottom, so it follows whichever
+    /// row is last — find-only or the revealed replace row.
+    private let bottomBorder = NSView()
     private var grid: NSGridView!
 
     // Event callbacks, wired by the controller.
@@ -327,6 +333,15 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
             refreshKeyViewLoop()
             needsLayout = true
             invalidateIntrinsicContentSize()
+        }
+    }
+
+    /// Keeps the hairline's colour correct across a light/dark switch — a
+    /// `cgColor` snapshot doesn't follow the appearance on its own.
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            bottomBorder.layer?.backgroundColor = NSColor.separatorColor.cgColor
         }
     }
 
@@ -444,6 +459,17 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
         grid.column(at: 1).xPlacement = .leading      // col1 hugs content (driven by the wider cluster)
         grid.row(at: 0).yPlacement = .center
         grid.row(at: 1).yPlacement = .center
+
+        bottomBorder.wantsLayer = true
+        bottomBorder.layer?.backgroundColor = NSColor.separatorColor.cgColor
+        bottomBorder.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(bottomBorder)
+        NSLayoutConstraint.activate([
+            bottomBorder.leadingAnchor.constraint(equalTo: leadingAnchor),
+            bottomBorder.trailingAnchor.constraint(equalTo: trailingAnchor),
+            bottomBorder.bottomAnchor.constraint(equalTo: bottomAnchor),
+            bottomBorder.heightAnchor.constraint(equalToConstant: 1 / (NSScreen.main?.backingScaleFactor ?? 2)),
+        ])
 
         grid.translatesAutoresizingMaskIntoConstraints = false
         addSubview(grid)

--- a/Sources/edmd/Views/FindBarView.swift
+++ b/Sources/edmd/Views/FindBarView.swift
@@ -68,29 +68,93 @@ final class CountingSearchField: NSSearchField {
         sfCell.searchButtonCell = blank
     }
 
-    /// Draws the magnifier (and the ▾ search-menu affordance, when there is a
-    /// menu) centred on the button rect, matching the stock glyph's geometry.
+    // Ink geometry of the stock glyph, measured off a screenshot of the native
+    // search field (device pixels ÷ 2), stated as an offset from the button
+    // rect's leading edge. The magnifier and the ▾ are both centred on the
+    // composite, so centring each on the button rect keeps their relationship
+    // while lifting the whole glyph onto the field's centre.
+    private static let magnifierInk = (x: CGFloat(1.5), size: NSSize(width: 12.5, height: 12.5))
+    private static let chevronInk = (x: CGFloat(14.0), size: NSSize(width: 6.1, height: 4.3))
+
+    /// Draws the magnifier — and the ▾ search-menu affordance, when there is a
+    /// menu — replicating the stock glyph, but centred on the button rect
+    /// instead of sitting low in it.
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
-        guard let sfCell = cell as? NSSearchFieldCell, let magnifier = Self.magnifier else { return }
+        guard let sfCell = cell as? NSSearchFieldCell else { return }
         let button = sfCell.searchButtonRect(forBounds: bounds)
-        var x = button.minX + 2
-        func place(_ image: NSImage) {
-            let s = image.size
-            tint(image).draw(in: NSRect(x: x, y: button.midY - s.height / 2,
-                                        width: s.width, height: s.height))
-            x += s.width
+        if let magnifier = Self.magnifier {
+            draw(magnifier, inkAt: Self.magnifierInk.x, size: Self.magnifierInk.size, in: button)
         }
-        place(magnifier)
-        if searchMenuTemplate != nil, let chevron = Self.menuChevron { place(chevron) }
+        if searchMenuTemplate != nil, let chevron = Self.menuChevron {
+            draw(chevron, inkAt: Self.chevronInk.x, size: Self.chevronInk.size, in: button)
+        }
     }
 
-    private static let magnifier = NSImage(systemSymbolName: "magnifyingglass",
-                                           accessibilityDescription: "Search")?
-        .withSymbolConfiguration(NSImage.SymbolConfiguration(pointSize: 11, weight: .regular))
-    private static let menuChevron = NSImage(systemSymbolName: "chevron.down",
-                                             accessibilityDescription: "Search options")?
-        .withSymbolConfiguration(NSImage.SymbolConfiguration(pointSize: 7, weight: .semibold))
+    /// Scales and offsets `glyph` so its *ink* — not its padded image bounds —
+    /// lands `x` points in from the button rect's leading edge, `size` big, and
+    /// centred on the rect. SF Symbol images carry internal padding that varies
+    /// with the symbol, so placing them by image bounds would miss the stock
+    /// geometry; going through the ink makes the measured numbers exact.
+    private func draw(_ glyph: (image: NSImage, ink: NSRect), inkAt x: CGFloat,
+                      size: NSSize, in button: NSRect) {
+        guard glyph.ink.width > 0, glyph.ink.height > 0 else { return }
+        let sx = size.width / glyph.ink.width, sy = size.height / glyph.ink.height
+        tint(glyph.image).draw(in: NSRect(
+            x: button.minX + x - glyph.ink.minX * sx,
+            y: button.midY - size.height / 2 - glyph.ink.minY * sy,
+            width: glyph.image.size.width * sx, height: glyph.image.size.height * sy))
+    }
+
+    // Point sizes chosen so the ink is already near its target size and the
+    // rescale above stays ≈1 — scaling far from 1 would thicken or thin the
+    // strokes away from the stock weight.
+    private static let magnifier = glyph("magnifyingglass", pointSize: 13, weight: .light)
+    private static let menuChevron = glyph("chevron.down", pointSize: 9, weight: .regular)
+
+    private static func glyph(_ name: String, pointSize: CGFloat,
+                              weight: NSFont.Weight) -> (image: NSImage, ink: NSRect)? {
+        guard let image = NSImage(systemSymbolName: name, accessibilityDescription: nil)?
+            .withSymbolConfiguration(NSImage.SymbolConfiguration(pointSize: pointSize, weight: weight))
+        else { return nil }
+        return (image, inkBounds(image))
+    }
+
+    /// Tight bounding box of an image's non-transparent pixels, in image points.
+    private static func inkBounds(_ image: NSImage) -> NSRect {
+        let scale = 2   // measure at 2× so half-point ink edges are visible
+        let w = Int(image.size.width.rounded(.up)) * scale
+        let h = Int(image.size.height.rounded(.up)) * scale
+        guard w > 0, h > 0,
+              let rep = NSBitmapImageRep(bitmapDataPlanes: nil, pixelsWide: w, pixelsHigh: h,
+                                         bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true,
+                                         isPlanar: false, colorSpaceName: .deviceRGB,
+                                         bytesPerRow: 0, bitsPerPixel: 0) else { return .zero }
+        // Must be set before the context is made — it defines the context's
+        // coordinate space, so a late assignment draws into the wrong scale.
+        rep.size = image.size
+        guard let ctx = NSGraphicsContext(bitmapImageRep: rep) else { return .zero }
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = ctx
+        image.draw(in: NSRect(origin: .zero, size: image.size))
+        NSGraphicsContext.restoreGraphicsState()
+
+        guard let data = rep.bitmapData else { return .zero }
+        let bytesPerRow = rep.bytesPerRow, perPixel = rep.samplesPerPixel
+        var minX = w, minY = h, maxX = -1, maxY = -1
+        for y in 0..<h {
+            for x in 0..<w where data[y * bytesPerRow + x * perPixel + 3] > 12 {
+                minX = min(minX, x); maxX = max(maxX, x)
+                minY = min(minY, y); maxY = max(maxY, y)
+            }
+        }
+        guard maxX >= minX else { return .zero }
+        // Bitmap rows run top-down; NSImage coordinates run bottom-up.
+        return NSRect(x: CGFloat(minX) / CGFloat(scale),
+                      y: CGFloat(h - 1 - maxY) / CGFloat(scale),
+                      width: CGFloat(maxX - minX + 1) / CGFloat(scale),
+                      height: CGFloat(maxY - minY + 1) / CGFloat(scale))
+    }
 
     /// Template images render flat black when drawn by hand; tint per draw so the
     /// glyph follows light/dark.
@@ -239,13 +303,10 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
         // A 2×2 grid: column 0 holds the two fields (stretch to fill), column 1
         // the two right-hand clusters. Row 1 (replace) is hidden in find-only.
 
-        // Top cluster: nav — spacer — Done (find-only), Replace. The spacer
-        // pushes Replace to the trailing edge (aligned with Done below), with
-        // nav on the leading edge. doneTop detaches when the replace row appears.
-        let topSpacer = NSView()
-        topSpacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        topSpacer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        let topRight = NSStackView(views: [nav, topSpacer, doneTop, replaceToggle])
+        // Top cluster: nav, Done (find-only), Replace — evenly spaced, leading,
+        // so nav shares its left edge with Replace|All below. doneTop detaches
+        // when the replace row appears.
+        let topRight = NSStackView(views: [nav, doneTop, replaceToggle])
         topRight.orientation = .horizontal
         topRight.spacing = 8
         topRight.alignment = .centerY
@@ -265,7 +326,7 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
         grid.rowSpacing = 3          // tight gap between the find and replace rows
         grid.column(at: 0).xPlacement = .fill        // fields stretch to fill
         grid.column(at: 1).xPlacement = .leading      // col1 hugs content (driven by the wider cluster)
-        grid.cell(atColumnIndex: 1, rowIndex: 0).xPlacement = .fill   // top cluster fills col1 so its spacer expands
+        grid.cell(atColumnIndex: 1, rowIndex: 0).xPlacement = .leading
         grid.row(at: 0).yPlacement = .center
         grid.row(at: 1).yPlacement = .center
 

--- a/Sources/edmd/Views/FindBarView.swift
+++ b/Sources/edmd/Views/FindBarView.swift
@@ -88,6 +88,8 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
     private let doneBottom = NSButton(title: "Done", target: nil, action: nil)
     /// Row-0 trailing cell: Done (find-only) + the Replace checkbox.
     private let trailing0 = NSStackView()
+    /// Row-1 trailing cell: Replace|All group butted up against Done (no gap).
+    private let trailing1 = NSStackView()
 
     private var grid: NSGridView!
 
@@ -143,6 +145,7 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
         searchField.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
         replaceField.placeholderString = "Replace"
+        replaceField.bezelStyle = .roundedBezel   // rounded + built-in left padding, matching the search field
         replaceField.target = self
         replaceField.action = #selector(replaceReturn)
         replaceField.setContentHuggingPriority(.defaultLow, for: .horizontal)
@@ -167,9 +170,13 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
         trailing0.spacing = 8
         trailing0.setViews([doneTop, replaceToggle], in: .leading)
 
+        trailing1.orientation = .horizontal
+        trailing1.spacing = 6   // Replace|All butted up against Done, per the reference
+        trailing1.setViews([replaceGroup, doneBottom], in: .leading)
+
         grid = NSGridView(views: [
             [searchField, nav, trailing0],
-            [replaceField, replaceGroup, doneBottom],
+            [replaceField, NSGridCell.emptyContentView, trailing1],
         ])
         grid.columnSpacing = 8
         grid.rowSpacing = 5

--- a/Sources/edmd/Views/FindBarView.swift
+++ b/Sources/edmd/Views/FindBarView.swift
@@ -86,9 +86,8 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
     // render). find-only shows the top one; replace shows the bottom one.
     private let doneTop = NSButton(title: "Done", target: nil, action: nil)
     private let doneBottom = NSButton(title: "Done", target: nil, action: nil)
-    /// Row-0 trailing cell: Done (find-only) + the Replace checkbox.
-    private let trailing0 = NSStackView()
-
+    /// Row-1 right cluster: Replace|All — spacer — Done.
+    private let bottomRightStack = NSStackView()
     private var grid: NSGridView!
 
     // Event callbacks, wired by the controller.
@@ -105,19 +104,20 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
     var wholeWord = false { didSet { syncOptionMenu() } }
 
     var showsReplaceRow: Bool {
-        get { replaceToggle.state == .on }
+        get { !grid.row(at: 1).isHidden }
         set {
             replaceToggle.state = newValue ? .on : .off
-            grid.row(at: 1).isHidden = !newValue   // hides replace field + group + doneBottom
-            doneTop.isHidden = newValue            // Done only on the visible row
+            grid.row(at: 1).isHidden = !newValue   // hides the replace field + right cluster
+            doneTop.isHidden = newValue            // Done lives on the visible row only
             needsLayout = true
+            invalidateIntrinsicContentSize()
         }
     }
 
     /// The bar's height for the active replace state (drives the content inset).
     var preferredHeight: CGFloat {
-        grid.layoutSubtreeIfNeeded()
-        return grid.fittingSize.height + 12
+        layoutSubtreeIfNeeded()
+        return fittingSize.height + 12
     }
 
     override init(frame frameRect: NSRect) {
@@ -164,23 +164,34 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
         replaceToggle.target = self
         replaceToggle.action = #selector(replaceToggled)
 
-        trailing0.orientation = .horizontal
-        trailing0.spacing = 8
-        trailing0.setViews([doneTop, replaceToggle], in: .leading)
+        // MARK: - Grid layout
+        // A 2×2 grid: column 0 holds the two fields (stretch to fill), column 1
+        // the two right-hand clusters. Row 1 (replace) is hidden in find-only.
 
-        // ‹›/Replace|All share col1's left edge; ☑Replace/Done share col2 (trailing,
-        // far right) — the reference grid. Done lands under the Replace checkbox
-        // with a small gap after Replace|All, driven by the column widths.
+        // Top cluster: nav, Done (find-only), Replace — leading, no spacer.
+        // doneTop detaches when the replace row appears.
+        let topRight = NSStackView(views: [nav, doneTop, replaceToggle])
+        topRight.orientation = .horizontal
+        topRight.spacing = 8
+        topRight.alignment = .centerY
+
+        // Bottom cluster: Replace|All, Done — leading, no spacer, so Replace|All
+        // shares the nav's left edge.
+        bottomRightStack.orientation = .horizontal
+        bottomRightStack.spacing = 8
+        bottomRightStack.alignment = .centerY
+        bottomRightStack.setViews([replaceGroup, doneBottom], in: .leading)
+
         grid = NSGridView(views: [
-            [searchField, nav, trailing0],
-            [replaceField, replaceGroup, doneBottom],
+            [searchField, topRight],
+            [replaceField, bottomRightStack],
         ])
         grid.columnSpacing = 8
         grid.rowSpacing = 5
-        grid.column(at: 0).xPlacement = .fill        // fields absorb slack
-        grid.column(at: 1).xPlacement = .leading      // ‹›/Replace|All share a left edge
-        grid.column(at: 2).xPlacement = .trailing
-        for r in 0..<grid.numberOfRows { grid.row(at: r).yPlacement = .center }
+        grid.column(at: 0).xPlacement = .fill        // fields stretch to fill
+        grid.column(at: 1).xPlacement = .leading      // both clusters leading; col1 hugs content
+        grid.row(at: 0).yPlacement = .center
+        grid.row(at: 1).yPlacement = .center
 
         grid.translatesAutoresizingMaskIntoConstraints = false
         addSubview(grid)
@@ -188,7 +199,11 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
             grid.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
             grid.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
             grid.topAnchor.constraint(equalTo: topAnchor, constant: 6),
+            grid.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6),
         ])
+
+        searchField.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        replaceField.setContentHuggingPriority(.defaultLow, for: .horizontal)
     }
 
     private func optionsMenu() -> NSMenu {

--- a/Tests/EdmundTests/FindEngineTests.swift
+++ b/Tests/EdmundTests/FindEngineTests.swift
@@ -1,0 +1,63 @@
+import Testing
+import Foundation
+@testable import EdmundCore
+
+@Suite("FindEngine")
+struct FindEngineTests {
+
+    @Test("Empty needle matches nothing")
+    func emptyNeedle() {
+        #expect(FindEngine.matches(of: "", in: "anything").isEmpty)
+    }
+
+    @Test("Case-insensitive substring by default")
+    func caseInsensitiveDefault() {
+        let m = FindEngine.matches(of: "hi", in: "Hi hi HI")
+        #expect(m == [NSRange(location: 0, length: 2),
+                      NSRange(location: 3, length: 2),
+                      NSRange(location: 6, length: 2)])
+    }
+
+    @Test("Case-sensitive toggle distinguishes case")
+    func caseSensitive() {
+        let m = FindEngine.matches(of: "Hi", in: "Hi hi HI", caseSensitive: true)
+        #expect(m == [NSRange(location: 0, length: 2)])
+    }
+
+    @Test("Adjacent occurrences are all found")
+    func adjacent() {
+        let m = FindEngine.matches(of: "aa", in: "aaaa")
+        // Non-overlapping: positions 0 and 2.
+        #expect(m == [NSRange(location: 0, length: 2),
+                      NSRange(location: 2, length: 2)])
+    }
+
+    @Test("Overlapping candidates do not double-count")
+    func overlapping() {
+        // "aba" in "ababa": only one non-overlapping hit at 0.
+        let m = FindEngine.matches(of: "aba", in: "ababa")
+        #expect(m == [NSRange(location: 0, length: 3)])
+    }
+
+    @Test("Whole-word rejects matches inside a larger word")
+    func wholeWordBoundaries() {
+        let hay = "cat category cat."
+        let all = FindEngine.matches(of: "cat", in: hay)
+        #expect(all.count == 3) // cat, cat(egory), cat
+        let words = FindEngine.matches(of: "cat", in: hay, wholeWord: true)
+        // The "cat" inside "category" is rejected; the two standalone ones stay.
+        #expect(words == [NSRange(location: 0, length: 3),
+                          NSRange(location: 13, length: 3)])
+    }
+
+    @Test("Whole-word matches at document edges")
+    func wholeWordEdges() {
+        let m = FindEngine.matches(of: "go", in: "go", wholeWord: true)
+        #expect(m == [NSRange(location: 0, length: 2)])
+    }
+
+    @Test("No match returns empty")
+    func noMatch() {
+        #expect(FindEngine.matches(of: "zzz", in: "hello world").isEmpty)
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -181,6 +181,7 @@ rawSource ─BlockParser─▶ [Block] ─SyntaxHighlighter─▶ spans ─style
 | Settings (SwiftUI) | `edmd/Settings/*` (AppSettings = UserDefaults keys; FontSettings; Appearance/General/Advanced views) |
 | Crash-log uploading | `EdmundCore/Diagnostics/CrashReporter.swift` (§7) |
 | Auto-update | Sparkle 2.x. `Info.plist`: `SUFeedURL` (raw GitHub URL to `appcast.xml`), `SUPublicEDKey`. `scripts/release.sh`: build → DMG (sindresorhus `create-dmg`, **npm** — not the homebrew tool) → EdDSA sign → update appcast → `gh release create`. The DMG is the Sparkle enclosure. CI: `.github/workflows/release.yml` (tag-triggered). Full pipeline + signing + `RELEASE_TOKEN`: §13. |
+| Find & Replace | `EdmundCore/Find/FindEngine.swift` (pure search), `TextView/EditorTextView+Find.swift` (match state, highlight drawing, pop animation, `EditorFindHandling`), `edmd/Views/FindBarView.swift` (the bar), `edmd/App/FindController.swift` (mediator); Edit ▸ Find menu in `main.swift` |
 | Status bar | `edmd/Views/StatusBarView.swift` |
 | Build/packaging | `scripts/build-app.sh` (release build + Sparkle.framework embedding + signing), `Package.swift`, `Info.plist`, `Resources/` |
 
@@ -235,6 +236,32 @@ Notable subsystems:
   **Export as PDF… / Print… (⌘P)** run the same HTML through
   `WKWebView.printOperation` (`MarkdownPrinter`; vector text, math is
   high-DPI PNG). Full spec: `docs/architecture/reader-and-export.md`.
+- **Find & Replace** (in-document, ⌘F / ⌥⌘F / ⌘G / ⇧⌘G): **not**
+  `NSTextFinder` — it renders the system bar rather than the Notes look, and
+  its highlighting drives `NSLayoutManager`, which the TextKit 2 tripwire
+  (§2) forbids. Instead: `FindEngine` is a pure `NSString.range(of:)` scan
+  (case-sensitive / whole-word options, no regex) over `rawSource`; because
+  of the identity invariant, search index == raw index == display index, so
+  there is **no offset mapping**. Highlighting is **draw-only** — a
+  `drawBackground(in:)` override fills rects from
+  `enumerateTextSegments(in:type:.highlight)`, offset by
+  `textContainerOrigin` — so it never writes attributes into storage and
+  can't perturb recompose. Navigation never moves the caret (that would
+  trigger the active-block-renders-raw recompose); it scrolls via
+  `revealFindMatch`, which leaves an already-visible match alone and
+  otherwise puts the hit's line at the top. Every match gets a grey resting
+  background; the one just navigated to also gets a Preview-style "pop" — a
+  drop-shadowed rounded yellow box that springs in from a larger scale with
+  an `easeOutBack` overshoot, holds, then fades, driven by a `CADisplayLink`
+  (constants at the top of `+Find.swift`). Replace / Replace All are the
+  only paths that touch text and go through the sanctioned edit cycle (§4),
+  Replace All rebuilding the source back-to-front so it lands as one undo
+  step. EdmundCore stays unaware of the controller via the
+  `EditorFindHandling` protocol — the same decoupling as
+  `contextFontMenuProvider`. The bar itself is an `NSGridView` (2×2) so the
+  two fields share a left edge and the `‹ ›` / `Replace|All` clusters share
+  theirs; find-only is one row and toggling Replace reveals the second and
+  moves **Done** down onto it.
 - **Mode-switch viewport sync** (Edit ↔ Read, line-accurate both ways):
   read HTML blocks carry `id="edmund-l<startLine>"` anchors; scroll maps as
   (anchor line, fraction-into-block) via API-injected `evaluateJavaScript`
@@ -436,6 +463,25 @@ Notable subsystems:
   `window.setFrame(_:)` **after the toolbar is installed** (the frame is
   only final then), so frame-in == frame-out (`windowDidResize` ↔
   `makeWindowControllers` in `Document.swift`).
+- **`NSSearchField`'s magnifier glyph can't be repositioned — draw your
+  own.** AppKit draws it ~3.75pt below the field's vertical centre (a 21×15
+  image in a rect the field's full 22pt height). Every built-in hook is a
+  dead end, and each was measured, not assumed:
+  `searchButtonRect(forBounds:)` is only a *sizing probe* (AppKit calls it
+  with a 40000×40000 bounds, never to position); the button cell's
+  `drawInterior(withFrame:in:)` is bypassed by the search field's private
+  draw path; the cell ignores a replacement image entirely (the Big Sur
+  regression, FB8913004), so re-padding the image does nothing; and the
+  glyph is not a subview, so there is nothing to move in `layout()`.
+  `imageRect(forBounds:)` *is* honoured, but drawing is clipped to a fixed
+  band, so shifting or growing the rect just chops the top off the glyph.
+  What works (`FindBarView.swift`): swap in a button cell whose
+  `imageRect` returns `.zero` — it draws nothing but still handles the
+  click, so the search-options menu keeps working — and draw the
+  magnifier + ▾ yourself in the field's `draw(_:)`, centred on
+  `searchButtonRect(forBounds: bounds)` (that call *is* correct for real
+  bounds). Template images drawn by hand render flat black, so tint per
+  draw or the glyph won't follow light/dark.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -182,6 +182,7 @@ rawSource ─BlockParser─▶ [Block] ─SyntaxHighlighter─▶ spans ─style
 | Crash-log uploading | `EdmundCore/Diagnostics/CrashReporter.swift` (§7) |
 | Auto-update | Sparkle 2.x. `Info.plist`: `SUFeedURL` (raw GitHub URL to `appcast.xml`), `SUPublicEDKey`. `scripts/release.sh`: build → DMG (sindresorhus `create-dmg`, **npm** — not the homebrew tool) → EdDSA sign → update appcast → `gh release create`. The DMG is the Sparkle enclosure. CI: `.github/workflows/release.yml` (tag-triggered). Full pipeline + signing + `RELEASE_TOKEN`: §13. |
 | Find & Replace | `EdmundCore/Find/FindEngine.swift` (pure search), `TextView/EditorTextView+Find.swift` (match state, highlight drawing, pop animation, `EditorFindHandling`), `edmd/Views/FindBarView.swift` (the bar), `edmd/App/FindController.swift` (mediator); Edit ▸ Find menu in `main.swift` |
+| Standard text menus | `edmd/App/main.swift` — Edit ▸ Spelling and Grammar, Transformations, Speech; stock `NSTextView` actions routed to the first responder. **Substitutions is deliberately excluded** (§8) |
 | Status bar | `edmd/Views/StatusBarView.swift` |
 | Build/packaging | `scripts/build-app.sh` (release build + Sparkle.framework embedding + signing), `Package.swift`, `Info.plist`, `Resources/` |
 
@@ -261,7 +262,23 @@ Notable subsystems:
   `contextFontMenuProvider`. The bar itself is an `NSGridView` (2×2) so the
   two fields share a left edge and the `‹ ›` / `Replace|All` clusters share
   theirs; find-only is one row and toggling Replace reveals the second and
-  moves **Done** down onto it.
+  moves **Done** down onto it, with a hairline along the bar's bottom edge
+  (whichever row is last) matching the toolbar separator.
+  **Keyboard model.** ⌘F and ⌥⌘F each *toggle their own* bar — the shortcut
+  for the bar already showing closes it, the other switches to it, so ⌘F from
+  the replace bar drops the replace row rather than closing outright:
+
+  | from | ⌘F | ⌥⌘F |
+  | --- | --- | --- |
+  | closed | find | replace |
+  | find | closed | replace |
+  | replace | find | closed |
+
+  Return / ⇧Return in the search field step to the next / previous match, as
+  do ⌘G / ⇧⌘G. Tab walks the bar in visual order and wraps — including
+  *inside* the segmented controls, so `‹`, `›`, `Replace` and `All` are each
+  individually reachable — and ⇧Tab walks it in reverse. Both behaviours
+  needed AppKit worked around; see §8.
 - **Mode-switch viewport sync** (Edit ↔ Read, line-accurate both ways):
   read HTML blocks carry `id="edmund-l<startLine>"` anchors; scroll maps as
   (anchor line, fraction-into-block) via API-injected `evaluateJavaScript`
@@ -492,6 +509,39 @@ Notable subsystems:
   measures at the wrong scale; and a text field's coordinate space is **flipped**,
   so a positive y offset moves a glyph *down*. Both were found by sweeping the
   constant and measuring, which is the only way to settle a sign question here.
+- **A first-responder menu command dies wherever the target isn't in the
+  responder chain.** The Edit ▸ Find items route to `EditorTextView`, so with
+  focus inside the find bar the editor is *not* in the chain — the bar is —
+  and ⌘F / ⌥⌘F / ⌘G / ⇧⌘G greyed out exactly while you were typing a query.
+  Fix: implement the same selectors on the focused view too (`FindBarView`
+  forwards them). Applies to any overlay that takes focus.
+- **AppKit rebuilds the window's key-view loop and wipes your `nextKeyView`.**
+  A hand-built Tab chain silently reverts whenever the view tree changes;
+  `window.autorecalculatesKeyViewLoop = false` is what makes it stick. Views
+  that can't become key views are skipped automatically, so declaring the
+  whole chain (buttons included) is safe — but buttons only join when macOS
+  *Keyboard navigation* is on, which nothing in-app can override.
+- **Tab never enters an `NSSegmentedControl`.** AppKit focuses segments
+  individually — the focus ring sits on one segment and ← / → move it — but
+  Tab always leaves the whole control, so a trailing segment (`›`, `All`) is
+  unreachable by Tab alone. `SegmentTabbingControl` translates Tab into that
+  arrow handling until the last segment, then releases it to the key-view
+  loop. The focused index has no public accessor, so it's mirrored, and the
+  mirror must be seeded by *entry direction* — AppKit enters on the leading
+  segment forwards and the trailing one via ⇧Tab.
+- **`NSVisualEffectView` ignores `draw(_:)`.** It renders its material through
+  layers and never calls a custom draw, so a border painted there is simply
+  invisible (measured: nothing appeared). Use a pinned subview with a layer
+  background, and refresh its `cgColor` on
+  `viewDidChangeEffectiveAppearance` — a colour snapshot won't follow the
+  appearance by itself.
+- **Edit ▸ Substitutions is deliberately absent.** Smart quotes/dashes, text
+  replacement and autocorrect are switched off in
+  `EditorTextView.commonInit()` on purpose: they rewrite typed Markdown, and
+  the completion machinery can strand marked text and break
+  storage == rawSource (delete-drift investigation). Don't add the standard
+  Substitutions menu back — it re-exposes exactly those toggles. Same reason
+  "Correct Spelling Automatically" is left out of Spelling and Grammar.
 - **Visual work is measured, not eyeballed — and the measuring rig is
   reusable.** Aligning chrome takes a dozen launch/state/capture/measure cycles;
   `.claude/skills/edmund-live-repro-and-diagnostics/scripts/ui-harness.sh` and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -482,6 +482,23 @@ Notable subsystems:
   `searchButtonRect(forBounds: bounds)` (that call *is* correct for real
   bounds). Template images drawn by hand render flat black, so tint per
   draw or the glyph won't follow light/dark.
+- **Place a hand-drawn SF Symbol by its *ink*, not its image bounds.** Symbol
+  images carry internal padding that varies per symbol, so drawing one at its
+  image rect lands it a couple of points off whatever you measured. Render the
+  symbol once, scan its alpha for a tight bounding box, then scale/offset so the
+  *ink* hits the measured target (`CountingSearchField.inkBounds`). Two traps:
+  `NSBitmapImageRep.size` must be assigned **before** the `NSGraphicsContext` is
+  made — it defines the context's coordinate space, and a late assignment
+  measures at the wrong scale; and a text field's coordinate space is **flipped**,
+  so a positive y offset moves a glyph *down*. Both were found by sweeping the
+  constant and measuring, which is the only way to settle a sign question here.
+- **Visual work is measured, not eyeballed — and the measuring rig is
+  reusable.** Aligning chrome takes a dozen launch/state/capture/measure cycles;
+  `.claude/skills/edmund-live-repro-and-diagnostics/scripts/ui-harness.sh` and
+  `ui-measure.py` are that loop, already encoding the flaky bits (AX-driven
+  clicks, appearance forced per-launch via `-settings.appearance.mode`, capture
+  by window id without stealing focus). Extend them for new surfaces rather than
+  rebuilding one-off shell; they are permanent fixtures, not scratch files.
 
 ---
 
@@ -557,9 +574,17 @@ only with reason):
 
 1. **`swift test` is green** (all pass). Add tests for new behavior / bug
    repros.
-2. **Visual changes are eyeballed** — build the app and `screencapture` the
-   result (§8), or render offscreen to a PNG. Don't trust headless layout
-   alone for anything that draws.
+2. **Visual changes are measured, not eyeballed** — build the app and
+   `screencapture` the result (§8), or render offscreen to a PNG. Don't trust
+   headless layout alone for anything that draws. For anything phrased as
+   *align / centre / balance the padding / match the native control*, report
+   **numbers** (device px and points, 2:1 on Retina), not an impression —
+   "the glyph's centre is 137.5, the field's is 137.5" settles what "looks
+   right" cannot. Drive the app with the reusable harness rather than fresh
+   one-off shell: `ui-harness.sh` + `ui-measure.py` in
+   `.claude/skills/edmund-live-repro-and-diagnostics/scripts/`. **Keep and
+   extend those tools** — they're checked-in fixtures, and the setup cost is
+   otherwise paid again every visual task.
 3. **Frequent, small, logical commits** — one feature/fix each. Don't
    discard uncommited changes.
 4. **Don't autopush, PR, or merge unless asked.** Branch off `main` (don't


### PR DESCRIPTION
Adds in-document Find & Replace to Edmund — a Notes-styled bar under the toolbar, with draw-only match highlighting and full keyboard control.

## What

- **Search** — `FindEngine`, a pure `NSString` scan with case-sensitive and whole-word options (no regex). Because of the identity invariant, search index == raw index == display index, so there is no offset mapping.
- **Highlighting is draw-only** — a `drawBackground(in:)` override fills rects from `enumerateTextSegments(in:type:.highlight)`. It never writes attributes into storage, so it cannot perturb recompose or the `storage == rawSource` invariant, and never touches `NSLayoutManager` (TextKit 2 tripwire). Every match gets a grey resting background; the one just navigated to also gets a Preview-style "pop" — a drop-shadowed rounded box that springs in with an `easeOutBack` overshoot, holds, then fades, driven by a `CADisplayLink`.
- **Navigation never moves the caret** (that would trigger the active-block-renders-raw recompose); it scrolls via `revealFindMatch`, which leaves an already-visible match alone and otherwise puts the hit's line at the top.
- **Replace / Replace All** are the only paths that touch text, and go through the sanctioned edit cycle (`shouldChangeText` → `replaceCharacters` → `didChangeText`), Replace All rebuilding the source back-to-front so it lands as one undo step.
- **Keyboard** — ⌘F and ⌥⌘F each toggle their own bar; Return/⇧Return and ⌘G/⇧⌘G step matches; Tab walks the bar in visual order and wraps, including *inside* the segmented controls so `‹`, `›`, `Replace` and `All` are each individually reachable.
- **Edit menu** also gains Spelling and Grammar, Transformations and Speech. Substitutions is deliberately excluded — smart quotes/dashes, text replacement and autocorrect are switched off in `EditorTextView.commonInit()` on purpose, and the completion machinery can strand marked text and break `storage == rawSource`.

## Why not `NSTextFinder`

It renders the system bar rather than the Notes look, and its match highlighting drives `NSLayoutManager`, which this editor's DEBUG tripwire forbids.

## Verification

`swift test` — 1128 tests pass. The visual and keyboard work was measured, not eyeballed: glyph and field centres compared in device pixels, control gaps measured, and each Tab step confirmed by screenshotting the focus ring. The reusable harness that does this (`ui-harness.sh`, `ui-measure.py`) ships with the branch, along with ARCHITECTURE notes for the AppKit workarounds behind the bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)