### PR TITLE
Make Find and Focus Mode rebindable

### DIFF
--- a/Sources/edmd/App/ViewMenu.swift
+++ b/Sources/edmd/App/ViewMenu.swift
@@ -37,11 +37,10 @@ enum ViewMenu {
 
         // Dims everything but the lines the selection touches. Same setting as
         // Settings ▸ Edit ▸ Editor, so the two always agree.
-        let focusItem = viewMenu.addItem(
-            withTitle: "Focus Mode",
-            action: #selector(AppDelegate.toggleFocusMode(_:)),
-            keyEquivalent: "")
+        let focusItem = MenuCommand(id: "view.focusMode", group: "View", title: "Focus Mode",
+                                    action: #selector(AppDelegate.toggleFocusMode(_:))).makeItem()
         focusItem.state = AppSettings.focusMode ? .on : .off
+        viewMenu.addItem(focusItem)
 
         // View-mode toggle (Edit ↔ Read) + the Source-mode checkbox.
         viewMenu.addItem(.separator())

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -175,6 +175,19 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 
     // MARK: - Menu Bar
 
+    /// Edit ▸ Find. Edmund's own commands, so they are rebindable — the standard
+    /// Edit items above them (Cut/Copy/Paste, Undo) keep their system shortcuts.
+    @MainActor private static let findCommands: [MenuCommand] = [
+        MenuCommand(id: "find.show", group: "Edit", submenu: "Find", title: "Find\u{2026}",
+                    action: #selector(EditorTextView.showFindBar(_:)), shortcut: .cmd("f")),
+        MenuCommand(id: "find.replace", group: "Edit", submenu: "Find", title: "Find and Replace\u{2026}",
+                    action: #selector(EditorTextView.showFindReplaceBar(_:)), shortcut: .cmdOpt("f")),
+        MenuCommand(id: "find.next", group: "Edit", submenu: "Find", title: "Find Next",
+                    action: #selector(EditorTextView.findNext(_:)), shortcut: .cmd("g")),
+        MenuCommand(id: "find.previous", group: "Edit", submenu: "Find", title: "Find Previous",
+                    action: #selector(EditorTextView.findPrevious(_:)), shortcut: .cmdShift("g")),
+    ]
+
     @MainActor private func setupMenuBar() {
         let mainMenu = NSMenu()
 
@@ -300,18 +313,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         // mode (the web view is first responder and implements none of these).
         let findMenuItem = NSMenuItem()
         let findMenu = NSMenu(title: "Find")
-        findMenu.addItem(withTitle: "Find…",
-                         action: #selector(EditorTextView.showFindBar(_:)),
-                         keyEquivalent: "f")
-        findMenu.addItem(withTitle: "Find and Replace…",
-                         action: #selector(EditorTextView.showFindReplaceBar(_:)),
-                         keyEquivalent: "f").keyEquivalentModifierMask = [.command, .option]
-        findMenu.addItem(withTitle: "Find Next",
-                         action: #selector(EditorTextView.findNext(_:)),
-                         keyEquivalent: "g")
-        findMenu.addItem(withTitle: "Find Previous",
-                         action: #selector(EditorTextView.findPrevious(_:)),
-                         keyEquivalent: "g").keyEquivalentModifierMask = [.command, .shift]
+        for command in Self.findCommands { findMenu.addItem(command.makeItem()) }
         findMenuItem.submenu = findMenu
         findMenuItem.title = "Find"
         editMenu.addItem(findMenuItem)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 - Check grammar while typing (Settings ▸ Edit ▸ Words)
 - Focus mode: dims everything but the lines the selection touches, including code blocks, callouts and other drawn chrome (Settings ▸ Edit ▸ Editor, View ▸ Focus Mode; off by default)
 - Typewriter scroll is now also a checkbox in Settings ▸ Edit ▸ Editor (same setting as View ▸ Typewriter Scroll)
-- Settings ▸ Key Bindings: customize the shortcut of any Edmund menu command (File, Format, View). A shortcut already used elsewhere in the app is refused, and Restore Defaults puts everything back
+- Settings ▸ Key Bindings: customize the shortcut of any Edmund menu command (File, Edit ▸ Find, Format, View). A shortcut already used elsewhere in the app is refused, and Restore Defaults puts everything back
 - macOS Services menu: "Open in Edmund" and "New Edmund Document with Selection"
 - App Intents ("Open in Edmund", "New Edmund Document") for Shortcuts / Spotlight (metadata generation requires an Xcode-project build; see build-app.sh)
 - Quick Look preview extension: renders Markdown as rich text, following the system light/dark appearance


### PR DESCRIPTION
Follow-up to #246. Find and Focus Mode landed on main while the Key
Bindings pane was being written, as plain
`addItem(withTitle:action:keyEquivalent:)` calls, so they never passed
through `MenuCommand` — they didn't appear in the pane and their
shortcuts couldn't be changed.

Find's ⌘F / ⌥⌘F / ⌘G / ⇧⌘G were already *enforced*, since the conflict
check walks the live `NSApp.mainMenu` rather than the catalog. They just
weren't editable themselves.

## What

- Edit ▸ Find is a `MenuCommand` table now, listed under a Find submenu
  the way the menu bar nests it: Find… ⌘F, Find and Replace… ⌥⌘F, Find
  Next ⌘G, Find Previous ⇧⌘G.
- View ▸ Focus Mode joins the View group, with no default shortcut. Its
  checkmark still comes from `validateMenuItem`, unchanged.

The standard Edit items above Find (Cut/Copy/Paste, Undo/Redo, Select
All) stay fixed, as before.

## Testing

`swift test` — 1239 pass. Both groups were verified by capturing the
built app: Edit shows the Find submenu with all four defaults rendered,
View shows Focus Mode between Typewriter Scroll and Toggle View Mode.

Not included: Edit ▸ Hard Wrap Paragraphs is still a plain menu item.
Same one-line conversion whenever it's wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)