### PR TITLE
Make the Services menu entries actually appear

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -64,6 +64,11 @@
             </array>
         </dict>
     </array>
+    <!-- Every service needs an NSRequiredContext, even an empty one: without
+         the key macOS parses the entry (it shows up in `pbs -dump` and the
+         services cache) but never lists it in any Services menu. Empty means
+         "no extra requirement" — eligibility is decided by the send types
+         below, which is what we want. Measured both ways on macOS 15. -->
     <key>NSServices</key>
     <array>
         <dict>
@@ -74,6 +79,8 @@
             </dict>
             <key>NSMessage</key>
             <string>openInEdmund</string>
+            <key>NSRequiredContext</key>
+            <dict/>
             <key>NSSendFileTypes</key>
             <array>
                 <string>net.daringfireball.markdown</string>
@@ -88,6 +95,8 @@
             </dict>
             <key>NSMessage</key>
             <string>newDocumentWithSelection</string>
+            <key>NSRequiredContext</key>
+            <dict/>
             <key>NSSendTypes</key>
             <array>
                 <string>public.utf8-plain-text</string>


### PR DESCRIPTION
## The bug

Neither of Edmund's two Services entries ever showed up: not **Open in
Edmund** in Finder's right-click ▸ Services for a Markdown file, and not
**New Edmund Document with Selection** in any text app's Services menu.

## Root cause

The declarations were being read the whole time — both entries appear in
`pbs -dump` and in `~/Library/Caches/com.apple.nsservicescache.plist`. What
they lacked, and what every service that *does* show up on this machine has
(Skim, CotEditor, MacVim), is an **`NSRequiredContext`** key. Without it macOS
parses the entry and then lists it nowhere.

An empty dict is enough: it means "no extra requirement", so eligibility is
decided by `NSSendFileTypes` / `NSSendTypes`, which is what we want.

## How this was narrowed down

Measured on macOS 15.7.8, one key at a time, forcing LaunchServices to point
at the test build each round (16 stale copies of `Edmund.app` share the bundle
id, and `/Applications` otherwise wins):

| change | Finder | text app |
|---|---|---|
| as shipped | missing | missing |
| + `NSRequiredContext` on both | **present** | **present** |
| − `NSRequiredContext` (file service only) | missing | present |
| − `NSRequiredContext` (text service only) | present | missing |

`NSPortName`, `CFBundleDevelopmentRegion`, a `public.file-url` send type, and
matching the code-signing identifier to the bundle id were each tested and
made no difference either way, so none of them are in this diff.

## Verification

- `swift test` — 1273 tests in 180 suites pass.
- Live: Finder ▸ Services ▸ **Open in Edmund** opens the selected file;
  TextEdit ▸ Services ▸ **New Edmund Document with Selection** creates a
  document containing the selected text (contents read back via the
  accessibility API).

Note for anyone re-testing: the Services submenu is often empty the first
time it is opened after a `pbs -flush`, which reads as a false negative — the
measurements above retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)