### PR TITLE
docs: reorganize ARCHITECTURE and split the essay-sized feature rows

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,7 +16,7 @@ rule applies to both.
 
 ```bash
 swift build                 # debug build of both targets
-swift test                  # full suite (≈750+ tests, ~10s)
+swift test                  # full suite (≈1200 tests, ~10s)
 swift test --filter Callout # one suite
 ./scripts/build-app.sh      # builds build/Edmund.app (release + bundles + icon + codesign)
 ```
@@ -178,17 +178,19 @@ rawSource ─BlockParser─▶ [Block] ─SyntaxHighlighter─▶ spans ─style
 | --- | --- |
 | Editor core / state | `TextView/EditorTextView.swift` (+ many extensions) |
 | Parsing | `Parsing/BlockParser.swift`, `SyntaxHighlighter*.swift`, `CodeHighlighter.swift`, `CodeSyntaxPalette.swift` (shared Tomorrow/One-Dark hex table — read by both the editor's `NSColor` palette and the HTML CSS generator) |
-| Block model | `Model/Block.swift`, `Callout.swift`, `EditorTheme.swift`, `ListIndentState.swift` |
-| Markdown feature toggles | `Model/MarkdownFeatures.swift` — one `OptionSet` (`.all` default) gating each extension (highlight, `%%`comment, callout, wikilink, footnote, math, image dimensions `\|WxH`, `![[embed]]`, collapsible callouts `[!x]-/+`, plus Phase-2 front-matter/tag/blockRef/multi-block-comment). Threaded into `SyntaxHighlighter.parse(features:)` (gates each custom-parser pass; callout gated at render via `calloutInfo`), `EditorTextView.markdownFeatures` (didSet recompose), and `ReadRenderOptions.features` (→ `HTMLRenderer`). Assembled from per-feature UserDefaults toggles by `AppSettings.markdownFeatures`; Settings ▸ Markdown pane. A cleared flag renders the syntax as plain text in **both** back-ends. |
+| Code-fence highlighting | A pluggable seam, not a hardcoded scanner. `CodeHighlighter` is the facade: it resolves the effective language, then hands `(code, language)` to the active `CodeSyntaxBackend`. `BuiltinSyntaxBackend` is the default — one single-pass O(n) char scanner driven by a declarative `LanguageDefinition` (keywords, comment/string delimiters) rather than per-language code. `SyntaxDefinitionStore` loads those definitions from two places: the bundled JSON in `EdmundCore/Resources/Syntaxes/` and the user's Application Support dir, so **users can add a language without a rebuild**. Settings ▸ Syntax picks the fallback language (`settings.syntax.defaultCodeSyntax`). |
+| Block model | `Model/Block.swift`, `Callout.swift`, `EditorTheme.swift`, `ListIndentState.swift`, `LinkDefinitionState.swift` (incremental index of `[label]: dest` reference-link definitions, which resolve across blocks — so a definition edit dirties the blocks that cite it), `LineEnding.swift` (buffer is always LF internally so `BlockParser`'s `\n` split stays clean; the file's original CRLF/CR style is remembered and written back on save), `StatusBarPrefs.swift`, `SVGPath.swift` (minimal SVG→`CGPath` for the vendored Lucide geometry — §5's wrapping-callout icon) |
+| Text storage | `TextView/EditorTextStorage.swift` — `NSTextStorage` subclass whose `fixAttributes` does **font substitution only**. The editor manages every attribute on every character (incl. custom keys like `.blockDecoration`/`.fragmentOverlay`), so AppKit's usual attribute fixing would fight it. Also carries the `pendingEdit` that drives incremental reparse (§4) and the bypassed-edit heal (§8). |
+| Markdown feature toggles | `Model/MarkdownFeatures.swift` — one `OptionSet` (`.all` default) gating each extension (highlight, `%%`comment, callout, wikilink, footnote, math, image dimensions `\|WxH`, `![[embed]]`, collapsible callouts `[!x]-/+`, plus Phase-2 front-matter/tag/blockRef/multi-block-comment). Threaded into `SyntaxHighlighter.parse(features:)` (gates each custom-parser pass; callout gated at render via `calloutInfo`), `EditorTextView.markdownFeatures` (didSet recompose), and `ReadRenderOptions.features` (→ `HTMLRenderer`). Assembled from per-feature UserDefaults toggles by `AppSettings.markdownFeatures`; Settings ▸ Syntax pane. A cleared flag renders the syntax as plain text in **both** back-ends. |
 | Rendering | `Rendering/EditorTextView+*Rendering.swift` (Callout, Code, Image, List, Math, Table, WikiLinks) |
-| Invisible characters | `TextView/EditorTextView+Invisibles.swift` — faint marks (· → ¬ ␣ ▯) overdrawn on laid-out whitespace, riding `DecoratedTextLayoutFragment.draw`. Pure display overlay: inserts no characters (storage == rawSource), TextKit 2 path only. Delegate vends the decorated fragment for every visible paragraph while on (viewport-bounded); plain fast path when off (default). Config pushed via `EditorTextView.invisibles` from `AppSettings.invisiblesConfig`; Settings ▸ Edit. **Editor-only by design** (like CotEditor) — an edit affordance, not content, so Read mode / Export never show it (the one deliberate exception to §5's "one parser, two back-ends"). |
-| List indent guides | Faint vertical hairlines on list items: one per *ancestor* level spanning the item, plus the item's **own** column drawn only beside its wrapped continuation lines (the first line holds the marker). Columns are computed by `listGuideOffsets(depth:slotWidth:)` (`Rendering/EditorTextView+ListRendering.swift`) as the center of each level's marker slot, and written to `.listGuides` by `styleListItemSpan` **whether or not the setting is on** — the fragment gates the drawing, so toggling needs only a re-vend (`refreshOverdraw()`), never a whole-document restyle (there is no such call). Offsets are *container*-relative, not `point.x`-relative: the fragment frame hugs the laid-out text, so `point.x` moves with each item's `firstLineHeadIndent` (an ordered marker right-aligns into its slot). They are measured from the container's **text** origin, so the draw adds `lineFragmentPadding` (the default 5pt — the head indents the columns derive from are relative to it, and omitting it shifts every guide left by exactly that). Drawn under the text in `DecoratedTextLayoutFragment.draw`, filled at one device pixel like the table gridlines. List paragraphs carry no paragraph spacing, so per-fragment fills tile into one continuous line down a nested run. Pushed via `EditorTextView.showListIndentGuides`; Settings ▸ Edit. Editor-only, like invisibles. |
-| Line numbers | `TextView/EditorTextView+LineNumbers.swift` — source line numbers (Settings ▸ Edit ▸ Lines, off by default), pushed via `EditorTextView.showLineNumbers`. **Two placements over one walk** (`enumerateVisibleLineNumbers`, `lineNumberStyle`), and **the placement is not a setting** — `lineNumbersFitBesideContent` (`textContainerOrigin.x >= lineNumbersRequiredInset`) picks it, so a margin too narrow to hold the numbers raises the gutter instead of dropping them. It moves with the content-width cap, the window width and the document's digit count (no cap ⇒ a 24 pt base inset, which a 3-digit document already overruns). The switch can't oscillate: the gutter only ever *shrinks* the margin, so a document that didn't fit still doesn't, and one that fits without the gutter fits all the more once it's gone. Re-evaluated from `updateContentInset()` — which runs even when the inset held steady, since the digit count grows on its own — but **only scheduled** there (`scheduleLineNumberPlacementUpdate`, one coalesced `RunLoop.main.perform`): `updateContentInset` runs inside `setFrameSize`, and adding or removing a ruler re-tiles the scroll view, so applying it inline mutates the scroll view from inside its own layout — that **SIGSEGV'd the whole test process on macOS 14** (CI caught what six clean local runs on macOS 15 did not). Same constraint as `ruleThickness`, one layer up. The margin itself is recomputed from the cap (`horizontalInset(viewWidth:maxContentWidth:)`), *not* read off `textContainerOrigin`, which is only correct after `updateContentInset` has run once — reading the live inset made a freshly built editor see a zero margin, raise a gutter and immediately drop it. *Beside the content* (the default): drawn in the reading column's own margin on `drawBackground(in:)` — the pass Find already uses — right-aligned a `lineNumberPadding` short of the text. Reserves **nothing** — the content-width cap owns the margin, so the reading column always stretches to the full cap and the column never moves when the numbers come on. The deliberate consequence: when what's left of the margin can't hold `lineNumbersRequiredInset` (a wide cap, a narrow window), the numbers step aside rather than print over the text — all of them, never just the ones that fit, so they can't go ragged with `9` drawn and `100` missing. Reserving that space instead was tried and reverted: it stopped the column reaching the cap, and the cap winning is the point. Window-edge is the placement for "always visible". *By the window edge* (automatic, when the margin can't hold them): a `LineNumberRulerView` on the scroll view — AppKit owns the scroll sync and clipping, but it reserves width, so the centered column re-centers when it is switched on. Installed by `updateLineNumberRuler()`, which `viewDidMoveToSuperview` replays; it assigns `lineNumberRuler` **before** telling the scroll view, because showing or hiding a ruler resizes the document view synchronously and re-enters through `setFrameSize` — assigning afterwards lets that re-entrant call see nil and build a second ruler — `Document` configures the editor *before* putting it in a scroll view, so the setter alone would miss at launch. Draw rules: **walk the viewport the text view already laid out** (`textViewportLayoutController.viewportRange`) — forcing layout from a draw re-enters the layout controller and blanks the text view, and enumerating from the document start would lay out the whole file; each number comes from its own fragment's offset through the cached `lineStarts` table, so nothing can drift when scrolled; a line whose first line fragment is shorter than half a body line is *counted but not drawn*, which is how a table's `hiddenFont` separator row (0.01 pt) avoids stacking its number on its neighbor's — so the visible sequence legitimately skips in Edit mode and is gapless in Source mode. `clipsToBounds = true` is **required** on the ruler: against the macOS 14 SDK it defaults to false, and the background fill then paints over the whole scroll view (the document goes blank). Ink is `lineNumberColor`, one tier below `syntaxDimColor` (quaternary / `darkRuleGray`), except every line the selection touches (`selectedLineSpans`, kept as ranges so selecting a huge document doesn't build a per-line set each redraw), which takes `foregroundColor` so it reads as a position rather than chrome — `selectionDidChange` calls `invalidateLineNumbers()` **before** its own guards, since the highlight has to follow selection changes that bail out of restyling, and it dirties only the numbers' strip. Face is **Avenir Next Condensed** (`lineNumberFont`, CotEditor's choice for the same job), sized to the theme's monospace face and falling back to `monospacedDigitSystemFont`. It is *not* monospaced — its **figures are tabular**, which is the only property the drawing needs: labels are right-aligned from one measured digit advance rather than measuring each number (`LineNumberFaceTests` pins this, since a proportional-figure face would break the alignment silently). Vertical placement centers the digit's **cap band** on the text's cap band (tallest font on the line, read off the line fragment's own attributes — the storage's first character can be a list item's 0.01 pt hidden font and would report no cap). Centering the drawn *box* instead rides ~2.5 pt high, because `draw(at:)` lays out a box far taller than the figures in it; baselining instead sits ~0.8 pt low. Measured on screen: cap-centering lands within 0.1 device px. `line(forOffset:)`/`offset(forLine:)` live here too, binary-searching `lineStarts` (dropped by `rawSource.didSet`) instead of scanning the document; the status bar and Read-mode scroll sync ride the same speedup. Editor-only, like invisibles — and never printed, since the ruler isn't part of the text view. |
-| Focus mode | `TextView/EditorTextView+FocusMode.swift` — dims everything but the lines the selection touches (Settings ▸ Edit ▸ Editor, and View ▸ Focus Mode; off by default), pushed via `EditorTextView.focusMode`. The fade is **one transparency layer around `DecoratedTextLayoutFragment.draw`** at `focusDimOpacity` (0.35), so a fragment's text *and* everything drawn with it — code/callout boxes, quote bars, table borders, list guides, math and bullet overlays — fade as one composite. That is the point: those live in `BlockDecoration` / `FragmentOverlay` values and cached images, so fading them through color attributes would mean recomputing decorations and regenerating overlays on every caret move; fading a pixel toward an opaque background is the same result as lerping its color toward it anyway (measured: ink 230 → 107.7 against a predicted 107.2). It **cannot** be a scrim the text view paints over its content — NSTextView composites its fragments *after* `draw(_:)` returns, so a fill there lands under the glyphs and under every box (measured with a full-view test fill: the code block drew clean over it). Which fragments dim is decided at draw time from `textLayoutManager.textSelections` (the invisibles trick — no restyle, no re-vend, and no work on a caret move beyond the redraw AppKit already does for the old and new selection), and the mode itself is read live off the vending editor (`owner`) rather than captured. One text element is one source line, so element-range containment *is* line granularity, and it agrees with `selectedLineSpans` behind the line-number highlight — including the rule that a selection ending exactly at a line start doesn't claim that line. While the mode is on every paragraph must vend the custom fragment (a plain one has no draw to hook); that plain ↔ decorated swap is the only part needing a re-vend, which is what `refreshOverdraw()` forces. Editor-only. |
+| Invisible characters | `TextView/EditorTextView+Invisibles.swift` — faint marks (· → ¬ ␣ ▯) overdrawn on laid-out whitespace, riding `DecoratedTextLayoutFragment.draw`. Pure display overlay: no characters inserted, TextKit 2 only. `EditorTextView.invisibles` ← `AppSettings.invisiblesConfig`; Settings ▸ Edit. Mechanism: [`architecture/editor-affordances.md`](architecture/editor-affordances.md). |
+| List indent guides | Faint vertical hairlines on list items: one per *ancestor* level spanning the item, plus the item's own column beside its wrapped continuation lines. Offsets from `listGuideOffsets(depth:slotWidth:)` (`Rendering/EditorTextView+ListRendering.swift`), written to `.listGuides` **whether or not the setting is on** — the fragment gates the drawing, so toggling is a re-vend, never a restyle. `EditorTextView.showListIndentGuides`; Settings ▸ Edit. Geometry traps (container-relative offsets, `lineFragmentPadding`): [`architecture/editor-affordances.md`](architecture/editor-affordances.md). |
+| Line numbers | `TextView/EditorTextView+LineNumbers.swift` — source line numbers (Settings ▸ Edit ▸ Lines, off by default), `EditorTextView.showLineNumbers`. **Two placements over one walk**, and the placement is **not** a setting: it follows whether the margin can hold them (beside the content by default, a `LineNumberRulerView` at the window edge otherwise). Also home to `line(forOffset:)`/`offset(forLine:)`, binary-searching the cached `lineStarts`. Editor-only; never printed. Placement rules, the macOS 14 SIGSEGV, draw rules and the tabular-figure face: [`architecture/editor-affordances.md`](architecture/editor-affordances.md). |
+| Focus mode | `TextView/EditorTextView+FocusMode.swift` — dims all but the lines the selection touches (Settings ▸ Edit ▸ Editor, View ▸ Focus Mode; off by default), `EditorTextView.focusMode`. **One transparency layer around `DecoratedTextLayoutFragment.draw`**, so text and its decorations fade as one composite; it cannot be a scrim (NSTextView composites fragments *after* `draw(_:)` returns). Editor-only. Why, and the measurements: [`architecture/editor-affordances.md`](architecture/editor-affordances.md). |
 | Read mode / Export | `Export/` — `HTMLRenderer` (MarkupVisitor → HTML; callout/checkbox icons are inline Lucide SVGs from `LucideIcons`), `HTMLTheme` (EditorTheme → CSS), `DocumentHTML` (assembly + asset inlining: math + local images → data URIs), `ReadModeWebView`, `MarkdownPrinter` (PDF/Print). `Document.refreshReadView()` keeps an open Read view in sync with edits and theme changes. |
 | Icons | `Model/LucideIcons.swift` — vendored [Lucide](https://lucide.dev) SVGs (ISC, `LICENSES/lucide.txt`). Callout headers use them in **both** modes: Read inlines the SVG (CSS-tinted via `currentColor`); Edit rasterizes to a tinted `NSImage` overlay. SF Symbols can't ship in exported PDFs (license); app-chrome SF Symbols are fine (in-app UI). Edit-mode task checkboxes still use SF Symbols (on-screen only); Read-mode checkboxes are a composed Lucide SVG. |
 | Edit behaviors | `Editing/EditorTextView+{List,Blockquote}Continuation.swift`, `+Indentation.swift`, `+AutoPairs.swift`, `+ListRenumbering.swift` |
-| Hard wrap | `Editing/HardWrap.swift` (pure `wrap`/`unwrap`) + `Editing/EditorTextView+HardWrap.swift` (Edit ▸ Hard Wrap Paragraphs). Settings ▸ Edit ▸ Document ("Detect hard wrap pattern for lines on document opening"), off by default — one switch for the whole feature; read at **load/save time in `Document`**, not pushed onto the editor — like `strictLineBreaks` there is no live editor behavior to configure. Hard wrap is treated as a property of the *file*: opening one joins each paragraph's soft-broken lines so editing works on one long logical line, and `data(ofType:)` re-wraps at 80 on the way out, so the buffer deliberately differs from the file on disk. **Only files that arrived wrapped are wrapped** — `EditorTextView.wasHardWrapped` is set when the join on open actually changed the text, which is exactly the signal that the file had wrapping; a file of long single lines is written back verbatim and the menu command is the only way to wrap it. The unwrap runs *inside* `loadContent`, after `LineEnding.detect`/`normalize`: doing it in `Document` would hand the detector text whose CRLFs were already rewritten and silently convert every CRLF file to LF. Requires strict line breaks (the checkbox greys out without it): with those off a single newline renders as a literal `<br>`, so joining would delete visible breaks and wrapping would invent them. Only `.paragraph` blocks are rewritten — every other kind is copied through, so fences, tables, headings and front matter are safe by construction — and because plain text parses **one `.paragraph` block per source line**, the transform runs over *runs* of consecutive paragraph blocks rather than block by block. Two GFM rules the fill has to respect: a two-space or unescaped-backslash line ending is a hard break (content, not formatting) and bounds a segment in both directions; and a break is **refused in front of a block-opening token** (`#`, `>`, `-`, `1.`, `|`, fences …) because a greedy fill would otherwise turn "…costs 1. 50 per unit…" into an ordered list on the next parse — the line overflows instead. The menu command rebuilds `rawSource` and goes through `recomposeReplacing` (the Tab/Shift-Tab route, one undoable step); it deliberately does **not** set `wasHardWrapped`, which describes the file rather than the buffer — setting it would make undo look broken, since the text would revert but the next save would wrap it straight back. **The width is the file's own** (`detectColumn` → `EditorTextView.hardWrapColumn`), so a file wrapped at 72 isn't reflowed to 80 on its first save. It is *derived, not guessed*: the longest line would undershoot the real column by however much the next word overhung, so the existing breaks are read as constraints instead — every line had to fit (`column >= len(line)`) and every break had to be forced (`column < len(line) + 1 + len(next word)`) — which leaves a range of columns that **all reproduce the file's breaks exactly**. The pick therefore only affects text typed later, and the endpoints are both wrong for that: taking the low end shaves a few characters off on every save and creeps the document narrower, so a conventional width (80, 100, 120, 72, 60) is preferred when one qualifies, with the widest consistent column as the fallback. Cost is **all parsing** — the transforms themselves are single-digit ms, while `BlockParser.parse` is ~95% of the time — so open takes `unwrapDetectingColumn`, which gets the join *and* the column off one parse rather than two. Measured (release): +2 ms on a 5 KB note, +14 ms at 30 KB, +74 ms on this file, +0.6 s on a 1.3 MB document; save is one more parse. Nothing is paid at all with the setting off, which is the default. |
+| Hard wrap | `Editing/HardWrap.swift` (pure `wrap`/`unwrap`) + `Editing/EditorTextView+HardWrap.swift` (Edit ▸ Hard Wrap Paragraphs). Settings ▸ Edit ▸ Document, off by default; read at **load/save time in `Document`**, not pushed onto the editor. Treated as a property of the *file*: opening a wrapped file joins its paragraphs, save re-wraps, and **only files that arrived wrapped are wrapped** (`wasHardWrapped`). The column is **derived from the file's own existing breaks**, not guessed. Requires strict line breaks. Full rules, GFM constraints and perf numbers: [`architecture/hard-wrap.md`](architecture/hard-wrap.md). |
 | Formatting commands | `Editing/EditorTextView+Formatting{Core,Commands}.swift` (Format-menu actions); menu built from `edmd/App/FormatMenu.swift` |
 | Lazy/compose/undo/scroll | `TextView/EditorTextView+{Composition,LazyStyling,Undo,TypewriterScroll,SelectionTracking,ContentWidth,EditFlow}.swift` |
 | App shell | `edmd/App/{main,Document,DocumentController}.swift`; menu bar in `main.swift` `setupMenuBar()` + `FormatMenu.swift`; Sparkle `SPUStandardUpdaterController` in `AppDelegate` |
@@ -204,15 +206,14 @@ rawSource ─BlockParser─▶ [Block] ─SyntaxHighlighter─▶ spans ─style
 Notable subsystems:
 
 - **A draw-only setting needs more than `invalidateLayout` to appear.** The
-  layout manager caches its fragments and hands the cached ones back, so a
-  paragraph vended as a plain `NSTextLayoutFragment` stays plain and the new
-  overdraw never shows (measured: a live toggle drew nothing until the next
-  edit). `refreshOverdraw()` therefore also pokes the storage with an
-  attributes-only `edited(.editedAttributes, …)` — no text change, no restyle,
-  no undo entry — which makes the content storage re-offer its elements to the
-  layout delegate. Invisibles, list indent guides and focus mode all depend on
-  it.
-
+  layout manager hands back its *cached* fragments, so a paragraph vended as a
+  plain `NSTextLayoutFragment` stays plain and the new overdraw never shows
+  (measured: a live toggle drew nothing until the next edit). `refreshOverdraw()`
+  also pokes the storage with an attributes-only `edited(.editedAttributes, …)`
+  — no text change, no restyle, no undo entry — to force a re-vend. Invisibles,
+  list indent guides and focus mode all depend on it; the affordances that use
+  it are in
+  [`architecture/editor-affordances.md`](architecture/editor-affordances.md).
 
 - **Typewriter scroll**: keeps caret vertically centered. Must lay out the
   viewport↔caret span before measuring (else stale TK2 estimates);
@@ -323,6 +324,15 @@ Notable subsystems:
 - `AppSettings` (`edmd/Settings`) = UserDefaults keys + typed accessors.
   SwiftUI panes use `@AppStorage`. Live changes broadcast to every open
   `Document.editor` (the font/line-height/content-width `applyTo…` helpers).
+- **Five panes**, built by `SettingsWindowController.addPane`: General,
+  Appearance, Edit, Syntax, Advanced. Keys are namespaced to match
+  (`settings.<pane>.<name>`), so the key tells you which pane owns it. There is
+  no "Markdown" pane — the Markdown feature toggles (§6) live under
+  `settings.syntax.*`.
+- This section owns the *mechanism* and the settings with non-obvious
+  behavior, not the full key list — that inventory drifts fastest and lives in
+  `.claude/skills/edmund-config-and-flags/`. Grep
+  `Sources/edmd/Settings/AppSettings.swift` for the current truth.
 - Theme/appearance/fonts flow into `EditorTheme` → the editor's derived
   `bodyFont`, colors, paragraph styles.
 - **Max content width** persists as **centimetres** (`maxContentWidthCm`);
@@ -331,7 +341,8 @@ Notable subsystems:
   and is the slider's magnetic snap point; slider range: 3 in floor → the
   screen's physical width (`NSScreen.physicalWidthCm`).
 - **Window size** persists as the last window's full **frame** size
-  (`lastWindowSize`) — §8 on why frame, not content size.
+  (`settings.window.lastWidth`/`lastHeight`) — §8 on why frame, not content
+  size.
 - **Diagnostic logging** (`EdmundCore/Diagnostics/Log.swift`): always-on
   (opt-out) file logger. `Log.{debug,info,error}(_:category:)` and
   `Log.measure(_:) { … }` (single-line durations) write to
@@ -355,6 +366,8 @@ Notable subsystems:
 ---
 
 ## 8. Quirks & gotchas (will bite you)
+
+### Build, signing & packaging
 
 - **SwiftMath fonts**: `build-app.sh` must copy `*.bundle` into the `.app`
   root (it does). Without it the app **crashes the instant it renders any
@@ -394,6 +407,9 @@ Notable subsystems:
   take", `rm -rf .build` and rebuild. `shasum` the binary to confirm it
   changed. Never hand-delete `.build/…/edmd.build/` — corrupts the
   output-file-map and wedges the target until a full clean.
+
+### Running & verifying the app
+
 - **`open Edmund.app` foregrounds a running instance** instead of
   relaunching. `pkill -x edmd` first, or launch the binary directly
   (`build/Edmund.app/Contents/MacOS/edmd file.md &`).
@@ -405,6 +421,16 @@ Notable subsystems:
   windows, state restoration) —
   `rm -rf ~/Library/"Saved Application State"/com.i7t5.edmund.savedState`
   and relaunch.
+- **Visual work is measured, not eyeballed — and the measuring rig is
+  reusable.** Aligning chrome takes a dozen launch/state/capture/measure cycles;
+  `.claude/skills/edmund-live-repro-and-diagnostics/scripts/ui-harness.sh` and
+  `ui-measure.py` are that loop, already encoding the flaky bits (AX-driven
+  clicks, appearance forced per-launch via `-settings.appearance.mode`, capture
+  by window id without stealing focus). Extend them for new surfaces rather than
+  rebuilding one-off shell; they are permanent fixtures, not scratch files.
+
+### TextKit 2 layout & geometry
+
 - **Width not known at first styling**: on load the view may be unsized, so
   anything that bakes the content width (e.g. callout header images)
   renders at a fallback width until a width-settled re-render. Prefer real
@@ -432,6 +458,9 @@ Notable subsystems:
 - **A selection taller than the viewport must be revealed at its *nearest*
   end** (`scrollRangeToVisible` override): always revealing the top fought
   drag-selection autoscroll and oscillated the viewport mid-drag.
+
+### Edit, selection & storage integrity
+
 - **Never mutate storage while an IME is composing (`hasMarkedText()`)**:
   during composition storage holds the provisional marked text, so
   `storage == rawSource` is transiently false and `didChangeText` defers
@@ -487,6 +516,9 @@ Notable subsystems:
   (`ensureBlocksStyled(upTo:)` + `ensureLayout`) — the drain's later layout
   invalidation is *not* scroll-compensated, so landing first and letting
   styling catch up slides the just-anchored viewport.
+
+### AppKit chrome & controls
+
 - **A custom toolbar item can't win a right-click from a view-level
   handler.** With `allowsUserCustomization = true` the toolbar turns any
   secondary (right / control) click over the toolbar — *including* a custom
@@ -561,6 +593,9 @@ Notable subsystems:
   background, and refresh its `cgColor` on
   `viewDidChangeEffectiveAppearance` — a colour snapshot won't follow the
   appearance by itself.
+
+### Deliberate omissions
+
 - **Edit ▸ Substitutions is deliberately absent.** Smart quotes/dashes, text
   replacement and autocorrect are switched off in
   `EditorTextView.commonInit()` on purpose: they rewrite typed Markdown, and
@@ -568,13 +603,7 @@ Notable subsystems:
   storage == rawSource (delete-drift investigation). Don't add the standard
   Substitutions menu back — it re-exposes exactly those toggles. Same reason
   "Correct Spelling Automatically" is left out of Spelling and Grammar.
-- **Visual work is measured, not eyeballed — and the measuring rig is
-  reusable.** Aligning chrome takes a dozen launch/state/capture/measure cycles;
-  `.claude/skills/edmund-live-repro-and-diagnostics/scripts/ui-harness.sh` and
-  `ui-measure.py` are that loop, already encoding the flaky bits (AX-driven
-  clicks, appearance forced per-launch via `-settings.appearance.mode`, capture
-  by window id without stealing focus). Extend them for new surfaces rather than
-  rebuilding one-off shell; they are permanent fixtures, not scratch files.
+
 
 ---
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -82,6 +82,12 @@ write-ups:
 - [`macos-integrations.md`](macos-integrations.md) — Services, App Intents,
   Quick Look preview, AppleScript syntax; and the two signing/toolchain
   limitations (App Intents metadata, ad-hoc appex launch).
+- [`editor-affordances.md`](editor-affordances.md) — the editor-only display
+  features: invisibles, list indent guides, line numbers, focus mode, and the
+  re-vend rule (`refreshOverdraw()`) they all depend on.
+- [`hard-wrap.md`](hard-wrap.md) — hard wrap as a property of the *file*:
+  unwrap on open, re-wrap on save, and how the column is derived from the
+  file's own existing breaks.
 - Planned, not yet written: `edit-flow-and-undo.md`,
   `app-shell-and-settings.md`.
 

--- a/docs/architecture/editor-affordances.md
+++ b/docs/architecture/editor-affordances.md
@@ -1,0 +1,221 @@
+# Editor affordances: invisibles, indent guides, line numbers, focus mode
+
+The editor-only display features. None of them are content: they are edit
+affordances, so Read mode and Export never show them (the deliberate exception
+to the "one parser, two back-ends" rule — [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §5).
+All four are **draw-only**: they write no characters, and — except for the list
+guides' cached offsets — no attributes either, so they can't perturb recompose
+or break `storage == rawSource` (§2).
+
+`ARCHITECTURE.md` §6 owns the one-line statement of each; this doc owns the
+mechanism.
+
+## The rule they all share
+
+**A draw-only setting needs more than `invalidateLayout` to appear.** The
+layout manager caches its fragments and hands the cached ones back, so a
+paragraph vended as a plain `NSTextLayoutFragment` stays plain and the new
+overdraw never shows (measured: a live toggle drew nothing until the next
+edit). `refreshOverdraw()` therefore also pokes the storage with an
+attributes-only `edited(.editedAttributes, …)` — no text change, no restyle, no
+undo entry — which makes the content storage re-offer its elements to the
+layout delegate. Invisibles, list indent guides and focus mode all depend on it.
+
+The corollary is what makes these features cheap: toggling one needs only a
+re-vend, never a whole-document restyle.
+
+---
+
+## Invisible characters
+
+`TextView/EditorTextView+Invisibles.swift` — faint marks (· → ¬ ␣ ▯) overdrawn
+on laid-out whitespace, riding `DecoratedTextLayoutFragment.draw`. Pure display
+overlay: inserts no characters (storage == rawSource), TextKit 2 path only. The
+delegate vends the decorated fragment for every visible paragraph while on
+(viewport-bounded); plain fast path when off (default). Config pushed via
+`EditorTextView.invisibles` from `AppSettings.invisiblesConfig`; Settings ▸ Edit.
+**Editor-only by design** (like CotEditor) — an edit affordance, not content.
+
+---
+
+## List indent guides
+
+Faint vertical hairlines on list items: one per *ancestor* level spanning the
+item, plus the item's **own** column drawn only beside its wrapped continuation
+lines (the first line holds the marker).
+
+Columns are computed by `listGuideOffsets(depth:slotWidth:)`
+(`Rendering/EditorTextView+ListRendering.swift`) as the center of each level's
+marker slot, and written to `.listGuides` by `styleListItemSpan` **whether or
+not the setting is on** — the fragment gates the drawing, so toggling needs only
+a re-vend (`refreshOverdraw()`), never a whole-document restyle (there is no
+such call).
+
+Offsets are *container*-relative, not `point.x`-relative: the fragment frame
+hugs the laid-out text, so `point.x` moves with each item's
+`firstLineHeadIndent` (an ordered marker right-aligns into its slot). They are
+measured from the container's **text** origin, so the draw adds
+`lineFragmentPadding` (the default 5pt — the head indents the columns derive
+from are relative to it, and omitting it shifts every guide left by exactly
+that).
+
+Drawn under the text in `DecoratedTextLayoutFragment.draw`, filled at one device
+pixel like the table gridlines. List paragraphs carry no paragraph spacing, so
+per-fragment fills tile into one continuous line down a nested run. Pushed via
+`EditorTextView.showListIndentGuides`; Settings ▸ Edit.
+
+---
+
+## Line numbers
+
+`TextView/EditorTextView+LineNumbers.swift` — source line numbers (Settings ▸
+Edit ▸ Lines, off by default), pushed via `EditorTextView.showLineNumbers`.
+Editor-only, like invisibles — and never printed, since the ruler isn't part of
+the text view.
+
+### Two placements over one walk
+
+`enumerateVisibleLineNumbers` / `lineNumberStyle`, and **the placement is not a
+setting** — `lineNumbersFitBesideContent`
+(`textContainerOrigin.x >= lineNumbersRequiredInset`) picks it, so a margin too
+narrow to hold the numbers raises the gutter instead of dropping them. It moves
+with the content-width cap, the window width and the document's digit count (no
+cap ⇒ a 24 pt base inset, which a 3-digit document already overruns).
+
+The switch can't oscillate: the gutter only ever *shrinks* the margin, so a
+document that didn't fit still doesn't, and one that fits without the gutter
+fits all the more once it's gone.
+
+### The re-evaluation must be scheduled, not inline
+
+Re-evaluated from `updateContentInset()` — which runs even when the inset held
+steady, since the digit count grows on its own — but **only scheduled** there
+(`scheduleLineNumberPlacementUpdate`, one coalesced `RunLoop.main.perform`):
+`updateContentInset` runs inside `setFrameSize`, and adding or removing a ruler
+re-tiles the scroll view, so applying it inline mutates the scroll view from
+inside its own layout — that **SIGSEGV'd the whole test process on macOS 14**
+(CI caught what six clean local runs on macOS 15 did not). Same constraint as
+`ruleThickness`, one layer up.
+
+The margin itself is recomputed from the cap
+(`horizontalInset(viewWidth:maxContentWidth:)`), *not* read off
+`textContainerOrigin`, which is only correct after `updateContentInset` has run
+once — reading the live inset made a freshly built editor see a zero margin,
+raise a gutter and immediately drop it.
+
+### Beside the content (the default)
+
+Drawn in the reading column's own margin on `drawBackground(in:)` — the pass
+Find already uses — right-aligned a `lineNumberPadding` short of the text.
+
+Reserves **nothing**: the content-width cap owns the margin, so the reading
+column always stretches to the full cap and the column never moves when the
+numbers come on. The deliberate consequence: when what's left of the margin
+can't hold `lineNumbersRequiredInset` (a wide cap, a narrow window), the numbers
+step aside rather than print over the text — all of them, never just the ones
+that fit, so they can't go ragged with `9` drawn and `100` missing.
+
+Reserving that space instead was tried and reverted: it stopped the column
+reaching the cap, and the cap winning is the point. Window-edge is the placement
+for "always visible".
+
+### By the window edge (automatic, when the margin can't hold them)
+
+A `LineNumberRulerView` on the scroll view — AppKit owns the scroll sync and
+clipping, but it reserves width, so the centered column re-centers when it is
+switched on.
+
+Installed by `updateLineNumberRuler()`, which `viewDidMoveToSuperview` replays;
+it assigns `lineNumberRuler` **before** telling the scroll view, because showing
+or hiding a ruler resizes the document view synchronously and re-enters through
+`setFrameSize` — assigning afterwards lets that re-entrant call see nil and
+build a second ruler. `Document` configures the editor *before* putting it in a
+scroll view, so the setter alone would miss at launch.
+
+`clipsToBounds = true` is **required** on the ruler: against the macOS 14 SDK it
+defaults to false, and the background fill then paints over the whole scroll
+view (the document goes blank).
+
+### Draw rules
+
+**Walk the viewport the text view already laid out**
+(`textViewportLayoutController.viewportRange`) — forcing layout from a draw
+re-enters the layout controller and blanks the text view, and enumerating from
+the document start would lay out the whole file. Each number comes from its own
+fragment's offset through the cached `lineStarts` table, so nothing can drift
+when scrolled.
+
+A line whose first line fragment is shorter than half a body line is *counted
+but not drawn*, which is how a table's `hiddenFont` separator row (0.01 pt)
+avoids stacking its number on its neighbor's — so the visible sequence
+legitimately skips in Edit mode and is gapless in Source mode.
+
+Ink is `lineNumberColor`, one tier below `syntaxDimColor` (quaternary /
+`darkRuleGray`), except every line the selection touches (`selectedLineSpans`,
+kept as ranges so selecting a huge document doesn't build a per-line set each
+redraw), which takes `foregroundColor` so it reads as a position rather than
+chrome — `selectionDidChange` calls `invalidateLineNumbers()` **before** its own
+guards, since the highlight has to follow selection changes that bail out of
+restyling, and it dirties only the numbers' strip.
+
+### The face, and why its figures matter
+
+**Avenir Next Condensed** (`lineNumberFont`, CotEditor's choice for the same
+job), sized to the theme's monospace face and falling back to
+`monospacedDigitSystemFont`. It is *not* monospaced — its **figures are
+tabular**, which is the only property the drawing needs: labels are
+right-aligned from one measured digit advance rather than measuring each number
+(`LineNumberFaceTests` pins this, since a proportional-figure face would break
+the alignment silently).
+
+Vertical placement centers the digit's **cap band** on the text's cap band
+(tallest font on the line, read off the line fragment's own attributes — the
+storage's first character can be a list item's 0.01 pt hidden font and would
+report no cap). Centering the drawn *box* instead rides ~2.5 pt high, because
+`draw(at:)` lays out a box far taller than the figures in it; baselining instead
+sits ~0.8 pt low. Measured on screen: cap-centering lands within 0.1 device px.
+
+### Line ↔ offset lookup
+
+`line(forOffset:)` / `offset(forLine:)` live here too, binary-searching
+`lineStarts` (dropped by `rawSource.didSet`) instead of scanning the document;
+the status bar and Read-mode scroll sync ride the same speedup.
+
+---
+
+## Focus mode
+
+`TextView/EditorTextView+FocusMode.swift` — dims everything but the lines the
+selection touches (Settings ▸ Edit ▸ Editor, and View ▸ Focus Mode; off by
+default), pushed via `EditorTextView.focusMode`. Editor-only.
+
+The fade is **one transparency layer around `DecoratedTextLayoutFragment.draw`**
+at `focusDimOpacity` (0.35), so a fragment's text *and* everything drawn with it
+— code/callout boxes, quote bars, table borders, list guides, math and bullet
+overlays — fade as one composite.
+
+That is the point: those live in `BlockDecoration` / `FragmentOverlay` values
+and cached images, so fading them through color attributes would mean
+recomputing decorations and regenerating overlays on every caret move; fading a
+pixel toward an opaque background is the same result as lerping its color toward
+it anyway (measured: ink 230 → 107.7 against a predicted 107.2).
+
+It **cannot** be a scrim the text view paints over its content — NSTextView
+composites its fragments *after* `draw(_:)` returns, so a fill there lands under
+the glyphs and under every box (measured with a full-view test fill: the code
+block drew clean over it).
+
+Which fragments dim is decided at draw time from
+`textLayoutManager.textSelections` (the invisibles trick — no restyle, no
+re-vend, and no work on a caret move beyond the redraw AppKit already does for
+the old and new selection), and the mode itself is read live off the vending
+editor (`owner`) rather than captured.
+
+One text element is one source line, so element-range containment *is* line
+granularity, and it agrees with `selectedLineSpans` behind the line-number
+highlight — including the rule that a selection ending exactly at a line start
+doesn't claim that line.
+
+While the mode is on every paragraph must vend the custom fragment (a plain one
+has no draw to hook); that plain ↔ decorated swap is the only part needing a
+re-vend, which is what `refreshOverdraw()` forces.

--- a/docs/architecture/hard-wrap.md
+++ b/docs/architecture/hard-wrap.md
@@ -1,0 +1,80 @@
+# Hard wrap
+
+`Editing/HardWrap.swift` (pure `wrap`/`unwrap`) +
+`Editing/EditorTextView+HardWrap.swift` (Edit ▸ Hard Wrap Paragraphs).
+
+Settings ▸ Edit ▸ Document ("Detect hard wrap pattern for lines on document
+opening"), off by default — one switch for the whole feature; read at **load/save
+time in `Document`**, not pushed onto the editor. Like `strictLineBreaks` there
+is no live editor behavior to configure.
+
+`ARCHITECTURE.md` §6 owns the one-line statement; this doc owns the mechanism.
+
+## Hard wrap is a property of the file, not the buffer
+
+Opening a hard-wrapped file joins each paragraph's soft-broken lines so editing
+works on one long logical line, and `data(ofType:)` re-wraps on the way out — so
+the buffer deliberately differs from the file on disk.
+
+**Only files that arrived wrapped are wrapped.** `EditorTextView.wasHardWrapped`
+is set when the join on open actually changed the text, which is exactly the
+signal that the file had wrapping; a file of long single lines is written back
+verbatim, and the menu command is the only way to wrap it.
+
+The menu command rebuilds `rawSource` and goes through `recomposeReplacing` (the
+Tab/Shift-Tab route, one undoable step). It deliberately does **not** set
+`wasHardWrapped`, which describes the file rather than the buffer — setting it
+would make undo look broken, since the text would revert but the next save would
+wrap it straight back.
+
+## Ordering constraints
+
+The unwrap runs *inside* `loadContent`, after `LineEnding.detect` / `normalize`:
+doing it in `Document` would hand the detector text whose CRLFs were already
+rewritten, and silently convert every CRLF file to LF.
+
+It requires strict line breaks (the checkbox greys out without it): with those
+off a single newline renders as a literal `<br>`, so joining would delete visible
+breaks and wrapping would invent them.
+
+## What gets rewritten
+
+Only `.paragraph` blocks — every other kind is copied through, so fences, tables,
+headings and front matter are safe by construction. Because plain text parses
+**one `.paragraph` block per source line**, the transform runs over *runs* of
+consecutive paragraph blocks rather than block by block.
+
+Two GFM rules the fill has to respect:
+
+1. A two-space or unescaped-backslash line ending is a **hard break** (content,
+   not formatting) and bounds a segment in both directions.
+2. A break is **refused in front of a block-opening token** (`#`, `>`, `-`,
+   `1.`, `|`, fences …) because a greedy fill would otherwise turn
+   "…costs 1. 50 per unit…" into an ordered list on the next parse — the line
+   overflows instead.
+
+## The width is the file's own, and it is derived rather than guessed
+
+`detectColumn` → `EditorTextView.hardWrapColumn`, so a file wrapped at 72 isn't
+reflowed to 80 on its first save.
+
+The longest line would undershoot the real column by however much the next word
+overhung, so the existing breaks are read as **constraints** instead: every line
+had to fit (`column >= len(line)`) and every break had to be forced
+(`column < len(line) + 1 + len(next word)`). That leaves a *range* of columns
+which all reproduce the file's breaks exactly.
+
+The pick therefore only affects text typed later — and the endpoints are both
+wrong for that. Taking the low end shaves a few characters off on every save and
+creeps the document narrower, so a conventional width (80, 100, 120, 72, 60) is
+preferred when one qualifies, with the widest consistent column as the fallback.
+
+## Cost
+
+**All parsing.** The transforms themselves are single-digit ms, while
+`BlockParser.parse` is ~95% of the time — so open takes `unwrapDetectingColumn`,
+which gets the join *and* the column off one parse rather than two.
+
+Measured (release): +2 ms on a 5 KB note, +14 ms at 30 KB, +74 ms on
+`ARCHITECTURE.md` itself, +0.6 s on a 1.3 MB document; save is one more parse.
+Nothing is paid at all with the setting off, which is the default.


### PR DESCRIPTION
## Why

`docs/ARCHITECTURE.md` §6 is a *"where to look"* table, but it had become **43% of the whole document (27.3k chars)** — five feature rows had grown into essays inside table cells. Line numbers alone was **5,896 characters in a single table cell**.

## What changed

**Split, narrowly.** Splitting the file wholesale would be wrong — its §N anchors are referenced from `CLAUDE.md`, `misc/`, and the skills, and agents want one greppable doc. So only the essay-cells moved out, into two deep docs following the pattern already in use (statement in ARCHITECTURE, explanation in the deep doc):

- `docs/architecture/editor-affordances.md` — invisibles, list indent guides, line numbers, focus mode, and the `refreshOverdraw()` re-vend rule all four share.
- `docs/architecture/hard-wrap.md` — unwrap-on-open / re-wrap-on-save, the GFM constraints, and how the column is derived from the file's own existing breaks.

**§8 regrouped.** The flat 26-bullet list is now six labeled subsections: build/signing, running & verifying, TextKit 2 geometry, edit & storage integrity, AppKit chrome, deliberate omissions. Section *numbers* are unchanged, so every `§N` reference across the repo still resolves.

**Drift fixed** (found by verifying claims against the tree, not by reading):

- test count `750+` → `~1200`
- **"Settings ▸ Markdown pane" does not exist** — the panes are General/Appearance/Edit/**Syntax**/Advanced, and those toggles are `settings.syntax.*`
- window size persists as `settings.window.lastWidth`/`lastHeight`, not `lastWindowSize`
- documented the **pluggable code-fence syntax backend** (`CodeSyntaxBackend`, `BuiltinSyntaxBackend`, `LanguageDefinition`, `SyntaxDefinitionStore`) — users can add a language via Application Support with no rebuild. This subsystem was previously undocumented entirely.
- documented `EditorTextStorage`, `LinkDefinitionState`, `LineEnding`, `SVGPath`, `StatusBarPrefs`, and the five settings panes

Net: ARCHITECTURE.md 63.8k → 51.5k chars.

## Verification

- `swift test` — 1219 passed
- §8 regrouping was script-asserted: all 26 bullets present, none dropped or duplicated
- every moved passage confirmed still present by keyword grep (`SIGSEGV`, `Avenir Next Condensed`, `unwrapDetectingColumn`, `focusDimOpacity`, `LineNumberFaceTests`, `detectColumn`, …)
- all relative links in the four touched docs resolve; every `§N` reference in the repo is still ≤ 14

Docs-only — no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)