### PR TITLE
fix(editor): keep the viewport put across whole-document refreshes

### DIFF
--- a/Sources/EdmundCore/TextView/EditorTextView+Composition.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+Composition.swift
@@ -188,11 +188,19 @@ extension EditorTextView {
     /// Restyles every block in place (attribute-only). For theme and
     /// appearance changes: the string is unchanged but every attribute
     /// derives from the new theme/appearance.
+    ///
+    /// Anchored: marking every block unstyled drops the whole document back to
+    /// base-height estimates, so the content *above* the viewport re-measures
+    /// and the same clip origin lands somewhere else entirely — measured at +64
+    /// lines on a 2000-line file when the appearance switched. Pinning the
+    /// viewport top keeps the user looking at what they were looking at.
     func recomposeAllDirty() {
-        for i in blocks.indices { blocks[i].isStyled = false }
-        recomposeDirty(IndexSet(blocks.indices),
-                       cursorInRaw: currentCursorInRaw(),
-                       settingSelection: true)
+        preservingViewportAnchor {
+            for i in blocks.indices { blocks[i].isStyled = false }
+            recomposeDirty(IndexSet(blocks.indices),
+                           cursorInRaw: currentCursorInRaw(),
+                           settingSelection: true)
+        }
     }
 
     /// Attribute-only restyle of the whole document, for the app layer to call

--- a/Sources/EdmundCore/TextView/EditorTextView+Invisibles.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+Invisibles.swift
@@ -101,23 +101,31 @@ extension EditorTextView {
     /// attributes, so a restyle wouldn't re-consult the layout delegate;
     /// invalidating layout forces the plain ↔ decorated swap and a redraw.
     /// Call after every such assignment.
+    /// Anchored, and it re-lays the viewport itself: invalidating the whole
+    /// document drops every fragment back to a height estimate, so without the
+    /// anchor the visible band slides (measured on a 2000-line file), and
+    /// nothing forces a viewport layout afterward — the editor sat blank until
+    /// a click supplied the missing event. Same repair as `swapToEditor`.
     @MainActor public func refreshOverdraw() {
-        if let tlm = textLayoutManager {
-            tlm.invalidateLayout(for: tlm.documentRange)
+        preservingViewportAnchor {
+            if let tlm = textLayoutManager {
+                tlm.invalidateLayout(for: tlm.documentRange)
+            }
+            // Invalidating layout is not enough on its own: the layout manager
+            // keeps its fragments and hands the cached ones back, so a paragraph
+            // that was vended plain stays plain and the new overdraw never appears
+            // (measured — a live toggle drew nothing until the next edit). Only the
+            // content storage re-offering its elements re-vends them, and an
+            // attributes-only edit is the cheapest way to ask for that: no text
+            // changes, no restyle, no undo entry — the same call every `setAttributes`
+            // already makes (EditorTextStorage).
+            if let storage = textStorage, storage.length > 0 {
+                storage.edited(.editedAttributes,
+                               range: NSRange(location: 0, length: storage.length),
+                               changeInLength: 0)
+            }
         }
-        // Invalidating layout is not enough on its own: the layout manager
-        // keeps its fragments and hands the cached ones back, so a paragraph
-        // that was vended plain stays plain and the new overdraw never appears
-        // (measured — a live toggle drew nothing until the next edit). Only the
-        // content storage re-offering its elements re-vends them, and an
-        // attributes-only edit is the cheapest way to ask for that: no text
-        // changes, no restyle, no undo entry — the same call every `setAttributes`
-        // already makes (EditorTextStorage).
-        if let storage = textStorage, storage.length > 0 {
-            storage.edited(.editedAttributes,
-                           range: NSRange(location: 0, length: storage.length),
-                           changeInLength: 0)
-        }
+        textLayoutManager?.textViewportLayoutController.layoutViewport()
         needsDisplay = true
     }
 }

--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -223,7 +223,13 @@ public class EditorTextView: NSTextView {
     public var maxContentWidthPoints: CGFloat = .greatestFiniteMagnitude {
         didSet {
             guard oldValue != maxContentWidthPoints else { return }
-            updateContentInset()
+            // Anchored: a narrower column re-wraps every paragraph, so the
+            // content above the viewport changes height and the unchanged clip
+            // origin lands elsewhere (measured at 1641 characters on a
+            // 120-paragraph file). Only here, not in `updateContentInset`
+            // itself — that also runs from `setFrameSize` during a live window
+            // resize, which must not scroll the clip view from inside layout.
+            preservingViewportAnchor { updateContentInset() }
         }
     }
 
@@ -319,7 +325,9 @@ public class EditorTextView: NSTextView {
     public var showLineNumbers = false {
         didSet {
             guard oldValue != showLineNumbers else { return }
-            updateLineNumberRuler()
+            // Anchored for the same reason as `maxContentWidthPoints`: adding
+            // or removing the gutter narrows the text and re-wraps it.
+            preservingViewportAnchor { updateLineNumberRuler() }
         }
     }
 

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -660,8 +660,7 @@ class Document: NSDocument, HeadingNavigable {
     }
 
     /// Swaps the editing view to whatever the source-mode setting now says.
-    /// Called after the menu item toggles it, and by Settings ▸ Edit ▸ Display
-    /// (which writes the setting itself, via @AppStorage).
+    /// Called after `toggleSourceMode` flips it.
     func applySourceMode() {
         if editor.viewMode != .reading { setViewMode(editingMode) }
     }

--- a/Sources/edmd/Settings/EditSettingsView.swift
+++ b/Sources/edmd/Settings/EditSettingsView.swift
@@ -43,7 +43,6 @@ struct EditSettingsView: View {
             GridRow {
                 Text("Indentation:")
                     .gridColumnAlignment(.trailing)
-                    .padding(.top, -6)
                 VStack(alignment: .leading, spacing: 6) {
                     HStack {
                         Text("Prefer using")
@@ -63,9 +62,8 @@ struct EditSettingsView: View {
                             .labelsHidden()
                         Text("spaces")
                     }
-                    Toggle("Detect and learn indent style on document opening", isOn: $detectIndent)
+                    Toggle("Detect indent style on document opening", isOn: $detectIndent)
                 }
-                .padding(.top, -6)
                 .onChange(of: indentStyle) { AppSettings.applyEditSettingsToOpenDocuments() }
                 .onChange(of: indentWidth) { AppSettings.applyEditSettingsToOpenDocuments() }
             }
@@ -73,7 +71,7 @@ struct EditSettingsView: View {
             GridRow {
                 Text("Words:")
                 VStack(alignment: .leading, spacing: 6) {
-                    Toggle("Automatically insert closing parentheses and quotes", isOn: $autoCloseBrackets)
+                    Toggle("Automatically close parentheses and quotes", isOn: $autoCloseBrackets)
                     Toggle("Check spelling while typing", isOn: $spellCheck)
                     // AppKit checks grammar as part of the continuous
                     // spell-checking pass (hence the menu's "Check Grammar With

--- a/Sources/edmd/Settings/EditSettingsView.swift
+++ b/Sources/edmd/Settings/EditSettingsView.swift
@@ -6,7 +6,6 @@ import AppKit
 import EdmundCore
 
 struct EditSettingsView: View {
-    @AppStorage(AppSettings.Key.sourceMode)      private var sourceMode = false
     @AppStorage(AppSettings.Key.showInvisibles) private var showInvisibles = false
     // Parked with the rest of the Always mode — see the "Characters:" row.
     // @AppStorage(AppSettings.Key.invisiblesMode)
@@ -18,8 +17,6 @@ struct EditSettingsView: View {
     @AppStorage(AppSettings.Key.invisibleControl)    private var otherControl = true
     @AppStorage(AppSettings.Key.showListIndentGuides) private var showListIndentGuides = false
     @AppStorage(AppSettings.Key.showLineNumbers)      private var showLineNumbers = false
-    @AppStorage(AppSettings.Key.typewriterMode) private var typewriterScroll = true
-    @AppStorage(AppSettings.Key.focusMode) private var focusMode = false
     @AppStorage(AppSettings.Key.indentStyle)
     private var indentStyle = AppSettings.IndentStyle.spaces
     @AppStorage(AppSettings.Key.indentWidth)       private var indentWidth = 2
@@ -33,30 +30,14 @@ struct EditSettingsView: View {
 
     var body: some View {
         Grid(alignment: .leadingFirstTextBaseline, verticalSpacing: 18) {
-            // MARK: - Window-level settings
-            // Toolbar visibility and its full-screen auto-hide live in the
-            // View menu, not here.
+            // Window- and view-level state isn't configured here: toolbar
+            // visibility and its full-screen auto-hide, typewriter scroll,
+            // focus mode and source mode are all things you flip while working
+            // and see immediately, so they live in the View menu. This pane is
+            // for the defaults you set once — how text is indented, checked and
+            // displayed.
 
             // TODO: Move Max Content Width here, after Settings ▸ Themes
-
-            GridRow {
-                Text("Editor:").gridColumnAlignment(.trailing)
-                VStack(alignment: .leading, spacing: 6) {
-                    Toggle("Typewriter scroll", isOn: $typewriterScroll)
-                        .onChange(of: typewriterScroll) { AppSettings.applyEditSettingsToOpenDocuments() }
-                    Toggle("Focus mode", isOn: $focusMode)
-                        .onChange(of: focusMode) { AppSettings.applyEditSettingsToOpenDocuments() }
-                }
-            }
-            
-            GridRow {
-                Text("Source mode:").gridColumnAlignment(.trailing)
-                // The same setting as View ▸ Show Source in Editor
-                Toggle("Show raw source in editor", isOn: $sourceMode)
-                    .onChange(of: sourceMode) { applySourceMode() }
-            }
-            
-            GridRow { Divider().gridCellColumns(2) }
 
             // MARK: - Content-level editing settings
             GridRow {
@@ -218,14 +199,6 @@ struct EditSettingsView: View {
         Toggle(label, isOn: binding)
             .fixedSize()
             .gridColumnAlignment(.leading)
-    }
-
-    /// The setting is already written by @AppStorage; each open document just
-    /// needs to swap its editing view over.
-    private func applySourceMode() {
-        for case let document as Document in NSDocumentController.shared.documents {
-            document.applySourceMode()
-        }
     }
 
     /// Strict line breaks changes Read-mode output, so re-render every open

--- a/Tests/EdmundTests/ScrollStabilityTests.swift
+++ b/Tests/EdmundTests/ScrollStabilityTests.swift
@@ -173,4 +173,37 @@ struct ScrollStabilityTests {
         #expect(editor.topmostVisibleCharacterOffset() == before,
                 "top line moved from \(before ?? -1) to \(editor.topmostVisibleCharacterOffset() ?? -1)")
     }
+
+    // Narrowing the text re-wraps every paragraph, so the content above the
+    // viewport changes height — the same drift as a whole-document restyle,
+    // reached through the column width instead. Both settings are reachable
+    // live: the Appearance pane's width slider (and zoom), and Settings ▸ Edit.
+
+    @Test("Narrowing the content column keeps the viewport put")
+    @MainActor func maxContentWidthKeepsViewport() {
+        let (editor, _) = scrolledEditor()
+        let before = editor.topmostVisibleCharacterOffset()
+        #expect(before ?? 0 > 0)
+
+        editor.maxContentWidthPoints = 260
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+        editor.layoutSubtreeIfNeeded()
+
+        #expect(editor.topmostVisibleCharacterOffset() == before,
+                "top line moved from \(before ?? -1) to \(editor.topmostVisibleCharacterOffset() ?? -1)")
+    }
+
+    @Test("Turning on line numbers keeps the viewport put")
+    @MainActor func lineNumbersKeepViewport() {
+        let (editor, _) = scrolledEditor()
+        let before = editor.topmostVisibleCharacterOffset()
+        #expect(before ?? 0 > 0)
+
+        editor.showLineNumbers = true
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+        editor.layoutSubtreeIfNeeded()
+
+        #expect(editor.topmostVisibleCharacterOffset() == before,
+                "top line moved from \(before ?? -1) to \(editor.topmostVisibleCharacterOffset() ?? -1)")
+    }
 }

--- a/Tests/EdmundTests/ScrollStabilityTests.swift
+++ b/Tests/EdmundTests/ScrollStabilityTests.swift
@@ -98,4 +98,79 @@ struct ScrollStabilityTests {
         #expect(abs(yAfter - yBefore) < 2.0,
                 "scroll lurched by \(yAfter - yBefore) on Tab indent")
     }
+
+    /// A scrolled editor with content above the viewport, ready for the
+    /// whole-document refreshes below.
+    @MainActor private func scrolledEditor() -> (EditorTextView, NSScrollView) {
+        let editor = makeEditor()
+        let win = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 500, height: 300),
+                           styleMask: [.titled], backing: .buffered, defer: false)
+        let scroll = NSScrollView(frame: win.contentLayoutRect)
+        scroll.documentView = editor
+        win.contentView = scroll
+        win.makeFirstResponder(editor)
+        editor.typewriterModeEnabled = false
+        editor.isVerticallyResizable = true
+        editor.minSize = NSSize(width: 0, height: 0)
+        editor.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude,
+                                height: CGFloat.greatestFiniteMagnitude)
+        editor.autoresizingMask = [.width]
+
+        var doc = ""
+        // Headings and callouts, so the styled heights differ from the base
+        // estimates the invalidation falls back to — that gap is the bug.
+        for i in 0..<120 {
+            if i % 10 == 0 { doc += "## Section \(i)\n\n" }
+            doc += "paragraph number \(i) with enough text on it to wrap once\n\n"
+        }
+        editor.loadContent(doc)
+        ensureFullLayout(editor); drainAllStyling(editor)
+        editor.sizeToFit(); editor.layoutSubtreeIfNeeded()
+
+        let target = (editor.rawSource as NSString).range(of: "paragraph number 80").location
+        guard let lineY = editor.lineRect(forCharacterAt: target)?.minY else { return (editor, scroll) }
+        scroll.contentView.scroll(to: NSPoint(x: 0, y: lineY))
+        scroll.reflectScrolledClipView(scroll.contentView)
+        return (editor, scroll)
+    }
+
+    // Both refreshes throw away layout for the WHOLE document, dropping every
+    // fragment back to a height estimate. Unanchored, the content above the
+    // viewport re-measures and the same clip origin lands elsewhere: measured
+    // at +64 lines on a 2000-line file when the appearance switched.
+
+    @Test("A whole-document restyle (appearance/theme) keeps the viewport put")
+    @MainActor func rerenderStylesKeepsViewport() {
+        let (editor, _) = scrolledEditor()
+        let before = editor.topmostVisibleCharacterOffset()
+        #expect(before ?? 0 > 0)
+
+        editor.rerenderStyles()
+        // The app's own settle, not a raw `ensureFullLayout`: correcting the
+        // estimates is what moves the content, and the settle is the thing that
+        // is supposed to compensate for it.
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+        editor.layoutSubtreeIfNeeded()
+
+        #expect(editor.topmostVisibleCharacterOffset() == before,
+                "top line moved from \(before ?? -1) to \(editor.topmostVisibleCharacterOffset() ?? -1)")
+    }
+
+    @Test("A draw-only setting toggle (focus, invisibles) keeps the viewport put")
+    @MainActor func refreshOverdrawKeepsViewport() {
+        let (editor, _) = scrolledEditor()
+        let before = editor.topmostVisibleCharacterOffset()
+        #expect(before ?? 0 > 0)
+
+        editor.focusMode = true
+        editor.refreshOverdraw()
+        // The app's own settle, not a raw `ensureFullLayout`: correcting the
+        // estimates is what moves the content, and the settle is the thing that
+        // is supposed to compensate for it.
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+        editor.layoutSubtreeIfNeeded()
+
+        #expect(editor.topmostVisibleCharacterOffset() == before,
+                "top line moved from \(before ?? -1) to \(editor.topmostVisibleCharacterOffset() ?? -1)")
+    }
 }


### PR DESCRIPTION
Switching appearance, or toggling a draw-only Edit setting, left the editor showing a different part of the document — sometimes blank until you clicked.

## Root cause

Both paths throw away the layout for the **entire** document: `recomposeAllDirty` marks every block unstyled, `refreshOverdraw` invalidates `documentRange`. Every fragment falls back to a base-height estimate, so the content *above* the viewport re-measures and the unchanged clip origin lands somewhere else. Nothing forced a viewport layout afterward either, so the visible band could stay blank until a click supplied the missing event — the same failure `swapToEditor` already documents.

Measured live, scrolled into a document, on the appearance switch:

| document | drift |
|---|---|
| 240 lines | +4 lines |
| 2000 lines | **+64 lines** |

It scales with scroll depth, which is why it feels random in use.

## Fix

Both now run inside `preservingViewportAnchor` — which the settle and repair paths already use for exactly this — and `refreshOverdraw` lays the viewport out itself. Fixing the two shared choke points also covers zoom, theme and syntax changes, which route through `recomposeAllDirty` too.

## Audit of the sibling paths

Every other path that changes whole-document geometry was probed the same way (top-line drift on a scrolled 120-paragraph document):

| path | trigger | drift | |
|---|---|---|---|
| content-width cap | Appearance slider, zoom, PPI change | −1641 chars | fixed here |
| line-number gutter | Settings ▸ Edit ▸ Lines | −243 chars | fixed here |
| zoom font size | View ▸ Zoom In/Out | 0 | clean |
| antialias flip | Appearance pane | 0 | clean |
| markdown features | Extensions pane | 0 | clean |
| remote images | Advanced pane | 0 | clean |

The two failures reach the same defect through the text *width* rather than styling, which is why the first fix missed them. Both are anchored at their setters rather than inside `updateContentInset`, which also runs from `setFrameSize` during a live window resize — that path must not scroll the clip view from inside layout.

## Also here

Typewriter scroll, Focus mode and Show source are transient view state, and all three already exist in the View menu; the duplicate copies in Settings ▸ Edit meant two controls and two `@AppStorage` bindings per setting, kept in step by hand. Removed. Spell check and grammar deliberately stay — AppKit's Edit ▸ Spelling and Grammar items flip the key text view only and never write the default back, so those checkboxes are the only way to set it.

## Verification

- `swift test` — 1277 tests, 180 suites, green.
- Four new tests in `ScrollStabilityTests.swift`, each confirmed to fail without its fix (4684 → 4497, → 3043, → 4441).
- Live on a 2000-line document: appearance switch and Settings ▸ Edit ▸ Focus mode both leave the visible band pixel-identical.
- Settings ▸ Edit pane captured and checked after the removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)