### PR TITLE
fix(documents): stop stale untitled drafts reopening at every launch

### DIFF
--- a/Sources/edmd/App/DocumentController.swift
+++ b/Sources/edmd/App/DocumentController.swift
@@ -91,6 +91,30 @@ class DocumentController: NSDocumentController {
         }
     }
 
+    // MARK: - Draft Reopening
+    //
+    // With autosave-in-place on, AppKit keeps every unsaved *untitled* document as
+    // a draft in ~/Library/Autosave Information and reopens it through this method
+    // at the next launch. That path is not gated by `NSWindow.isRestorable`, so the
+    // clearing in `AppDelegate.applicationShouldTerminate` never reached it: drafts
+    // came back at every launch — stacking up as "Untitled", "Untitled 2", … on top
+    // of the blank launch document — whatever "Reopen windows from last session"
+    // said. Honor that preference here too. Nothing is deleted: the draft files stay
+    // in ~/Library/Autosave Information, they are simply not reopened.
+    //
+    // `urlOrNil == nil` is exactly the draft case; a document that has a file on
+    // disk reopens as before.
+    override func reopenDocument(for urlOrNil: URL?, withContentsOf contentsURL: URL,
+                                 display displayDocument: Bool,
+                                 completionHandler: @escaping (NSDocument?, Bool, Error?) -> Void) {
+        if urlOrNil == nil && !AppSettings.reopenWindows {
+            completionHandler(nil, false, nil)
+            return
+        }
+        super.reopenDocument(for: urlOrNil, withContentsOf: contentsURL,
+                             display: displayDocument, completionHandler: completionHandler)
+    }
+
     /// Closes the most-recently-opened blank Untitled window the user never
     /// typed into — e.g. the automatic blank document from launch — once a
     /// real file opens. Only the last one, so opening several Untitled

