### PR TITLE
Conform Read mode to Edit mode: color space, line height, headings, list spacing

### DIFF
--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -260,7 +260,13 @@ enum HTMLTheme {
     .callout-body > ul, .callout-body > ol { margin: 1.3em 0; padding-left: 2.25em; }
     li > ul, li > ol { margin: 0; }
     ul { list-style-type: disc; }
-    li { margin: 0.35em 0; }
+    /* No inter-item margin: the editor's list paragraph style sets both
+       paragraphSpacing and paragraphSpacingBefore to 0 (see listParagraphStyle in
+       EditorTextView+ListRendering.swift), so consecutive items there are one
+       line pitch apart — same as a wrapped line inside an item. Any margin here
+       makes Read mode's lists looser than the text you typed them into; measured,
+       0.35em put items 31.5pt apart against the editor's 26.0pt. */
+    li { margin: 0; }
     li::marker { color: var(--marker); font-size: 0.85em; }
     /* Numbers read as text, not as a glyph: keep them at the item's own size so
        Read mode matches Edit mode, where the "N." keeps the body font. */

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -49,9 +49,19 @@ enum HTMLTheme {
         let codeBg = dark ? "#333333" : "#f4f4f4"
 
         // line-height: editor `NSParagraphStyle.lineSpacing` adds extra points
-        // *between* lines on top of the font's natural leading (~1.2×). The CSS
-        // equivalent is 1.2 + (lineSpacing / fontSize).
-        let lineHeight = 1.2 + theme.lineSpacing / theme.fontSize
+        // *between* lines on top of the font's natural line height. That natural
+        // height is MEASURED from the resolved font, not assumed — this used to
+        // hardcode 1.2×, but Iowan Old Style (the default body face) is 1.375×,
+        // so every Read-mode line came out ~11% tighter than the editor's and the
+        // font-size stepper moved the two modes apart instead of together.
+        //
+        // `defaultLineHeight`, NOT `ascender - descender + leading`: the two
+        // disagree (Iowan 22.0 vs 21.84; Helvetica 19.0 vs 16.0 — a 19% gap), and
+        // measuring real TextKit 2 line fragments shows the layout matches
+        // `defaultLineHeight` for every face tried. It's the TextKit 1 class, used
+        // here purely as the metrics oracle that agrees with TextKit 2's layout.
+        let naturalLineHeight = NSLayoutManager().defaultLineHeight(for: theme.bodyFont)
+        let lineHeight = (naturalLineHeight + theme.lineSpacing) / theme.fontSize
 
         // CSS px and AppKit points are both device-independent, so the editor's
         // physical cap (EditorTextView.maxContentWidthPoints) carries over as-is.
@@ -170,15 +180,21 @@ enum HTMLTheme {
        rather than a collapsed publication layout. */
     p { margin: 0 0 1em; }
     h1, h2, h3, h4, h5, h6 { line-height: 1.25; font-weight: 600; margin: 1.7em 0 0.7em; }
-    h1 { font-size: 1.9em; } h2 { font-size: 1.55em; } h3 { font-size: 1.3em; }
-    h4 { font-size: 1.1em; } h5 { font-size: 1em; } h6 { font-size: 0.9em; color: var(--faint); }
+    /* Heading scale mirrors the editor's, which is the source of truth — see the
+       `case .heading` arm in EditorTextView+Rendering.swift. Keep the two in step:
+       h4-h6 stay at body size there, and h6 carries no dimming, so it carries
+       none here either. */
+    h1 { font-size: 1.5em; } h2 { font-size: 1.3em; } h3 { font-size: 1.15em; }
+    h4 { font-size: 1em; } h5 { font-size: 1em; } h6 { font-size: 1em; }
     :is(h1, h2, h3, h4, h5, h6):first-child { margin-top: 0; }
     a { color: var(--accent); text-decoration: underline; }
     /* Body color, not --code: the editor draws inline code in the body color
        too, and the two views must agree. --code still tints block code. */
+    /* Radii are em, not px, so the chip's corners keep their proportion as the
+       font-size stepper moves — a fixed 4px reads as square at large sizes. */
     code { font-family: var(--mono-font); font-size: 0.92em; color: var(--fg);
-           background: var(--inline-code-bg); padding: 0.1em 0.35em; border-radius: 4px; }
-    pre { background: var(--code-bg); padding: 12px 14px; border-radius: 8px; overflow-x: auto;
+           background: var(--inline-code-bg); padding: 0.1em 0.35em; border-radius: 0.25em; }
+    pre { background: var(--code-bg); padding: 12px 14px; border-radius: 0.5em; overflow-x: auto;
           /* tab-size: browsers default to 8; match the common editor convention of 4. */
           tab-size: 4; -moz-tab-size: 4; }
     pre code { color: var(--fg); background: none; padding: 0; font-size: var(--mono-size); }
@@ -314,7 +330,23 @@ enum HTMLTheme {
     /* Outer margin matches the gap between two consecutive <pre> blocks (UA
        stylesheet gives pre { margin: 1em 0 }; collapsing → 1em gap). Using
        the same value here means neighboring callouts look equally spaced. */
-    .callout { background: var(--c-bg); border-radius: 8px; padding: 10px 14px; margin: 1em 0; }
+    /* Square corners and em padding both track the editor, which fills a square
+       rect per layout fragment (they tile into one box) and derives its pads from
+       `pointSize`: the rendered top gap is ~1.2em, calloutBottomPad is 1.14em, and
+       the text inset is 2pt + quoteMarkerWidth ≈ 1.24em. The editor's right inset
+       is narrower (a `tailIndent = -10` artifact, not a design choice), so both
+       sides use the left value rather than reproducing a lopsided box.
+       Top padding is NOT a flat 1.2em: what the eye reads as the gap runs from the
+       box edge to the title's cap-top, and the title's line box adds half-leading
+       above the glyph — so a flat 1.2em rendered ~6pt too deep (measured 25.5pt
+       against the editor's 19.5pt). Subtracting half the line box's excess over the
+       cap height puts the *rendered* gap on the editor's, and keeps it there as the
+       line-height stepper moves. The 0.78 stands in for the body face's cap height
+       in em; it is a serif-ish average, not a per-font measurement — a font-agnostic
+       version would emit the real capHeight/unitsPerEm ratio alongside --body-size.
+       The bottom needs no such correction: it is measured box-edge to box-edge. */
+    .callout { background: var(--c-bg); border-radius: 0; margin: 1em 0;
+               padding: calc(1.22em - (var(--line-height) - 0.78) * 0.5em) 1.24em 1.14em; }
     /* Icon sits at the top so it stays on the first line of a wrapped title; its
        box is exactly one line tall and centers the glyph, so it lines up with the
        first line's text rather than floating above it. */

--- a/Sources/EdmundCore/Model/EditorTheme.swift
+++ b/Sources/EdmundCore/Model/EditorTheme.swift
@@ -260,6 +260,13 @@ public struct EditorTheme: Equatable, Sendable {
 extension NSColor {
 
     /// Create a color from a hex string like "#3366E6" or "3366E6".
+    ///
+    /// sRGB, not the calibrated space: a hex literal means the same thing in CSS
+    /// (Read mode, PDF export) as it does here, and calibrated RGB composites
+    /// visibly lighter than that — every project hex drifted, most obviously the
+    /// `warning` callout's orange (#EC7500 painted as #F28900 in the editor while
+    /// Read mode showed the literal). Decoding as sRGB makes the two agree and
+    /// makes hex → NSColor → `hexString` round-trip exactly.
     public convenience init?(hex: String) {
         var h = hex.trimmingCharacters(in: .whitespacesAndNewlines)
         if h.hasPrefix("#") { h.removeFirst() }
@@ -267,7 +274,7 @@ extension NSColor {
         let r = CGFloat((rgb >> 16) & 0xFF) / 255.0
         let g = CGFloat((rgb >> 8) & 0xFF) / 255.0
         let b = CGFloat(rgb & 0xFF) / 255.0
-        self.init(calibratedRed: r, green: g, blue: b, alpha: 1.0)
+        self.init(srgbRed: r, green: g, blue: b, alpha: 1.0)
     }
 
     /// Returns the hex string representation (e.g. "#3366E6").

--- a/Tests/EdmundTests/HTMLThemeTests.swift
+++ b/Tests/EdmundTests/HTMLThemeTests.swift
@@ -19,8 +19,15 @@ struct HTMLThemeTests {
         #expect(out.contains("--accent: #3366E6;"))
         #expect(out.contains("--code: #8A2425;"))
         #expect(out.contains("--body-size: 16px;"))
-        // 1.2 + 4/16 = 1.45
-        #expect(out.contains("--line-height: 1.45;"))
+        // Natural line height is measured from the font, not assumed: derive the
+        // expectation the same way rather than pinning a literal that silently
+        // encodes whichever body face happens to be installed.
+        let font = NSFont(name: "Iowan Old Style", size: 16) ?? .systemFont(ofSize: 16)
+        let expected = (NSLayoutManager().defaultLineHeight(for: font) + 4) / 16
+        #expect(out.contains("--line-height: \(String(format: "%g", expected));"))
+        // …and it must be materially looser than the old hardcoded 1.2 base,
+        // which is what made Read mode ~11% tighter than the editor.
+        #expect(expected > 1.5)
         // Multi-word family is quoted with a fallback stack.
         #expect(out.contains("\"Iowan Old Style\""))
     }

--- a/Tests/EdmundTests/RenderingRegressionTests.swift
+++ b/Tests/EdmundTests/RenderingRegressionTests.swift
@@ -167,6 +167,81 @@ struct RenderingRegressionTests {
                 "rule must sit between the text lines (above=\(gapAbove), below=\(gapBelow))")
     }
 
+    // MARK: Read mode's CSS line-height matches Edit mode's real line pitch
+
+    /// Read mode used to hardcode the body font's natural line height as 1.2×,
+    /// which is wrong for the default face (Iowan Old Style is 1.365×) — so every
+    /// Read-mode line came out ~11% tighter than the editor's, and the font-size
+    /// stepper moved the two modes apart instead of together. Measure the editor's
+    /// actual line pitch and hold the emitted CSS to it.
+    @Test("CSS --line-height equals the editor's measured line pitch")
+    @MainActor func cssLineHeightMatchesEditorLinePitch() {
+        // One paragraph long enough to wrap: successive line-fragment origins
+        // inside a single layout fragment give the true pitch (natural line
+        // height + the paragraph style's lineSpacing) with no ambiguity about
+        // whether typographicBounds already folds lineSpacing in.
+        let (e, _) = windowed(String(repeating: "wrapping body text ", count: 40))
+        guard let tlm = e.textLayoutManager else { Issue.record("no tlm"); return }
+
+        var first: NSTextLayoutFragment?
+        tlm.enumerateTextLayoutFragments(from: tlm.documentRange.location, options: []) {
+            first = $0; return false
+        }
+        guard let frag = first, frag.textLineFragments.count >= 2 else {
+            Issue.record("paragraph did not wrap"); return
+        }
+        let origins = frag.textLineFragments.map { $0.typographicBounds.minY }
+        let pitch = origins[1] - origins[0]
+
+        // The same theme the editor is rendering with, through the Read-mode CSS.
+        let css = HTMLTheme.css(e.theme, callouts: Callout.defaultStyles, dark: false)
+        guard let range = css.range(of: "--line-height: "),
+              let end = css[range.upperBound...].firstIndex(of: ";"),
+              let cssLineHeight = Double(css[range.upperBound..<end]) else {
+            Issue.record("no --line-height in emitted CSS"); return
+        }
+        let cssPitch = CGFloat(cssLineHeight) * e.theme.fontSize
+
+        // Tight on purpose: the two are the same number by construction now, so
+        // any real drift (a changed metric, a reintroduced constant) shows up.
+        #expect(abs(cssPitch - pitch) < 0.05,
+                "Read mode line pitch \(cssPitch)pt must match Edit mode's \(pitch)pt")
+    }
+
+    /// The same equality, for a face whose two candidate metrics disagree sharply
+    /// (Helvetica: defaultLineHeight 19.0 vs ascender−descender+leading 16.0).
+    /// Iowan alone cannot tell the two formulas apart — they differ by 0.7% there.
+    @Test("CSS line-height tracks the editor for a font with unusual metrics")
+    @MainActor func cssLineHeightMatchesForHelvetica() {
+        let e = makeEditor()
+        var theme = e.theme
+        theme.fontName = "Helvetica"
+        e.theme = theme
+        e.textContainerInset = NSSize(width: 24, height: 18)
+        e.loadContent(String(repeating: "wrapping body text ", count: 40))
+        ensureFullLayout(e); drainAllStyling(e); e.sizeToFit(); ensureFullLayout(e)
+
+        guard let tlm = e.textLayoutManager else { Issue.record("no tlm"); return }
+        var first: NSTextLayoutFragment?
+        tlm.enumerateTextLayoutFragments(from: tlm.documentRange.location, options: []) {
+            first = $0; return false
+        }
+        guard let frag = first, frag.textLineFragments.count >= 2 else {
+            Issue.record("paragraph did not wrap"); return
+        }
+        let origins = frag.textLineFragments.map { $0.typographicBounds.minY }
+        let pitch = origins[1] - origins[0]
+
+        let css = HTMLTheme.css(theme, callouts: Callout.defaultStyles, dark: false)
+        guard let range = css.range(of: "--line-height: "),
+              let end = css[range.upperBound...].firstIndex(of: ";"),
+              let cssLineHeight = Double(css[range.upperBound..<end]) else {
+            Issue.record("no --line-height in emitted CSS"); return
+        }
+        #expect(abs(CGFloat(cssLineHeight) * theme.fontSize - pitch) < 0.05,
+                "Helvetica: CSS pitch \(CGFloat(cssLineHeight) * theme.fontSize)pt vs editor \(pitch)pt")
+    }
+
     // MARK: Scroll targets accurate under lazy layout
 
     @Test("The drain styling blocks above the viewport does not shift visible content")


### PR DESCRIPTION
Read mode and Edit mode render the same document two ways — TextKit 2 vs. CSS
emitted by `HTMLTheme`. `HTMLTheme` was built to derive from the *same*
`EditorTheme` / `CalloutStyle` models so the two can't drift, but several values
were written in as document defaults rather than derived, and had drifted enough
to read as two different designs.

## Color space (`NSColor(hex:)` → sRGB)

`NSColor(hex:)` built its color in the **calibrated** RGB space, but the same hex
literal reaches Read mode and PDF export as CSS, where it means **sRGB**. The two
composite differently, so every hex-derived color in the editor drifted from its
Read-mode twin — most visibly the `warning` callout's orange, which painted as
`#F28900` in Edit mode while Read mode showed the literal `#EC7500`.

Fixing the shared decoder fixes every caller at once: callout accent/border/
background, link blue, inline-code color, math operator/number, the code syntax
palette (whose hexes go verbatim into the CSS), and the webview's
`underPageBackgroundColor`. Two call sites already bypassed the helper with
`NSColor(srgbRed:)` and a comment saying calibrated "renders visibly lighter" —
this makes the helper itself do the right thing.

Measured over the 15 hexes the project uses, `hex → NSColor → hexString` now
round-trips exactly: **0/15 drift, was 15/15**.

## Line height

The CSS hardcoded the body font's natural line height as `1.2×`. The default face
(Iowan Old Style) is `1.375×`, so every Read line came out ~11% tighter than the
editor's, and the font-size stepper moved the two modes apart instead of together.
It is now measured from the resolved font.

The metric is `defaultLineHeight`, **not** `ascender − descender + leading`: the
two disagree (Iowan 22.0 vs 21.84; Helvetica 19.0 vs 16.0 — a 19% gap), and
measuring real TextKit 2 line fragments shows the layout follows
`defaultLineHeight` for every face tried.

## Also

- Headings adopt the editor's scale (1.5 / 1.3 / 1.15 / 1 / 1 / 1); `h6` loses its
  dimming, which the editor doesn't apply either.
- Callout padding becomes em-relative, matching the editor's `pointSize`-derived
  pads. Top padding is a `calc` rather than a flat `1.2em` because the perceived
  gap runs to the title's cap-top and the title's line box adds half-leading above
  the glyph; a flat value rendered ~6pt too deep.
- Lists lose their inter-item margin. The editor's list paragraph style sets both
  `paragraphSpacing` and `paragraphSpacingBefore` to 0, so items there sit exactly
  one line pitch apart — `li { margin: 0.35em 0 }` added a gap the editor never
  shows.
- Inline-code and code-block radii become `em` so they keep their proportion as the
  font size changes. No other code styling is touched.

Deliberately unchanged: the list block's outer margin, the dark-mode checkbox and
chrome grays, `.table-wrap`, and paragraph spacing.

## Verification

`swift test` — 1273 passing.

Two new tests hold the CSS `--line-height` to the editor's measured line pitch:
one for the default face, one for Helvetica, whose two candidate metrics differ
sharply enough to tell the formulas apart. That is the check that would have
caught the original bug.

Measured off screenshots of both modes, light and dark:

| | before | after | Edit mode |
|---|---|---|---|
| callout title ink | `#F28900` | **`#EC7600`** | `#EC7600` |
| box-top → title cap | 25.5pt | **19.5–20.0pt** | 19.5pt |
| callout bottom gap | 18.0pt | 18.0pt | 18.0pt |
| list item pitch | 31.5pt | **26.0pt** | 26.0pt |
| body line pitch | ~8% tight | matched | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)