### PR TITLE
feat(settings): Manage Version History, autosave backup, and a quit preference

### DIFF
--- a/Sources/EdmundCore/Model/VersionHistory.swift
+++ b/Sources/EdmundCore/Model/VersionHistory.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+// MARK: - Version history model
+//
+// Edmund keeps NO version history of its own. macOS's "Auto Save with Versions"
+// (opted into via Document.autosavesInPlace) stores historical copies in a hidden,
+// per-volume system store. The only sanctioned way to read or delete them is
+// `NSFileVersion`, and it works one known file URL at a time — there is no API to
+// enumerate "all versioned files". So the popup can only surface documents whose URL
+// we already have (recent/open docs, or a folder the user asks us to scan).
+//
+// This file is split so the grouping/filtering logic is unit-testable without touching
+// the disk; the `VersionHistoryStore` I/O layer does the NSFileVersion calls.
+
+/// One historical (non-current) version of a document.
+public struct VersionInfo: Identifiable, Hashable, Sendable {
+    /// The version's own store URL — unique per version within a single query.
+    public let id: URL
+    /// The live document this version belongs to.
+    public let sourceURL: URL
+    public let date: Date
+    /// Size on disk, in bytes.
+    public let size: Int64
+
+    public init(id: URL, sourceURL: URL, date: Date, size: Int64) {
+        self.id = id
+        self.sourceURL = sourceURL
+        self.date = date
+        self.size = size
+    }
+}
+
+public struct VersionNode: Identifiable, Hashable, Sendable {
+    public let info: VersionInfo
+    public var id: URL { info.id }
+    public var date: Date { info.date }
+    public var size: Int64 { info.size }
+    public init(_ info: VersionInfo) { self.info = info }
+}
+
+public struct FileNode: Identifiable, Hashable, Sendable {
+    public let url: URL
+    public let versions: [VersionNode]
+    public var id: URL { url }
+    public var name: String { url.lastPathComponent }
+    public var size: Int64 { versions.reduce(0) { $0 + $1.size } }
+    public init(url: URL, versions: [VersionNode]) {
+        self.url = url
+        self.versions = versions
+    }
+}
+
+public struct FolderNode: Identifiable, Hashable, Sendable {
+    /// The directory containing the files.
+    public let url: URL
+    public let files: [FileNode]
+    public var id: URL { url }
+    public var name: String { url.lastPathComponent }
+    /// Path with a leading `~` for the home directory, for display.
+    public var displayPath: String { abbreviatingHome(url.path) }
+    public var size: Int64 { files.reduce(0) { $0 + $1.size } }
+    public init(url: URL, files: [FileNode]) {
+        self.url = url
+        self.files = files
+    }
+}
+
+/// Group flat version infos into folder → file → version, newest version first,
+/// folders and files sorted case-insensitively by path/name.
+public func buildVersionTree(_ infos: [VersionInfo]) -> [FolderNode] {
+    let byFile = Dictionary(grouping: infos, by: \.sourceURL)
+    let files: [FileNode] = byFile.map { url, list in
+        FileNode(url: url, versions: list.sorted { $0.date > $1.date }.map(VersionNode.init))
+    }
+    let byDir = Dictionary(grouping: files, by: { $0.url.deletingLastPathComponent() })
+    return byDir.map { dir, fs in
+        FolderNode(url: dir,
+                   files: fs.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending })
+    }.sorted { $0.url.path.localizedCaseInsensitiveCompare($1.url.path) == .orderedAscending }
+}
+
+/// Filter the tree by a filename/filepath substring (case-insensitive). A folder
+/// whose own path matches is kept whole; otherwise only its matching files survive.
+/// Empty/whitespace query passes everything through unchanged.
+public func filterVersionTree(_ folders: [FolderNode], query: String) -> [FolderNode] {
+    let q = query.trimmingCharacters(in: .whitespaces)
+    guard !q.isEmpty else { return folders }
+    return folders.compactMap { folder in
+        if folder.url.path.localizedCaseInsensitiveContains(q) { return folder }
+        let matches = folder.files.filter {
+            $0.name.localizedCaseInsensitiveContains(q) || $0.url.path.localizedCaseInsensitiveContains(q)
+        }
+        return matches.isEmpty ? nil : FolderNode(url: folder.url, files: matches)
+    }
+}
+
+/// Versions strictly older than `date` — the targets for "clear before [date]".
+public func versions(olderThan date: Date, in infos: [VersionInfo]) -> [VersionInfo] {
+    infos.filter { $0.date < date }
+}
+
+private func abbreviatingHome(_ path: String) -> String {
+    let home = FileManager.default.homeDirectoryForCurrentUser.path
+    return path == home ? "~"
+        : path.hasPrefix(home + "/") ? "~" + path.dropFirst(home.count)
+        : path
+}
+
+// MARK: - NSFileVersion I/O
+//
+// Disk I/O — call `gather`/`remove` off the main actor. `remove()` is irreversible.
+
+public enum VersionHistoryStore {
+    /// Recursively find Markdown files under a folder.
+    public static func scanFolder(_ folder: URL) -> [URL] {
+        let fm = FileManager.default
+        guard let en = fm.enumerator(at: folder, includingPropertiesForKeys: nil) else { return [] }
+        var out: [URL] = []
+        for case let url as URL in en where ["md", "markdown"].contains(url.pathExtension.lowercased()) {
+            out.append(url)
+        }
+        return out
+    }
+
+    /// Query macOS version history for each URL and flatten to `VersionInfo`.
+    public static func gather(urls: [URL]) -> [VersionInfo] {
+        var infos: [VersionInfo] = []
+        for url in urls {
+            guard let versions = NSFileVersion.otherVersionsOfItem(at: url) else { continue }
+            for v in versions {
+                let vurl = v.url
+                let values = try? vurl.resourceValues(forKeys: [.totalFileAllocatedSizeKey, .fileSizeKey])
+                let size = Int64(values?.totalFileAllocatedSize ?? values?.fileSize ?? 0)
+                infos.append(VersionInfo(id: vurl, sourceURL: url,
+                                         date: v.modificationDate ?? .distantPast, size: size))
+            }
+        }
+        return infos
+    }
+
+    /// Permanently delete the given versions. Returns any errors encountered.
+    public static func remove(_ targets: [VersionInfo]) -> [Error] {
+        var errors: [Error] = []
+        let bySource = Dictionary(grouping: targets, by: \.sourceURL)
+        for (source, list) in bySource {
+            guard let versions = NSFileVersion.otherVersionsOfItem(at: source) else { continue }
+            let wanted = Set(list.map(\.id))
+            for v in versions where wanted.contains(v.url) {
+                do { try v.remove() } catch { errors.append(error) }
+            }
+        }
+        return errors
+    }
+}