--- a/Tests/EdmundTests/DraftReopenTests.swift
+++ b/Tests/EdmundTests/DraftReopenTests.swift
@@ -1,0 +1,54 @@
+import Testing
+import AppKit
+@testable import edmd
+
+/// Regression: unsaved *untitled* documents are kept by AppKit as drafts in
+/// ~/Library/Autosave Information and reopened through
+/// `reopenDocument(for:withContentsOf:display:)` at the next launch — a path that
+/// `NSWindow.isRestorable` does not gate, so old drafts came back at every launch
+/// and stacked up ("Untitled", "Untitled 2", …) on top of the blank launch
+/// document, whatever "Reopen windows from last session" said.
+@MainActor
+@Suite("Draft reopening")
+struct DraftReopenTests {
+
+    /// A readable draft file on disk, so the only thing that can stop it from
+    /// being reopened is the preference check.
+    private func draftFile() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Unsaved edmd Document \(UUID().uuidString).md")
+        try? "draft contents".write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    /// Lets AppKit's asynchronous open finish (or not happen at all).
+    private func settle() {
+        RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+    }
+
+    @Test("A draft is not reopened when reopening windows is off")
+    func draftSkippedWhenReopeningOff() {
+        let saved = AppSettings.reopenWindows
+        AppSettings.reopenWindows = false
+        defer { AppSettings.reopenWindows = saved }
+
+        let url = draftFile()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let controller = DocumentController()
+        let before = controller.documents.count
+        var completions = 0
+        var reopened: NSDocument?
+
+        // `urlOrNil == nil` is how AppKit spells "this is a draft".
+        controller.reopenDocument(for: nil, withContentsOf: url, display: false) { document, _, _ in
+            completions += 1
+            reopened = document
+        }
+        settle()
+
+        #expect(completions == 1)
+        #expect(reopened == nil)
+        #expect(controller.documents.count == before)
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -369,6 +369,26 @@ Notable subsystems:
 - **Window size** persists as the last window's full **frame** size
   (`settings.window.lastWidth`/`lastHeight`) — §8 on why frame, not content
   size.
+- **"Reopen windows from last session" (`reopenWindows`) has to be enforced in
+  two places**, because AppKit brings work back by two independent routes:
+  1. *Window restoration.* Document windows are `isRestorable = true` for the
+     whole session so a crash can hand back unsaved work;
+     `AppDelegate.applicationShouldTerminate` clears the flag on a **clean**
+     quit when the preference is off, so nothing is archived.
+  2. *Drafts.* With autosave-in-place on (`Document.autosavesInPlace` =
+     `autoSaveWithVersions`, default on), every unsaved **untitled** document is
+     kept by AppKit as a draft in `~/Library/Autosave Information/Unsaved edmd
+     Document N.md` (`edmd` = the executable name) and reopened at the next
+     launch through
+     `NSDocumentController.reopenDocument(for:withContentsOf:display:)`. That
+     route ignores `isRestorable` entirely, so route 1 never reached it: stale
+     drafts came back at *every* launch and stacked up as "Untitled",
+     "Untitled 2", … on top of the blank launch document.
+     `DocumentController.reopenDocument` overrides it and skips drafts
+     (`urlOrNil == nil`) when the preference is off. It only skips the reopen —
+     the draft files are never deleted. Once skipped, AppKit drops the draft
+     from its restore record, so turning the preference back on later does not
+     resurrect old drafts; the file is still on disk.
 - **Diagnostic logging** (`EdmundCore/Diagnostics/Log.swift`): always-on
   (opt-out) file logger. `Log.{debug,info,error}(_:category:)` and
   `Log.measure(_:) { … }` (single-line durations) write to
@@ -467,6 +487,33 @@ Notable subsystems:
   windows, state restoration) —
   `rm -rf ~/Library/"Saved Application State"/com.i7t5.edmund.savedState`
   and relaunch.
+- **Counting an app's windows is the flakiest measurement in this repo — don't
+  trust one source.** `CGWindowListCopyWindowInfo(.optionAll)` (what
+  `winid.swift` uses) lists windows the app has already *closed*, so a stale
+  entry reads as a window that is still open — enough to invent a bug that
+  isn't there. `.optionOnScreenOnly` fixes that but lists nothing for an app
+  launched with `open -g` (backgrounded), and System Events' `name of every
+  window` is intermittently empty for a process that was never activated or was
+  started by exec'ing the binary. Cross-check at least two, and when the answer
+  actually matters, ask the app: a temporary probe that appends to a file from
+  `Document.makeWindowControllers` counts documents exactly, needs no focus, and
+  works before `Log.configure` has run (the logger silently drops everything
+  emitted earlier in launch, including from `applicationShouldOpenUntitledFile`).
+  `Thread.callStackSymbols` in that probe is what names the *creator* of a
+  surprise window — the AppKit frames say whether it came from restoration,
+  draft reopening, or the delegate.
+- **State restoration needs a signed bundle.** An unsigned debug build never
+  restores anything, so restoration bugs are invisible in the usual
+  `build/EdmundDbg.app` loop. Reproduce with a *signed* release clone under its
+  own bundle id (`scripts/build-app.sh`, then `PlistBuddy` the
+  `CFBundleIdentifier` to e.g. `com.i7t5.edmundrepro` and `codesign -s -`) so
+  the run has its own defaults and its own saved state and can never disturb the
+  maintainer's installed Edmund. `codesign --deep` fails with "unsealed contents
+  present in the bundle root" until the SwiftPM `*.bundle` resources at the
+  `.app` root are moved aside and put back after signing. Note the isolated
+  clone still shares `~/Library/Autosave Information` and the "Unsaved edmd
+  Document" namespace with the real app — a draft it reopens may be the
+  maintainer's.
 - **Visual work is measured, not eyeballed — and the measuring rig is
   reusable.** Aligning chrome takes a dozen launch/state/capture/measure cycles;
   `.claude/skills/edmund-live-repro-and-diagnostics/scripts/ui-harness.sh` and


### PR DESCRIPTION
Launching Edmund with "Reopen windows from last session" **off** still opened two blank windows, `Untitled` and `Untitled 2`, on every single launch.

## Cause

With autosave-in-place on (`Document.autosavesInPlace` = `autoSaveWithVersions`, default on), AppKit keeps every unsaved **untitled** document as a *draft* in `~/Library/Autosave Information/Unsaved edmd Document N.md`, and reopens it at the next launch through `NSDocumentController.reopenDocument(for:withContentsOf:display:)`.

That route is not gated by `NSWindow.isRestorable`, so the clearing in `AppDelegate.applicationShouldTerminate` never reached it. Drafts therefore came back at every launch and stacked up on top of the blank launch document, whatever the preference said. On the machine this was found on, two drafts left over from 2026-07-09 had been reopening daily ever since.

Confirmed by a stack trace captured at window creation: the extra window is built from `NSDocumentControllerPersistentRestoration` / `reopenDocumentForURL:`, not from `applicationShouldOpenUntitledFile` or `applicationShouldHandleReopen`.

## Fix

`DocumentController.reopenDocument` skips drafts (`urlOrNil == nil`) when `reopenWindows` is off. Documents backed by a file on disk reopen exactly as before, so crash recovery of saved work is untouched.

Nothing is deleted — draft files stay in `~/Library/Autosave Information`, they are simply not reopened. One consequence worth knowing: once a draft is skipped, AppKit drops it from its restore record, so turning the preference back on later will not resurrect old drafts (the file is still on disk).

## Verification

- Live A/B on a signed, isolated release clone: `reopenWindows` off → one `Untitled`; on → `Untitled` + `Untitled 2` (recovery still works).
- New `Tests/EdmundTests/DraftReopenTests.swift` — fails without the fix, passes with it.
- Full suite: 1295 tests green.

`docs/ARCHITECTURE.md` gains the two-routes-to-enforce note (§7) and the window-counting / signed-bundle measurement pitfalls that made this slow to pin down (§8).