### PR TITLE
Don't let agents edit README or misc/backlog.md

### DIFF
--- a/.claude/hooks/guard-maintainer-prose.sh
+++ b/.claude/hooks/guard-maintainer-prose.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# PreToolUse guard: the maintainer's own prose is not agent-editable.
+#
+# Blocks Edit/Write/NotebookEdit on the repo-root README.md and misc/backlog.md.
+# Those two are the maintainer's voice — user-facing copy and a hand-sorted
+# priority list — and a "small wording fix" there is invisible without a diff.
+# The rule is written up in .claude/skills/edmund-docs-and-writing/SKILL.md §7;
+# this hook is the part that doesn't rely on an agent having read it.
+#
+# Deliberately narrow:
+#   * The root README only. `docs/architecture/README.md` and any other nested
+#     README are the engineering record — freely editable. "Root" is decided by
+#     `Package.swift` sitting next to the file, not by the session's cwd, so it
+#     holds in every worktree.
+#   * `misc/backlog.md` only. Creating any *other* file under `misc/` is
+#     explicitly fine and needs no permission.
+#   * Read is untouched — agents still need to quote these files.
+set -euo pipefail
+
+path="$(jq -r '.tool_input.file_path // empty')"
+[[ -n "$path" ]] || { echo '{}'; exit 0; }
+
+case "$path" in
+  */misc/backlog.md) what="misc/backlog.md — the maintainer's hand-sorted priority list" ;;
+  */README.md)
+    # Root README only: the one with Package.swift beside it.
+    if [[ -f "$(dirname "$path")/Package.swift" ]]; then
+      what="README.md — the project's user-facing front page"
+    else
+      echo '{}'; exit 0
+    fi
+    ;;
+  *) echo '{}'; exit 0 ;;
+esac
+
+jq -nc --arg what "$what" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: ($what + " is the maintainer'"'"'s prose, not the engineering record. Do not edit it unasked — report the change you would make and let them decide. See .claude/skills/edmund-docs-and-writing/SKILL.md §7. (ARCHITECTURE.md, docs/architecture/**, docs/investigations/** and new files under misc/ are all fair game.)")
+  }
+}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,15 @@
             "command": "jq -r '.tool_input.command // empty' | { read -r cmd; if echo \"$cmd\" | grep -Eq '(^|&&|;|\\|)[[:space:]]*git[[:space:]]+(checkout[[:space:]]+-b|switch[[:space:]]+-c)\\b' || echo \"$cmd\" | grep -Eq '(^|&&|;|\\|)[[:space:]]*git[[:space:]]+branch[[:space:]]+[^-[:space:]][^[:space:]]*([[:space:]]|$)'; then printf '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Edmund prefers git worktrees over branch-switching for concurrent local work: git worktree add .worktrees/<branch> <branch> (branch keeps its normal type/slug name). See CLAUDE.md Git practices / docs/ARCHITECTURE.md \\u00a712.\"}}'; else echo '{}'; fi; }"
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/guard-maintainer-prose.sh\""
+          }
+        ]
       }
     ]
   }

--- a/.claude/skills/edmund-docs-and-writing/SKILL.md
+++ b/.claude/skills/edmund-docs-and-writing/SKILL.md
@@ -9,8 +9,9 @@ description: >
   bug, or feature idea belongs. Covers the docs-of-record map, the
   fact-routing decision table, the investigation-doc template, CHANGELOG
   format (machine-extracted for release notes), commit-message conventions,
-  and doc maintenance duties. Not for making the code change itself, release
-  mechanics, or debugging — see "When NOT to use this skill".
+  doc maintenance duties, and which docs are the maintainer's own prose that
+  agents must not edit unasked (§7). Not for making the code change itself,
+  release mechanics, or debugging — see "When NOT to use this skill".
 ---
 
 # Edmund docs and writing
@@ -243,6 +244,29 @@ Do these whenever you touch the relevant doc; they rot otherwise.
 - **Section renumbering** in ARCHITECTURE: grep the whole repo (docs, misc,
   CLAUDE.md, skills) for `§` references before and after.
 - **Never edit `test-files/todo.md`** — the maintainer owns it.
+
+## 7. Whose prose is it — ask before editing
+
+Some docs are the maintainer's own voice; the rest are the engineering
+record. Agents may write freely in the second group and **not at all** in the
+first without being asked for that specific edit.
+
+| | Files | What an agent may do |
+| --- | --- | --- |
+| **Maintainer's voice — don't edit unasked** | `README.md`, `misc/backlog.md`, and any other user-facing or personal prose (blog drafts, marketing copy, `test-files/todo.md`) | Nothing. Report what you'd change and let the maintainer decide. |
+| **Engineering record — edit freely** | `docs/ARCHITECTURE.md`, `docs/architecture/**`, `docs/investigations/**`, `docs/dev-guides/**`, `.claude/skills/**`, code comments | Write, restructure, correct. The same-PR rule (§2) *requires* it. |
+| **Mixed** | `CHANGELOG.md`, `docs/ROADMAP.md` | Add the mechanical entry — a new bullet, a ticked `- [x]` box, a `Last updated:` bump. Leave the surrounding wording and the maintainer's priority ordering alone. |
+
+`misc/` is the exception in the other direction: **creating** a new file
+there is always fine, no permission needed, and it's the default home for any
+doc that doesn't have one yet (`misc/` is gitignored, so nothing you put
+there lands in a commit). Editing `misc/backlog.md` is still off-limits.
+
+Why this rule exists: a "small wording fix" to README lands in the file
+users read first, in a voice that isn't yours, and the maintainer usually
+can't tell it happened without diffing. A typo in `README.md` is worth one
+line in your report — never a silent commit. This includes uncommenting the
+maintainer's own `<!-- -->` edit notes (§6).
 
 ## Provenance and maintenance
 

--- a/.claude/skills/edmund-docs-and-writing/SKILL.md
+++ b/.claude/skills/edmund-docs-and-writing/SKILL.md
@@ -262,6 +262,13 @@ there is always fine, no permission needed, and it's the default home for any
 doc that doesn't have one yet (`misc/` is gitignored, so nothing you put
 there lands in a commit). Editing `misc/backlog.md` is still off-limits.
 
+The two named files are enforced, not just documented: a `PreToolUse` hook
+(`.claude/hooks/guard-maintainer-prose.sh`, wired in `.claude/settings.json`)
+denies `Edit`/`Write`/`NotebookEdit` on the repo-root `README.md` and
+`misc/backlog.md`. Reading them is untouched. If you get that denial, you are
+not blocked from *working* — report the edit you wanted and move on. The rest
+of the "maintainer's voice" column is on your judgment.
+
 Why this rule exists: a "small wording fix" to README lands in the file
 users read first, in a voice that isn't yours, and the maintainer usually
 can't tell it happened without diffing. A typo in `README.md` is worth one


### PR DESCRIPTION
Two files in this repo are the maintainer's own voice — `README.md` (the
project's front page) and `misc/backlog.md` (a hand-sorted priority list).
Everything else under `docs/` is the engineering record, which agents are
*supposed* to keep current under the same-PR rule.

Nothing marked that boundary, so an agent "fixing a word" in README changed
the file users read first, in a voice that isn't its own, and the change was
invisible without diffing.

## The rule

`.claude/skills/edmund-docs-and-writing/SKILL.md` §7 — a three-row table:

| | Files | What an agent may do |
| --- | --- | --- |
| Maintainer's voice | `README.md`, `misc/backlog.md`, other user-facing prose | Nothing. Report the change instead. |
| Engineering record | `ARCHITECTURE.md`, `docs/architecture/**`, `docs/investigations/**`, `docs/dev-guides/**`, skills, code comments | Edit freely — the same-PR rule requires it. |
| Mixed | `CHANGELOG.md`, `docs/ROADMAP.md` | Add the mechanical entry; leave the wording and priority ordering alone. |

Creating a *new* file under `misc/` stays explicitly permission-free.

## The hook

Documentation holds only as long as an agent has read it, so the two named
files are also enforced: `.claude/hooks/guard-maintainer-prose.sh`, wired as
a `PreToolUse` matcher on `Edit|Write|NotebookEdit`, denies with a reason
pointing back at §7.

Deliberately narrow, and each case exercised directly against the script:

| path | |
| --- | --- |
| root `README.md` | **deny** |
| `misc/backlog.md` | **deny** |
| `docs/architecture/README.md` | allow |
| `docs/ARCHITECTURE.md` | allow |
| a new file under `misc/` | allow |
| a `.swift` file | allow |
| no `file_path` (Bash-shaped input) | allow |

The root README is identified by the `Package.swift` beside it rather than by
the session's cwd, so nested READMEs stay editable and the check holds from
any worktree. `Read` is untouched — agents still need to quote these files.

`swift test`: 1280 tests in 181 suites pass (no source changes here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)