### PR TITLE
fix(table): keep wrapped cells in their column, aligned, and clickable

### DIFF
--- a/Sources/EdmundCore/Rendering/EditorTextView+TableRendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+TableRendering.swift
@@ -107,7 +107,12 @@ extension EditorTextView {
             var colStartX: [CGFloat] = []
             var cumX: CGFloat = 0
             for ci in 0..<numCols {
-                colStartX.append(cumX + cellHPad)
+                // Relative to the row's *text* start, which is where a wrapped
+                // cell is drawn from — and that already includes this row's
+                // firstLineHeadIndent (= cellHPad), so the left pad must not be
+                // added again here or the cell sits a pad right of the in-line
+                // cells above and below it.
+                colStartX.append(cumX)
                 cumX += colWidths[ci]
                 if ci < numCols - 1 { borderXOffsets.append(cumX - cellHPad) }
             }

--- a/Sources/EdmundCore/Rendering/EditorTextView+TableRendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+TableRendering.swift
@@ -230,9 +230,21 @@ extension EditorTextView {
                 // "before" kern goes on the char preceding the cell content.
                 if i != 1, i < rowCells.count {
                     for ci in 0..<min(rowCells[i].count, numCols) {
-                        guard !overflowsCol[ci] else { continue }
                         let cr = rowCells[i][ci]
-                        let cellWidth = cr.styled.size().width
+                        // An overflowing cell is redrawn wrapped from its own
+                        // column x, but its real characters still sit in the
+                        // line at `hiddenFont` — so it must kern out its whole
+                        // column too, or every cell after it in the row slides
+                        // left onto its neighbour (#251). Its hidden run is
+                        // measured rather than assumed zero: 0.01 pt advances
+                        // over a long cell would otherwise push the row past
+                        // the container edge and force-wrap the paragraph.
+                        let cellWidth = overflowsCol[ci]
+                            ? NSAttributedString(
+                                string: lineNS.substring(
+                                    with: NSRange(location: cr.start, length: cr.end - cr.start)),
+                                attributes: [.font: hiddenFont]).size().width
+                            : cr.styled.size().width
                         let padding = colWidths[ci] - cellWidth
                         guard padding > 0.5 else { continue }
                         let leadingIdx = (cr.start - 1 >= 0 && lineNS.character(at: cr.start - 1) == 0x7C)
@@ -242,7 +254,9 @@ extension EditorTextView {
                             result.addAttribute(.kern, value: amount,
                                                 range: NSRange(location: lineOffset + idx, length: 1))
                         }
-                        switch aligns[ci] {
+                        // A wrapped cell always draws left-aligned from its
+                        // column start, so all of its slack goes after it.
+                        switch overflowsCol[ci] ? .left : aligns[ci] {
                         case .left:   kern(padding, at: trailingIdx)
                         case .right:  kern(padding, at: leadingIdx)
                         case .center:

--- a/Sources/EdmundCore/Rendering/EditorTextView+TableRendering.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+TableRendering.swift
@@ -90,7 +90,15 @@ extension EditorTextView {
             // screen — the overflow gets wrapped (below) instead. Columns
             // that already fit their fair share keep their natural width.
             let minColWidth = bodyFont.pointSize * 3
-            let available = max(0, availableContentWidth - CGFloat(numCols) * 2 * cellHPad)
+            // Leave the row some slack at the container edge. A right- or
+            // center-aligned column kerns its pad *before* its text, so the
+            // cell's real glyphs sit at the very end of the row's advance;
+            // filling the container exactly then force-wraps the row, because
+            // a trailing pad may hang past the edge but glyphs may not. Same
+            // reason `applyOverlay` caps its kern short of the full width.
+            let rowSlack: CGFloat = 8
+            let available = max(0, availableContentWidth
+                - CGFloat(numCols) * 2 * cellHPad - rowSlack)
             let clamped = distributeColumnWidths(natural: natural, available: available,
                                                  minWidth: minColWidth)
             // Add horizontal padding to each column (space after cell text).
@@ -194,7 +202,8 @@ extension EditorTextView {
                             result.addAttribute(.font, value: hiddenFont, range: hideRange)
                             result.addAttribute(.foregroundColor, value: NSColor.clear, range: hideRange)
                             wraps.append(TableCellWrap(styled: cell.styled, x: colStartX[ci],
-                                                       contentWidth: colWidths[ci] - 2 * cellHPad))
+                                                       contentWidth: colWidths[ci] - 2 * cellHPad,
+                                                       align: aligns[ci], charStart: cell.start))
                         } else {
                             cell.styled.enumerateAttributes(
                                 in: NSRange(location: 0, length: cell.styled.length)
@@ -259,8 +268,11 @@ extension EditorTextView {
                             result.addAttribute(.kern, value: amount,
                                                 range: NSRange(location: lineOffset + idx, length: 1))
                         }
-                        // A wrapped cell always draws left-aligned from its
-                        // column start, so all of its slack goes after it.
+                        // A wrapped cell's slack always goes after it: the pad
+                        // only reserves the column (its characters are hidden
+                        // and the visible text is drawn separately, aligned
+                        // per line), so keeping them at the column start keeps
+                        // them inside the column they belong to.
                         switch overflowsCol[ci] ? .left : aligns[ci] {
                         case .left:   kern(padding, at: trailingIdx)
                         case .right:  kern(padding, at: leadingIdx)

--- a/Sources/EdmundCore/Rendering/EditorTextView+TableSupport.swift
+++ b/Sources/EdmundCore/Rendering/EditorTextView+TableSupport.swift
@@ -46,7 +46,7 @@ func distributeColumnWidths(natural: [CGFloat], available: CGFloat,
 // MARK: - Column Alignment
 
 /// GFM table column alignment, parsed from the separator row's `:` markers.
-enum ColumnAlign: Equatable { case left, center, right }
+public enum ColumnAlign: Hashable { case left, center, right }
 
 /// Parses per-column alignment from a table's separator row (`:--`/`:-:`/`--:`).
 /// `:` on both ends = center, trailing only = right, otherwise left. Padded to

--- a/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+TextKit2.swift
@@ -280,22 +280,32 @@ public final class FragmentOverlay: NSObject, @unchecked Sendable {
 /// this holds what to draw instead. `x` is text-relative (same coordinate
 /// space as `BlockDecoration.tableRow`'s `columnXOffsets`) — the cell's
 /// content start. `contentWidth` is the column's clamped content width (the
-/// width the cell's text must wrap within).
+/// width the cell's text must wrap within). `align` is the column's declared
+/// alignment, applied per drawn line. `charStart` is the cell's first character
+/// as an offset within its row's paragraph, which is what maps a click inside
+/// the drawn text back to a real character (see `cellWrapCharacterIndex`).
 public final class TableCellWrap: NSObject, @unchecked Sendable {
     public let styled: NSAttributedString
     public let x: CGFloat
     public let contentWidth: CGFloat
+    public let align: ColumnAlign
+    public let charStart: Int
     private let cachedHash: Int
 
-    public init(styled: NSAttributedString, x: CGFloat, contentWidth: CGFloat) {
+    public init(styled: NSAttributedString, x: CGFloat, contentWidth: CGFloat,
+                align: ColumnAlign = .left, charStart: Int = 0) {
         let frozenStyled = styled.copy() as! NSAttributedString
         self.styled = frozenStyled
         self.x = x
         self.contentWidth = contentWidth
+        self.align = align
+        self.charStart = charStart
         var hasher = Hasher()
         Self.combine(frozenStyled, into: &hasher)
         hasher.combine(x)
         hasher.combine(contentWidth)
+        hasher.combine(align)
+        hasher.combine(charStart)
         self.cachedHash = hasher.finalize()
     }
 
@@ -303,6 +313,7 @@ public final class TableCellWrap: NSObject, @unchecked Sendable {
         guard let other = object as? TableCellWrap else { return false }
         return other.styled.isEqual(to: styled)
             && other.x == x && other.contentWidth == contentWidth
+            && other.align == align && other.charStart == charStart
     }
 
     public override var hash: Int { cachedHash }
@@ -327,6 +338,25 @@ public final class TableCellWrap: NSObject, @unchecked Sendable {
             }
         }
     }
+}
+
+/// How far one line of a wrapped cell shifts inside its column for the column's
+/// alignment. Trailing whitespace is left out of the line's visual width — a
+/// wrapped line ends with the space it broke on, and counting it would hang a
+/// right-aligned line a space past its column edge.
+func cellWrapLineOffset(_ line: NSTextLineFragment,
+                        contentWidth: CGFloat,
+                        align: ColumnAlign) -> CGFloat {
+    guard align != .left else { return 0 }
+    let text = line.attributedString.attributedSubstring(from: line.characterRange)
+    let trimmed = (text.string as NSString)
+        .rangeOfCharacter(from: CharacterSet.whitespacesAndNewlines.inverted, options: .backwards)
+    guard trimmed.location != NSNotFound else { return 0 }
+    let visible = text.attributedSubstring(
+        from: NSRange(location: 0, length: trimmed.upperBound)).size().width
+    let slack = contentWidth - visible
+    guard slack > 0 else { return 0 }
+    return align == .center ? (slack / 2).rounded() : slack
 }
 
 /// A table row's overflowing cells, one `TableCellWrap` per overflowing cell.
@@ -364,7 +394,7 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
     /// Each overflowing cell's x and pre-laid-out lines, from a detached
     /// scratch text stack sized to the column's content width. The stack
     /// itself is retained (`scratchStacks`) so the line fragments stay valid.
-    private let resolvedCellWraps: [(x: CGFloat, lines: [NSTextLineFragment])]
+    private let resolvedCellWraps: [(wrap: TableCellWrap, lines: [NSTextLineFragment])]
     private let scratchStacks: [(NSTextContentStorage, NSTextLayoutManager, NSTextContainer)]
 
     /// A fenced code block's display language, present only on the block's
@@ -413,7 +443,7 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
         self.codeBlockLabelAnchor = codeBlockLabelAnchor
         self.codeBlockLabelFont = codeBlockLabelFont
         self.invisibles = invisibles
-        var resolved: [(x: CGFloat, lines: [NSTextLineFragment])] = []
+        var resolved: [(wrap: TableCellWrap, lines: [NSTextLineFragment])] = []
         var stacks: [(NSTextContentStorage, NSTextLayoutManager, NSTextContainer)] = []
         for wrap in cellWraps {
             let contentStorage = NSTextContentStorage()
@@ -431,12 +461,54 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
                 lines.append(contentsOf: frag.textLineFragments)
                 return true
             }
-            resolved.append((wrap.x, lines))
+            resolved.append((wrap, lines))
             stacks.append((contentStorage, layoutManager, container))
         }
         self.resolvedCellWraps = resolved
         self.scratchStacks = stacks
         super.init(textElement: textElement, range: range)
+    }
+
+    /// Where a wrapped cell's first line starts, relative to the fragment's
+    /// top: the row's own line box does not start at the fragment's edge (the
+    /// row paragraph reserves `paragraphSpacingBefore` above it), and a wrapped
+    /// cell has to sit on that same line, not above it.
+    private var cellWrapTopInset: CGFloat {
+        textLineFragments.first?.typographicBounds.minY ?? 0
+    }
+
+    /// The paragraph-relative character index under `point` (fragment
+    /// coordinates) when it lands on a wrapped cell's drawn text, else nil.
+    ///
+    /// The cell's real characters are hidden at ~zero advance and one of them
+    /// carries the column's whole kern pad, so the layout manager's own
+    /// hit-testing maps every point in the cell to that single character. The
+    /// scratch layout holds the very characters the document has (styling never
+    /// changes characters — storage == rawSource), so resolving the point
+    /// against it instead is exact.
+    func cellWrapCharacterIndex(for point: CGPoint) -> Int? {
+        for (wrap, lines) in resolvedCellWraps {
+            guard point.x >= wrap.x, point.x <= wrap.x + wrap.contentWidth,
+                  !lines.isEmpty else { continue }
+            var top = cellWrapTopInset
+            for (li, line) in lines.enumerated() {
+                let height = line.typographicBounds.height
+                // Past the last line means the click was in the row's bottom
+                // padding — that still belongs to the last line.
+                guard point.y < top + height || li == lines.count - 1 else {
+                    top += height
+                    continue
+                }
+                let dx = cellWrapLineOffset(line, contentWidth: wrap.contentWidth, align: wrap.align)
+                // The line's own bounds carry the scratch container's stacking
+                // offset; only its x matters here, so probe at its own midY.
+                let local = CGPoint(x: point.x - wrap.x - dx, y: line.typographicBounds.midY)
+                let index = line.characterIndex(for: local)
+                guard index >= 0 else { return nil }
+                return wrap.charStart + index
+            }
+        }
+        return nil
     }
 
     /// Extra row height needed to fit the tallest wrapped cell, beyond the
@@ -604,13 +676,12 @@ final class DecoratedTextLayoutFragment: NSTextLayoutFragment {
         }
         // Overflowing table cells: the real characters are hidden, so draw
         // each cell's pre-wrapped lines here instead, stacked top-down at the
-        // cell's column x. Left-aligned regardless of the column's declared
-        // alignment (ponytail: not requested; upgrade path is the same
-        // per-line x-shift math the kern-based alignment above already uses).
-        for cellWrap in resolvedCellWraps {
-            var y = point.y
-            for line in cellWrap.lines {
-                line.draw(at: CGPoint(x: point.x + cellWrap.x, y: y), in: context)
+        // cell's column x, each line shifted for the column's alignment.
+        for (wrap, lines) in resolvedCellWraps {
+            var y = point.y + cellWrapTopInset
+            for line in lines {
+                let dx = cellWrapLineOffset(line, contentWidth: wrap.contentWidth, align: wrap.align)
+                line.draw(at: CGPoint(x: point.x + wrap.x + dx, y: y), in: context)
                 y += line.typographicBounds.height
             }
         }

--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -596,9 +596,22 @@ public class EditorTextView: NSTextView {
                 return
             }
         }
+        // A wrapped table cell is drawn from a detached layout, so AppKit's own
+        // hit-testing can only ever land on the hidden characters underneath it
+        // (all of which sit at one x). Resolve the click against the drawn text
+        // instead — before `super`, while the table is still rendered — and put
+        // the caret there once the gesture is over. The offset stays valid
+        // across the click's activate-the-table restyle because it is a raw
+        // source offset (storage == rawSource).
+        let wrappedCellCaret = wrappedCellCharIndex(at: event)
         suppressTypewriterCentering = true
         super.mouseDown(with: event)
         suppressTypewriterCentering = false
+        // Only a plain click: a drag or a double-click made a real selection,
+        // and honouring those would collapse it.
+        if let wrappedCellCaret, selectedRange().length == 0 {
+            setSelectedRange(NSRange(location: wrappedCellCaret, length: 0))
+        }
         // `super.mouseDown` returns only after the whole tracking loop (drag +
         // mouse-up) finishes; `sel` in this line is the gesture's net result.
         traceEdit("mouseDown done")
@@ -655,6 +668,27 @@ public class EditorTextView: NSTextView {
               let paraStart = fragment.textElement?.elementRange?.location else { return nil }
         let charIndex = tlm.offset(from: tlm.documentRange.location, to: paraStart) + indexInParagraph
         return charIndex < storage.length ? charIndex : nil
+    }
+
+    /// The storage character index under a mouse event when it lands on the
+    /// drawn text of a wrapped (overflowing) table cell, else nil — see
+    /// `DecoratedTextLayoutFragment.cellWrapCharacterIndex`.
+    func wrappedCellCharIndex(at event: NSEvent) -> Int? {
+        guard let tlm = textLayoutManager,
+              let storage = textStorage, storage.length > 0 else { return nil }
+
+        var point = convert(event.locationInWindow, from: nil)
+        point.x -= textContainerOrigin.x
+        point.y -= textContainerOrigin.y
+
+        guard let fragment = tlm.textLayoutFragment(for: point)
+                as? DecoratedTextLayoutFragment else { return nil }
+        let frame = fragment.layoutFragmentFrame
+        let inFragment = CGPoint(x: point.x - frame.minX, y: point.y - frame.minY)
+        guard let indexInParagraph = fragment.cellWrapCharacterIndex(for: inFragment),
+              let paraStart = fragment.textElement?.elementRange?.location else { return nil }
+        let charIndex = tlm.offset(from: tlm.documentRange.location, to: paraStart) + indexInParagraph
+        return charIndex <= storage.length ? charIndex : nil
     }
 
     /// The raw destination string of the regular link under a mouse event, or

--- a/Tests/EdmundTests/TableWrapRenderingTests.swift
+++ b/Tests/EdmundTests/TableWrapRenderingTests.swift
@@ -98,6 +98,116 @@ struct TableWrapRenderingTests {
         #expect(abs(wrap.x - cellStartX(styled, rowIndex: 2, cellIndex: 1)) < 0.5)
     }
 
+    /// The editor with `source` styled and the caret parked outside the table,
+    /// so its rows are rendered (not shown as raw monospace), plus the layout
+    /// fragment of the table row at `rowIndex`.
+    private func laidOutRow(_ source: String, rowIndex: Int)
+        -> (editor: EditorTextView, fragment: DecoratedTextLayoutFragment, rowStart: Int)? {
+        let editor = makeEditor()
+        let full = source + "\n\nafter"
+        editor.loadContent(full)
+        editor.recompose(cursorInRaw: (full as NSString).length)
+        editor.layoutSubtreeIfNeeded()
+        guard let tlm = editor.textLayoutManager else { return nil }
+        tlm.ensureLayout(for: tlm.documentRange)
+
+        let rowStart = source.components(separatedBy: "\n")[0..<rowIndex]
+            .reduce(0) { $0 + ($1 as NSString).length + 1 }
+        var found: DecoratedTextLayoutFragment?
+        tlm.enumerateTextLayoutFragments(from: tlm.documentRange.location,
+                                         options: [.ensuresLayout]) { fragment in
+            let offset = tlm.offset(from: tlm.documentRange.location,
+                                    to: fragment.rangeInElement.location)
+            if offset == rowStart { found = fragment as? DecoratedTextLayoutFragment }
+            return found == nil
+        }
+        guard let found else { return nil }
+        return (editor, found, rowStart)
+    }
+
+    /// `styled` laid out into lines at `width`, the same way the fragment lays
+    /// a wrapped cell out for drawing.
+    private func scratchLines(_ styled: NSAttributedString, width: CGFloat) -> [NSTextLineFragment] {
+        let contentStorage = NSTextContentStorage()
+        contentStorage.textStorage = NSTextStorage(attributedString: styled)
+        let layoutManager = NSTextLayoutManager()
+        contentStorage.addTextLayoutManager(layoutManager)
+        let container = NSTextContainer(size: NSSize(width: width, height: .greatestFiniteMagnitude))
+        container.lineFragmentPadding = 0
+        layoutManager.textContainer = container
+        var lines: [NSTextLineFragment] = []
+        layoutManager.enumerateTextLayoutFragments(
+            from: layoutManager.documentRange.location, options: [.ensuresLayout]
+        ) { fragment in
+            lines.append(contentsOf: fragment.textLineFragments)
+            return true
+        }
+        return lines
+    }
+
+    @Test("A click inside a wrapped cell resolves to the character it landed on")
+    func clickInsideWrappedCellIsExact() throws {
+        let long = Array(repeating: "overflow", count: 30).joined(separator: " ")
+        let source = "| a | b | c |\n|---|---|---|\n| x | \(long) | y |"
+        let row = try #require(laidOutRow(source, rowIndex: 2))
+        let storage = try #require(row.editor.textStorage)
+        let wrap = try #require(
+            (storage.attribute(.tableCellWraps, at: row.rowStart, effectiveRange: nil)
+                as? TableCellWrapList)?.wraps.first)
+
+        // Sweep the cell's drawn width: without the wrap-aware mapping every
+        // one of these lands on the single character carrying the column's
+        // kern pad, so the indices must both move and stay inside the cell.
+        var indices: [Int] = []
+        for x in stride(from: wrap.x + 2, to: wrap.x + wrap.contentWidth, by: 20) {
+            let point = CGPoint(x: x, y: row.fragment.layoutFragmentFrame.height / 4)
+            if let index = row.fragment.cellWrapCharacterIndex(for: point) {
+                indices.append(index)
+            }
+        }
+        #expect(indices.count > 5)
+        #expect(Set(indices).count > 5)
+        #expect(indices == indices.sorted())
+        // Every hit is inside the cell, and the text there is the cell's.
+        let cellRange = NSRange(location: wrap.charStart, length: wrap.styled.length)
+        #expect(indices.allSatisfy { NSLocationInRange($0, cellRange) })
+    }
+
+    @Test("Wrapped cell lines shift for a centered or right-aligned column")
+    func wrappedCellHonorsColumnAlignment() throws {
+        let long = Array(repeating: "overflow", count: 30).joined(separator: " ")
+        for (separator, align) in [("|---|:-:|---|", ColumnAlign.center),
+                                   ("|---|--:|---|", ColumnAlign.right)] {
+            let source = "| a | b | c |\n\(separator)\n| x | \(long) | y |"
+            let row = try #require(laidOutRow(source, rowIndex: 2))
+            let storage = try #require(row.editor.textStorage)
+            let wrap = try #require(
+                (storage.attribute(.tableCellWraps, at: row.rowStart, effectiveRange: nil)
+                    as? TableCellWrapList)?.wraps.first)
+            #expect(wrap.align == align)
+
+            // The last line is the short one, so it has slack to distribute;
+            // a full line has none either way.
+            let last = try #require(scratchLines(wrap.styled, width: wrap.contentWidth).last)
+            let offset = cellWrapLineOffset(last, contentWidth: wrap.contentWidth, align: align)
+            #expect(offset > 0)
+            #expect(cellWrapLineOffset(last, contentWidth: wrap.contentWidth, align: .left) == 0)
+            if align == .right {
+                // Right-aligned means the line's *visible* text ends at the
+                // column edge. The cell's trailing space (`… |`) is excluded
+                // on purpose — counting it would push the text a space short.
+                let text = last.attributedString.attributedSubstring(from: last.characterRange)
+                let full = text.size().width
+                let lastInk = (text.string as NSString).rangeOfCharacter(
+                    from: CharacterSet.whitespacesAndNewlines.inverted, options: .backwards)
+                let visible = text.attributedSubstring(
+                    from: NSRange(location: 0, length: lastInk.upperBound)).size().width
+                #expect(abs(offset + visible - wrap.contentWidth) < 0.5)
+                #expect(full > visible)
+            }
+        }
+    }
+
     @Test("Table storage stays byte-for-byte unchanged when a cell wraps")
     func storageUnchangedByWrapping() {
         let editor = makeEditor()

--- a/Tests/EdmundTests/TableWrapRenderingTests.swift
+++ b/Tests/EdmundTests/TableWrapRenderingTests.swift
@@ -52,6 +52,36 @@ struct TableWrapRenderingTests {
         #expect(wrap.contentWidth > 0)
     }
 
+    /// Advance width from the start of `rowIndex`'s line to the start of its
+    /// `cellIndex`-th cell — i.e. where that cell's glyphs actually land.
+    private func cellStartX(_ styled: NSAttributedString,
+                            rowIndex: Int, cellIndex: Int) -> CGFloat {
+        let lines = styled.string.components(separatedBy: "\n")
+        var rowStart = 0
+        for i in 0..<rowIndex { rowStart += (lines[i] as NSString).length + 1 }
+        let cells = cellRanges(in: lines[rowIndex] as NSString)
+        let run = NSRange(location: rowStart, length: cells[cellIndex].start)
+        return styled.attributedSubstring(from: run).size().width
+    }
+
+    @Test("A cell after a wrapping cell still starts at its column's x (#251)")
+    func cellAfterWrapKeepsColumnX() {
+        let editor = makeEditor()
+        let longText = Array(repeating: "overflow", count: 30).joined(separator: " ")
+        let source = "| a | b | c |\n|---|---|---|\n| x | \(longText) | y |\n| p | q | r |"
+        let styled = editor.styleBlock(source, cursorPosition: nil)
+
+        // Row 2 wraps its middle cell; row 3 doesn't. Both must put their
+        // third cell at the same x — the wrapping cell's hidden characters
+        // still have to reserve their whole column.
+        let wrapRowStart = (source.components(separatedBy: "\n")[0...1]
+            .map { ($0 as NSString).length + 1 }).reduce(0, +)
+        #expect(!cellWraps(at: wrapRowStart, in: styled).isEmpty)
+        let wrapped = cellStartX(styled, rowIndex: 2, cellIndex: 2)
+        let plain = cellStartX(styled, rowIndex: 3, cellIndex: 2)
+        #expect(abs(wrapped - plain) < 1)
+    }
+
     @Test("Table storage stays byte-for-byte unchanged when a cell wraps")
     func storageUnchangedByWrapping() {
         let editor = makeEditor()

--- a/Tests/EdmundTests/TableWrapRenderingTests.swift
+++ b/Tests/EdmundTests/TableWrapRenderingTests.swift
@@ -82,6 +82,22 @@ struct TableWrapRenderingTests {
         #expect(abs(wrapped - plain) < 1)
     }
 
+    @Test("A wrapped cell draws from the same x its in-line characters would")
+    func wrapDrawXMatchesInlineCellX() {
+        let editor = makeEditor()
+        let longText = Array(repeating: "overflow", count: 30).joined(separator: " ")
+        let source = "| a | b | c |\n|---|---|---|\n| x | \(longText) | y |"
+        let styled = editor.styleBlock(source, cursorPosition: nil)
+        let rowStart = lastRowStart(styled)
+
+        // `x` is relative to the row's text start, which the drawing code
+        // passes in already indented by the cell padding.
+        let wraps = cellWraps(at: rowStart, in: styled)
+        #expect(wraps.count == 1)
+        guard let wrap = wraps.first else { return }
+        #expect(abs(wrap.x - cellStartX(styled, rowIndex: 2, cellIndex: 1)) < 0.5)
+    }
+
     @Test("Table storage stays byte-for-byte unchanged when a cell wraps")
     func storageUnchangedByWrapping() {
         let editor = makeEditor()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -719,7 +719,9 @@ Notable subsystems:
   only wraps a whole paragraph at the container edge and has no per-cell
   flow region (that's NSTextTable/NSTextBlock, banned per §2).
   Click-to-caret inside a wrapped, non-active cell is approximate as a
-  result. Interior data rows draw a full-width bottom grid line (`.tableRow`'s
+  result. Such a cell still kerns out its full column: its hidden characters
+  advance ~nothing, so without that pad every cell after it in the row slid
+  left onto its neighbour (#251). Interior data rows draw a full-width bottom grid line (`.tableRow`'s
   `bottomBorder`) — the header/body boundary already gets its line from
   `separator`, and the last row draws none, so the table's bottom edge is open
   like its left and right edges.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -718,10 +718,20 @@ Notable subsystems:
   the visual yourself" pattern as `.fragmentOverlay`, needed because TK2
   only wraps a whole paragraph at the container edge and has no per-cell
   flow region (that's NSTextTable/NSTextBlock, banned per §2).
-  Click-to-caret inside a wrapped, non-active cell is approximate as a
-  result. Such a cell still kerns out its full column: its hidden characters
+  Such a cell still kerns out its full column: its hidden characters
   advance ~nothing, so without that pad every cell after it in the row slid
-  left onto its neighbour (#251). Interior data rows draw a full-width bottom grid line (`.tableRow`'s
+  left onto its neighbour (#251). Its drawn lines carry the column's
+  alignment individually, and a click inside one is resolved against the
+  scratch layout (`cellWrapCharacterIndex`, used from `mouseDown`) rather
+  than the hidden characters — all of which sit at one x, so AppKit's own
+  hit-testing would answer the same character everywhere in the cell. Two
+  geometry traps: the fragment's draw point is the row's *text* start
+  (already indented by the cell pad, like `.tableRow`'s `leftInset`), and a
+  row's own line box starts below its `paragraphSpacingBefore` — a wrapped
+  cell has to match both or it draws a pad right of, and a hair above, the
+  in-line cells beside it. Column widths also leave the row a little slack
+  at the container edge, or a right-aligned column's glyphs reach the edge
+  and force-wrap the row. Interior data rows draw a full-width bottom grid line (`.tableRow`'s
   `bottomBorder`) — the header/body boundary already gets its line from
   `separator`, and the last row draws none, so the table's bottom edge is open
   like its left and right edges.


### PR DESCRIPTION
Fixes #251.

A table cell wider than its (clamped) column is rendered by hiding its real
characters and redrawing them, wrapped, from a detached scratch layout. Three
defects lived in the seam between those hidden characters and the drawn text.

### The reported bug (#251)

The kern loop skipped overflowing cells entirely, so the hidden run reserved
~no advance — and every cell *after* it in the row slid left onto its
neighbour. That is the misalignment in the issue's screenshot: the third
column's values painted on top of column two, but only on rows that had an
overflowing cell.

Overflowing cells now kern out their whole column. The hidden run is measured
rather than assumed zero, so 0.01 pt advances over a long cell can't push the
row past the container edge and force-wrap the paragraph.

### Two more found while verifying

- **A pad of horizontal drift.** `TableCellWrap.x` was the column start
  *including* its left padding, but the fragment's draw point is the row's
  *text* start, which already carries the row paragraph's
  `firstLineHeadIndent`. The pad applied twice, so a wrapped cell's text sat
  one pad right of the in-line cells above and below it in the same column.
  Measured on the issue's table: wrapped row at px 1340, plain rows at 1331,
  same first glyph.
- **A half-line of vertical drift.** The drawn lines stacked from the
  fragment's top edge, but a row's own line box starts below its
  `paragraphSpacingBefore`.

### Alignment and caret

Wrapped cells previously ignored `:-:` / `--:` and always drew left, and they
swallowed clicks: because one hidden character carries the column's whole kern
pad, the layout manager answered that same character for *every* point in the
cell — you could not click into the middle of a wrapped cell's text at all.

- Each drawn line now shifts for the column's alignment, measured without its
  trailing whitespace (a wrapped line ends on the space it broke at; counting
  it leaves right-aligned text a space short of the edge).
- Clicks resolve against the scratch layout, which holds the very characters
  the document has (storage == rawSource), so the offset is exact. `mouseDown`
  applies it after the gesture and only when no real selection was made, so
  drags and double-clicks are untouched.

Right-aligning a column then exposed one more: the pad kerns *before* the
text, so the glyphs sit at the very end of the row's advance, and a table that
filled the container exactly force-wrapped the row. Rows now reserve a little
slack at the container edge — the same idiom as `applyOverlay`'s kern cap.
Side effect: tables are 8 pt narrower, so a borderline cell may wrap where it
previously didn't.

### Verification

- `swift test` — 1284 tests in 181 suites, green.
- Six new tests, covering the column-x invariant (#251), the wrap draw x, the
  per-line alignment offset including the trailing-space trim, and a sweep of
  click points across a wrapped cell asserting the resolved indices move and
  stay inside the cell.
- Live `screencapture` of the issue's CJK table, plain and with
  `| --- | :-: | ---: |`.

One gap worth naming: CGEvent posting is blocked in this environment and the
repro rig only replays keystrokes, so the click *wiring* is unit-tested and
reviewed rather than clicked live. The coordinate conversion it uses is taken
verbatim from `clickCharIndex`, which already ships for ⌘-click links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)