### PR TITLE
fix(window): untie the initial window size from its minimum, and make the default canonical

### DIFF
--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -98,7 +98,7 @@ class Document: NSDocument, HeadingNavigable {
         // full window frame at the end of setup (below), once the toolbar is in
         // place — so the frame round-trips exactly and doesn't drift by the
         // title bar + toolbar height each time.
-        let windowWidth: CGFloat = 200
+        let windowWidth: CGFloat = 800
         let windowHeight: CGFloat = 560
 
         let window = DocumentWindow(
@@ -118,7 +118,7 @@ class Document: NSDocument, HeadingNavigable {
         // this off before terminating when it is disabled, so nothing is archived
         // and the next launch starts fresh.
         window.isRestorable = true
-        window.minSize = NSSize(width: 200, height: 400)
+        window.minSize = NSSize(width: 320, height: 400)
         window.backgroundColor = NSColor.textBackgroundColor
 
         // Build the TextKit 2 text system chain (viewport-based layout).

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -98,8 +98,13 @@ class Document: NSDocument, HeadingNavigable {
         // full window frame at the end of setup (below), once the toolbar is in
         // place — so the frame round-trips exactly and doesn't drift by the
         // title bar + toolbar height each time.
+        //
+        // Sized so the *window* lands on a canonical 800x600: the height is the
+        // content area, and the title bar + unified toolbar add 80pt on top.
+        // The width also leaves the reading column (12cm / 5in physical, ~605pt
+        // on a 14" display) balanced margins rather than being arbitrary.
         let windowWidth: CGFloat = 800
-        let windowHeight: CGFloat = 560
+        let windowHeight: CGFloat = 520
 
         let window = DocumentWindow(
             contentRect: NSRect(x: 0, y: 0, width: windowWidth, height: windowHeight),

--- a/Sources/edmd/App/FindController.swift
+++ b/Sources/edmd/App/FindController.swift
@@ -30,6 +30,17 @@ final class FindController: NSObject, EditorFindHandling {
 
         bar.isHidden = true
         bar.autoresizingMask = [.width, .minYMargin]   // pinned to the top edge
+        // Park it at the container's full width, not the default zero frame.
+        // A flexible-width autoresizing view only grows by the *delta* from the
+        // width it was added at, so a zero-width bar reaches the minimum width
+        // its own (required) constraints demand — the fields and buttons — only
+        // once the window is that much wider than it started. AppKit turns that
+        // into the window's contentMinSize, which both pins the minimum width to
+        // `initial width + bar minimum` and inflates the opening frame to match,
+        // leaving `window.minSize` moot. Sized here, the bar tracks the container
+        // and the window's own minSize governs again. `layoutBar` positions it
+        // (and sets the content inset) on every show.
+        bar.setFrameSize(NSSize(width: container.bounds.width, height: bar.preferredHeight))
         // Below the floating status bar so counts stay on top.
         container.addSubview(bar, positioned: .below, relativeTo: statusBar)
 

--- a/Tests/EdmundTests/WindowMinSizeTests.swift
+++ b/Tests/EdmundTests/WindowMinSizeTests.swift
@@ -1,0 +1,55 @@
+import Testing
+import AppKit
+import EdmundCore
+@testable import edmd
+
+/// The find bar must not decide how small the document window can get.
+///
+/// It is frame-managed (`autoresizingMask`), but its *contents* are laid out by
+/// Auto Layout, so its required constraints reach the window as a
+/// `contentMinSize`. A flexible-width autoresizing view only grows by the delta
+/// from the width it was added at — so a bar parked at the default zero frame
+/// only reaches the width its fields and buttons demand once the window is that
+/// much wider than it opened. AppKit then took the minimum to be
+/// `initial width + bar minimum` and inflated the opening frame to match, which
+/// tied the window's initial size to its minimum and left `window.minSize`
+/// doing nothing: an 800pt default opened at 1014pt and refused to shrink below
+/// it, and dropping `minSize` to 320 changed neither number.
+///
+/// Only the live window server applies that minimum, so the window-level
+/// symptom can't be asserted in-process (a headless `NSWindow` happily reports
+/// a small `contentMinSize` and shrinks either way — both were tried, and both
+/// passed against the bug). What is checkable here is the invariant the fix
+/// rests on: the parked bar spans its container, so autoresizing keeps it
+/// there instead of chasing the width the window opened at. Measured against
+/// the running app: 800pt default → opens 800, shrinks to the 320 `minSize`.
+@MainActor
+@Suite("Document window minimum size")
+struct WindowMinSizeTests {
+
+    @Test("The parked find bar spans the container")
+    func parkedBarSpansContainer() {
+        let width: CGFloat = 800, height: CGFloat = 560
+
+        // The document window's view stack, built the way
+        // `makeWindowControllers` builds it: editor in a scroll view, status
+        // bar over it, find bar added last.
+        let editor = EditorTextView.makeTextKit2(
+            frame: NSRect(x: 0, y: 0, width: width, height: height),
+            containerSize: NSSize(width: width, height: CGFloat.greatestFiniteMagnitude)
+        )
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: width, height: height))
+        let scrollView = NSScrollView(frame: container.bounds)
+        scrollView.autoresizingMask = [.width, .height]
+        scrollView.documentView = editor
+        let statusBar = NSView(frame: NSRect(x: 0, y: 0, width: width, height: 22))
+        container.addSubview(scrollView)
+        container.addSubview(statusBar)
+
+        _ = FindController(editor: editor, scrollView: scrollView,
+                           container: container, statusBar: statusBar)
+
+        let bar = container.subviews.first { $0 is FindBarView }
+        #expect(bar?.frame.width == width)
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -574,6 +574,20 @@ Notable subsystems:
   `window.setFrame(_:)` **after the toolbar is installed** (the frame is
   only final then), so frame-in == frame-out (`windowDidResize` ↔
   `makeWindowControllers` in `Document.swift`).
+- **A frame-managed subview parked at the zero frame sets the window's
+  minimum width.** The find bar resizes by `autoresizingMask`, but its
+  contents are Auto Layout, so its required constraints reach the window as
+  a `contentMinSize`. A flexible-width autoresizing view only grows by the
+  *delta* from the width it was added at — so a bar added at `.zero` first
+  reaches the width its fields and buttons need when the window is that much
+  wider than it opened. AppKit reads the minimum as `initial width + bar
+  minimum` and inflates the opening frame to satisfy it: the 800pt default
+  opened at 1014 and would not shrink below it, `window.minSize` was
+  inert (dropping it to 320 moved neither number), and the initial size and
+  the minimum moved together. Fix: size the bar to the container when
+  parking it (`FindController.init`). Note this is invisible to headless
+  tests — only the live window server applies `contentMinSize`, so verify by
+  launching and asking AX to resize the window smaller than it can go.
 - **`NSSearchField`'s magnifier glyph can't be repositioned — draw your
   own.** AppKit draws it ~3.75pt below the field's vertical centre (a 21×15
   image in a rect the field's full 22pt height). Every built-in hook is a


### PR DESCRIPTION
## What

New document windows opened at 1014pt wide from an 800pt default and refused to shrink below that. `window.minSize` was inert — the initial size and the minimum moved together, and the minimum was far too large.

## Root cause

Not `minSize`. `FindController.init` parked the find bar at the default zero frame. The bar resizes by `autoresizingMask` but lays its contents out with Auto Layout, so its required constraints reach the window as a `contentMinSize`. A flexible-width autoresizing view only grows by the *delta* from the width it was added at — so a zero-width bar only reached the width its fields and buttons demand once the window was ~214pt wider than it opened. AppKit read the minimum as `initial width + 214` and inflated the opening frame to satisfy it.

Measured against the running app:

| build | initial | effective min |
|---|---|---|
| before the temp fix (800 / min 320) | 1014 | 1014 |
| temp fix 69ee1da (200 / min 200) | 414 | 414 |
| find bar disabled (proof) | 800 | 320 |
| **fixed** | **800** | **320** |

## Changes

- `FindController.swift` — size the bar to its container when parking it.
- `Document.swift` — revert 69ee1da's temporary 320→200 minimum and 800→200 default. The minimum is back to 320, its value since `d0e48ef` and unchanged until the temp fix.
- `Document.swift` — the default was 800x560 of content, which chrome turned into an 800x640 window. Take the 80pt of title bar + toolbar off the height so the window itself lands on a canonical 800x600. Width unchanged; it already leaves the reading column (12cm / 5in physical, ~605pt on a 14" display) balanced margins.
- `WindowMinSizeTests.swift`, `ARCHITECTURE.md` §8 gotcha.

## Testing

- `swift test` — 1285 tests pass.
- Live verification: launches at 800x600, shrinks to the 320pt minimum, find bar opens and lays out correctly at that minimum width.
- Note the window-level symptom **cannot** be asserted headlessly — only the live window server applies `contentMinSize`. Two window-level tests were written first and both passed *against* the bug, so they were dropped; the test that ships covers the invariant the fix rests on (the parked bar spans its container) and does fail without it.