### PR TITLE
fix(release): use docs/CHANGELOG.md, restore missing 0.3.0 appcast item

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -186,5 +186,46 @@
                        length="7793566"
                        type="application/x-apple-diskimage"/>
         </item>
+        <item>
+            <title>Edmund 0.3.0</title>
+            <pubDate>Mon, 27 Jul 2026 16:54:35 +0000</pubDate>
+            <description><![CDATA[
+<style>body{font:13px -apple-system,system-ui;color:#111;margin:8px}h3{font-size:13px;margin:12px 0 4px}ul{margin:0 0 8px;padding-left:20px}li{margin:2px 0}code{font-family:ui-monospace,monospace;background:rgba(127,127,127,.15);padding:1px 4px;border-radius:3px}@media(prefers-color-scheme:dark){body{color:#eee}}</style>
+<p>Settings stuff.</p>
+<p>Thanks to @CaliLuke for his first contribution (#236) and for being the first community contributor :D</p>
+<h3>Added</h3>
+<ul>
+<li>Improved performance (#236 @CaliLuke)</li>
+<li><strong>(Almost) Full Obsidian-flavored Markdown support</strong>: YAML front matter, <code>[image|dimension()</code> (implicit), <code>^block</code>, <code>#tag</code>, collapsible callout</li>
+<li><strong>Find and replace</strong> in Apple Notes fashion</li>
+<li><strong>Settings &gt; Edit</strong>: Hide toolbar, focus mode, detect indentation, show invisible characters, show line numbers, hard-wrap long lines</li>
+<li><strong>Settings &gt; Syntax</strong>: Toggle Markdown syntax support, add code block syntax</li>
+<li><strong>Settings &gt; Key Bindings</strong></li>
+<li>Edit &gt; Find, Spelling &amp; Grammar, Transformations, Speech menus</li>
+<li>Finder services</li>
+<li><code>Option+Cmd+I</code> to open inspector</li>
+</ul>
+<h3>Changed</h3>
+<ul>
+<li>Misc UI improvements: Numbered lists marker in read mode, thicker thematic break, removed bottom border from edit mode tables, removed inline code color from read mode</li>
+<li>Dark mode readability: Empty checkbox in edit mode, blockquote bars in read mode, table borders in edit mode</li>
+<li>Code block syntax highlighting is now controlled by syntax-based JSON instead of general regex</li>
+<li>Inline math block renders as block in read mode</li>
+<li>Format &gt; Comments now wraps selection in <code>&lt;!-- selection --&gt;</code></li>
+</ul>
+<h3>Fixed</h3>
+<ul>
+<li>Headers render spaces after <code>#...</code></li>
+<li>Indented code block renders as monospace</li>
+<li>Replace right-click &quot;Font&quot; menu in edit mode with our Format &gt; Font menu</li>
+</ul>
+]]></description>
+            <enclosure url="https://github.com/I7T5/Edmund/releases/download/v0.3.0/Edmund-0.3.0.dmg"
+                       sparkle:version="8"
+                       sparkle:shortVersionString="0.3.0"
+                       sparkle:edSignature="ky3kunM5LGdyUlLTBhZ5ukSiQtTIlIhznlNerk15czWpAf2ZFaV53oLYAky3Rm7rlLzPFrcUHXb6sGj28ZaBBw=="
+                       length="13636661"
+                       type="application/x-apple-diskimage"/>
+        </item>
     </channel>
 </rss>

--- a/scripts/changelog-to-html.py
+++ b/scripts/changelog-to-html.py
@@ -76,7 +76,7 @@ def main() -> int:
         print("usage: changelog-to-html.py <version>", file=sys.stderr)
         return 2
     version = sys.argv[1]
-    with open("CHANGELOG.md", encoding="utf-8") as f:
+    with open("docs/CHANGELOG.md", encoding="utf-8") as f:
         section = extract(version, f.readlines())
     body = to_html(section)
     if not body:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -116,12 +116,12 @@ echo "appcast.xml updated."
 # ── GitHub Release ────────────────────────────────────────────────────────────
 echo "Creating GitHub Release v${VERSION}..."
 
-# Extract this version's section from CHANGELOG.md as the release body.
+# Extract this version's section from docs/CHANGELOG.md as the release body.
 # Falls back to a plain link if the section isn't found.
 NOTES_FILE=$(mktemp)
-awk "BEGIN{p=0} /^## \[${VERSION}\]/{p=1;next} p && /^## \[/{exit} p{print}" CHANGELOG.md > "$NOTES_FILE"
+awk "BEGIN{p=0} /^## \[${VERSION}\]/{p=1;next} p && /^## \[/{exit} p{print}" docs/CHANGELOG.md > "$NOTES_FILE"
 if [ ! -s "$NOTES_FILE" ]; then
-    echo "See [CHANGELOG](https://github.com/${REPO}/blob/main/CHANGELOG.md) for details." > "$NOTES_FILE"
+    echo "See [CHANGELOG](https://github.com/${REPO}/blob/main/docs/CHANGELOG.md) for details." > "$NOTES_FILE"
 fi
 
 gh release create "v${VERSION}" "$DMG" \


### PR DESCRIPTION
## What

- `scripts/changelog-to-html.py` and `scripts/release.sh` now read `docs/CHANGELOG.md` instead of the repo-root path the CHANGELOG no longer lives at.
- `appcast.xml` gets the `Edmund 0.3.0` item that the release run failed to write.

## Why

The v0.3.0 release only half-shipped. Two runs failed on the same stale path:

- Run [30283714705](https://github.com/I7T5/Edmund/actions/runs/30283714705) died at *Create GitHub Release* — `awk: can't open file CHANGELOG.md`. `release.yml` was patched in e6b3070 and the tag re-cut.
- Run [30286653082](https://github.com/I7T5/Edmund/actions/runs/30286653082) built, signed, uploaded the DMG and published the release, then died at *Update appcast.xml* with `FileNotFoundError: [Errno 2] No such file or directory: 'CHANGELOG.md'` from `scripts/changelog-to-html.py`.

So the GitHub release looks complete, but `appcast.xml` never received the 0.3.0 item — and `SUFeedURL` points at `raw.githubusercontent.com/I7T5/Edmund/main/appcast.xml`. No installed copy of Edmund has ever been offered the update; everyone is still on 0.2.1.

`scripts/release.sh` (the manual release path) carried the identical stale path in its awk extraction and its fallback link, so it would have failed the same way.

## The appcast item

Reconstructed exactly as the failed step would have written it, using the same `printf` template from `release.yml` and the `edSignature` / `length` verbatim from run 30286653082's step env. The published asset's `content-length` is `13636661`, matching the signed length — so that signature covers the DMG that is actually live, and no re-sign was needed.

## Verification

- `swift test` — 1239 tests pass.
- `appcast.xml` parses; 8 items; 0.3.0 is `sparkle:version="8"` (> 0.2.1's `7`), so Sparkle will offer it; release-notes CDATA present.
- Published DMG `content-length` verified against the signed `length`.
- No stale root-`CHANGELOG.md` references remain anywhere in the repo.

Once this lands on `main`, the feed goes live and 0.2.1 users get the update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)