### PR TITLE
chore(hooks): one source of truth for the agent guards

### DIFF
--- a/.claude/hooks/guard-branch-create.sh
+++ b/.claude/hooks/guard-branch-create.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash): creating a branch means reaching for a worktree instead.
+#
+# Was an inline jq one-liner in .claude/settings.json. It lives in a file now so
+# that .opencode/plugin/edmund-guards.mjs can execute it directly — OpenCode has
+# no settings.json, and a rule that exists only as JSON embedded in one agent's
+# config cannot be shared with another. Every guard in this directory is a file
+# with the same contract, and the OpenCode bridge runs all of them.
+#
+# Contract (Claude Code's PreToolUse shape, which the bridge also speaks):
+#   stdin  — hook JSON with .tool_input.command / .tool_input.file_path
+#   stdout — `{}` to allow, or a hookSpecificOutput deny decision
+set -uo pipefail
+
+# Whole command, not just its first line: the old `read -r cmd` saw only line 1,
+# so a heredoc or multi-line && chain slipped straight past this guard.
+cmd="$(jq -r '.tool_input.command // empty')"
+[[ -n "$cmd" ]] || { echo '{}'; exit 0; }
+
+is_branch_create() {
+  grep -Eq '(^|&&|;|\|)[[:space:]]*git[[:space:]]+(checkout[[:space:]]+-b|switch[[:space:]]+-c)\b' <<<"$cmd" ||
+    # Bare `git branch <name>` creates; `-a`, `-d`, `--list` do not.
+    grep -Eq '(^|&&|;|\|)[[:space:]]*git[[:space:]]+branch[[:space:]]+[^-[:space:]][^[:space:]]*([[:space:]]|$)' <<<"$cmd"
+}
+
+if is_branch_create; then
+  jq -nc '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: "Edmund prefers git worktrees over branch-switching for concurrent local work: git worktree add .worktrees/<branch> <branch> (branch keeps its normal type/slug name). See CLAUDE.md Git practices / docs/ARCHITECTURE.md §12."
+    }
+  }'
+  exit 0
+fi
+
+echo '{}'

--- a/.claude/hooks/guard-commit-tests.sh
+++ b/.claude/hooks/guard-commit-tests.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash): never commit a red tree.
+#
+# Claude Code enforces this from the other end — a Stop hook runs `swift test`
+# at the end of every turn that touches code. OpenCode has no end-of-turn hook
+# whose output reaches the model, so the suite has to run at the moment it
+# actually decides something: the commit itself.
+#
+# Written as a guard script rather than plugin code so both agents can use it,
+# and so the rule lives in one place. Only the OpenCode bridge wires it today;
+# Claude Code keeps its Stop hook (see .claude/settings.json).
+set -uo pipefail
+
+cmd="$(jq -r '.tool_input.command // empty')"
+[[ -n "$cmd" ]] || { echo '{}'; exit 0; }
+
+grep -Eq '(^|&&|;|\|)[[:space:]]*git[[:space:]]+commit\b' <<<"$cmd" || { echo '{}'; exit 0; }
+
+# Docs-only commit: nothing the suite can tell us. Skip the two-minute wait.
+git diff --cached --name-only | grep -q '\.swift$' || { echo '{}'; exit 0; }
+
+if ! out="$(swift test 2>&1)"; then
+  jq -nc --arg tail "$(tail -20 <<<"$out")" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: ("swift test failed — commit blocked (project rule: never commit a red tree).\n" + $tail)
+    }
+  }'
+  exit 0
+fi
+
+echo '{}'

--- a/.claude/hooks/sync-opencode.sh
+++ b/.claude/hooks/sync-opencode.sh
@@ -15,10 +15,12 @@
 #                silently — the description is dropped and the whole `---` block
 #                leaks into the prompt. So regenerate with a description-only
 #                whitelist rather than copying.
