### PR TITLE
Make full-screen toolbar auto-hide work, and move it to the View menu

### DIFF
--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -204,6 +204,14 @@ class Document: NSDocument, HeadingNavigable {
             self, selector: #selector(windowDidChangeScreen(_:)),
             name: NSWindow.didChangeScreenNotification, object: window
         )
+        // Auto-hide is a full-screen-only affair, and applyToolbarAutoHide may
+        // have hidden the toolbar outright to honour it. Put it back on the way
+        // out, or a window that left full screen with auto-hide on keeps a
+        // toolbar that Show/Hide Toolbar says is showing.
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(windowDidExitFullScreen(_:)),
+            name: NSWindow.didExitFullScreenNotification, object: window
+        )
 
         // Restore the last window's frame size (the toolbar is now installed, so
         // the frame is final). Applied as a frame, not a contentRect, so it
@@ -215,6 +223,15 @@ class Document: NSDocument, HeadingNavigable {
 
         let wc = DocumentWindowController(window: window)
         addWindowController(wc)
+        // Assigned by hand: NSWindowController only makes itself the window's
+        // delegate on the nib-loading path, and this window is built in code, so
+        // `init(window:)` leaves `delegate` nil — which silently killed the
+        // full-screen toolbar auto-hide (the delegate method below was never
+        // called). Safe to point at the controller: NSWindowController itself
+        // implements none of NSWindowDelegate, so nothing else changes hands —
+        // in particular the undo manager still comes from the window, not the
+        // document.
+        window.delegate = wc
         window.makeFirstResponder(editor)
         applyToolbarVisibility()
         // Honor the persisted source-mode preference for the editing view.
@@ -235,6 +252,10 @@ class Document: NSDocument, HeadingNavigable {
         guard let window = notification.object as? NSWindow,
               let screen = window.screen else { return }
         editor?.maxContentWidthPoints = screen.cmToPoints(AppSettings.maxContentWidthCm) * zoomFactor
+    }
+
+    @objc private func windowDidExitFullScreen(_ notification: Notification) {
+        applyToolbarVisibility()
     }
 
     // MARK: - Zoom (View ▸ Actual Size / Zoom In / Zoom Out)
@@ -659,6 +680,35 @@ class Document: NSDocument, HeadingNavigable {
         window?.toolbar?.isVisible = AppSettings.showToolbar
     }
 
+    /// View ▸ Auto-Hide Toolbar: in full screen, slide the toolbar away with the
+    /// menu bar until the pointer reaches the top of the screen.
+    @objc func toggleAutoHideToolbar(_ sender: Any?) {
+        AppSettings.autoHideToolbar.toggle()
+        for case let document as Document in NSDocumentController.shared.documents {
+            document.applyToolbarAutoHide()
+        }
+    }
+
+    /// Applies the setting to a window that is *already* full screen.
+    ///
+    /// The presentation-option route does not work here, which is worth knowing
+    /// before anyone tries it again: full screen is window-managed, so the
+    /// window's own options — fixed when it entered, from the delegate method
+    /// below — outrank the app's. Measured live while full screen with
+    /// auto-hide on: `currentSystemPresentationOptions` reads
+    /// `fullScreen|autoHideToolbar` (3072), and assigning `NSApp
+    /// .presentationOptions` a set without `.autoHideToolbar` leaves it at
+    /// 3072 — the flag is simply re-imposed.
+    ///
+    /// So show or hide the toolbar outright instead. That is the visible half
+    /// of the setting; the reveal-on-pointer behaviour itself is whatever the
+    /// window picked up on entry, and follows on the next one.
+    func applyToolbarAutoHide() {
+        guard let window = windowControllers.first?.window,
+              window.styleMask.contains(.fullScreen) else { return }
+        window.toolbar?.isVisible = AppSettings.showToolbar && !AppSettings.autoHideToolbar
+    }
+
     /// Keeps the View-menu "Show Source in Editor" checkmark and the
     /// Show/Hide Toolbar title in sync with the settings.
     override func validateMenuItem(_ item: NSMenuItem) -> Bool {
@@ -667,6 +717,11 @@ class Document: NSDocument, HeadingNavigable {
         }
         if item.action == #selector(toggleToolbarShown(_:)) {
             item.title = AppSettings.showToolbar ? "Hide Toolbar" : "Show Toolbar"
+        }
+        if item.action == #selector(toggleAutoHideToolbar(_:)) {
+            item.state = AppSettings.autoHideToolbar ? .on : .off
+            // Nothing to auto-hide with the toolbar switched off entirely.
+            return AppSettings.showToolbar
         }
         return super.validateMenuItem(item)
     }
