### PR TITLE
chore: ignore local OpenCode config, drop /ship attribution

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -22,20 +22,14 @@ stopping and reporting if any step fails:
    derived from the description). If already on a non-main branch, reuse it.
 
 4. **Commit.** Stage only the files that belong to this change (surgical — no
-   unrelated files). Write a commit message: a concise imperative subject line,
-   a body explaining the *why*, and the trailer:
-   ```
-   Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
-   ```
+   unrelated files). Write a commit message: a concise imperative subject line
+   and a body explaining the *why*. No attribution trailer.
    Keep it one logical change per commit.
 
 5. **Push.** `git push -u origin <branch>`.
 
 6. **Open the PR.** `gh pr create` with a title matching the subject and a body
-   that explains what and why, ending with:
-   ```
-   🤖 Generated with [Claude Code](https://claude.com/claude-code)
-   ```
+   that explains what and why. No generated-by / attribution footer.
 
 7. **Auto-merge.** `gh pr merge <#> --auto --merge --delete-branch`. Branch
    protection requires the `test` check, so this queues the PR to merge itself

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 AGENTS.md
 .agents/
 .codex/
+.opencode/
+opencode.json
 
 # local tooling
 .worktrees/


### PR DESCRIPTION
Sets this repo up to run under OpenCode alongside Claude Code, and removes the attribution stamp from the `/ship` template.

## Why

OpenCode 1.18.12 already discovers `.claude/skills/<name>/SKILL.md` and walks the project tree for `CLAUDE.md`, so all 16 Edmund skills and the root instructions load there with no migration at all (verified live against `opencode serve`: `GET /skill` lists every `edmund-*` / `textkit2-*` skill straight out of `.claude/skills/`).

What OpenCode has no equivalent for is `settings.json` hooks and `.claude/commands/`. Those were ported into an `opencode.json` + `.opencode/` setup: the three `PreToolUse` guards plus a commit gate that runs `swift test` before `git commit` (replacing the `Stop` hook, which has no OpenCode counterpart that can feed output back to the model).

That setup is **deliberately untracked** — it encodes one machine's model/provider wiring and a local plugin path, and is not part of the project's contract with contributors. So this PR only adds the ignore rules, matching how `.claude/settings.json` and `AGENTS.md` are already handled directly above it.

The second commit drops the `Co-Authored-By` trailer and the "Generated with" PR footer from `.claude/commands/ship.md`. The maintainer does not want that mark on this repo's history, and it was also factually wrong under any agent other than the one hardcoded in the template.

## Changes

- `.gitignore` — ignore `.opencode/` and `opencode.json`
- `.claude/commands/ship.md` — no attribution trailer, no generated-by footer

## Test

`swift test` — 1294 tests in 183 suites, all passing.