### PR TITLE
fix(document): restore window contents, and recover unsaved work after a crash

### DIFF
--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -36,8 +36,13 @@ class Document: NSDocument, HeadingNavigable {
 
     /// Content loaded from disk before the editor window exists.
     /// `nonisolated(unsafe)` because `read(from:ofType:)` may be called
-    /// off the main actor, but the value is only consumed on main via `showWindows`.
+    /// off the main actor, but the value is only consumed on main via
+    /// `adoptPendingContent`.
     nonisolated(unsafe) var pendingContent: String?
+
+    /// Content already in the editor but not yet checked for mixed line endings —
+    /// the check shows a sheet, so it waits until the window is on screen.
+    private var contentPendingWarning: String?
 
     // MARK: - Type Registration
     //
@@ -105,10 +110,14 @@ class Document: NSDocument, HeadingNavigable {
         window.titleVisibility = .visible
         window.titlebarAppearsTransparent = false
         window.isMovableByWindowBackground = true
-        // Don't persist/restore document windows: macOS state restoration
-        // otherwise reopens the last-edited file on the next launch, so a fresh
-        // start (or File ▸ New) shows that document instead of a blank Untitled.
-        window.isRestorable = AppSettings.reopenWindows
+        // Restorable for the whole session, whatever "Reopen windows from last
+        // session" says: state restoration is also how AppKit hands back a
+        // document that was open when the app died, and unsaved work should
+        // survive a crash regardless of that preference. A *clean* quit is where
+        // the preference applies — AppDelegate.applicationShouldTerminate turns
+        // this off before terminating when it is disabled, so nothing is archived
+        // and the next launch starts fresh.
+        window.isRestorable = true
         window.minSize = NSSize(width: 320, height: 400)
         window.backgroundColor = NSColor.textBackgroundColor
 
@@ -234,6 +243,8 @@ class Document: NSDocument, HeadingNavigable {
         window.delegate = wc
         window.makeFirstResponder(editor)
         applyToolbarVisibility()
+        // Before the source-mode switch below, which reads the editor's text.
+        adoptPendingContent()
         // Honor the persisted source-mode preference for the editing view.
         if AppSettings.sourceMode { setViewMode(.source) }
         updateStatusBar()
@@ -325,18 +336,36 @@ class Document: NSDocument, HeadingNavigable {
         pendingContent = contents
     }
 
+    /// Moves what `read(from:)` parked in `pendingContent` into the editor.
+    ///
+    /// Called from `makeWindowControllers`, not only from `showWindows`: window
+    /// restoration reopens a document with `display: false` and never calls
+    /// `showWindows`, so hanging the load off that alone left restored — and
+    /// crash-recovered — windows showing an empty buffer while the text sat
+    /// unread in `pendingContent`. Saving such a window wrote that emptiness back
+    /// over the file, since `data(ofType:)` serializes `editor.rawSource`.
+    /// Idempotent: whichever path reaches it first does the work.
+    private func adoptPendingContent() {
+        guard let content = pendingContent, let editor else { return }
+        editor.loadContent(content, unwrapHardWrapping: AppSettings.hardWrapLongLines)
+        // Learn this document's indent from what it actually uses, overriding
+        // the global style for this window only (never writes the setting).
+        if AppSettings.detectIndent, let detected = EditorTextView.detectIndent(in: content) {
+            editor.indentUsesTabs = detected.usesTabs
+            if !detected.usesTabs { editor.indentWidth = detected.width }
+        }
+        pendingContent = nil
+        contentPendingWarning = content
+    }
+
     /// Called after makeWindowControllers when opening an existing file.
     override func showWindows() {
         super.showWindows()
-        if let content = pendingContent {
-            editor?.loadContent(content, unwrapHardWrapping: AppSettings.hardWrapLongLines)
-            // Learn this document's indent from what it actually uses, overriding
-            // the global style for this window only (never writes the setting).
-            if AppSettings.detectIndent, let detected = EditorTextView.detectIndent(in: content) {
-                editor?.indentUsesTabs = detected.usesTabs
-                if !detected.usesTabs { editor?.indentWidth = detected.width }
-            }
-            pendingContent = nil
+        adoptPendingContent()
+        // Deferred to here because the warning is a sheet: by the time the content
+        // is adopted (in makeWindowControllers) there is no window to attach it to.
+        if let content = contentPendingWarning {
+            contentPendingWarning = nil
             warnIfInconsistentLineEndings(in: content)
         }
         updateStatusBar()

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -77,12 +77,26 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         CommandLine.arguments.count <= 1 && AppSettings.startupAction == .createNewDocument
     }
 
+    // Declares that our restorable state is archived with secure coding — not a
+    // switch for whether windows come back. Wiring it to the "Reopen windows"
+    // preference only opted the app into legacy insecure archiving.
     func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
-        AppSettings.reopenWindows
+        true
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         true
+    }
+
+    // Document windows stay restorable all session so a crash can hand back
+    // unsaved work (Document.makeWindowControllers). On a clean quit, honor
+    // "Reopen windows from last session" instead: drop the flag before AppKit
+    // archives the window state, so the next launch has nothing to restore.
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        if !AppSettings.reopenWindows {
+            for window in NSApp.windows { window.isRestorable = false }
+        }
+        return .terminateNow
     }
 
     // Reopen a new untitled document when the app is activated with no windows.


### PR DESCRIPTION
## What

Two defects in the document restoration path, found while crash-testing autosave.

**A restored window came back blank.** Right title, empty editor, while the file on
disk still had its contents — and saving that window wrote the emptiness back over the
file, since `data(ofType:)` serializes `editor.rawSource`.

`read(from:)` parks the text in `pendingContent` because it can run off the main actor
before any editor exists. The only consumer was `showWindows()`, but restoration
reopens a document with `display: false` and never calls it, so the text sat unread
forever. It is now adopted in `makeWindowControllers` — the first point where the
editor exists, and the one step the open path and the restore path share.
`showWindows` keeps the mixed-line-endings alert, which needs a window to attach its
sheet to. (CotEditor solves the same problem by loading into its own `textStorage`
inside `read(from:)`; Edmund's storage belongs to the text view, so this is the
earliest equivalent moment.)

**Unsaved work did not survive a crash under default settings.** Window restoration is
also how AppKit hands back a document that was open when the app died, so tying
`window.isRestorable` to "Reopen windows from last session" meant a crash lost every
unsaved edit whenever that preference was off — including the recovery copy AppKit had
just written. Document windows now stay restorable for the session, and the preference
is applied where it belongs: `applicationShouldTerminate` drops the flag on a clean
quit, so the next launch starts fresh.

Also stops returning that preference from `applicationSupportsSecureRestorableState`.
That method declares restorable state is archived with secure coding; using it as a
feature switch only opted the app into legacy insecure archiving. On its own it changed
nothing — confirmed by crash-testing it in isolation before adding the `isRestorable`
change.

## Verification

`swift test` — 1277 tests pass. `Document` and `AppSettings` live in the `edmd`
executable target, which the test target cannot import, so both fixes are verified live
against the built bundle:

- Auto Save and reopen both off: 16 characters typed and never saved, `kill -9`,
  relaunch → the document returns **with the text**. The log settles which file was
  read — `Read 43 bytes` where the file on disk is 27, i.e. the autosave copy, not the
  file. ⌘S then wrote the recovered text through. Repeated on a second file (40 bytes
  vs 23).
- Clean quit with the preference off still restores nothing.
- Across five restore events on the fixed build, no window came back blank; before the
  fix, the blank window reproduced with Auto Save *on*, i.e. with the autosave changes
  inactive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)