@@ -816,8 +871,9 @@ final class DocumentWindow: NSWindow {
 // MARK: - Document Window Controller
 
 /// The document window's controller. Exists only to answer the full-screen
-/// presentation query — NSWindowController makes itself the window's delegate,
-/// and `.autoHideToolbar` can only be requested from there.
+/// presentation query — `.autoHideToolbar` can only be requested from the
+/// window's delegate, which `makeWindowControllers` wires to this object by
+/// hand (see the note there).
 final class DocumentWindowController: NSWindowController, NSWindowDelegate {
     func window(_ window: NSWindow,
                 willUseFullScreenPresentationOptions proposedOptions: NSApplication.PresentationOptions)

--- a/Sources/edmd/App/ViewMenu.swift
+++ b/Sources/edmd/App/ViewMenu.swift
@@ -20,6 +20,12 @@ enum ViewMenu {
         viewMenu.addItem(MenuCommand(id: "view.toggleToolbar", group: "View", title: "Hide Toolbar",
                                      action: #selector(Document.toggleToolbarShown(_:))).makeItem())
 
+        // Full-screen auto-hide. Lives here rather than in Settings, next to
+        // the switch it qualifies.
+        viewMenu.addItem(MenuCommand(id: "view.autoHideToolbar", group: "View",
+                                     title: autoHideToolbarTitle,
+                                     action: #selector(Document.toggleAutoHideToolbar(_:))).makeItem())
+
         // Routes through the responder chain to the key window's toolbar.
         // AppKit auto-inserts "Show Tab Bar"/"Show All Tabs" above this at
         // runtime (window tabbing is on by default) — that position isn't
@@ -68,6 +74,12 @@ enum ViewMenu {
         viewMenuItem.submenu = viewMenu
         return viewMenuItem
     }
+
+    /// Title case, like every other menu item. Only in the View menu — the
+    /// toolbar's own context menu is AppKit's (Icon and Text / … / Customize
+    /// Toolbar…) and Apple's apps put this setting in View, the way Safari
+    /// carries "Always Show Toolbar in Full Screen".
+    static let autoHideToolbarTitle = "Auto-Hide Toolbar"
 
     private static let zoomCommands: [MenuCommand] = [
         MenuCommand(id: "view.actualSize", group: "View", title: "Actual Size",

--- a/Sources/edmd/Settings/EditSettingsView.swift
+++ b/Sources/edmd/Settings/EditSettingsView.swift
@@ -6,8 +6,6 @@ import AppKit
 import EdmundCore
 
 struct EditSettingsView: View {
-    @AppStorage(AppSettings.Key.showToolbar)     private var showToolbar = true
-    @AppStorage(AppSettings.Key.autoHideToolbar) private var autoHideToolbar = true
     @AppStorage(AppSettings.Key.sourceMode)      private var sourceMode = false
     @AppStorage(AppSettings.Key.showInvisibles) private var showInvisibles = false
     // Parked with the rest of the Always mode — see the "Characters:" row.
@@ -36,24 +34,11 @@ struct EditSettingsView: View {
     var body: some View {
         Grid(alignment: .leadingFirstTextBaseline, verticalSpacing: 18) {
             // MARK: - Window-level settings
-            GridRow {
-                // Cancel the extra space .leadingFirstTextBaseline adds above
-                // the first row (both cells, so they stay aligned).
-                Text("Toolbar:")
-                    .gridColumnAlignment(.trailing)
-                    .padding(.top, -6)
-                VStack(alignment: .leading, spacing: 6) {
-                    Toggle("Show toolbar", isOn: $showToolbar)
-                    Toggle("Automatically hide toolbar in full screen", isOn: autoHideInFullScreen)
-                        .padding(.leading, 20)
-                        .disabled(!showToolbar)
-                }
-                .padding(.top, 2)
-                .onChange(of: showToolbar) { AppSettings.applyEditSettingsToOpenDocuments() }
-            }
-            
-            // TODO: Move Max Content Width here, after Settings ▸ Themes 
-            
+            // Toolbar visibility and its full-screen auto-hide live in the
+            // View menu, not here.
+
+            // TODO: Move Max Content Width here, after Settings ▸ Themes
+
             GridRow {
                 Text("Editor:").gridColumnAlignment(.trailing)
                 VStack(alignment: .leading, spacing: 6) {
@@ -210,15 +195,6 @@ struct EditSettingsView: View {
             }
         }
         .settingsPanePadding()
-    }
-
-    /// With the toolbar hidden outright there is nothing left to auto-hide, so
-    /// the checkbox reads as on and greys out. It reports `true` rather than
-    /// writing it, so whatever the user actually picked comes back untouched
-    /// when the toolbar returns.
-    private var autoHideInFullScreen: Binding<Bool> {
-        Binding(get: { showToolbar ? autoHideToolbar : true },
-                set: { autoHideToolbar = $0 })
     }
 
     private var invisibleCharacterGrid: some View {


### PR DESCRIPTION
## What

**The full-screen toolbar auto-hide setting never did anything.** `.autoHideToolbar` can only be requested from the window's delegate, and the document window had none: `NSWindowController` makes itself the delegate only on the nib-loading path, so building the window in code and handing it to `init(window:)` left `delegate` nil — `window(_:willUseFullScreenPresentationOptions:)` was never called.

Fix: point the window at its controller.

Safe to do — `NSWindowController` implements *none* of `NSWindowDelegate` (verified with `respondsToSelector` across `windowShouldClose:`, `windowWillReturnUndoManager:`, `windowWillClose:`, `windowDidBecomeKey:` and the rest), so nothing else silently changes hands. The undo manager in particular still comes from the window, not the document.

With the setting actually working, it moves next to the switch it qualifies:

- **Added** View ▸ Auto-Hide Toolbar, directly under Show/Hide Toolbar. Disabled only when the toolbar is hidden outright.
- **Removed** the Settings ▸ Edit ▸ Toolbar row (Show toolbar was already in the View menu).

This is where Apple's apps keep it — Safari's "Always Show Toolbar in Full Screen" — and the toolbar's own context menu is left to AppKit.

## Toggling while already full screen

Handled by showing/hiding the toolbar directly, plus a resync on exiting full screen so a hidden toolbar cannot leak into the windowed state.

The presentation-option route cannot work there, and the comment on `applyToolbarAutoHide` records why with measured values: full screen is window-managed, so the window's entry-time options outrank the app's. With auto-hide on, `currentSystemPresentationOptions` reads 3072 (`fullScreen|autoHideToolbar`), and assigning `NSApp.presentationOptions` a set *without* the flag leaves it at 3072 — the flag is re-imposed.

## Verification

`swift test` — 1273 tests in 180 suites pass.

Verified live (debug build, light appearance):

- Full screen with auto-hide **on** → no toolbar, document text at the top of the screen.
- Full screen with auto-hide **off** → toolbar present.
- View menu reads `Hide Toolbar, Auto-Hide Toolbar, Customize Toolbar…`; item enabled, checkmark tracks the setting.

**Not verified on screen:** toggling the item *while already* in full screen. Three consecutive automation runs failed to bring the app forward, and I stopped rather than keep retrying. The mechanism is a direct `toolbar.isVisible` assignment — the same call `applyToolbarVisibility()` already uses — and the exit-full-screen resync bounds the risk, but it deserves a manual look.

Note the reveal-on-pointer behaviour itself still only changes on the *next* entry into full screen. That is an AppKit limit, per the measurement above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)