--- a/Sources/EdmundCore/Model/VersionHistory.swift
+++ b/Sources/EdmundCore/Model/VersionHistory.swift
@@ -43,6 +43,7 @@ public struct FileNode: Identifiable, Hashable, Sendable {
     public let versions: [VersionNode]
     public var id: URL { url }
     public var name: String { url.lastPathComponent }
+    public var versionCount: Int { versions.count }
     public var size: Int64 { versions.reduce(0) { $0 + $1.size } }
     public init(url: URL, versions: [VersionNode]) {
         self.url = url
@@ -58,6 +59,7 @@ public struct FolderNode: Identifiable, Hashable, Sendable {
     public var name: String { url.lastPathComponent }
     /// Path with a leading `~` for the home directory, for display.
     public var displayPath: String { abbreviatingHome(url.path) }
+    public var versionCount: Int { files.reduce(0) { $0 + $1.versionCount } }
     public var size: Int64 { files.reduce(0) { $0 + $1.size } }
     public init(url: URL, files: [FileNode]) {
         self.url = url

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -38,6 +38,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         AppSettings.applyLogging()
+        AppSettings.applyAutosaving()
         Log.info("Edmund launched", category: .app)
         AppSettings.applyAppearance()
         AppSettings.applyCodeSyntax()

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -83,7 +83,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-        true
+        AppSettings.quitWhenAllWindowsClosed
     }
 
     // Reopen a new untitled document when the app is activated with no windows.

--- a/Sources/edmd/Settings/AppSettings.swift
+++ b/Sources/edmd/Settings/AppSettings.swift
@@ -287,6 +287,20 @@ enum AppSettings {
         set { UserDefaults.standard.set(newValue, forKey: Key.autoSaveWithVersions) }
     }
 
+    /// Autosave interval for the "elsewhere" backup AppKit keeps when Auto Save with
+    /// Versions is off — a recovery copy in ~/Library/Autosave Information/ that it
+    /// offers back after an unexpected quit, without ever touching the document or
+    /// the version store. TextEdit behaves the same way. Zero is AppKit's "no timer"
+    /// value: with autosave-in-place on, it drives its own change-count schedule.
+    static var autosavingDelay: TimeInterval { autoSaveWithVersions ? 0 : 30 }
+
+    /// Pushes the autosave interval into the document controller. Called at launch
+    /// and whenever the Auto Save toggle changes.
+    @MainActor
+    static func applyAutosaving() {
+        NSDocumentController.shared.autosavingDelay = autosavingDelay
+    }
+
     static var conflictResolution: ConflictResolution {
         get {
             guard let raw = UserDefaults.standard.string(forKey: Key.conflictResolution),

--- a/Sources/edmd/Settings/AppSettings.swift
+++ b/Sources/edmd/Settings/AppSettings.swift
@@ -18,20 +18,6 @@ enum AppSettings {
         }
     }
 
-    enum ConflictResolution: String, CaseIterable, Identifiable {
-        case keepCurrent
-        case ask
-        case updateToModified
-        var id: Self { self }
-        var label: String {
-            switch self {
-            case .keepCurrent: return "Keep Edmund’s edition"
-            case .ask: return "Ask how to resolve"
-            case .updateToModified: return "Update to modified edition"
-            }
-        }
-    }
-
 
     enum AppearanceMode: String, CaseIterable, Identifiable {
         case matchSystem
@@ -97,7 +83,7 @@ enum AppSettings {
         static let automaticallyChecksForUpdates = "SUAutomaticallyChecksForUpdates"
         static let startupAction = "settings.general.startupAction"
         static let autoSaveWithVersions = "settings.general.autoSaveWithVersions"
-        static let conflictResolution = "settings.general.conflictResolution"
+        static let quitWhenAllWindowsClosed = "settings.general.quitWhenAllWindowsClosed"
         static let appearanceMode = "settings.appearance.mode"
         static let maxContentWidthCm = "settings.appearance.maxContentWidthCm"
         // "cm" / "in" override the locale default for the content-width control.
@@ -301,15 +287,12 @@ enum AppSettings {
         NSDocumentController.shared.autosavingDelay = autosavingDelay
     }
 
-    static var conflictResolution: ConflictResolution {
-        get {
-            guard let raw = UserDefaults.standard.string(forKey: Key.conflictResolution),
-                  let resolution = ConflictResolution(rawValue: raw) else {
-                return .ask
-            }
-            return resolution
-        }
-        set { UserDefaults.standard.set(newValue.rawValue, forKey: Key.conflictResolution) }
+    /// Whether closing the last window quits the app. Off by default, the way
+    /// most document apps behave — the app stays running and File ▸ New reopens
+    /// a window. Mutually exclusive with `reopenWindows` (see GeneralSettingsView).
+    static var quitWhenAllWindowsClosed: Bool {
+        get { UserDefaults.standard.bool(forKey: Key.quitWhenAllWindowsClosed) }
+        set { UserDefaults.standard.set(newValue, forKey: Key.quitWhenAllWindowsClosed) }
     }
 
     static var appearanceMode: AppearanceMode {

--- a/Sources/edmd/Settings/GeneralSettingsView.swift
+++ b/Sources/edmd/Settings/GeneralSettingsView.swift
@@ -21,8 +21,16 @@ struct GeneralSettingsView: View {
                 // Paired with "Reopen windows": quitting on the last close means
                 // the session ends there, so restoring it next launch is the
                 // opposite intent. Turning either on turns the other off.
-                Toggle("Quit when all windows are closed", isOn: $quitWhenAllClosed)
-                    .onChange(of: quitWhenAllClosed) { if quitWhenAllClosed { reopenWindows = false } }
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Quit when all windows are closed", isOn: $quitWhenAllClosed)
+                        .onChange(of: quitWhenAllClosed) { if quitWhenAllClosed { reopenWindows = false } }
+                    Text("Mutually exclusive with \"Reopen windows from last session\"")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(width: 380, alignment: .leading)
+                        .padding(.leading, 20)
+                }
             }
 
             Divider().gridCellUnsizedAxes(.horizontal)

--- a/Sources/edmd/Settings/GeneralSettingsView.swift
+++ b/Sources/edmd/Settings/GeneralSettingsView.swift
@@ -11,6 +11,7 @@ struct GeneralSettingsView: View {
     @AppStorage(AppSettings.Key.autoSaveWithVersions) private var autoSave = true
     @AppStorage(AppSettings.Key.conflictResolution) private var conflict = AppSettings.ConflictResolution.ask
     @State private var showingWarnings = false
+    @State private var showingVersionHistory = false
 
     var body: some View {
         Grid(alignment: .leadingFirstTextBaseline, verticalSpacing: 18) {
@@ -40,6 +41,8 @@ struct GeneralSettingsView: View {
                         .fixedSize(horizontal: false, vertical: true)
                         .frame(width: 380, alignment: .leading)
                         .padding(.leading, 20)
+                    Button("Clear Version History…") { showingVersionHistory = true }
+                        .padding(.leading, 20)
                 }
             }
 
@@ -66,6 +69,7 @@ struct GeneralSettingsView: View {
         }
         .settingsPanePadding()
         .sheet(isPresented: $showingWarnings) { ManageWarningsView() }
+        .sheet(isPresented: $showingVersionHistory) { VersionHistoryView() }
     }
 }
 

--- a/Sources/edmd/Settings/GeneralSettingsView.swift
+++ b/Sources/edmd/Settings/GeneralSettingsView.swift
@@ -36,7 +36,7 @@ struct GeneralSettingsView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Toggle("Enable Auto Save with Versions", isOn: $autoSave)
                         .onChange(of: autoSave) { AppSettings.applyAutosaving() }
-                    Text("A system feature that automatically overwrites your files while editing. Even if turned off, Edmund creates a backup in case it unexpectedly quits.")
+                    Text("Files are backed up even when auto-save is off.")
                         .font(.callout)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -44,6 +44,7 @@ struct GeneralSettingsView: View {
                         .padding(.leading, 20)
                     Button("Manage Version History…") { showingVersionHistory = true }
                         .padding(.leading, 20)
+                        .padding(.top, 3)
                 }
             }
 

--- a/Sources/edmd/Settings/GeneralSettingsView.swift
+++ b/Sources/edmd/Settings/GeneralSettingsView.swift
@@ -35,12 +35,6 @@ struct GeneralSettingsView: View {
                     .gridColumnAlignment(.trailing)
                 VStack(alignment: .leading, spacing: 4) {
                     Toggle("Enable Auto Save with Versions", isOn: $autoSave)
-                    Text("A system feature that automatically overwrites your files while editing. Even if turned off, Edmund creates a backup in case it unexpectedly quits.")
-                        .foregroundStyle(.secondary)
-                        .controlSize(.small)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(width: 380, alignment: .leading)
-                        .padding(.leading, 20)
                     Button("Clear Version History…") { showingVersionHistory = true }
                         .padding(.leading, 20)
                 }

--- a/Sources/edmd/Settings/GeneralSettingsView.swift
+++ b/Sources/edmd/Settings/GeneralSettingsView.swift
@@ -1,4 +1,4 @@
-// The General settings pane (startup, document saving, conflict resolution).
+// The General settings pane (quitting, startup, document saving).
 
 import SwiftUI
 import AppKit
@@ -6,20 +6,33 @@ import AppKit
 // MARK: - General
 
 struct GeneralSettingsView: View {
+    @AppStorage(AppSettings.Key.quitWhenAllWindowsClosed) private var quitWhenAllClosed = false
     @AppStorage(AppSettings.Key.reopenWindows) private var reopenWindows = false
     @AppStorage(AppSettings.Key.startupAction) private var startupAction = AppSettings.StartupAction.createNewDocument
     @AppStorage(AppSettings.Key.autoSaveWithVersions) private var autoSave = true
-    @AppStorage(AppSettings.Key.conflictResolution) private var conflict = AppSettings.ConflictResolution.ask
     @State private var showingWarnings = false
     @State private var showingVersionHistory = false
 
     var body: some View {
         Grid(alignment: .leadingFirstTextBaseline, verticalSpacing: 18) {
             GridRow {
+                Text("Closing:")
+                    .gridColumnAlignment(.trailing)
+                // Paired with "Reopen windows": quitting on the last close means
+                // the session ends there, so restoring it next launch is the
+                // opposite intent. Turning either on turns the other off.
+                Toggle("Quit when all windows are closed", isOn: $quitWhenAllClosed)
+                    .onChange(of: quitWhenAllClosed) { if quitWhenAllClosed { reopenWindows = false } }
+            }
+
+            Divider().gridCellUnsizedAxes(.horizontal)
+
+            GridRow {
                 Text("On startup:")
                     .gridColumnAlignment(.trailing)
                 VStack(alignment: .leading, spacing: 6) {
                     Toggle("Reopen windows from last session", isOn: $reopenWindows)
+                        .onChange(of: reopenWindows) { if reopenWindows { quitWhenAllClosed = false } }
                     Text("When nothing else is open:")
                     Picker("", selection: $startupAction) {
                         ForEach(AppSettings.StartupAction.allCases) { Text($0.label).tag($0) }
@@ -46,21 +59,6 @@ struct GeneralSettingsView: View {
                         .padding(.leading, 20)
                         .padding(.top, 3)
                 }
-            }
-
-            GridRow {
-                Text("When document is changed by another application:")
-                    .gridCellColumns(2)
-            }
-            .padding(.bottom, -8)
-
-            GridRow {
-                Color.clear.frame(width: 1, height: 1)
-                Picker("", selection: $conflict) {
-                    ForEach(AppSettings.ConflictResolution.allCases) { Text($0.label).tag($0) }
-                }
-                .pickerStyle(.radioGroup)
-                .labelsHidden()
             }
 
             GridRow {

--- a/Sources/edmd/Settings/GeneralSettingsView.swift
+++ b/Sources/edmd/Settings/GeneralSettingsView.swift
@@ -35,7 +35,7 @@ struct GeneralSettingsView: View {
                     .gridColumnAlignment(.trailing)
                 VStack(alignment: .leading, spacing: 4) {
                     Toggle("Enable Auto Save with Versions", isOn: $autoSave)
-                    Button("Clear Version History…") { showingVersionHistory = true }
+                    Button("Manage Version History…") { showingVersionHistory = true }
                         .padding(.leading, 20)
                 }
             }

--- a/Sources/edmd/Settings/GeneralSettingsView.swift
+++ b/Sources/edmd/Settings/GeneralSettingsView.swift
@@ -35,6 +35,13 @@ struct GeneralSettingsView: View {
                     .gridColumnAlignment(.trailing)
                 VStack(alignment: .leading, spacing: 4) {
                     Toggle("Enable Auto Save with Versions", isOn: $autoSave)
+                        .onChange(of: autoSave) { AppSettings.applyAutosaving() }
+                    Text("A system feature that automatically overwrites your files while editing. Even if turned off, Edmund creates a backup in case it unexpectedly quits.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(width: 380, alignment: .leading)
+                        .padding(.leading, 20)
                     Button("Manage Version History…") { showingVersionHistory = true }
                         .padding(.leading, 20)
                 }

--- a/Sources/edmd/Settings/GeneralSettingsView.swift
+++ b/Sources/edmd/Settings/GeneralSettingsView.swift
@@ -24,7 +24,7 @@ struct GeneralSettingsView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Toggle("Quit when all windows are closed", isOn: $quitWhenAllClosed)
                         .onChange(of: quitWhenAllClosed) { if quitWhenAllClosed { reopenWindows = false } }
-                    Text("Mutually exclusive with \"Reopen windows from last session\"")
+                    Text("Mutually exclusive with “Reopen windows from last session”")
                         .font(.callout)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)

--- a/Sources/edmd/Settings/VersionHistoryOutline.swift
+++ b/Sources/edmd/Settings/VersionHistoryOutline.swift
@@ -71,6 +71,9 @@ struct VersionOutline: NSViewRepresentable {
         outline.rowHeight = 22
         outline.usesAlternatingRowBackgroundColors = true
         outline.indentationPerLevel = 14
+        // Item absorbs the slack; the two value columns are capped, so the
+        // default (last-column) autoresizing would leave a dead strip.
+        outline.columnAutoresizingStyle = .firstColumnOnlyAutoresizingStyle
         outline.dataSource = context.coordinator
         outline.delegate = context.coordinator
 

--- a/Sources/edmd/Settings/VersionHistoryOutline.swift
+++ b/Sources/edmd/Settings/VersionHistoryOutline.swift
@@ -1,0 +1,253 @@
+// The version-history tree, as a real NSOutlineView wrapped for SwiftUI.
+//
+// AppKit gives us the parts SwiftUI would have needed hand-rolling: disclosure
+// hierarchy, resizable header columns, and native tri-state checkboxes (an
+// NSButton with allowsMixedState draws the mixed dash for free).
+
+import SwiftUI
+import AppKit
+import EdmundCore
+
+/// One outline row. NSOutlineView identifies items by object identity, so the
+/// value-type tree is projected into these reference nodes once per data change
+/// (never per SwiftUI body pass — new objects would reset expansion state).
+final class VersionOutlineItem: NSObject {
+    let title: String
+    let symbol: String
+    /// Versions beneath this row; 0 for a version row itself (column shows "—").
+    let versionCount: Int
+    let size: Int64
+    /// The version ids this row owns — the unit of selection.
+    let ids: [URL]
+    let children: [VersionOutlineItem]
+
+    init(title: String, symbol: String, versionCount: Int, size: Int64,
+         ids: [URL], children: [VersionOutlineItem] = []) {
+        self.title = title
+        self.symbol = symbol
+        self.versionCount = versionCount
+        self.size = size
+        self.ids = ids
+        self.children = children
+    }
+}
+
+/// Project folder → file → version nodes into outline rows.
+func versionOutlineItems(_ folders: [FolderNode]) -> [VersionOutlineItem] {
+    folders.map { folder in
+        VersionOutlineItem(
+            title: folder.displayPath, symbol: "folder",
+            versionCount: folder.versionCount, size: folder.size,
+            ids: folder.files.flatMap { $0.versions.map(\.id) },
+            children: folder.files.map { file in
+                VersionOutlineItem(
+                    title: file.name, symbol: "doc.text",
+                    versionCount: file.versionCount, size: file.size,
+                    ids: file.versions.map(\.id),
+                    children: file.versions.map { v in
+                        VersionOutlineItem(
+                            title: v.date.formatted(date: .abbreviated, time: .shortened),
+                            symbol: "clock", versionCount: 0, size: v.size, ids: [v.id])
+                    })
+            })
+    }
+}
+
+private extension NSUserInterfaceItemIdentifier {
+    static let itemColumn = Self("item")
+    static let versionsColumn = Self("versions")
+    static let sizeColumn = Self("size")
+}
+
+struct VersionOutline: NSViewRepresentable {
+    let roots: [VersionOutlineItem]
+    @Binding var selection: Set<URL>
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let outline = NSOutlineView()
+        outline.style = .inset
+        outline.rowHeight = 22
+        outline.usesAlternatingRowBackgroundColors = true
+        outline.indentationPerLevel = 14
+        outline.dataSource = context.coordinator
+        outline.delegate = context.coordinator
+
+        let item = NSTableColumn(identifier: .itemColumn)
+        item.title = "Item"
+        item.minWidth = 220
+        item.resizingMask = .autoresizingMask
+        let versions = NSTableColumn(identifier: .versionsColumn)
+        versions.title = "Versions"
+        versions.width = 70
+        versions.minWidth = 60
+        versions.maxWidth = 100
+        let size = NSTableColumn(identifier: .sizeColumn)
+        size.title = "Size"
+        size.width = 90
+        size.minWidth = 70
+        size.maxWidth = 140
+        for column in [item, versions, size] { outline.addTableColumn(column) }
+        outline.outlineTableColumn = item
+
+        let scroll = NSScrollView()
+        scroll.documentView = outline
+        scroll.hasVerticalScroller = true
+        scroll.drawsBackground = false
+        context.coordinator.outline = outline
+        return scroll
+    }
+
+    func updateNSView(_ scroll: NSScrollView, context: Context) {
+        let coordinator = context.coordinator
+        coordinator.selection = $selection
+        if coordinator.roots.map(ObjectIdentifier.init) != roots.map(ObjectIdentifier.init) {
+            coordinator.roots = roots
+            coordinator.outline?.reloadData()
+            for root in roots { coordinator.outline?.expandItem(root) }
+        } else {
+            coordinator.refreshCheckboxes()
+        }
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, NSOutlineViewDataSource, NSOutlineViewDelegate {
+        var roots: [VersionOutlineItem] = []
+        var selection: Binding<Set<URL>>?
+        weak var outline: NSOutlineView?
+
+        // MARK: Data source
+
+        func outlineView(_ view: NSOutlineView, numberOfChildrenOfItem item: Any?) -> Int {
+            (item as? VersionOutlineItem)?.children.count ?? roots.count
+        }
+
+        func outlineView(_ view: NSOutlineView, child index: Int, ofItem item: Any?) -> Any {
+            (item as? VersionOutlineItem)?.children[index] ?? roots[index]
+        }
+
+        func outlineView(_ view: NSOutlineView, isItemExpandable item: Any) -> Bool {
+            !((item as? VersionOutlineItem)?.children.isEmpty ?? true)
+        }
+
+        // MARK: Delegate
+
+        func outlineView(_ view: NSOutlineView, viewFor tableColumn: NSTableColumn?, item: Any) -> NSView? {
+            guard let node = item as? VersionOutlineItem, let id = tableColumn?.identifier else { return nil }
+            switch id {
+            case .itemColumn:
+                let cell = view.makeView(withIdentifier: id, owner: self) as? ItemCell ?? ItemCell(identifier: id)
+                cell.configure(node, state: state(for: node), target: self, action: #selector(toggle(_:)))
+                return cell
+            case .versionsColumn:
+                return valueCell(view, id, node.versionCount > 0 ? "\(node.versionCount)" : "—")
+            default:
+                return valueCell(view, id, ByteCountFormatter.string(fromByteCount: node.size, countStyle: .file))
+            }
+        }
+
+        private func valueCell(_ view: NSOutlineView, _ id: NSUserInterfaceItemIdentifier, _ text: String) -> NSView {
+            let cell = view.makeView(withIdentifier: id, owner: self) as? ValueCell ?? ValueCell(identifier: id)
+            cell.label.stringValue = text
+            return cell
+        }
+
+        // MARK: Selection
+
+        func state(for node: VersionOutlineItem) -> NSControl.StateValue {
+            let selected = selection?.wrappedValue ?? []
+            let hits = node.ids.filter(selected.contains).count
+            return hits == 0 ? .off : (hits == node.ids.count ? .on : .mixed)
+        }
+
+        @objc func toggle(_ sender: CheckBox) {
+            guard let node = sender.item, let selection else { return }
+            // Mixed and off both mean "not fully selected" → select all.
+            if state(for: node) == .on {
+                selection.wrappedValue.subtract(node.ids)
+            } else {
+                selection.wrappedValue.formUnion(node.ids)
+            }
+            refreshCheckboxes()
+        }
+
+        /// Re-derive every visible checkbox: one click changes ancestors and
+        /// descendants too, and AppKit has no notion of the dependency.
+        func refreshCheckboxes() {
+            guard let outline else { return }
+            let column = outline.column(withIdentifier: .itemColumn)
+            guard column >= 0 else { return }
+            for row in 0..<outline.numberOfRows {
+                guard let cell = outline.view(atColumn: column, row: row, makeIfNecessary: false) as? ItemCell,
+                      let node = cell.check.item else { continue }
+                cell.check.state = state(for: node)
+            }
+        }
+    }
+}
+
+/// Checkbox that remembers which row it belongs to, so the action knows what to toggle.
+final class CheckBox: NSButton {
+    var item: VersionOutlineItem?
+}
+
+private final class ItemCell: NSTableCellView {
+    let check = CheckBox()
+    private let icon = NSImageView()
+    private let label = NSTextField(labelWithString: "")
+
+    init(identifier: NSUserInterfaceItemIdentifier) {
+        super.init(frame: .zero)
+        self.identifier = identifier
+        check.setButtonType(.switch)
+        check.title = ""
+        icon.contentTintColor = .secondaryLabelColor
+        label.lineBreakMode = .byTruncatingMiddle
+        let stack = NSStackView(views: [check, icon, label])
+        stack.spacing = 6
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stack.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
+            stack.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+        textField = label
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) unused") }
+
+    func configure(_ node: VersionOutlineItem, state: NSControl.StateValue,
+                   target: AnyObject, action: Selector) {
+        check.item = node
+        check.allowsMixedState = !node.children.isEmpty
+        check.state = state
+        check.target = target
+        check.action = action
+        icon.image = NSImage(systemSymbolName: node.symbol, accessibilityDescription: nil)
+        label.stringValue = node.title
+    }
+}
+
+private final class ValueCell: NSTableCellView {
+    let label = NSTextField(labelWithString: "")
+
+    init(identifier: NSUserInterfaceItemIdentifier) {
+        super.init(frame: .zero)
+        self.identifier = identifier
+        label.alignment = .right
+        label.font = .monospacedDigitSystemFont(ofSize: NSFont.systemFontSize, weight: .regular)
+        label.textColor = .secondaryLabelColor
+        label.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(label)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: leadingAnchor),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+        textField = label
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) unused") }
+}

--- a/Sources/edmd/Settings/VersionHistoryView.swift
+++ b/Sources/edmd/Settings/VersionHistoryView.swift
@@ -1,4 +1,4 @@
-// The Clear Version History popup: browse macOS Auto Save versions grouped by
+// The Manage Version History popup: browse macOS Auto Save versions grouped by
 // folder → file → version, and clear them (by selection or older than a date),
 // with filename/path search. See EdmundCore/Model/VersionHistory.swift for the model.
 
@@ -27,7 +27,6 @@ struct VersionHistoryView: View {
     @State private var scannedURLs: [URL] = []
     @State private var isLoading = false
     @State private var refreshToken = 0
-    @State private var showingCalendar = false
 
     /// Outline rows, rebuilt only when the data or the search query changes —
     /// NSOutlineView keys off object identity, so rebuilding per body pass
@@ -121,16 +120,11 @@ struct VersionHistoryView: View {
     private var footer: some View {
         VStack(spacing: 10) {
             HStack(spacing: 8) {
-                Text("Delete versions before")
-                Button(beforeDate.formatted(.dateTime.month(.twoDigits).day(.twoDigits).year())) {
-                    showingCalendar = true
-                }
-                .popover(isPresented: $showingCalendar, arrowEdge: .bottom) {
-                    DatePicker("", selection: $beforeDate, displayedComponents: .date)
-                        .datePickerStyle(.graphical)
-                        .labelsHidden()
-                        .padding(12)
-                }
+                // Stock NSDatePicker field: mm/dd/yyyy in en_US, keyboard-editable,
+                // localized elsewhere for free.
+                DatePicker("Delete versions before", selection: $beforeDate,
+                           displayedComponents: .date)
+                    .fixedSize()
                 Spacer()
             }
             HStack {
@@ -141,7 +135,7 @@ struct VersionHistoryView: View {
                 Button("Done") { dismiss() }
                     .keyboardShortcut(.defaultAction)
                 Button { confirm(deleteTargets) } label: {
-                    Text("Delete…").foregroundStyle(.red)
+                    Text("Delete").foregroundStyle(.red)
                 }
                 .disabled(deleteTargets.isEmpty)
             }

--- a/Sources/edmd/Settings/VersionHistoryView.swift
+++ b/Sources/edmd/Settings/VersionHistoryView.swift
@@ -139,12 +139,10 @@ struct VersionHistoryView: View {
                 Text("Total: \(byteString(totalSize))").foregroundStyle(.secondary)
                 Spacer()
                 Button("Done") { dismiss() }
-                // Count in the title makes the date cutoff visible: checked
-                // versions newer than it aren't included.
-                Button(deleteTargets.isEmpty ? "Delete…" : "Delete \(deleteTargets.count)…") {
-                    confirm(deleteTargets)
+                    .keyboardShortcut(.defaultAction)
+                Button { confirm(deleteTargets) } label: {
+                    Text("Delete…").foregroundStyle(.red)
                 }
-                .keyboardShortcut(.defaultAction)
                 .disabled(deleteTargets.isEmpty)
             }
         }

--- a/Sources/edmd/Settings/VersionHistoryView.swift
+++ b/Sources/edmd/Settings/VersionHistoryView.swift
@@ -1,0 +1,264 @@
+// The Clear Version History popup: browse macOS Auto Save versions grouped by
+// folder → file → version, and clear them (by selection or older than a date),
+// with filename/path search. See EdmundCore/Model/VersionHistory.swift for the model.
+
+import SwiftUI
+import AppKit
+import EdmundCore
+
+/// Recent + currently-open document URLs, deduped, existing files only.
+@MainActor
+private func candidateDocumentURLs() -> [URL] {
+    var urls = NSDocumentController.shared.recentDocumentURLs
+    for doc in NSDocumentController.shared.documents {
+        if let u = doc.fileURL { urls.append(u) }
+    }
+    var seen = Set<URL>()
+    return urls.filter { FileManager.default.fileExists(atPath: $0.path) && seen.insert($0).inserted }
+}
+
+private enum CheckState { case on, off, mixed }
+
+struct VersionHistoryView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var folders: [FolderNode] = []
+    @State private var query = ""
+    @State private var selection: Set<URL> = []      // selected version ids
+    @State private var beforeDate = Date()
+    @State private var scannedURLs: [URL] = []
+    @State private var isLoading = false
+    @State private var refreshToken = 0
+
+    @State private var pendingTargets: [VersionInfo] = []
+    @State private var confirmClear = false
+    @State private var errorMessage: String?
+
+    private var displayed: [FolderNode] { filterVersionTree(folders, query: query) }
+    private var allInfos: [VersionInfo] { folders.flatMap { $0.files.flatMap { $0.versions.map(\.info) } } }
+    private var selectedInfos: [VersionInfo] { allInfos.filter { selection.contains($0.id) } }
+    private var totalSize: Int64 { allInfos.reduce(0) { $0 + $1.size } }
+    private var selectedSize: Int64 { selectedInfos.reduce(0) { $0 + $1.size } }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider()
+            toolbar
+            Divider()
+            content
+            Divider()
+            footer
+        }
+        .frame(width: 720, height: 560)
+        .task(id: refreshToken) { await reload() }
+        .confirmationDialog(
+            "Delete \(pendingTargets.count) version\(pendingTargets.count == 1 ? "" : "s")?",
+            isPresented: $confirmClear, titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) { performRemove(pendingTargets) }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("This permanently deletes the selected saved versions. It can't be undone.")
+        }
+        .alert("Couldn't delete some versions",
+               isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
+            Button("OK") { errorMessage = nil }
+        } message: { Text(errorMessage ?? "") }
+    }
+
+    // MARK: Sections
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: 14) {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.system(size: 34))
+                .foregroundStyle(.tint)
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Version History").font(.headline)
+                Text("Auto Save keeps past versions of your documents. Review and delete them to reclaim disk space. Only documents Edmund knows about are shown — use Scan Folder to add more.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(16)
+    }
+
+    private var toolbar: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
+            TextField("Search filename or path", text: $query)
+                .textFieldStyle(.plain)
+            Spacer()
+            Button { scanFolder() } label: { Label("Scan Folder…", systemImage: "folder.badge.plus") }
+            Button { refreshToken += 1 } label: { Image(systemName: "arrow.clockwise") }
+                .help("Refresh")
+        }
+        .padding(.horizontal, 16).padding(.vertical, 8)
+    }
+
+    @ViewBuilder private var content: some View {
+        if isLoading {
+            centered { ProgressView() }
+        } else if displayed.isEmpty {
+            centered {
+                Text(folders.isEmpty ? "No version history found for these documents."
+                                     : "No matches.")
+                    .foregroundStyle(.secondary)
+            }
+        } else {
+            List {
+                ForEach(displayed) { folder in
+                    DisclosureGroup {
+                        ForEach(folder.files) { file in
+                            DisclosureGroup {
+                                ForEach(file.versions) { v in versionRow(v) }
+                            } label: { fileRow(file) }
+                        }
+                    } label: { folderRow(folder) }
+                }
+            }
+            .listStyle(.inset)
+        }
+    }
+
+    private var footer: some View {
+        VStack(spacing: 10) {
+            HStack {
+                DatePicker("Delete versions before", selection: $beforeDate, displayedComponents: .date)
+                    .datePickerStyle(.compact)
+                    .fixedSize()
+                Button("Delete Before Date…") {
+                    confirm(versions(olderThan: beforeDate, in: allInfos))
+                }
+                .disabled(allInfos.allSatisfy { $0.date >= beforeDate })
+                Spacer()
+            }
+            HStack {
+                Text("Selected: \(byteString(selectedSize))").foregroundStyle(.secondary)
+                Text("·").foregroundStyle(.tertiary)
+                Text("Total: \(byteString(totalSize))").foregroundStyle(.secondary)
+                Spacer()
+                Button("Done") { dismiss() }
+                Button("Delete Selected…") { confirm(selectedInfos) }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(selection.isEmpty)
+            }
+        }
+        .padding(16)
+    }
+
+    // MARK: Rows
+
+    private func folderRow(_ folder: FolderNode) -> some View {
+        let all = folder.files.flatMap { $0.versions.map(\.id) }
+        return row(check: checkState(all),
+                   toggle: { toggle(all) },
+                   icon: "folder",
+                   title: folder.name,
+                   subtitle: folder.displayPath,
+                   size: folder.size)
+    }
+
+    private func fileRow(_ file: FileNode) -> some View {
+        let ids = file.versions.map(\.id)
+        return row(check: checkState(ids),
+                   toggle: { toggle(ids) },
+                   icon: "doc.text",
+                   title: file.name,
+                   subtitle: "\(file.versions.count) version\(file.versions.count == 1 ? "" : "s")",
+                   size: file.size)
+    }
+
+    private func versionRow(_ v: VersionNode) -> some View {
+        row(check: selection.contains(v.id) ? .on : .off,
+            toggle: { toggle([v.id]) },
+            icon: "clock",
+            title: v.date.formatted(date: .abbreviated, time: .shortened),
+            subtitle: nil,
+            size: v.size)
+    }
+
+    private func row(check: CheckState, toggle: @escaping () -> Void,
+                     icon: String, title: String, subtitle: String?, size: Int64) -> some View {
+        HStack(spacing: 8) {
+            checkbox(check, toggle)
+            Image(systemName: icon).foregroundStyle(.secondary).frame(width: 16)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                if let subtitle { Text(subtitle).font(.caption).foregroundStyle(.secondary).lineLimit(1).truncationMode(.middle) }
+            }
+            Spacer()
+            Text(byteString(size)).foregroundStyle(.secondary).monospacedDigit()
+        }
+    }
+
+    private func checkbox(_ s: CheckState, _ action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: s == .on ? "checkmark.square.fill"
+                            : s == .mixed ? "minus.square.fill" : "square")
+                .foregroundStyle(s == .off ? Color.secondary : Color.accentColor)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func centered<V: View>(@ViewBuilder _ v: () -> V) -> some View {
+        VStack { Spacer(); v(); Spacer() }.frame(maxWidth: .infinity)
+    }
+
+    // MARK: Selection
+
+    private func checkState(_ ids: [URL]) -> CheckState {
+        let n = ids.filter(selection.contains).count
+        return n == 0 ? .off : (n == ids.count ? .on : .mixed)
+    }
+
+    private func toggle(_ ids: [URL]) {
+        if checkState(ids) == .on { selection.subtract(ids) } else { selection.formUnion(ids) }
+    }
+
+    // MARK: Actions
+
+    private func reload() async {
+        isLoading = true
+        let urls = Array(Set(candidateDocumentURLs() + scannedURLs))
+        let infos = await Task.detached { VersionHistoryStore.gather(urls: urls) }.value
+        folders = buildVersionTree(infos)
+        selection.formIntersection(Set(infos.map(\.id)))   // drop ids that no longer exist
+        isLoading = false
+    }
+
+    private func confirm(_ targets: [VersionInfo]) {
+        guard !targets.isEmpty else { return }
+        pendingTargets = targets
+        confirmClear = true
+    }
+
+    private func performRemove(_ targets: [VersionInfo]) {
+        Task {
+            let errors = await Task.detached { VersionHistoryStore.remove(targets) }.value
+            selection.subtract(targets.map(\.id))
+            if !errors.isEmpty { errorMessage = errors.first?.localizedDescription }
+            refreshToken += 1
+        }
+    }
+
+    private func scanFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.prompt = "Scan"
+        panel.message = "Choose a folder to scan for Markdown files with version history"
+        guard panel.runModal() == .OK, let dir = panel.url else { return }
+        Task {
+            let found = await Task.detached { VersionHistoryStore.scanFolder(dir) }.value
+            scannedURLs = Array(Set(scannedURLs + found))
+            refreshToken += 1
+        }
+    }
+}
+
+private func byteString(_ n: Int64) -> String {
+    ByteCountFormatter.string(fromByteCount: n, countStyle: .file)
+}

--- a/Sources/edmd/Settings/VersionHistoryView.swift
+++ b/Sources/edmd/Settings/VersionHistoryView.swift
@@ -17,8 +17,6 @@ private func candidateDocumentURLs() -> [URL] {
     return urls.filter { FileManager.default.fileExists(atPath: $0.path) && seen.insert($0).inserted }
 }
 
-private enum CheckState { case on, off, mixed }
-
 struct VersionHistoryView: View {
     @Environment(\.dismiss) private var dismiss
 
@@ -29,16 +27,23 @@ struct VersionHistoryView: View {
     @State private var scannedURLs: [URL] = []
     @State private var isLoading = false
     @State private var refreshToken = 0
+    @State private var showingCalendar = false
+
+    /// Outline rows, rebuilt only when the data or the search query changes —
+    /// NSOutlineView keys off object identity, so rebuilding per body pass
+    /// would collapse the tree on every checkbox click.
+    @State private var roots: [VersionOutlineItem] = []
 
     @State private var pendingTargets: [VersionInfo] = []
     @State private var confirmClear = false
     @State private var errorMessage: String?
 
-    private var displayed: [FolderNode] { filterVersionTree(folders, query: query) }
     private var allInfos: [VersionInfo] { folders.flatMap { $0.files.flatMap { $0.versions.map(\.info) } } }
     private var selectedInfos: [VersionInfo] { allInfos.filter { selection.contains($0.id) } }
     private var totalSize: Int64 { allInfos.reduce(0) { $0 + $1.size } }
     private var selectedSize: Int64 { selectedInfos.reduce(0) { $0 + $1.size } }
+    /// Checked versions older than the cutoff — exactly what Delete removes.
+    private var deleteTargets: [VersionInfo] { selectedInfos.filter { $0.date < beforeDate } }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -52,6 +57,7 @@ struct VersionHistoryView: View {
         }
         .frame(width: 720, height: 560)
         .task(id: refreshToken) { await reload() }
+        .onChange(of: query) { rebuildRoots() }
         .confirmationDialog(
             "Delete \(pendingTargets.count) version\(pendingTargets.count == 1 ? "" : "s")?",
             isPresented: $confirmClear, titleVisibility: .visible
@@ -101,38 +107,30 @@ struct VersionHistoryView: View {
     @ViewBuilder private var content: some View {
         if isLoading {
             centered { ProgressView() }
-        } else if displayed.isEmpty {
+        } else if roots.isEmpty {
             centered {
                 Text(folders.isEmpty ? "No version history found for these documents."
                                      : "No matches.")
                     .foregroundStyle(.secondary)
             }
         } else {
-            List {
-                ForEach(displayed) { folder in
-                    DisclosureGroup {
-                        ForEach(folder.files) { file in
-                            DisclosureGroup {
-                                ForEach(file.versions) { v in versionRow(v) }
-                            } label: { fileRow(file) }
-                        }
-                    } label: { folderRow(folder) }
-                }
-            }
-            .listStyle(.inset)
+            VersionOutline(roots: roots, selection: $selection)
         }
     }
 
     private var footer: some View {
         VStack(spacing: 10) {
-            HStack {
-                DatePicker("Delete versions before", selection: $beforeDate, displayedComponents: .date)
-                    .datePickerStyle(.compact)
-                    .fixedSize()
-                Button("Delete Before Date…") {
-                    confirm(versions(olderThan: beforeDate, in: allInfos))
+            HStack(spacing: 8) {
+                Text("Delete versions before")
+                Button(beforeDate.formatted(.dateTime.month(.twoDigits).day(.twoDigits).year())) {
+                    showingCalendar = true
                 }
-                .disabled(allInfos.allSatisfy { $0.date >= beforeDate })
+                .popover(isPresented: $showingCalendar, arrowEdge: .bottom) {
+                    DatePicker("", selection: $beforeDate, displayedComponents: .date)
+                        .datePickerStyle(.graphical)
+                        .labelsHidden()
+                        .padding(12)
+                }
                 Spacer()
             }
             HStack {
@@ -141,81 +139,20 @@ struct VersionHistoryView: View {
                 Text("Total: \(byteString(totalSize))").foregroundStyle(.secondary)
                 Spacer()
                 Button("Done") { dismiss() }
-                Button("Delete Selected…") { confirm(selectedInfos) }
-                    .keyboardShortcut(.defaultAction)
-                    .disabled(selection.isEmpty)
+                // Count in the title makes the date cutoff visible: checked
+                // versions newer than it aren't included.
+                Button(deleteTargets.isEmpty ? "Delete…" : "Delete \(deleteTargets.count)…") {
+                    confirm(deleteTargets)
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(deleteTargets.isEmpty)
             }
         }
         .padding(16)
     }
 
-    // MARK: Rows
-
-    private func folderRow(_ folder: FolderNode) -> some View {
-        let all = folder.files.flatMap { $0.versions.map(\.id) }
-        return row(check: checkState(all),
-                   toggle: { toggle(all) },
-                   icon: "folder",
-                   title: folder.name,
-                   subtitle: folder.displayPath,
-                   size: folder.size)
-    }
-
-    private func fileRow(_ file: FileNode) -> some View {
-        let ids = file.versions.map(\.id)
-        return row(check: checkState(ids),
-                   toggle: { toggle(ids) },
-                   icon: "doc.text",
-                   title: file.name,
-                   subtitle: "\(file.versions.count) version\(file.versions.count == 1 ? "" : "s")",
-                   size: file.size)
-    }
-
-    private func versionRow(_ v: VersionNode) -> some View {
-        row(check: selection.contains(v.id) ? .on : .off,
-            toggle: { toggle([v.id]) },
-            icon: "clock",
-            title: v.date.formatted(date: .abbreviated, time: .shortened),
-            subtitle: nil,
-            size: v.size)
-    }
-
-    private func row(check: CheckState, toggle: @escaping () -> Void,
-                     icon: String, title: String, subtitle: String?, size: Int64) -> some View {
-        HStack(spacing: 8) {
-            checkbox(check, toggle)
-            Image(systemName: icon).foregroundStyle(.secondary).frame(width: 16)
-            VStack(alignment: .leading, spacing: 1) {
-                Text(title)
-                if let subtitle { Text(subtitle).font(.caption).foregroundStyle(.secondary).lineLimit(1).truncationMode(.middle) }
-            }
-            Spacer()
-            Text(byteString(size)).foregroundStyle(.secondary).monospacedDigit()
-        }
-    }
-
-    private func checkbox(_ s: CheckState, _ action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Image(systemName: s == .on ? "checkmark.square.fill"
-                            : s == .mixed ? "minus.square.fill" : "square")
-                .foregroundStyle(s == .off ? Color.secondary : Color.accentColor)
-        }
-        .buttonStyle(.plain)
-    }
-
     private func centered<V: View>(@ViewBuilder _ v: () -> V) -> some View {
         VStack { Spacer(); v(); Spacer() }.frame(maxWidth: .infinity)
-    }
-
-    // MARK: Selection
-
-    private func checkState(_ ids: [URL]) -> CheckState {
-        let n = ids.filter(selection.contains).count
-        return n == 0 ? .off : (n == ids.count ? .on : .mixed)
-    }
-
-    private func toggle(_ ids: [URL]) {
-        if checkState(ids) == .on { selection.subtract(ids) } else { selection.formUnion(ids) }
     }
 
     // MARK: Actions
@@ -226,7 +163,12 @@ struct VersionHistoryView: View {
         let infos = await Task.detached { VersionHistoryStore.gather(urls: urls) }.value
         folders = buildVersionTree(infos)
         selection.formIntersection(Set(infos.map(\.id)))   // drop ids that no longer exist
+        rebuildRoots()
         isLoading = false
+    }
+
+    private func rebuildRoots() {
+        roots = versionOutlineItems(filterVersionTree(folders, query: query))
     }
 
     private func confirm(_ targets: [VersionInfo]) {

--- a/Tests/EdmundTests/VersionHistoryTests.swift
+++ b/Tests/EdmundTests/VersionHistoryTests.swift
@@ -31,6 +31,7 @@ struct VersionHistoryTests {
         #expect(tree.count == 2)                       // Work + Notes
         let workFolder = try! #require(tree.first { $0.name == "Work" })
         #expect(workFolder.files.count == 2)           // spec.md + notes.md
+        #expect(workFolder.versionCount == 3)          // 2 of spec.md + 1 of notes.md
         #expect(workFolder.size == 350)                // 100 + 200 + 50
 
         let spec = try! #require(workFolder.files.first { $0.name == "spec.md" })

--- a/Tests/EdmundTests/VersionHistoryTests.swift
+++ b/Tests/EdmundTests/VersionHistoryTests.swift
@@ -1,0 +1,71 @@
+import Testing
+import Foundation
+@testable import EdmundCore
+
+/// The pure grouping/filtering logic behind the Clear Version History popup.
+/// The NSFileVersion I/O in `VersionHistoryStore` needs the real system store,
+/// so it isn't covered here — only the tree math, which must not need the disk.
+@Suite("Version history")
+struct VersionHistoryTests {
+
+    let work = URL(fileURLWithPath: "/Users/x/Work")
+    let notes = URL(fileURLWithPath: "/Users/x/Notes")
+
+    func info(_ source: String, _ id: String, day: Int, size: Int64) -> VersionInfo {
+        VersionInfo(id: URL(fileURLWithPath: id),
+                    sourceURL: URL(fileURLWithPath: source),
+                    date: Date(timeIntervalSince1970: TimeInterval(day) * 86_400),
+                    size: size)
+    }
+
+    @Test("Groups folder → file → version and sums sizes bottom-up")
+    func grouping() {
+        let infos = [
+            info("/Users/x/Work/spec.md",  "/v/a", day: 2, size: 100),
+            info("/Users/x/Work/spec.md",  "/v/b", day: 1, size: 200),
+            info("/Users/x/Work/notes.md", "/v/c", day: 1, size: 50),
+            info("/Users/x/Notes/todo.md", "/v/d", day: 3, size: 400),
+        ]
+        let tree = buildVersionTree(infos)
+
+        #expect(tree.count == 2)                       // Work + Notes
+        let workFolder = try! #require(tree.first { $0.name == "Work" })
+        #expect(workFolder.files.count == 2)           // spec.md + notes.md
+        #expect(workFolder.size == 350)                // 100 + 200 + 50
+
+        let spec = try! #require(workFolder.files.first { $0.name == "spec.md" })
+        #expect(spec.size == 300)
+        #expect(spec.versions.map(\.size) == [100, 200])   // newest (day 2) first
+    }
+
+    @Test("Search matches filename and filepath, case-insensitive; empty = passthrough")
+    func filtering() {
+        let tree = buildVersionTree([
+            info("/Users/x/Work/spec.md",  "/v/a", day: 1, size: 1),
+            info("/Users/x/Notes/todo.md", "/v/b", day: 1, size: 1),
+        ])
+
+        #expect(filterVersionTree(tree, query: "").count == 2)
+        #expect(filterVersionTree(tree, query: "   ").count == 2)
+
+        // Filename match keeps only the matching file.
+        let byName = filterVersionTree(tree, query: "SPEC")
+        #expect(byName.count == 1)
+        #expect(byName.first?.files.first?.name == "spec.md")
+
+        // Folder-path match keeps the whole folder.
+        let byPath = filterVersionTree(tree, query: "notes")
+        #expect(byPath.first?.name == "Notes")
+    }
+
+    @Test("Before-date cutoff selects strictly older versions")
+    func cutoff() {
+        let infos = [
+            info("/f/a.md", "/v/a", day: 1, size: 1),
+            info("/f/a.md", "/v/b", day: 5, size: 1),
+        ]
+        let cut = Date(timeIntervalSince1970: 3 * 86_400)
+        let old = versions(olderThan: cut, in: infos)
+        #expect(old.map(\.id) == [URL(fileURLWithPath: "/v/a")])
+    }
+}


### PR DESCRIPTION
## What

Three related pieces of work in Settings ▸ General.

**Manage Version History.** macOS Auto Save keeps historical copies of every edited
file in a hidden per-volume store that could not be inspected or cleared from inside
Edmund. A new sheet browses them folder → file → version in a real `NSOutlineView`
(Item / Versions / Size columns, native tri-state checkboxes), with filename/path
search and a "Scan Folder…" button. A single red **Delete** removes the checked
versions older than the date in a stock `NSDatePicker` field.

`NSFileVersion` exposes versions only per known file URL — there is no API to
enumerate every versioned file — so the list covers recent + open documents plus any
folder the user scans. That constraint is documented at the top of the model file.

**A backup when Auto Save is off.** With the toggle off, documents had no safety net
at all: no autosave, no backup file, no crash recovery. `NSDocumentController.autosavingDelay`
was never set, so AppKit's autosave-elsewhere path never ran. It is now driven by the
toggle (30s off / 0 on), giving the TextEdit behaviour — a recovery copy in
`~/Library/Autosave Information/` that never touches the document or the version store.

**Quit when all windows are closed.** Closing the last window quit the app
unconditionally; that is now a preference, off by default, paired with "Reopen windows
from last session" so turning either on turns the other off.

Also removes "When document is changed by another application". Nothing read
`AppSettings.conflictResolution` and there are no `NSFilePresenter` overrides, so the
radio group was a placebo — Edmund has always had stock AppKit behaviour (unedited
documents reload silently; edited ones warn at save). Behaviour is unchanged.

## Verification

- `swift test` — 1280 tests pass. New unit tests cover the version tree: grouping,
  bottom-up size sums, version counts, case-insensitive filename/path search, and the
  before-date cutoff.
- Live in the built bundle, screencapture-verified: the outline's three levels and
  columns, the checkbox cascade, the date field, the red Delete (correctly targeting 4
  of 6 checked versions given the cutoff), and the General pane after each change.
- Autosave-elsewhere verified by hand: 40s of unsaved edits with Auto Save off left the
  file on disk byte-identical.
- The quit preference verified by closing every window in-process — on, the app
  terminates; off, it stays alive with no windows.

The `NSFileVersion` I/O and the settings model live in the `edmd` executable target,
which the test target cannot import, so those parts are live-verified rather than unit
tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)