-#   hooks/       CANNOT be synced. The guards are hand-ported matcher logic in
-#                .opencode/plugin/edmund-guards.mjs, not a format transform of
-#                these shell scripts. Best available is to say so out loud when
-#                one side moves.
+#   hooks/       nothing to do either, as of the guard-bridge change.
+#                .opencode/plugin/edmund-guards.mjs no longer re-implements the
+#                guards, it executes guard-*.sh directly, so an edit to one is
+#                live on both sides immediately. A new guard-*.sh is picked up
+#                by OpenCode automatically; Claude Code needs one line in
+#                .claude/settings.json, having no auto-discovery.
 #
 # Writes only into .opencode/, which is gitignored — no tracked churn.
 
@@ -32,14 +34,7 @@ root="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
 
 case "$path" in
   "$root"/.claude/commands/*.md) ;;
-  "$root"/.claude/settings.json | "$root"/.claude/hooks/*)
-    # Drift notice, not a block: the mjs mirrors these rules by hand.
-    echo "Changed $(basename "$path"), which .opencode/plugin/edmund-guards.mjs mirrors by hand \
-(guards: branch-create, focus-steal, maintainer-prose, commit gate). OpenCode has no settings.json \
-hooks, so this does NOT propagate on its own — check whether the plugin needs the same change, then \
-re-run its self-check: node .opencode/plugin/edmund-guards.mjs" >&2
-    exit 2 ;;
-  *) exit 0 ;;
+  *) exit 0 ;;   # guards need no sync — see the header
 esac
 
 src="$root/.claude/commands"

--- a/.claude/hooks/sync-opencode.sh
+++ b/.claude/hooks/sync-opencode.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# PostToolUse(Edit|Write): keep the OpenCode setup in step with .claude/.
+#
+# Only two of the four .claude/ surfaces actually need anything:
+#
+#   skills/      nothing to do. OpenCode discovers .claude/skills/<name>/SKILL.md
+#                natively (kill switch: OPENCODE_DISABLE_CLAUDE_CODE_SKILLS), and
+#                the frontmatter is the same name+description pair. Verified live:
+#                all 16 show up in `GET /skill` on `opencode serve`.
+#   CLAUDE.md    likewise — OpenCode walks the project tree for AGENTS.md /
+#                CLAUDE.md / CONTEXT.md. Nothing to sync.
+#   commands/    DOES need work, and a plain cp is wrong: OpenCode only parses
+#                the frontmatter when it recognises every key. Leave Claude's
+#                `allowed-tools:` / `argument-hint:` in and parsing fails
+#                silently — the description is dropped and the whole `---` block
+#                leaks into the prompt. So regenerate with a description-only
+#                whitelist rather than copying.
+#   hooks/       CANNOT be synced. The guards are hand-ported matcher logic in
+#                .opencode/plugin/edmund-guards.mjs, not a format transform of
+#                these shell scripts. Best available is to say so out loud when
+#                one side moves.
+#
+# Writes only into .opencode/, which is gitignored — no tracked churn.
+
+set -uo pipefail
+
+path="$(jq -r '.tool_input.file_path // empty')"
+[[ -n "$path" ]] || exit 0
+
+root="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+[[ -n "$root" && -d "$root/.claude" ]] || exit 0
+
+case "$path" in
+  "$root"/.claude/commands/*.md) ;;
+  "$root"/.claude/settings.json | "$root"/.claude/hooks/*)
+    # Drift notice, not a block: the mjs mirrors these rules by hand.
+    echo "Changed $(basename "$path"), which .opencode/plugin/edmund-guards.mjs mirrors by hand \
+(guards: branch-create, focus-steal, maintainer-prose, commit gate). OpenCode has no settings.json \
+hooks, so this does NOT propagate on its own — check whether the plugin needs the same change, then \
+re-run its self-check: node .opencode/plugin/edmund-guards.mjs" >&2
+    exit 2 ;;
+  *) exit 0 ;;
+esac
+
+src="$root/.claude/commands"
+dst="$root/.opencode/command"
+mkdir -p "$dst"
+
+# Full regenerate: picks up adds, edits and deletes in one pass. Two small files.
+find "$dst" -maxdepth 1 -name '*.md' -delete
+
+for f in "$src"/*.md; do
+  [[ -e "$f" ]] || continue
+  # Keep only `description` inside the frontmatter; pass the body through as-is.
+  # ponytail: single-line description only — the repo's commands all use one.
+  # A folded `description: >` would need a real YAML parser.
+  awk '
+    NR == 1 && $0 == "---" { infm = 1; print; next }
+    infm && $0 == "---"    { infm = 0; print; next }
+    infm                   { if ($0 ~ /^description:/) print; next }
+                           { print }
+  ' "$f" > "$dst/$(basename "$f")"
+done
+
+echo "synced $(ls -1 "$dst"/*.md 2>/dev/null | wc -l | tr -d ' ') command(s) to .opencode/command/" >&2
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,6 +40,19 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/sync-opencode.sh\"",
+            "timeout": 15,
+            "statusMessage": "Syncing OpenCode config…"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.command // empty' | { read -r cmd; if echo \"$cmd\" | grep -Eq '(^|&&|;|\\|)[[:space:]]*git[[:space:]]+(checkout[[:space:]]+-b|switch[[:space:]]+-c)\\b' || echo \"$cmd\" | grep -Eq '(^|&&|;|\\|)[[:space:]]*git[[:space:]]+branch[[:space:]]+[^-[:space:]][^[:space:]]*([[:space:]]|$)'; then printf '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Edmund prefers git worktrees over branch-switching for concurrent local work: git worktree add .worktrees/<branch> <branch> (branch keeps its normal type/slug name). See CLAUDE.md Git practices / docs/ARCHITECTURE.md \\u00a712.\"}}'; else echo '{}'; fi; }"
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/guard-branch-create.sh\""
           }
         ]
       },


### PR DESCRIPTION
Makes the guard rules live in exactly one place, so Claude Code and OpenCode enforce the same thing without a sync step.

## Why

The OpenCode plugin (`.opencode/plugin/edmund-guards.mjs`, untracked) was a hand-written JS re-implementation of the guards in `.claude/hooks/`. Every rule existed twice, in two languages, with nothing keeping the copies honest — the best a sync hook could do was warn *after* they had already drifted.

The plugin now **executes** those scripts instead of reproducing them. The shell is the single source of truth, and an edit to a guard is live on both sides immediately. Dropping a new `guard-*.sh` into `.claude/hooks/` arms it in OpenCode automatically; Claude Code still needs its one line in `settings.json`, having no auto-discovery.

## What moved, and one real fix

For the plugin to run them, every guard has to be a file. Two were not:

- **`guard-branch-create.sh`** — was an inline `jq` one-liner in `settings.json`. A rule embedded in one agent's config cannot be shared with another. Extracting it also closed a genuine hole: `read -r cmd` consumed only the *first line* of the command, so a multi-line `&&` chain or heredoc walked straight past the guard. `echo hi\ngit checkout -b sneaky` was never blocked. Now covered by a regression case.
- **`guard-commit-tests.sh`** — was plugin-only logic. It is the commit gate that stands in for Claude's `Stop` hook under OpenCode, which has no end-of-turn hook whose output reaches the model. As a script it is available to both agents. Only the OpenCode bridge wires it today; Claude Code keeps its `Stop` hook.

The sync hook added in the first commit drops its drift warning, which this change makes meaningless.

## Also here

The first commit adds `.claude/hooks/sync-opencode.sh`, a `PostToolUse(Edit|Write)` hook that regenerates `.opencode/command/` from `.claude/commands/`. That one is a real transform, not a copy: OpenCode parses a command's frontmatter only when it recognises every key, so leaving Claude's `allowed-tools:` / `argument-hint:` in makes parsing fail silently — the description is dropped and the whole `---` block leaks into the prompt template. The hook regenerates with a description-only whitelist.

Skills and `CLAUDE.md` need nothing: OpenCode discovers `.claude/skills/<name>/SKILL.md` and walks the project tree for `CLAUDE.md` natively.

## Verification

- Live propagation: patched a sentinel string into `guard-branch-create.sh`; OpenCode's next call returned it, with no sync step or restart.
- Auto-discovery: a throwaway `guard-zztest.sh` armed immediately and blocked with zero wiring.
- Plugin self-check (`node .opencode/plugin/edmund-guards.mjs`) runs the real scripts — 4 guards discovered, all block/allow cases green, including the multi-line regression.
- `swift test` — 1294 tests in 183 suites, all passing.

Note: `.opencode/` and `opencode.json` remain untracked, so the plugin itself is not in this diff.