### PR TITLE
feat: Apple Mail-style format bar

### DIFF
--- a/.claude/hooks/guard-focus-steal.sh
+++ b/.claude/hooks/guard-focus-steal.sh
@@ -44,4 +44,20 @@ if grep -q 'System Events' <<<"$cmd" &&
 See Sources/edmd/App/ReproScript.swift for the command list and the live-repro skill for the escalation ladder. If a real CGEvent path is genuinely required, ask the user first — they may be at the keyboard.'
 fi
 
+# The same steal, one level down. `ui-harness.sh raise` (and open-find /
+# replace / shot, which all call cmd_raise) runs `set frontmost` *inside the
+# script*, so the check above only ever sees the word "ui-harness.sh" and waves
+# it through. This gap let an agent foreground the app repeatedly while the
+# maintainer was working, which is the exact thing this file exists to stop.
+# Match the subcommand, not the osascript it hides.
+if grep -Eq 'ui-harness\.sh[[:space:]]+(raise|open-find|replace|shot)\b' <<<"$cmd"; then
+  deny 'ui-harness.sh raise / open-find / replace / shot all activate Edmund and pull the maintainer out of what they were doing — the osascript is inside the script, which is why the System Events rule above does not catch it.
+Capture instead, which works on a background window and steals nothing:
+  ui-harness.sh capture out.png          # or capture-window.sh <title> out.png
+To reach a bar or a control without focus, relaunch with the state you need and drive the app in-process:
+  open -g -n build/EdmundDbg.app --args file.md -settings.edit.showFormatBar NO
+  edmd file.md -debug.reproScript script.txt
+`open -g` starts the app in the background; launching the bare binary foregrounds it. If you truly need the app frontmost, ask the maintainer first — they may be at the keyboard.'
+fi
+
 echo '{}'

--- a/.claude/skills/edmund-config-and-flags/SKILL.md
+++ b/.claude/skills/edmund-config-and-flags/SKILL.md
@@ -45,6 +45,7 @@ Swift name) is what you pass as a launch arg.
 | `contentWidthUnit` | `settings.appearance.contentWidthUnit` | Display unit only (cm/in); the stored value is always cm |
 | `renderBlankLinesAsBreaks` | `settings.reading.renderBlankLinesAsBreaks` | Read-mode blank-line handling |
 | `sourceMode` | `settings.view.sourceMode` | When on, **Source replaces Edit** in the ⌘E toggle; honored on open |
+| `showFormatBar` | `settings.edit.showFormatBar` | **Show the format bar** (View ▸ Show Format Bar, no shortcut; default on, off in Reading mode) |
 | `verboseEditorDiagnostics` | `settings.advanced.verboseEditorDiagnostics` | **Verbose editor trace** (see §4; pairs with diagnosticLogging) |
 | `sendCrashLogs` | `settings.advanced.sendCrashLogs` | Opt-in crash upload — **currently INERT** (see note) |
 | `sentCrashReports` | `settings.advanced.sentCrashReports` | Dedup set of already-uploaded `.ips` filenames |

--- a/Sources/EdmundCore/Editing/EditorTextView+FormattingCommands.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+FormattingCommands.swift
@@ -67,6 +67,8 @@ extension EditorTextView {
     @objc public func formatCode(_ sender: Any?)          { toggleInlineWrap(open: "`", close: "`", expandToWord: true) }
     @objc public func formatInlineMath(_ sender: Any?)    { toggleInlineWrap(open: "$", close: "$", expandToWord: true) }
     @objc public func formatKeyboard(_ sender: Any?)      { toggleInlineWrap(open: "<kbd>", close: "</kbd>", expandToWord: true) }
+    @objc public func formatSubscript(_ sender: Any?)     { toggleInlineWrap(open: "<sub>", close: "</sub>", expandToWord: true) }
+    @objc public func formatSuperscript(_ sender: Any?)   { toggleInlineWrap(open: "<sup>", close: "</sup>", expandToWord: true) }
     @objc public func formatComment(_ sender: Any?)       { toggleInlineWrap(open: "<!-- ", close: " -->", expandToWord: true) }
 
     // MARK: - Inline links
@@ -90,7 +92,8 @@ extension EditorTextView {
     @objc public func formatMathBlock(_ sender: Any?)     { insertMathBlock() }
     @objc public func formatTable(_ sender: Any?)         { insertTable() }
 
-    /// Heading level read from the menu item's `tag` (1–6).
+    /// Heading level read from the menu item's `tag` (0 = Body, 1–6).
+    /// Level 0 strips any heading prefix (back to body text) without toggling.
     /// Heading H1–H6: strips any existing `#…` prefix and applies the new level.
     /// Re-applying the same level clears the heading. Applies per selected line.
     @objc public func formatHeading(_ sender: Any?) {
@@ -171,6 +174,7 @@ extension EditorTextView {
         #selector(formatBold(_:)), #selector(formatItalic(_:)), #selector(formatUnderline(_:)),
         #selector(formatStrikethrough(_:)), #selector(formatHighlight(_:)), #selector(formatCode(_:)),
         #selector(formatInlineMath(_:)), #selector(formatKeyboard(_:)), #selector(formatComment(_:)),
+        #selector(formatSubscript(_:)), #selector(formatSuperscript(_:)),
         #selector(formatWikilink(_:)), #selector(formatLink(_:)), #selector(formatImage(_:)),
         #selector(formatFootnote(_:)), #selector(formatBulletedList(_:)), #selector(formatNumberedList(_:)),
         #selector(formatChecklist(_:)), #selector(formatBlockQuote(_:)), #selector(formatThematicBreak(_:)),
@@ -181,6 +185,13 @@ extension EditorTextView {
     // MARK: - Heading
 
     func applyHeadingLevel(_ level: Int) {
+        // Level 0 (Body) strips the heading prefix unconditionally — never the
+        // same-level toggle-off, so a repeated Body pick is a no-op rather than
+        // re-applying `# `. Only reachable from the format bar / menu Body item.
+        guard level > 0 else {
+            transformSelectedLines { lines in lines.map { self.stripLeadingHashes($0) } }
+            return
+        }
         // All selected lines get the same heading level applied or cleared.
         // "Same level" is determined by majority: if every non-empty line already
         // has exactly `level` hashes, they are all cleared (toggle-off).

--- a/Sources/EdmundCore/Editing/EditorTextView+FormattingState.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+FormattingState.swift
@@ -191,7 +191,11 @@ extension EditorTextView {
         if lines.allSatisfy({ leadingListNumber($0) != nil }) {
             active.insert(#selector(formatNumberedList(_:)))
         }
-        if lines.allSatisfy({ $0.drop(while: { $0 == " " }).hasPrefix(">") }) {
+        // A callout is a block quote underneath, so this would light too. The
+        // callout pulldown already reports it, and showing both said the
+        // selection was two things at once.
+        if lines.allSatisfy({ $0.drop(while: { $0 == " " }).hasPrefix(">") }),
+           activeCalloutType() == nil {
             active.insert(#selector(formatBlockQuote(_:)))
         }
         return active

--- a/Sources/EdmundCore/Editing/EditorTextView+FormattingState.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+FormattingState.swift
@@ -1,0 +1,168 @@
+import AppKit
+
+// MARK: - Which formatting is in effect at the selection
+//
+// Read-only counterpart to the toggles in `EditorTextView+FormattingCommands`:
+// the commands decide "should this apply or unapply", this decides "is it on
+// right now", which is what the format bar's buttons light up from.
+//
+// Deliberately a delimiter scan over the selected lines rather than a look at
+// the rendered text attributes. Storage == rawSource, and the styled attributes
+// are lossy in the direction we need: a heading is bold, `==mark==` and a code
+// span are both background fills, so "which command produced this" cannot be
+// recovered from the font. The source delimiters say it exactly.
+//
+// Scope is the selected lines. Inline emphasis does not survive a blank line,
+// and a scan bounded by the paragraph keeps this cheap enough to run on every
+// caret move.
+
+extension EditorTextView {
+
+    /// Inline delimiters that are their own on-state, other than the `*` runs
+    /// (which need the run-length logic in `starEmphasisActions`).
+    private static let inlineWrapActions: [(Selector, open: String, close: String)] = [
+        (#selector(formatUnderline(_:)),     "<u>",   "</u>"),
+        (#selector(formatStrikethrough(_:)), "~~",    "~~"),
+        (#selector(formatSubscript(_:)),     "<sub>", "</sub>"),
+        (#selector(formatSuperscript(_:)),   "<sup>", "</sup>"),
+        (#selector(formatHighlight(_:)),     "==",    "=="),
+        (#selector(formatCode(_:)),          "`",     "`"),
+        (#selector(formatInlineMath(_:)),    "$",     "$"),
+        (#selector(formatKeyboard(_:)),      "<kbd>", "</kbd>"),
+    ]
+
+    /// The formatting actions currently in effect at the selection — the caret
+    /// sits inside the span, or the selection swallows it whole.
+    ///
+    /// Cheap by construction: one pass over the selected lines per delimiter,
+    /// no layout and no styling, so it is safe on every selection change.
+    public func activeFormattingActions() -> Set<Selector> {
+        let ns = rawSource as NSString
+        guard ns.length > 0 else { return [] }
+        let sel = clampedSelection(in: ns)
+        let lineRange = ns.lineRange(for: sel)
+        let line = ns.substring(with: lineRange) as NSString
+
+        var active: Set<Selector> = []
+        active.formUnion(starEmphasisActions(in: line, at: lineRange.location, sel: sel))
+        for (action, open, close) in Self.inlineWrapActions {
+            for span in wrappedSpans(in: line, open: open, close: close)
+            where covers(span, sel: sel, lineStart: lineRange.location) {
+                active.insert(action)
+                break
+            }
+        }
+        active.formUnion(linePrefixActions())
+        return active
+    }
+
+    // MARK: - Inline spans
+
+    /// `*` runs paired off into emphasis spans. Run length is what distinguishes
+    /// the two commands — `*x*` is italic, `**x**` bold, `***x***` both — so a
+    /// plain search for `*` (which would find the inner star of a `**` pair)
+    /// cannot answer this and the run length has to be measured.
+    private func starEmphasisActions(in line: NSString, at lineStart: Int,
+                                     sel: NSRange) -> Set<Selector> {
+        var runs: [NSRange] = []
+        var i = 0
+        while i < line.length {
+            guard line.character(at: i) == UInt16(UnicodeScalar("*").value) else { i += 1; continue }
+            var end = i
+            while end < line.length,
+                  line.character(at: end) == UInt16(UnicodeScalar("*").value) { end += 1 }
+            runs.append(NSRange(location: i, length: end - i))
+            i = end
+        }
+
+        var active: Set<Selector> = []
+        for pair in stride(from: 0, to: runs.count - 1, by: 2) {
+            let open = runs[pair], close = runs[pair + 1]
+            // An unbalanced pair (`**bold*`) emphasises only as far as the
+            // shorter run reaches.
+            let width = min(open.length, close.length)
+            let span = (inner: NSRange(location: open.upperBound,
+                                       length: close.location - open.upperBound),
+                        outer: NSRange(location: open.location,
+                                       length: close.upperBound - open.location))
+            guard covers(span, sel: sel, lineStart: lineStart) else { continue }
+            if width >= 2 { active.insert(#selector(formatBold(_:))) }
+            if width % 2 == 1 { active.insert(#selector(formatItalic(_:))) }
+        }
+        return active
+    }
+
+    /// Non-overlapping `open`…`close` spans, scanned left to right. Pairing as
+    /// it goes is what keeps `a **b** c **d** e` from reading as one span from
+    /// the first delimiter to the last.
+    private func wrappedSpans(in line: NSString, open: String,
+                              close: String) -> [(inner: NSRange, outer: NSRange)] {
+        var spans: [(inner: NSRange, outer: NSRange)] = []
+        var from = 0
+        while from < line.length {
+            let openHit = line.range(of: open, options: [],
+                                     range: NSRange(location: from, length: line.length - from))
+            guard openHit.location != NSNotFound else { break }
+            let afterOpen = openHit.upperBound
+            guard afterOpen < line.length else { break }
+            let closeHit = line.range(of: close, options: [],
+                                      range: NSRange(location: afterOpen,
+                                                     length: line.length - afterOpen))
+            guard closeHit.location != NSNotFound else { break }
+            spans.append((inner: NSRange(location: afterOpen,
+                                         length: closeHit.location - afterOpen),
+                          outer: NSRange(location: openHit.location,
+                                         length: closeHit.upperBound - openHit.location)))
+            from = closeHit.upperBound
+        }
+        return spans
+    }
+
+    /// The span counts as active when the caret is anywhere inside the
+    /// delimited content, or when the selection contains the whole thing
+    /// (delimiters included) — pressing the button in either state is what
+    /// would turn the formatting back off.
+    private func covers(_ span: (inner: NSRange, outer: NSRange),
+                        sel: NSRange, lineStart: Int) -> Bool {
+        let inner = NSRange(location: span.inner.location + lineStart, length: span.inner.length)
+        let outer = NSRange(location: span.outer.location + lineStart, length: span.outer.length)
+        if sel.length == 0 {
+            return sel.location >= inner.location && sel.location <= inner.upperBound
+        }
+        let insideInner = sel.location >= inner.location && sel.upperBound <= inner.upperBound
+        let swallowsOuter = sel.location <= outer.location && sel.upperBound >= outer.upperBound
+        return insideInner || swallowsOuter
+    }
+
+    // MARK: - Line prefixes
+
+    /// List and quote state, which is a property of the whole line rather than
+    /// of a span. Every non-empty selected line has to match, mirroring the
+    /// toggles: they clear the prefix only when all of them carry it.
+    private func linePrefixActions() -> Set<Selector> {
+        let lines = selectedLineContext().lines.filter { !$0.isEmpty }
+        guard !lines.isEmpty else { return [] }
+        var active: Set<Selector> = []
+        if lines.allSatisfy({ isBulletLine($0) }) {
+            active.insert(#selector(formatBulletedList(_:)))
+        }
+        if lines.allSatisfy({ isChecklistLine($0) }) {
+            active.insert(#selector(formatChecklist(_:)))
+        }
+        if lines.allSatisfy({ leadingListNumber($0) != nil }) {
+            active.insert(#selector(formatNumberedList(_:)))
+        }
+        if lines.allSatisfy({ $0.drop(while: { $0 == " " }).hasPrefix(">") }) {
+            active.insert(#selector(formatBlockQuote(_:)))
+        }
+        return active
+    }
+
+    /// The selection clamped into the current source, so a stale selection left
+    /// by an edit cannot walk `lineRange(for:)` off the end.
+    private func clampedSelection(in ns: NSString) -> NSRange {
+        let location = min(max(0, selectedRange().location), ns.length)
+        return NSRange(location: location,
+                       length: min(selectedRange().length, ns.length - location))
+    }
+}

--- a/Sources/EdmundCore/Editing/EditorTextView+FormattingState.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+FormattingState.swift
@@ -134,15 +134,54 @@ extension EditorTextView {
         return insideInner || swallowsOuter
     }
 
+    // MARK: - Pulldown state
+    //
+    // The two pulldowns each apply one of a set of mutually exclusive things, so
+    // their state is the member currently in effect rather than a yes/no — a
+    // checkmark in the menu, not a chip on the button.
+
+    /// The heading level shared by every non-empty selected line: 0 for body
+    /// text, 1–6 for `#`…`######`. Nil when the lines disagree, matching
+    /// `applyHeadingLevel`, which only treats a level as already-applied when
+    /// all of them carry it.
+    public func activeHeadingLevel() -> Int? {
+        let lines = selectedLineContext().lines.filter { !$0.isEmpty }
+        guard let first = lines.first else { return nil }
+        let level = leadingHashCount(first)
+        return lines.allSatisfy { leadingHashCount($0) == level } ? level : nil
+    }
+
+    /// The callout type at the selection, lowercased, or nil when the first
+    /// selected line is not a callout header.
+    ///
+    /// The first line is what `applyCalloutType` reads to decide whether it is
+    /// toggling a callout off, so the checkmark and the command agree about
+    /// which callout they are looking at. Parsing goes through
+    /// `Callout.parseMarker`, the same matcher the renderer uses, so `[!NOTE]`,
+    /// `[!note]` and a folded `[!note]-` all resolve alike.
+    public func activeCalloutType() -> String? {
+        guard let first = selectedLineContext().lines.first else { return nil }
+        let trimmed = first.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix(">") else { return nil }
+        let afterQuote = trimmed.dropFirst().drop { $0 == " " }
+        return Callout.parseMarker(String(afterQuote))?.type
+    }
+
     // MARK: - Line prefixes
 
     /// List and quote state, which is a property of the whole line rather than
     /// of a span. Every non-empty selected line has to match, mirroring the
     /// toggles: they clear the prefix only when all of them carry it.
     private func linePrefixActions() -> Set<Selector> {
-        let lines = selectedLineContext().lines.filter { !$0.isEmpty }
-        guard !lines.isEmpty else { return [] }
+        let context = selectedLineContext()
         var active: Set<Selector> = []
+        // The same line `insertThematicBreak` recognises when it is removing
+        // one, so the button lights exactly when pressing it would undo it.
+        if context.lines == ["---"] {
+            active.insert(#selector(formatThematicBreak(_:)))
+        }
+        let lines = context.lines.filter { !$0.isEmpty }
+        guard !lines.isEmpty else { return active }
         if lines.allSatisfy({ isBulletLine($0) }) {
             active.insert(#selector(formatBulletedList(_:)))
         }

--- a/Sources/EdmundCore/TextView/EditorTextView+ContentWidth.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+ContentWidth.swift
@@ -33,12 +33,19 @@ extension EditorTextView {
     /// document view keeps every point of the window inside the text view,
     /// where a click in the blank band lands on the nearest character.
     ///
-    /// The find bar adds its height on top via `additionalTopInset`.
+    /// The top bars are the exception, and go through `contentInsets` — see
+    /// `applyTopBarInset`. That objection does not apply to them: the band they
+    /// cost is the band they cover, so the live area only loses what the reader
+    /// could not click anyway.
     public func updateScrollOverscroll() {
         guard let scrollView = enclosingScrollView else { return }
         let clipHeight = scrollView.contentView.bounds.height
         guard clipHeight > 0 else { return }
-        let top = (typewriterModeEnabled ? clipHeight / 2 : 0) + additionalTopInset
+        applyTopBarInset(additionalTopInset, in: scrollView)
+        // Half of what the reader can *see*, not half the clip: the bars cover
+        // the top `viewportTopInset` of it, and the scroll range already starts
+        // at -inset, which supplies that much of the run-up for free.
+        let top = typewriterModeEnabled ? visibleContentHeight / 2 : 0
         let bottom = clipHeight / 2
         guard abs(top - overscrollTopPad) > 0.5
                 || abs(bottom - overscrollBottomPad) > 0.5 else { return }
@@ -56,6 +63,51 @@ extension EditorTextView {
         // it so the reader keeps looking at the same line.
         let origin = scrollView.contentView.bounds.origin
         let y = clampedScrollY(origin.y + shift)
+        guard abs(y - origin.y) > 0.5 else { return }
+        scrollView.contentView.scroll(to: NSPoint(x: origin.x, y: y))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+    }
+
+    /// The height of the chrome bars stacked over the top of the scroll view
+    /// (format bar, find bar), as a real `contentInsets.top`.
+    ///
+    /// AppKit does *not* shrink the clip view for a content inset — the clip
+    /// still spans the whole scroll view and the document scrolls under the
+    /// band. What the inset changes is the scroll range: its top end moves from
+    /// 0 to `-inset`, so the document can rest that far down with no extra
+    /// document height. Every conversion between clip coordinates and "the top
+    /// of what the reader can actually see" therefore has to add this.
+    var viewportTopInset: CGFloat { enclosingScrollView?.contentInsets.top ?? 0 }
+
+    /// The part of the clip view the bars leave visible.
+    var visibleContentHeight: CGFloat {
+        guard let clip = enclosingScrollView?.contentView else { return 0 }
+        return max(0, clip.bounds.height - viewportTopInset)
+    }
+
+    /// Mirrors `additionalTopInset` onto the scroll view and slides the document
+    /// down by the same amount.
+    ///
+    /// Both halves matter. The inset alone would only widen the scroll range —
+    /// the document would keep its old origin and the bar would simply cover the
+    /// top lines. Following it with the matching scroll is what makes a bar
+    /// appearing *push* the text down and a bar closing pull it back up, with
+    /// the reader's line held at the same place on screen throughout.
+    private func applyTopBarInset(_ inset: CGFloat, in scrollView: NSScrollView) {
+        let delta = inset - scrollView.contentInsets.top
+        guard abs(delta) > 0.5 else { return }
+        // Sampled *before* the inset changes. Shrinking the inset immediately
+        // re-clamps the clip view against the narrower range, so reading the
+        // origin afterwards returns a position that has already absorbed part
+        // of `delta` — subtracting it again scrolled the document down by the
+        // bar's height on the way out instead of back up.
+        let origin = scrollView.contentView.bounds.origin
+        // Otherwise AppKit recomputes the insets from the window's titlebar and
+        // stamps on ours.
+        scrollView.automaticallyAdjustsContentInsets = false
+        scrollView.contentInsets = NSEdgeInsets(top: inset, left: 0, bottom: 0, right: 0)
+        // Clamped after, though — the permitted range depends on the new inset.
+        let y = clampedScrollY(origin.y - delta)
         guard abs(y - origin.y) > 0.5 else { return }
         scrollView.contentView.scroll(to: NSPoint(x: origin.x, y: y))
         scrollView.reflectScrolledClipView(scrollView.contentView)

--- a/Sources/EdmundCore/TextView/EditorTextView+TypewriterScroll.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+TypewriterScroll.swift
@@ -62,7 +62,12 @@ extension EditorTextView {
         // from settle-loop rounding) picks the fragment *above* — walking the
         // anchor up a line on every Edit→Read round trip. Sampling just inside
         // the viewport keeps the round trip fixed-point.
-        let topPoint = CGPoint(x: 0, y: visible.minY + 1 - textContainerOrigin.y)
+        // `+ viewportTopInset`: the clip view extends up behind the top bars, so
+        // its own minY names a line the reader cannot see. Anchor on the first
+        // line below the bars instead, or a round trip walks the viewport up by
+        // the bars' height every time.
+        let topPoint = CGPoint(x: 0,
+                               y: visible.minY + viewportTopInset + 1 - textContainerOrigin.y)
         guard let frag = tlm.textLayoutFragment(for: topPoint) else { return nil }
         return tlm.offset(from: tlm.documentRange.location, to: frag.rangeInElement.location)
     }
@@ -104,8 +109,12 @@ extension EditorTextView {
         guard let lineRect = caretLineRect() else { return }
         let cursorY = lineRect.midY + textContainerOrigin.y
 
-        let visibleHeight = scrollView.contentView.bounds.height
-        let clampedY = clampedScrollY(cursorY - visibleHeight / 2)
+        // Centre of the band the reader can see, not of the whole clip: the top
+        // bars cover `viewportTopInset` of it, and centring against the full
+        // height parked the caret that much too high — behind the bar outright
+        // once the format and find bars were both up.
+        let centerOffset = viewportTopInset + visibleContentHeight / 2
+        let clampedY = clampedScrollY(cursorY - centerOffset)
 
         scrollView.contentView.scroll(to: NSPoint(x: 0, y: clampedY))
         scrollView.reflectScrolledClipView(scrollView.contentView)
@@ -119,7 +128,7 @@ extension EditorTextView {
         for _ in 0..<3 {
             tlm.textViewportLayoutController.layoutViewport()
             guard let settled = caretLineRect() else { return }
-            let settledY = clampedScrollY(settled.midY + textContainerOrigin.y - visibleHeight / 2)
+            let settledY = clampedScrollY(settled.midY + textContainerOrigin.y - centerOffset)
             guard abs(settledY - scrollView.contentView.bounds.origin.y) > 1 else { return }
             scrollView.contentView.scroll(to: NSPoint(x: 0, y: settledY))
             scrollView.reflectScrolledClipView(scrollView.contentView)
@@ -151,7 +160,9 @@ extension EditorTextView {
             scrollRangeToVisible(NSRange(location: offset, length: 0)); return
         }
         guard let rect = lineRect(forCharacterAt: offset) else { return }
-        let clampedY = clampedScrollY(rect.minY + textContainerOrigin.y)
+        // Top of the *visible* area: without the inset the anchored line lands
+        // at the top of the clip, which is behind the bars.
+        let clampedY = clampedScrollY(rect.minY + textContainerOrigin.y - viewportTopInset)
 
         scrollView.contentView.scroll(to: NSPoint(x: 0, y: clampedY))
         scrollView.reflectScrolledClipView(scrollView.contentView)
@@ -160,7 +171,7 @@ extension EditorTextView {
         for _ in 0..<6 {
             tlm.textViewportLayoutController.layoutViewport()
             guard let settled = lineRect(forCharacterAt: offset) else { return }
-            let settledY = clampedScrollY(settled.minY + textContainerOrigin.y)
+            let settledY = clampedScrollY(settled.minY + textContainerOrigin.y - viewportTopInset)
             guard abs(settledY - scrollView.contentView.bounds.origin.y) > 1 else { return }
             scrollView.contentView.scroll(to: NSPoint(x: 0, y: settledY))
             scrollView.reflectScrolledClipView(scrollView.contentView)

--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -218,9 +218,13 @@ public class EditorTextView: NSTextView {
         }
     }
 
-    /// Extra space the app layer needs above the text — the find bar's height
-    /// while it is showing. Added to the overscroll the editor reserves for
-    /// itself; see `updateScrollOverscroll`.
+    /// Combined height of the chrome bars the app layer stacks over the top of
+    /// the scroll view (format bar, find bar). `Document.layoutTopBars` is the
+    /// only writer.
+    ///
+    /// Applied as the scroll view's `contentInsets.top`, *not* as overscroll:
+    /// the document is pushed down out from under the bars without gaining any
+    /// scrollable emptiness above its first line. See `updateScrollOverscroll`.
     public var additionalTopInset: CGFloat = 0 {
         didSet {
             guard abs(oldValue - additionalTopInset) > 0.5 else { return }

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -826,7 +826,8 @@ class Document: NSDocument, HeadingNavigable {
             item.title = AppSettings.showToolbar ? "Hide Toolbar" : "Show Toolbar"
         }
         if item.action == #selector(toggleFormatBar(_:)) {
-            item.state = AppSettings.showFormatBar ? .on : .off
+            // Title, not a checkmark — the same idiom as Hide Toolbar above.
+            item.title = AppSettings.showFormatBar ? "Hide Format Bar" : "Show Format Bar"
         }
         if item.action == #selector(toggleAutoHideToolbar(_:)) {
             item.state = AppSettings.autoHideToolbar ? .on : .off

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -323,12 +323,16 @@ class Document: NSDocument, HeadingNavigable {
 
     @objc private func editorDidChange(_ notification: Notification) {
         updateStatusBar()
+        // An edit can add or remove the delimiters around the caret without
+        // moving the selection, so the bar's on-state has to follow edits too.
+        refreshFormatBarState()
         // Keep an open Read view in sync with edits (it renders a snapshot).
         refreshReadView()
     }
 
     @objc private func editorSelectionDidChange(_ notification: Notification) {
         updateStatusBar()
+        refreshFormatBarState()
     }
 
     private func updateStatusBar() {
@@ -784,7 +788,17 @@ class Document: NSDocument, HeadingNavigable {
     func refreshFormatBar() {
         formatBar.isHidden = !AppSettings.showFormatBar || editor.viewMode == .reading
         formatBar.refreshEnabledState(editor: editor)
+        refreshFormatBarState()
         layoutTopBars()
+    }
+
+    /// Just the lit/unlit state of the bar's buttons. Split out from
+    /// `refreshFormatBar` because this one runs on every caret move and every
+    /// keystroke, where re-deciding visibility and re-stacking the bars would be
+    /// wasted work.
+    private func refreshFormatBarState() {
+        guard let formatBar, !formatBar.isHidden, let editor else { return }
+        formatBar.refreshActiveState(editor: editor)
     }
 
     /// Stacks the visible top bars under the toolbar and hands the editor their

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -26,6 +26,7 @@ class Document: NSDocument, HeadingNavigable {
     private var scrollView: NSScrollView!
     private var containerView: NSView!
     private var findController: FindController!
+    private var formatBar: FormatBarView!
     private var readView: ReadModeWebView?
 
     /// Editor character offset captured when entering Read mode (the topmost
@@ -206,6 +207,20 @@ class Document: NSDocument, HeadingNavigable {
 
         findController = FindController(editor: editor, scrollView: scrollView,
                                        container: containerView, statusBar: statusBar)
+        findController.onLayoutNeeded = { [weak self] in self?.layoutTopBars() }
+
+        // The format bar: a chrome strip across the top of the editor, above
+        // the find bar. Parked exactly like the find bar — sized to the
+        // container *before* `addSubview`, because a flexible-width autoresizing
+        // view only grows by the delta from the width it was added at, and a
+        // zero-width bar would inflate the window's opening frame (the
+        // contentMinSize scar documented at FindController.init).
+        formatBar = FormatBarView(frame: .zero)
+        formatBar.isHidden = true
+        formatBar.autoresizingMask = [.width, .minYMargin]   // pinned to the top edge
+        formatBar.setFrameSize(NSSize(width: containerView.bounds.width, height: formatBar.preferredHeight))
+        // Below the floating status bar so counts stay on top.
+        containerView.addSubview(formatBar, positioned: .below, relativeTo: statusBar)
 
         NotificationCenter.default.addObserver(
             self, selector: #selector(editorDidChange(_:)),
@@ -253,6 +268,7 @@ class Document: NSDocument, HeadingNavigable {
         window.delegate = wc
         window.makeFirstResponder(editor)
         applyToolbarVisibility()
+        refreshFormatBar()
         // Before the source-mode switch below, which reads the editor's text.
         adoptPendingContent()
         // Honor the persisted source-mode preference for the editing view.
@@ -605,6 +621,9 @@ class Document: NSDocument, HeadingNavigable {
                 swapToEditor()
             }
         }
+        // The bar hides in Reading mode (a read-only editor has no formatting
+        // commands) and returns on the way back — refresh on every mode change.
+        refreshFormatBar()
     }
 
     /// Reveals the editor's scroll view (hiding any read view) and repairs
@@ -747,6 +766,42 @@ class Document: NSDocument, HeadingNavigable {
         window.toolbar?.isVisible = AppSettings.showToolbar && !AppSettings.autoHideToolbar
     }
 
+    // MARK: - Format bar (top of the editor, above the find bar)
+
+    /// View ▸ Show Format Bar. Goes through the setting rather than a direct
+    /// `isHidden` flip so the menu item and any future Settings ▸ Edit checkbox
+    /// can't drift apart — the same idiom as `toggleToolbarShown`.
+    @objc func toggleFormatBar(_ sender: Any?) {
+        AppSettings.showFormatBar.toggle()
+        AppSettings.applyEditSettingsToOpenDocuments()
+    }
+
+    /// Applies the format bar's visibility rule (hidden in Reading mode or when
+    /// the Show Format Bar setting is off — the latter also removes any chance
+    /// of a click reaching a read-only editor), refreshes its controls' enabled
+    /// state, and re-stacks the top bars. Called on show, on view-mode change
+    /// and from `AppSettings.applyEditSettingsToOpenDocuments()`.
+    func refreshFormatBar() {
+        formatBar.isHidden = !AppSettings.showFormatBar || editor.viewMode == .reading
+        formatBar.refreshEnabledState(editor: editor)
+        layoutTopBars()
+    }
+
+    /// Stacks the visible top bars under the toolbar and hands the editor their
+    /// combined height. The sole writer of `additionalTopInset` — the find bar
+    /// used to write it directly, and a second writer (this bar) would clobber
+    /// whichever ran last. Order in the array is the on-screen order (top
+    /// first): format bar above find bar.
+    func layoutTopBars() {
+        var y = containerView.bounds.height
+        for bar in [formatBar!, findController.barView] where !bar.isHidden {
+            let h = bar.preferredHeight
+            y -= h
+            bar.frame = NSRect(x: 0, y: y, width: containerView.bounds.width, height: h)
+        }
+        editor.additionalTopInset = containerView.bounds.height - y
+    }
+
     /// Keeps the View-menu "Show Source in Editor" checkmark and the
     /// Show/Hide Toolbar title in sync with the settings.
     override func validateMenuItem(_ item: NSMenuItem) -> Bool {
@@ -755,6 +810,9 @@ class Document: NSDocument, HeadingNavigable {
         }
         if item.action == #selector(toggleToolbarShown(_:)) {
             item.title = AppSettings.showToolbar ? "Hide Toolbar" : "Show Toolbar"
+        }
+        if item.action == #selector(toggleFormatBar(_:)) {
+            item.state = AppSettings.showFormatBar ? .on : .off
         }
         if item.action == #selector(toggleAutoHideToolbar(_:)) {
             item.state = AppSettings.autoHideToolbar ? .on : .off

--- a/Sources/edmd/App/FindController.swift
+++ b/Sources/edmd/App/FindController.swift
@@ -15,6 +15,15 @@ final class FindController: NSObject, EditorFindHandling {
     private weak var container: NSView?
     private let bar = FindBarView()
 
+    /// Notifies the owner that the bar's size or visibility changed and the top
+    /// bars need re-laying-out. The owner (`Document`) is the sole writer of
+    /// `editor.additionalTopInset` now — the find bar used to write it directly,
+    /// but a second writer (the format bar) would clobber whichever ran last.
+    var onLayoutNeeded: (() -> Void)?
+
+    /// The bar view, exposed for `Document.layoutTopBars()`.
+    var barView: FindBarView { bar }
+
     /// The scroll view's top content inset before we pushed content down for the
     /// bar (usually the toolbar overlap). Restored on hide.
     private var isShowing = false
@@ -101,7 +110,7 @@ final class FindController: NSObject, EditorFindHandling {
         isShowing = false
         bar.isHidden = true
         editor?.clearFindMatches()
-        editor?.additionalTopInset = 0
+        onLayoutNeeded?()
         editor?.window?.makeFirstResponder(editor)
     }
 
@@ -115,18 +124,11 @@ final class FindController: NSObject, EditorFindHandling {
 
     // MARK: - Layout
 
-    /// Positions the bar under the toolbar and pushes the document content down
-    /// by the bar's height (varies with the replace row).
+    /// Delegates the whole job to the owner: `Document` stacks the format bar
+    /// above the find bar and writes the combined height as the editor's top
+    /// inset. It must stay the single writer of `additionalTopInset`.
     private func layoutBar() {
-        guard let container, let scrollView else { return }
-        let h = bar.preferredHeight
-        // The editor owns contentInsets (it reserves overscroll there); hand it
-        // the bar's height rather than writing the inset directly, so a resize
-        // recomputing the overscroll doesn't drop the bar's share.
-        bar.frame = NSRect(x: 0,
-                           y: container.bounds.height - h,
-                           width: container.bounds.width, height: h)
-        editor?.additionalTopInset = h
+        onLayoutNeeded?()
     }
 
     // MARK: - Search

--- a/Sources/edmd/App/FindController.swift
+++ b/Sources/edmd/App/FindController.swift
@@ -86,14 +86,20 @@ final class FindController: NSObject, EditorFindHandling {
         let firstShow = !isShowing
         if firstShow {
             isShowing = true
+            // Reveal *before* re-laying out the top bars: `Document.layoutTopBars()`
+            // stacks only visible bars, so a bar revealed after that call pops up
+            // at whatever stale frame it had — on the very first window, wherever
+            // the autoresizing mask left it, not under the format bar. (Layout-
+            // then-reveal worked pre-refactor only because the find bar used to
+            // position itself.)
+            bar.isHidden = false
         }
         bar.showsReplaceRow = replace
         layoutBar()
-        // Finish the bar's internal layout *before* revealing it, otherwise the
+        // Finish the bar's internal layout before the window draws, otherwise the
         // first painted frame is pre-layout and controls (the search field's
         // magnifier) visibly settle a pass later.
         bar.layoutSubtreeIfNeeded()
-        if firstShow { bar.isHidden = false }
 
         // Seed from the current selection when it's a single line of text.
         let sel = editor.selectedRange()

--- a/Sources/edmd/App/FormatMenu.swift
+++ b/Sources/edmd/App/FormatMenu.swift
@@ -135,6 +135,10 @@ enum FormatMenu {
                     action: #selector(EditorTextView.formatUnderline(_:)), shortcut: .cmd("u")),
         MenuCommand(id: "format.strikethrough", submenu: "Font", title: "Strikethrough",
                     action: #selector(EditorTextView.formatStrikethrough(_:))),
+        MenuCommand(id: "format.subscript", submenu: "Font", title: "Subscript",
+                    action: #selector(EditorTextView.formatSubscript(_:))),
+        MenuCommand(id: "format.superscript", submenu: "Font", title: "Superscript",
+                    action: #selector(EditorTextView.formatSuperscript(_:))),
         MenuCommand(id: "format.highlight", submenu: "Font", title: "Highlight",
                     action: #selector(EditorTextView.formatHighlight(_:))),
         MenuCommand(id: "format.code", submenu: "Font", title: "Code",
@@ -161,19 +165,40 @@ enum FormatMenu {
 
     private static func headingSubmenuItem() -> NSMenuItem {
         let item = NSMenuItem(title: "Heading", action: nil, keyEquivalent: "")
+        item.submenu = headingMenu()
+        return item
+    }
+
+    /// A fresh Heading submenu: Body (level 0, strips the `#` prefix), a
+    /// separator, then Heading 1–6. Shared by the menu bar and the format bar's
+    /// heading pulldown. Like `fontMenu()`, each call re-registers the ids in
+    /// `KeyBindingCatalog` — already the behaviour for the context Font menu.
+    static func headingMenu() -> NSMenu {
         let menu = NSMenu(title: "Heading")
+        menu.addItem(MenuCommand(id: "format.heading0", submenu: "Heading",
+                                 title: "Body",
+                                 action: #selector(EditorTextView.formatHeading(_:)),
+                                 tag: 0).makeItem())
+        menu.addItem(.separator())
         for level in 1...6 {
             menu.addItem(MenuCommand(id: "format.heading\(level)", submenu: "Heading",
                                      title: "Heading \(level)",
                                      action: #selector(EditorTextView.formatHeading(_:)),
                                      tag: level).makeItem())
         }
-        item.submenu = menu
-        return item
+        return menu
     }
 
     private static func calloutSubmenuItem() -> NSMenuItem {
         let item = NSMenuItem(title: "Alert / Callout", action: nil, keyEquivalent: "")
+        item.submenu = calloutMenu()
+        return item
+    }
+
+    /// A fresh Alert / Callout submenu: the five GitHub alerts, a separator,
+    /// then the Obsidian-only types. Shared by the menu bar and the format bar's
+    /// callout pulldown.
+    static func calloutMenu() -> NSMenu {
         let menu = NSMenu(title: "Alert / Callout")
         for type in githubCalloutTypes {
             menu.addItem(MenuCommand(id: "format.callout.\(type)", submenu: "Alert / Callout",
@@ -188,8 +213,7 @@ enum FormatMenu {
                                      action: #selector(EditorTextView.formatCallout(_:)),
                                      representedObject: type).makeItem())
         }
-        item.submenu = menu
-        return item
+        return menu
     }
 
     private static func fontSubmenuItem() -> NSMenuItem {

--- a/Sources/edmd/App/ReproScript.swift
+++ b/Sources/edmd/App/ReproScript.swift
@@ -20,6 +20,8 @@ import WebKit
 ///                     recentering, so a block can be driven off-screen)
 ///   logsel            log the current selection
 ///   viewmode          toggle Edit ↔ Read via the same action as ⌘E
+///   find on|off|replace  open/close the find bar (⌘F's own handler) without
+///                     activating the app the way an AX-driven ⌘F would
 ///   readscroll <y>    raw-scroll the Read-mode webview to y
 ///   logstate          NSLog view-swap state (mode, hidden flags, clip y,
 ///                     webview scrollTop) for mode-switch harness debugging
@@ -199,6 +201,23 @@ enum ReproScript {
                 scheduleDoc(after: delay) { doc in
                     doc.toggleViewMode(nil)
                     Log.info("repro viewmode toggled", category: .app)
+                }
+            case "find":
+                // Opens/closes the find bar through the same handler ⌘F fires.
+                // `find on|off|replace`. The AX route (ui-harness.sh open-find)
+                // activates the app, which takes the machine away from whoever
+                // is using it — guard-focus-steal.sh denies it, so this is how a
+                // harness gets the find bar up.
+                scheduleDoc(after: delay) { doc in
+                    guard let handler = doc.editor?.findHandler else {
+                        Log.info("repro find: no find handler", category: .app); return
+                    }
+                    switch arg {
+                    case "off":     handler.editorHideFind()
+                    case "replace": handler.editorToggleFind(replace: true)
+                    default:        handler.editorToggleFind(replace: false)
+                    }
+                    Log.info("repro find \(arg)", category: .app)
                 }
             case "readscroll":
                 // Raw-scrolls the Read-mode webview to y (simulates the user

--- a/Sources/edmd/App/ViewMenu.swift
+++ b/Sources/edmd/App/ViewMenu.swift
@@ -36,26 +36,12 @@ enum ViewMenu {
 
         // The format bar across the top of the editor, kept below the toolbar
         // section with a divider on each side. Titled for the default state
-        // (the bar starts shown) the way Hide Toolbar above is —
+        // (the bar starts hidden) the way Hide Toolbar above is —
         // Document.validateMenuItem flips it; no default shortcut.
         viewMenu.addItem(.separator())
         viewMenu.addItem(MenuCommand(id: "view.showFormatBar", group: "View",
-                                     title: "Hide Format Bar",
+                                     title: "Show Format Bar",
                                      action: #selector(Document.toggleFormatBar(_:))).makeItem())
-        viewMenu.addItem(.separator())
-
-        let typewriterItem = MenuCommand(id: "view.typewriterScroll", group: "View",
-                                         title: "Typewriter Scroll",
-                                         action: #selector(AppDelegate.toggleTypewriterMode(_:))).makeItem()
-        typewriterItem.state = AppDelegate.typewriterModeEnabled() ? .on : .off
-        viewMenu.addItem(typewriterItem)
-
-        // Dims everything but the lines the selection touches. Same setting as
-        // Settings ▸ Edit ▸ Editor, so the two always agree.
-        let focusItem = MenuCommand(id: "view.focusMode", group: "View", title: "Focus Mode",
-                                    action: #selector(AppDelegate.toggleFocusMode(_:))).makeItem()
-        focusItem.state = AppSettings.focusMode ? .on : .off
-        viewMenu.addItem(focusItem)
 
         // View-mode toggle (Edit ↔ Read) + the Source-mode checkbox.
         viewMenu.addItem(.separator())

--- a/Sources/edmd/App/ViewMenu.swift
+++ b/Sources/edmd/App/ViewMenu.swift
@@ -20,12 +20,6 @@ enum ViewMenu {
         viewMenu.addItem(MenuCommand(id: "view.toggleToolbar", group: "View", title: "Hide Toolbar",
                                      action: #selector(Document.toggleToolbarShown(_:))).makeItem())
 
-        // The format bar across the top of the editor. Checkmark lives in
-        // Document.validateMenuItem; no default shortcut.
-        viewMenu.addItem(MenuCommand(id: "view.showFormatBar", group: "View",
-                                     title: "Show Format Bar",
-                                     action: #selector(Document.toggleFormatBar(_:))).makeItem())
-
         // Full-screen auto-hide. Lives here rather than in Settings, next to
         // the switch it qualifies.
         viewMenu.addItem(MenuCommand(id: "view.autoHideToolbar", group: "View",
@@ -39,6 +33,14 @@ enum ViewMenu {
         viewMenu.addItem(withTitle: "Customize Toolbar…",
                          action: #selector(NSWindow.runToolbarCustomizationPalette(_:)),
                          keyEquivalent: "")
+
+        // The format bar across the top of the editor, kept below the toolbar
+        // section with a divider on each side. Checkmark lives in
+        // Document.validateMenuItem; no default shortcut.
+        viewMenu.addItem(.separator())
+        viewMenu.addItem(MenuCommand(id: "view.showFormatBar", group: "View",
+                                     title: "Show Format Bar",
+                                     action: #selector(Document.toggleFormatBar(_:))).makeItem())
         viewMenu.addItem(.separator())
 
         let typewriterItem = MenuCommand(id: "view.typewriterScroll", group: "View",

--- a/Sources/edmd/App/ViewMenu.swift
+++ b/Sources/edmd/App/ViewMenu.swift
@@ -20,6 +20,12 @@ enum ViewMenu {
         viewMenu.addItem(MenuCommand(id: "view.toggleToolbar", group: "View", title: "Hide Toolbar",
                                      action: #selector(Document.toggleToolbarShown(_:))).makeItem())
 
+        // The format bar across the top of the editor. Checkmark lives in
+        // Document.validateMenuItem; no default shortcut.
+        viewMenu.addItem(MenuCommand(id: "view.showFormatBar", group: "View",
+                                     title: "Show Format Bar",
+                                     action: #selector(Document.toggleFormatBar(_:))).makeItem())
+
         // Full-screen auto-hide. Lives here rather than in Settings, next to
         // the switch it qualifies.
         viewMenu.addItem(MenuCommand(id: "view.autoHideToolbar", group: "View",

--- a/Sources/edmd/App/ViewMenu.swift
+++ b/Sources/edmd/App/ViewMenu.swift
@@ -35,11 +35,12 @@ enum ViewMenu {
                          keyEquivalent: "")
 
         // The format bar across the top of the editor, kept below the toolbar
-        // section with a divider on each side. Checkmark lives in
-        // Document.validateMenuItem; no default shortcut.
+        // section with a divider on each side. Titled for the default state
+        // (the bar starts shown) the way Hide Toolbar above is —
+        // Document.validateMenuItem flips it; no default shortcut.
         viewMenu.addItem(.separator())
         viewMenu.addItem(MenuCommand(id: "view.showFormatBar", group: "View",
-                                     title: "Show Format Bar",
+                                     title: "Hide Format Bar",
                                      action: #selector(Document.toggleFormatBar(_:))).makeItem())
         viewMenu.addItem(.separator())
 

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -205,6 +205,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     ]
 
     @MainActor private func setupMenuBar() {
+        // Before any `makeItem()`, which resolves each command's override by id.
+        KeyBindingStore.migrateRenamedIDs()
+
         let mainMenu = NSMenu()
 
         // App menu (required for Cmd+Q)
@@ -315,11 +318,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
                          action: #selector(NSText.selectAll(_:)),
                          keyEquivalent: "a")
 
+        editMenu.addItem(NSMenuItem.separator())
+
         // Typing behaviour rather than window furniture, so they sit here with
-        // Hard Wrap Paragraphs instead of in View. The ids keep their `view.`
-        // prefix — they are what a user's rebinding is stored under, and
-        // renaming them would silently drop any existing override.
-        let typewriterItem = MenuCommand(id: "view.typewriterScroll", group: "Edit",
+        // Hard Wrap Paragraphs instead of in View. Renamed off the `view.`
+        // prefix to match; `KeyBindingStore.migrateRenamedIDs` carries any
+        // shortcut the user had set across to the new ids.
+        let typewriterItem = MenuCommand(id: "edit.typewriterScroll", group: "Edit",
                                          title: "Typewriter Scroll",
                                          action: #selector(AppDelegate.toggleTypewriterMode(_:))).makeItem()
         typewriterItem.state = AppDelegate.typewriterModeEnabled() ? .on : .off
@@ -327,7 +332,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 
         // Dims everything but the lines the selection touches. Same setting as
         // Settings ▸ Edit ▸ Editor, so the two always agree.
-        let focusItem = MenuCommand(id: "view.focusMode", group: "Edit", title: "Focus Mode",
+        let focusItem = MenuCommand(id: "edit.focusMode", group: "Edit", title: "Focus Mode",
                                     action: #selector(AppDelegate.toggleFocusMode(_:))).makeItem()
         focusItem.state = AppSettings.focusMode ? .on : .off
         editMenu.addItem(focusItem)

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -315,6 +315,23 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
                          action: #selector(NSText.selectAll(_:)),
                          keyEquivalent: "a")
 
+        // Typing behaviour rather than window furniture, so they sit here with
+        // Hard Wrap Paragraphs instead of in View. The ids keep their `view.`
+        // prefix — they are what a user's rebinding is stored under, and
+        // renaming them would silently drop any existing override.
+        let typewriterItem = MenuCommand(id: "view.typewriterScroll", group: "Edit",
+                                         title: "Typewriter Scroll",
+                                         action: #selector(AppDelegate.toggleTypewriterMode(_:))).makeItem()
+        typewriterItem.state = AppDelegate.typewriterModeEnabled() ? .on : .off
+        editMenu.addItem(typewriterItem)
+
+        // Dims everything but the lines the selection touches. Same setting as
+        // Settings ▸ Edit ▸ Editor, so the two always agree.
+        let focusItem = MenuCommand(id: "view.focusMode", group: "Edit", title: "Focus Mode",
+                                    action: #selector(AppDelegate.toggleFocusMode(_:))).makeItem()
+        focusItem.state = AppSettings.focusMode ? .on : .off
+        editMenu.addItem(focusItem)
+
         editMenu.addItem(NSMenuItem.separator())
 
         // Reflows the selected paragraphs, or the whole document when nothing

--- a/Sources/edmd/Settings/AppSettings.swift
+++ b/Sources/edmd/Settings/AppSettings.swift
@@ -450,10 +450,11 @@ enum AppSettings {
     }
 
     /// Whether document windows show the format bar across the top of the
-    /// editor. Defaults on — the feature is the point. Mirrored by the View
-    /// menu's Show Format Bar item.
+    /// editor. Defaults off: it costs a strip of the window and every command
+    /// on it is already on the Format menu, so it is opt-in. Mirrored by the
+    /// View menu's Show Format Bar item.
     static var showFormatBar: Bool {
-        get { boolDefaultTrue(Key.showFormatBar) }
+        get { UserDefaults.standard.bool(forKey: Key.showFormatBar) }
         set { UserDefaults.standard.set(newValue, forKey: Key.showFormatBar) }
     }
 

--- a/Sources/edmd/Settings/AppSettings.swift
+++ b/Sources/edmd/Settings/AppSettings.swift
@@ -118,6 +118,7 @@ enum AppSettings {
         static let defaultCodeSyntax = "settings.syntax.defaultCodeSyntax"
         // Edit ▸ Display.
         static let showToolbar         = "settings.edit.showToolbar"
+        static let showFormatBar       = "settings.edit.showFormatBar"
         static let autoHideToolbar     = "settings.edit.autoHideToolbar"
         static let showInvisibles      = "settings.edit.showInvisibles"
         // Parked with the rest of the Always mode (see `showInvisibles` below):
@@ -448,6 +449,14 @@ enum AppSettings {
         set { UserDefaults.standard.set(newValue, forKey: Key.autoHideToolbar) }
     }
 
+    /// Whether document windows show the format bar across the top of the
+    /// editor. Defaults on — the feature is the point. Mirrored by the View
+    /// menu's Show Format Bar item.
+    static var showFormatBar: Bool {
+        get { boolDefaultTrue(Key.showFormatBar) }
+        set { UserDefaults.standard.set(newValue, forKey: Key.showFormatBar) }
+    }
+
     static var indentStyle: IndentStyle {
         get {
             guard let raw = UserDefaults.standard.string(forKey: Key.indentStyle),
@@ -594,6 +603,7 @@ enum AppSettings {
         for case let document as Document in NSDocumentController.shared.documents {
             if let editor = document.editor { applyEditSettings(to: editor) }
             document.applyToolbarVisibility()
+            document.refreshFormatBar()
         }
     }
 

--- a/Sources/edmd/Settings/KeyBindingStore.swift
+++ b/Sources/edmd/Settings/KeyBindingStore.swift
@@ -152,6 +152,31 @@ enum KeyBindingStore {
     static func removeAllOverrides() {
         overrides = [:]
     }
+
+    /// Commands whose `id` has changed, old to new.
+    ///
+    /// An override is filed under the command's id, so renaming one strands the
+    /// user's shortcut under a key nothing reads again — it does not revert to
+    /// the default, it silently stops applying. Anything renamed belongs here.
+    private static let renamedIDs = [
+        "view.typewriterScroll": "edit.typewriterScroll",
+        "view.focusMode": "edit.focusMode",
+    ]
+
+    /// Re-files overrides left under an old id. Runs once, before the menus are
+    /// built, so `effective(id:default:)` finds them under the new name.
+    static func migrateRenamedIDs() {
+        var dict = overrides
+        var changed = false
+        for (old, new) in renamedIDs {
+            guard let shortcut = dict.removeValue(forKey: old) else { continue }
+            changed = true
+            // A binding already set under the new id was chosen more recently
+            // than one stranded under the old one; leave it alone.
+            if dict[new] == nil { dict[new] = shortcut }
+        }
+        if changed { overrides = dict }
+    }
 }
 
 // MARK: - Catalog

--- a/Sources/edmd/Settings/SyntaxSettingsView.swift
+++ b/Sources/edmd/Settings/SyntaxSettingsView.swift
@@ -199,6 +199,7 @@ struct SyntaxSettingsView: View {
         let features = AppSettings.markdownFeatures
         for case let document as Document in NSDocumentController.shared.documents {
             document.editor?.markdownFeatures = features
+            document.refreshFormatBar()
             document.refreshReadView()
         }
     }

--- a/Sources/edmd/Views/ChromeBarView.swift
+++ b/Sources/edmd/Views/ChromeBarView.swift
@@ -1,0 +1,50 @@
+import AppKit
+
+// MARK: - Shared chrome bar base
+
+/// A top bar that reads as window chrome: the titlebar material the toolbar
+/// uses, plus a hairline along the bottom edge matching the toolbar separator.
+/// Shared by the find bar and the format bar.
+class ChromeBarView: NSVisualEffectView {
+
+    /// The hairline along the bottom edge, matching the toolbar's separator so
+    /// the bar reads as window chrome. A subview, not a `draw(_:)` override:
+    /// `NSVisualEffectView` renders its material through layers and never calls
+    /// through to a custom `draw`. Pinned to the bottom.
+    private let bottomBorder = NSView()
+
+    /// The bar's height for its active state (drives the content inset).
+    /// `fittingSize` already carries the layout's top/bottom insets.
+    var preferredHeight: CGFloat {
+        layoutSubtreeIfNeeded()
+        return fittingSize.height
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        material = .titlebar
+        blendingMode = .withinWindow
+        state = .active
+
+        bottomBorder.wantsLayer = true
+        bottomBorder.layer?.backgroundColor = NSColor.separatorColor.cgColor
+        bottomBorder.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(bottomBorder)
+        NSLayoutConstraint.activate([
+            bottomBorder.leadingAnchor.constraint(equalTo: leadingAnchor),
+            bottomBorder.trailingAnchor.constraint(equalTo: trailingAnchor),
+            bottomBorder.bottomAnchor.constraint(equalTo: bottomAnchor),
+            bottomBorder.heightAnchor.constraint(equalToConstant: 1 / (NSScreen.main?.backingScaleFactor ?? 2)),
+        ])
+    }
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    /// Keeps the hairline's colour correct across a light/dark switch — a
+    /// `cgColor` snapshot doesn't follow the appearance on its own.
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            bottomBorder.layer?.backgroundColor = NSColor.separatorColor.cgColor
+        }
+    }
+}

--- a/Sources/edmd/Views/ChromeBarView.swift
+++ b/Sources/edmd/Views/ChromeBarView.swift
@@ -23,12 +23,15 @@ class ChromeBarView: NSVisualEffectView {
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         material = .titlebar
-        // `.withinWindow` would sample the editor content behind the bar
-        // (frosted-white over text), which reads as a floating panel instead
-        // of window chrome. `.behindWindow` samples the window backdrop the
-        // way the titlebar/toolbar does, so the bar matches them.
-        blendingMode = .behindWindow
-        state = .active
+        // `.withinWindow`, not `.behindWindow`: behind-window blending samples
+        // what is behind the *window* — the desktop — so the bar tracked the
+        // wallpaper instead of the chrome. It looked right only because this
+        // wallpaper happens to be near the light-mode chrome colour; in dark
+        // mode the bar measured 40 levels lighter than the toolbar above it.
+        blendingMode = .withinWindow
+        // Follows the window, so the bar dims with the toolbar when the window
+        // stops being key. `.active` pinned it bright on inactive windows.
+        state = .followsWindowActiveState
 
         bottomBorder.wantsLayer = true
         bottomBorder.layer?.backgroundColor = NSColor.separatorColor.cgColor

--- a/Sources/edmd/Views/ChromeBarView.swift
+++ b/Sources/edmd/Views/ChromeBarView.swift
@@ -23,7 +23,11 @@ class ChromeBarView: NSVisualEffectView {
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         material = .titlebar
-        blendingMode = .withinWindow
+        // `.withinWindow` would sample the editor content behind the bar
+        // (frosted-white over text), which reads as a floating panel instead
+        // of window chrome. `.behindWindow` samples the window backdrop the
+        // way the titlebar/toolbar does, so the bar matches them.
+        blendingMode = .behindWindow
         state = .active
 
         bottomBorder.wantsLayer = true

--- a/Sources/edmd/Views/ChromeBarView.swift
+++ b/Sources/edmd/Views/ChromeBarView.swift
@@ -13,6 +13,26 @@ class ChromeBarView: NSVisualEffectView {
     /// through to a custom `draw`. Pinned to the bottom.
     private let bottomBorder = NSView()
 
+    /// One device pixel. The hairline's thickness, and the amount by which the
+    /// bar's visible interior is shorter than its bounds.
+    static var hairlineHeight: CGFloat { 1 / (NSScreen.main?.backingScaleFactor ?? 2) }
+
+    /// The separator that lands on the bar's top edge — the toolbar's above the
+    /// format bar, the format bar's own hairline above the find bar. It is not
+    /// drawn by this view but it covers its first point, so the strip that
+    /// reads as the bar starts below it.
+    private static let topSeparatorHeight: CGFloat = 1
+
+    /// The strip that actually reads as the bar: its bounds less the separator
+    /// on its top edge and the hairline it draws along its bottom. Anything
+    /// centred on the bar centres on this — centring on `bounds` looks a point
+    /// high, because a point of those bounds is covered at the top and only
+    /// half a point at the bottom.
+    var interior: NSRect {
+        NSRect(x: 0, y: Self.hairlineHeight, width: bounds.width,
+               height: max(0, bounds.height - Self.hairlineHeight - Self.topSeparatorHeight))
+    }
+
     /// The bar's height for its active state (drives the content inset).
     /// `fittingSize` already carries the layout's top/bottom insets.
     var preferredHeight: CGFloat {
@@ -41,7 +61,7 @@ class ChromeBarView: NSVisualEffectView {
             bottomBorder.leadingAnchor.constraint(equalTo: leadingAnchor),
             bottomBorder.trailingAnchor.constraint(equalTo: trailingAnchor),
             bottomBorder.bottomAnchor.constraint(equalTo: bottomAnchor),
-            bottomBorder.heightAnchor.constraint(equalToConstant: 1 / (NSScreen.main?.backingScaleFactor ?? 2)),
+            bottomBorder.heightAnchor.constraint(equalToConstant: Self.hairlineHeight),
         ])
     }
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }

--- a/Sources/edmd/Views/FindBarView.swift
+++ b/Sources/edmd/Views/FindBarView.swift
@@ -275,7 +275,7 @@ private final class SegmentTabbingControl: NSSegmentedControl {
 ///
 /// Dumb view: owns the controls, reports events through closures. All logic is
 /// in `FindController`.
-final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
+final class FindBarView: ChromeBarView, NSSearchFieldDelegate {
 
     let searchField = CountingSearchField()
     let replaceField = NSTextField()
@@ -296,12 +296,6 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
     private let bottomRightStack = NSStackView()
     /// Row-0 slack, live only in replace mode — see `showsReplaceRow`.
     private let topSpacer = NSView()
-    /// Hairline along the bottom edge, matching the toolbar's separator so the
-    /// bar reads as window chrome. A subview, not a `draw(_:)` override:
-    /// `NSVisualEffectView` renders its material through layers and never calls
-    /// through to a custom `draw`. Pinned to the bottom, so it follows whichever
-    /// row is last — find-only or the revealed replace row.
-    private let bottomBorder = NSView()
     private var grid: NSGridView!
 
     // Event callbacks, wired by the controller.
@@ -336,15 +330,6 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
         }
     }
 
-    /// Keeps the hairline's colour correct across a light/dark switch — a
-    /// `cgColor` snapshot doesn't follow the appearance on its own.
-    override func viewDidChangeEffectiveAppearance() {
-        super.viewDidChangeEffectiveAppearance()
-        effectiveAppearance.performAsCurrentDrawingAppearance {
-            bottomBorder.layer?.backgroundColor = NSColor.separatorColor.cgColor
-        }
-    }
-
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         // AppKit rebuilds the window's key-view loop from view geometry whenever
@@ -374,19 +359,8 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
         }
     }
 
-    /// The bar's height for the active replace state (drives the content inset).
-    /// `fittingSize` already carries the grid's top/bottom insets, so no padding
-    /// is added here — adding more would stretch the grid and unbalance the rows.
-    var preferredHeight: CGFloat {
-        layoutSubtreeIfNeeded()
-        return fittingSize.height
-    }
-
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
-        material = .titlebar
-        blendingMode = .withinWindow
-        state = .active
         buildUI()
         showsReplaceRow = false
     }
@@ -459,17 +433,6 @@ final class FindBarView: NSVisualEffectView, NSSearchFieldDelegate {
         grid.column(at: 1).xPlacement = .leading      // col1 hugs content (driven by the wider cluster)
         grid.row(at: 0).yPlacement = .center
         grid.row(at: 1).yPlacement = .center
-
-        bottomBorder.wantsLayer = true
-        bottomBorder.layer?.backgroundColor = NSColor.separatorColor.cgColor
-        bottomBorder.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(bottomBorder)
-        NSLayoutConstraint.activate([
-            bottomBorder.leadingAnchor.constraint(equalTo: leadingAnchor),
-            bottomBorder.trailingAnchor.constraint(equalTo: trailingAnchor),
-            bottomBorder.bottomAnchor.constraint(equalTo: bottomAnchor),
-            bottomBorder.heightAnchor.constraint(equalToConstant: 1 / (NSScreen.main?.backingScaleFactor ?? 2)),
-        ])
 
         grid.translatesAutoresizingMaskIntoConstraints = false
         addSubview(grid)

--- a/Sources/edmd/Views/FormatBarControls.swift
+++ b/Sources/edmd/Views/FormatBarControls.swift
@@ -158,7 +158,10 @@ final class FormatBarButton: NSButton {
 
     override func updateTrackingAreas() {
         super.updateTrackingAreas()
-        trackingAreas.forEach(removeTrackingArea)
+        // Spelled out rather than `forEach(removeTrackingArea)`: an unapplied
+        // method reference is inferred as throwing under Swift 6.0 (Xcode 16.2,
+        // what CI builds with), which rejects it inside a non-throwing override.
+        trackingAreas.forEach { removeTrackingArea($0) }
         // `.inVisibleRect` keeps the area correct as the bar resizes without
         // recomputing the rect here.
         addTrackingArea(NSTrackingArea(rect: .zero,
@@ -195,7 +198,7 @@ final class FormatBarPopUpButton: NSPopUpButton {
 
     override func updateTrackingAreas() {
         super.updateTrackingAreas()
-        trackingAreas.forEach(removeTrackingArea)
+        trackingAreas.forEach { removeTrackingArea($0) }
         addTrackingArea(NSTrackingArea(rect: .zero,
                                        options: [.mouseEnteredAndExited, .activeInKeyWindow,
                                                  .inVisibleRect],

--- a/Sources/edmd/Views/FormatBarControls.swift
+++ b/Sources/edmd/Views/FormatBarControls.swift
@@ -1,0 +1,135 @@
+import AppKit
+
+// MARK: - Format bar control chrome
+//
+// The rounded chip that appears behind a bar control on hover and stays put
+// while the formatting under the caret is in effect — the accessory-bar idiom
+// Mail uses. AppKit has no borderless button style that does this, so it is
+// drawn here.
+
+/// The chip itself. A helper object rather than a base class because the two
+/// control kinds cannot share one: `NSPopUpButton` is already an `NSButton`, so
+/// a common superclass would have to be `NSButton` and the pulldown could not
+/// inherit from it.
+@MainActor
+final class BarControlChip {
+
+    /// Pointer is over the control.
+    var isHovered = false { didSet { if isHovered != oldValue { refresh() } } }
+
+    /// The formatting this control applies is in effect at the selection.
+    var isActive = false { didSet { if isActive != oldValue { refresh() } } }
+
+    private let chip = CALayer()
+    private unowned let host: NSView
+
+    init(host: NSView) {
+        self.host = host
+        host.wantsLayer = true
+        chip.cornerRadius = 5
+        chip.cornerCurve = .continuous
+        // Behind the control's own drawing, never over the glyph.
+        host.layer?.insertSublayer(chip, at: 0)
+    }
+
+    /// Called from the host's `layout()`; the chip tracks the whole control.
+    func layoutChip() {
+        // No implicit fade as the control moves during a resize.
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        chip.frame = host.bounds
+        CATransaction.commit()
+    }
+
+    /// Re-resolves the fill. Semantic colours are stored as `cgColor`, which is
+    /// a snapshot that does not follow a light/dark switch, so this has to run
+    /// again on an appearance change — same trap as the bar's hairline.
+    func refresh() {
+        host.effectiveAppearance.performAsCurrentDrawingAppearance {
+            chip.backgroundColor = fill?.cgColor
+        }
+    }
+
+    /// Active wins over hover: the chip is the on-state indicator first, and a
+    /// pointer passing over it must not read as switching it off.
+    private var fill: NSColor? {
+        if isActive { return .unemphasizedSelectedContentBackgroundColor }
+        if isHovered { return .quaternaryLabelColor }
+        return nil
+    }
+}
+
+// MARK: - Hover plumbing
+//
+// Identical in both controls below. Kept as duplicated overrides rather than
+// hoisted somewhere clever: it is six lines, and the alternative is a wrapper
+// view between the stack and every control.
+
+/// A plain format-bar button: symbol only, with the hover/active chip.
+final class FormatBarButton: NSButton {
+    private(set) lazy var chip = BarControlChip(host: self)
+
+    override func layout() {
+        super.layout()
+        chip.layoutChip()
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        trackingAreas.forEach(removeTrackingArea)
+        // `.inVisibleRect` keeps the area correct as the bar resizes without
+        // recomputing the rect here.
+        addTrackingArea(NSTrackingArea(rect: .zero,
+                                       options: [.mouseEnteredAndExited, .activeInKeyWindow,
+                                                 .inVisibleRect],
+                                       owner: self))
+    }
+
+    override func mouseEntered(with event: NSEvent) { chip.isHovered = true }
+    override func mouseExited(with event: NSEvent) { chip.isHovered = false }
+
+    /// The pointer cannot exit a view that is removed from the screen, so a bar
+    /// hidden mid-hover would come back still wearing the chip.
+    override func viewDidHide() {
+        super.viewDidHide()
+        chip.isHovered = false
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        chip.refresh()
+    }
+}
+
+/// A format-bar pulldown (heading, callout). Hover only — a pulldown applies
+/// several different things, so there is no single state for it to be in.
+final class FormatBarPopUpButton: NSPopUpButton {
+    private(set) lazy var chip = BarControlChip(host: self)
+
+    override func layout() {
+        super.layout()
+        chip.layoutChip()
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        trackingAreas.forEach(removeTrackingArea)
+        addTrackingArea(NSTrackingArea(rect: .zero,
+                                       options: [.mouseEnteredAndExited, .activeInKeyWindow,
+                                                 .inVisibleRect],
+                                       owner: self))
+    }
+
+    override func mouseEntered(with event: NSEvent) { chip.isHovered = true }
+    override func mouseExited(with event: NSEvent) { chip.isHovered = false }
+
+    override func viewDidHide() {
+        super.viewDidHide()
+        chip.isHovered = false
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        chip.refresh()
+    }
+}

--- a/Sources/edmd/Views/FormatBarControls.swift
+++ b/Sources/edmd/Views/FormatBarControls.swift
@@ -26,7 +26,7 @@ final class BarControlChip {
     init(host: NSView) {
         self.host = host
         host.wantsLayer = true
-        chip.cornerRadius = 5
+        chip.cornerRadius = 4
         chip.cornerCurve = .continuous
         // Behind the control's own drawing, never over the glyph.
         host.layer?.insertSublayer(chip, at: 0)

--- a/Sources/edmd/Views/FormatBarControls.swift
+++ b/Sources/edmd/Views/FormatBarControls.swift
@@ -30,10 +30,6 @@ final class BarControlChip {
     /// The formatting this control applies is in effect at the selection.
     var isActive = false { didSet { if isActive != oldValue { refresh() } } }
 
-    /// Whether anything is currently drawn behind the control. The group uses
-    /// this to drop the dividers touching it.
-    var isChipped: Bool { isActive || isHovered }
-
     /// Told to the owning group so it can re-run its divider rule.
     var onChange: (() -> Void)?
 
@@ -107,10 +103,14 @@ final class BarControlChip {
 /// each adjacent pair.
 ///
 /// The group owns the rule that a divider disappears while either of the two
-/// controls it separates is wearing a chip. That is how Mail draws it — look at
-/// its alignment group, where the divider beside the selected button is simply
-/// absent — and it is also what keeps a chip from ever sitting against a
-/// hairline, without having to shrink the chip to make room for one.
+/// controls it separates is *on*. That is how Mail draws it — look at its
+/// alignment group, where the divider beside the selected button is simply
+/// absent.
+///
+/// Hover deliberately does not do this. A divider vanishing under the pointer
+/// made the group twitch as it moved along the row, and the chip does not need
+/// the room: it is inset inside its control and the group's spacing keeps it
+/// clear of the hairlines on its own.
 final class FormatBarGroupView: NSStackView {
 
     /// Members and dividers in visual order: `dividers[i]` sits between
@@ -135,8 +135,8 @@ final class FormatBarGroupView: NSStackView {
         // than index past the end.
         guard chips.count == dividers.count + 1 else { return }
         for (i, divider) in dividers.enumerated() {
-            let touchesChip = chips[i].isChipped || chips[i + 1].isChipped
-            divider.alphaValue = touchesChip ? 0 : 1
+            let touchesOn = chips[i].isActive || chips[i + 1].isActive
+            divider.alphaValue = touchesOn ? 0 : 1
         }
     }
 }

--- a/Sources/edmd/Views/FormatBarControls.swift
+++ b/Sources/edmd/Views/FormatBarControls.swift
@@ -49,17 +49,37 @@ final class BarControlChip {
         host.layer?.insertSublayer(chip, at: 0)
     }
 
-    /// Called from the host's `layout()`. Centred on the control at the shared
-    /// size rather than filling it.
+    /// Called from the host's `layout()`. Centred on the *bar*, not on the
+    /// control.
+    ///
+    /// Centring on the control looked equivalent and was not: the controls do
+    /// not all share a height, and each one centred inside its own frame put
+    /// its chip a pixel or two off its neighbour's. Worse, they were off in the
+    /// same direction — 3.0pt of bar above the chip against 4.5pt below. Taking
+    /// the centre line from the bar means every chip on it resolves to one
+    /// vertical position, and the gap above equals the gap below by
+    /// construction.
     func layoutChip() {
         // No implicit fade as the control moves during a resize.
         CATransaction.begin()
         CATransaction.setDisableActions(true)
-        chip.frame = NSRect(x: Self.insetX,
-                            y: ((host.bounds.height - Self.height) / 2).rounded(),
+        chip.frame = NSRect(x: Self.insetX, y: chipOriginY,
                             width: max(0, host.bounds.width - Self.insetX * 2),
                             height: Self.height)
         CATransaction.commit()
+    }
+
+    /// The chip's bottom edge in the host's coordinates, placed so the chip
+    /// straddles the bar's centre line. Falls back to centring on the control
+    /// before the view is in a bar.
+    private var chipOriginY: CGFloat {
+        var bar: NSView? = host.superview
+        while let candidate = bar, !(candidate is ChromeBarView) { bar = candidate.superview }
+        guard let chrome = bar as? ChromeBarView else {
+            return ((host.bounds.height - Self.height) / 2).rounded()
+        }
+        let centre = host.convert(NSPoint(x: 0, y: chrome.interior.midY), from: chrome)
+        return centre.y - Self.height / 2
     }
 
     /// Re-resolves the fill. Semantic colours are stored as `cgColor`, which is

--- a/Sources/edmd/Views/FormatBarControls.swift
+++ b/Sources/edmd/Views/FormatBarControls.swift
@@ -14,11 +14,28 @@ import AppKit
 @MainActor
 final class BarControlChip {
 
+    /// One size for every chip on the bar, pulldowns included. Deliberately not
+    /// the control's own bounds: those follow each symbol's intrinsic size, and
+    /// letting the chip track them made the highlighter's 23.5pt tall and the
+    /// callout pulldown's 17pt — the same affordance in a dozen sizes.
+    static let height: CGFloat = 20
+
+    /// Horizontal breathing room inside the control, so a chip cannot reach the
+    /// group's dividers even before the adjacent one is hidden.
+    private static let insetX: CGFloat = 1
+
     /// Pointer is over the control.
     var isHovered = false { didSet { if isHovered != oldValue { refresh() } } }
 
     /// The formatting this control applies is in effect at the selection.
     var isActive = false { didSet { if isActive != oldValue { refresh() } } }
+
+    /// Whether anything is currently drawn behind the control. The group uses
+    /// this to drop the dividers touching it.
+    var isChipped: Bool { isActive || isHovered }
+
+    /// Told to the owning group so it can re-run its divider rule.
+    var onChange: (() -> Void)?
 
     private let chip = CALayer()
     private unowned let host: NSView
@@ -26,18 +43,22 @@ final class BarControlChip {
     init(host: NSView) {
         self.host = host
         host.wantsLayer = true
-        chip.cornerRadius = 4
+        chip.cornerRadius = 5
         chip.cornerCurve = .continuous
         // Behind the control's own drawing, never over the glyph.
         host.layer?.insertSublayer(chip, at: 0)
     }
 
-    /// Called from the host's `layout()`; the chip tracks the whole control.
+    /// Called from the host's `layout()`. Centred on the control at the shared
+    /// size rather than filling it.
     func layoutChip() {
         // No implicit fade as the control moves during a resize.
         CATransaction.begin()
         CATransaction.setDisableActions(true)
-        chip.frame = host.bounds
+        chip.frame = NSRect(x: Self.insetX,
+                            y: ((host.bounds.height - Self.height) / 2).rounded(),
+                            width: max(0, host.bounds.width - Self.insetX * 2),
+                            height: Self.height)
         CATransaction.commit()
     }
 
@@ -48,6 +69,7 @@ final class BarControlChip {
         host.effectiveAppearance.performAsCurrentDrawingAppearance {
             chip.backgroundColor = fill?.cgColor
         }
+        onChange?()
     }
 
     /// Active wins over hover: the chip is the on-state indicator first, and a
@@ -56,6 +78,46 @@ final class BarControlChip {
         if isActive { return .unemphasizedSelectedContentBackgroundColor }
         if isHovered { return .quaternaryLabelColor }
         return nil
+    }
+}
+
+// MARK: - Group
+
+/// One group of bar controls: the buttons run together with a hairline between
+/// each adjacent pair.
+///
+/// The group owns the rule that a divider disappears while either of the two
+/// controls it separates is wearing a chip. That is how Mail draws it — look at
+/// its alignment group, where the divider beside the selected button is simply
+/// absent — and it is also what keeps a chip from ever sitting against a
+/// hairline, without having to shrink the chip to make room for one.
+final class FormatBarGroupView: NSStackView {
+
+    /// Members and dividers in visual order: `dividers[i]` sits between
+    /// `chips[i]` and `chips[i + 1]`.
+    private var chips: [BarControlChip] = []
+    private var dividers: [NSView] = []
+
+    func adopt(chips: [BarControlChip], dividers: [NSView]) {
+        self.chips = chips
+        self.dividers = dividers
+        for chip in chips { chip.onChange = { [weak self] in self?.updateDividers() } }
+        updateDividers()
+    }
+
+    /// A hidden arranged subview is removed from an `NSStackView`'s layout, so
+    /// the buttons would close up and shuffle sideways every time a chip
+    /// appeared. `alphaValue` keeps the divider in the layout and only stops it
+    /// drawing.
+    private func updateDividers() {
+        // Every divider sits between two controls, so anything else means the
+        // two arrays were built out of step — leave them all showing rather
+        // than index past the end.
+        guard chips.count == dividers.count + 1 else { return }
+        for (i, divider) in dividers.enumerated() {
+            let touchesChip = chips[i].isChipped || chips[i + 1].isChipped
+            divider.alphaValue = touchesChip ? 0 : 1
+        }
     }
 }
 

--- a/Sources/edmd/Views/FormatBarView.swift
+++ b/Sources/edmd/Views/FormatBarView.swift
@@ -191,7 +191,7 @@ final class FormatBarView: ChromeBarView {
         group.alignment = .centerY
         // Same order as `views`, so the group can pair each divider with the two
         // controls it sits between.
-        group.adopt(chips: views.compactMap(Self.chip(of:)), dividers: dividers)
+        group.adopt(chips: views.compactMap { Self.chip(of: $0) }, dividers: dividers)
         return group
     }
 

--- a/Sources/edmd/Views/FormatBarView.swift
+++ b/Sources/edmd/Views/FormatBarView.swift
@@ -106,8 +106,7 @@ final class FormatBarView: ChromeBarView {
             ]),
             makeGroup([
                 makeButton(symbol: "highlighter", title: "Highlight",
-                           action: #selector(EditorTextView.formatHighlight(_:)),
-                           tint: .systemYellow),
+                           action: #selector(EditorTextView.formatHighlight(_:))),
             ]),
             makeGroup([
                 makeButton(symbol: "list.bullet", title: "Bulleted List",
@@ -191,7 +190,7 @@ final class FormatBarView: ChromeBarView {
     }
 
     private func makeButton(symbol name: String, title: String,
-                            action: Selector, tint: NSColor? = nil) -> FormatBarButton {
+                            action: Selector) -> FormatBarButton {
         let button = FormatBarButton(image: Self.symbol(name, desc: title) ?? NSImage(),
                                      target: nil, action: action)
         button.bezelStyle = .accessoryBarAction
@@ -208,7 +207,6 @@ final class FormatBarView: ChromeBarView {
         button.refusesFirstResponder = true
         button.setAccessibilityLabel(title)
         button.toolTip = title
-        if let tint { button.contentTintColor = tint }
         register(button, chip: button.chip, action: action, title: title)
         return button
     }

--- a/Sources/edmd/Views/FormatBarView.swift
+++ b/Sources/edmd/Views/FormatBarView.swift
@@ -42,6 +42,11 @@ final class FormatBarView: ChromeBarView {
     }
     private var commandItems: [BarControl] = []
 
+    /// Each pulldown's menu, by the action its items carry. The heading and
+    /// callout pulldowns apply one of a set of mutually exclusive things, so
+    /// their state is a checkmark on the member in effect rather than a chip.
+    private var pullDownMenus: [Selector: NSMenu] = [:]
+
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         buildUI()
@@ -76,6 +81,27 @@ final class FormatBarView: ChromeBarView {
         let active = editor.activeFormattingActions()
         for control in commandItems {
             control.chip.isActive = control.item.action.map(active.contains) ?? false
+        }
+        refreshPullDownState(editor: editor)
+    }
+
+    /// Ticks the heading level and callout type the caret is currently in.
+    ///
+    /// Items with no action are skipped: that is the hidden item 0 carrying the
+    /// button's icon, and its tag of 0 would otherwise read as "Body".
+    private func refreshPullDownState(editor: EditorTextView) {
+        if let menu = pullDownMenus[#selector(EditorTextView.formatHeading(_:))] {
+            let level = editor.activeHeadingLevel()
+            for item in menu.items where item.action != nil {
+                item.state = item.tag == level ? .on : .off
+            }
+        }
+        if let menu = pullDownMenus[#selector(EditorTextView.formatCallout(_:))] {
+            let type = editor.activeCalloutType()
+            for item in menu.items where item.action != nil {
+                let itemType = (item.representedObject as? String)?.lowercased()
+                item.state = itemType != nil && itemType == type ? .on : .off
+            }
         }
     }
 
@@ -220,10 +246,10 @@ final class FormatBarView: ChromeBarView {
         pop.refusesFirstResponder = true
         pop.setAccessibilityLabel(title)
         pop.toolTip = title
-        // Never mark a selection in the open menu: the bar tracks no state, so a
-        // checkmark on the last-picked item would misread as "this is the
-        // caret's level".
-        for item in menu.items { item.onStateImage = nil }
+        // Kept so `refreshPullDownState` can tick the member currently in
+        // effect. The checkmark reports the caret, never the last thing picked
+        // — nothing here records that.
+        pullDownMenus[action] = menu
         if let image = Self.symbol(name, desc: title) {
             // A pull-down's cell ignores the button's own `image` — only the
             // arrow draws — so the icon rides on a hidden display item 0, which

--- a/Sources/edmd/Views/FormatBarView.swift
+++ b/Sources/edmd/Views/FormatBarView.swift
@@ -64,6 +64,15 @@ final class FormatBarView: ChromeBarView {
     /// The pulldowns and Thematic Break never light: their selectors are not
     /// ones `activeFormattingActions()` reports, so this needs no special case.
     func refreshActiveState(editor: EditorTextView) {
+        #if DEBUG
+        // Chips can't be driven by a pointer from a headless harness, so this
+        // lights every one of them — the only way to check that they share a
+        // size without moving the maintainer's mouse.
+        if UserDefaults.standard.bool(forKey: "debug.formatBarAllActive") {
+            for control in commandItems { control.chip.isActive = true }
+            return
+        }
+        #endif
         let active = editor.activeFormattingActions()
         for control in commandItems {
             control.chip.isActive = control.item.action.map(active.contains) ?? false
@@ -140,17 +149,31 @@ final class FormatBarView: ChromeBarView {
     /// what separates those, which is how Mail's bar is drawn.
     private func makeGroup(_ views: [NSView]) -> NSStackView {
         var arranged: [NSView] = []
+        var dividers: [NSView] = []
         for (i, view) in views.enumerated() {
-            if i > 0 { arranged.append(Self.makeDivider()) }
+            if i > 0 {
+                let divider = Self.makeDivider()
+                dividers.append(divider)
+                arranged.append(divider)
+            }
             arranged.append(view)
         }
-        let group = NSStackView(views: arranged)
+        let group = FormatBarGroupView(views: arranged)
         group.orientation = .horizontal
         // Tight: the divider is the separation, so the buttons only need enough
-        // room that a hover chip doesn't crowd it.
-        group.spacing = 3
+        // room that a chip doesn't crowd it.
+        group.spacing = 4
         group.alignment = .centerY
+        // Same order as `views`, so the group can pair each divider with the two
+        // controls it sits between.
+        group.adopt(chips: views.compactMap(Self.chip(of:)), dividers: dividers)
         return group
+    }
+
+    /// The chip belonging to a bar control. The two control kinds carry one each
+    /// but share no type that exposes it.
+    private static func chip(of view: NSView) -> BarControlChip? {
+        (view as? FormatBarButton)?.chip ?? (view as? FormatBarPopUpButton)?.chip
     }
 
     /// `NSBox` in separator mode rather than a layer-backed view: it is the

--- a/Sources/edmd/Views/FormatBarView.swift
+++ b/Sources/edmd/Views/FormatBarView.swift
@@ -73,7 +73,8 @@ final class FormatBarView: ChromeBarView {
             ]),
             makeGroup([
                 makeButton(symbol: "highlighter", title: "Highlight",
-                           action: #selector(EditorTextView.formatHighlight(_:))),
+                           action: #selector(EditorTextView.formatHighlight(_:)),
+                           tint: .systemYellow),
             ]),
             makeGroup([
                 makeButton(symbol: "list.bullet", title: "Bulleted List",
@@ -166,7 +167,9 @@ final class FormatBarView: ChromeBarView {
             display.onStateImage = nil
             menu.insertItem(display, at: 0)
         }
-        pop.widthAnchor.constraint(equalToConstant: Self.controlWidth).isActive = true
+        // Height only. A pull-down draws its disclosure arrow *beside* the
+        // image, so pinning it to a plain button's width crushed the arrow into
+        // the glyph; let the cell ask for the width it needs.
         pop.heightAnchor.constraint(equalToConstant: Self.controlHeight).isActive = true
         register(pop, action: action, title: title)
         return pop

--- a/Sources/edmd/Views/FormatBarView.swift
+++ b/Sources/edmd/Views/FormatBarView.swift
@@ -19,6 +19,11 @@ final class FormatBarView: ChromeBarView {
     static let barHeight: CGFloat = 32
     override var preferredHeight: CGFloat { Self.barHeight }
 
+    /// The borderless controls' footprint — the same size the `.accessoryBarAction`
+    /// bezel gave them, so dropping the border doesn't shrink the hit area.
+    private static let controlWidth: CGFloat = 24
+    private static let controlHeight: CGFloat = 20
+
     /// Each control paired with a private, unregistered menu item carrying its
     /// selector — the input `EditorTextView.validateMenuItem` needs. Never
     /// installed in a menu; exists only so a button's enabled state follows the
@@ -68,8 +73,7 @@ final class FormatBarView: ChromeBarView {
             ]),
             makeGroup([
                 makeButton(symbol: "highlighter", title: "Highlight",
-                           action: #selector(EditorTextView.formatHighlight(_:)),
-                           tint: .systemYellow),
+                           action: #selector(EditorTextView.formatHighlight(_:))),
             ]),
             makeGroup([
                 makeButton(symbol: "list.bullet", title: "Bulleted List",
@@ -120,7 +124,13 @@ final class FormatBarView: ChromeBarView {
         let button = NSButton(image: Self.symbol(name, desc: title) ?? NSImage(),
                               target: nil, action: action)
         button.bezelStyle = .accessoryBarAction
+        button.isBordered = false
         button.imagePosition = .imageOnly
+        // Borderless sheds the bezel's padding, collapsing the intrinsic size to
+        // the bare glyph; pin the footprint to match the old bordered buttons —
+        // same hit area, no border.
+        button.widthAnchor.constraint(equalToConstant: Self.controlWidth).isActive = true
+        button.heightAnchor.constraint(equalToConstant: Self.controlHeight).isActive = true
         // Out of the key-view loop entirely: `FindBarView` opts the whole
         // window out of autorecalculating its key-view loop, so a Tab chain
         // that included these buttons would fight that hand-managed chain.
@@ -137,18 +147,27 @@ final class FormatBarView: ChromeBarView {
         let pop = NSPopUpButton(frame: .zero, pullsDown: true)
         pop.menu = menu
         pop.bezelStyle = .accessoryBarAction
+        pop.isBordered = false
         pop.refusesFirstResponder = true
         pop.setAccessibilityLabel(title)
         pop.toolTip = title
-        // Show the symbol, not the selected item's title, and never mark a
-        // selection in the open menu: the bar tracks no state, so a checkmark
-        // on the last-picked item would misread as "this is the caret's level".
-        if let cell = pop.cell as? NSPopUpButtonCell { cell.usesItemFromMenu = false }
+        // Never mark a selection in the open menu: the bar tracks no state, so a
+        // checkmark on the last-picked item would misread as "this is the
+        // caret's level".
         for item in menu.items { item.onStateImage = nil }
         if let image = Self.symbol(name, desc: title) {
-            pop.image = image
-            pop.imagePosition = .imageOnly
+            // A pull-down's cell ignores the button's own `image` — only the
+            // arrow draws — so the icon rides on a hidden display item 0, which
+            // the button shows but the open menu skips. Item 0 stays put:
+            // pull-downs keep displaying it no matter what the user picks.
+            let display = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+            display.image = image
+            display.isHidden = true
+            display.onStateImage = nil
+            menu.insertItem(display, at: 0)
         }
+        pop.widthAnchor.constraint(equalToConstant: Self.controlWidth).isActive = true
+        pop.heightAnchor.constraint(equalToConstant: Self.controlHeight).isActive = true
         register(pop, action: action, title: title)
         return pop
     }

--- a/Sources/edmd/Views/FormatBarView.swift
+++ b/Sources/edmd/Views/FormatBarView.swift
@@ -24,12 +24,19 @@ final class FormatBarView: ChromeBarView {
     private static let controlWidth: CGFloat = 24
     private static let controlHeight: CGFloat = 20
 
-    /// Each control paired with a private, unregistered menu item carrying its
+    /// One bar control and everything needed to keep it in sync.
+    ///
+    /// `item` is a private, unregistered menu item carrying the control's
     /// selector — the input `EditorTextView.validateMenuItem` needs. Never
-    /// installed in a menu; exists only so a button's enabled state follows the
-    /// Format menu's own gate (Reading mode, Markdown-feature toggles) with no
-    /// new public API.
-    private var commandItems: [(button: NSButton, item: NSMenuItem)] = []
+    /// installed in a menu; it exists only so a button's *enabled* state follows
+    /// the Format menu's own gate (Reading mode, Markdown-feature toggles) with
+    /// no new public API.
+    private struct BarControl {
+        let button: NSButton
+        let chip: BarControlChip
+        let item: NSMenuItem
+    }
+    private var commandItems: [BarControl] = []
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -41,8 +48,21 @@ final class FormatBarView: ChromeBarView {
     /// only `viewMode` and `markdownFeatures`, so this is needed on show, on
     /// view-mode change and when settings change — never per keystroke.
     func refreshEnabledState(editor: EditorTextView) {
-        for (button, item) in commandItems {
-            button.isEnabled = editor.validateMenuItem(item)
+        for control in commandItems {
+            control.button.isEnabled = editor.validateMenuItem(control.item)
+        }
+    }
+
+    /// Lights the controls whose formatting is in effect where the caret or
+    /// selection currently sits. Runs on every selection change and every edit,
+    /// so it stays a delimiter scan of the selected lines and nothing more.
+    ///
+    /// The pulldowns and Thematic Break never light: their selectors are not
+    /// ones `activeFormattingActions()` reports, so this needs no special case.
+    func refreshActiveState(editor: EditorTextView) {
+        let active = editor.activeFormattingActions()
+        for control in commandItems {
+            control.chip.isActive = control.item.action.map(active.contains) ?? false
         }
     }
 
@@ -121,9 +141,9 @@ final class FormatBarView: ChromeBarView {
     }
 
     private func makeButton(symbol name: String, title: String,
-                            action: Selector, tint: NSColor? = nil) -> NSButton {
-        let button = NSButton(image: Self.symbol(name, desc: title) ?? NSImage(),
-                              target: nil, action: action)
+                            action: Selector, tint: NSColor? = nil) -> FormatBarButton {
+        let button = FormatBarButton(image: Self.symbol(name, desc: title) ?? NSImage(),
+                                     target: nil, action: action)
         button.bezelStyle = .accessoryBarAction
         button.isBordered = false
         button.imagePosition = .imageOnly
@@ -139,13 +159,13 @@ final class FormatBarView: ChromeBarView {
         button.setAccessibilityLabel(title)
         button.toolTip = title
         if let tint { button.contentTintColor = tint }
-        register(button, action: action, title: title)
+        register(button, chip: button.chip, action: action, title: title)
         return button
     }
 
     private func makePullDown(symbol name: String, title: String,
-                              menu: NSMenu, action: Selector) -> NSPopUpButton {
-        let pop = NSPopUpButton(frame: .zero, pullsDown: true)
+                              menu: NSMenu, action: Selector) -> FormatBarPopUpButton {
+        let pop = FormatBarPopUpButton(frame: .zero, pullsDown: true)
         pop.menu = menu
         pop.bezelStyle = .accessoryBarAction
         pop.isBordered = false
@@ -171,13 +191,17 @@ final class FormatBarView: ChromeBarView {
         // image, so pinning it to a plain button's width crushed the arrow into
         // the glyph; let the cell ask for the width it needs.
         pop.heightAnchor.constraint(equalToConstant: Self.controlHeight).isActive = true
-        register(pop, action: action, title: title)
+        register(pop, chip: pop.chip, action: action, title: title)
         return pop
     }
 
-    private func register(_ button: NSButton, action: Selector, title: String) {
-        commandItems.append((button: button,
-                             item: NSMenuItem(title: title, action: action, keyEquivalent: "")))
+    /// The chip is passed in rather than read off the control: the two control
+    /// kinds carry one each but share no type that exposes it.
+    private func register(_ button: NSButton, chip: BarControlChip,
+                          action: Selector, title: String) {
+        commandItems.append(BarControl(
+            button: button, chip: chip,
+            item: NSMenuItem(title: title, action: action, keyEquivalent: "")))
     }
 
     private static func symbol(_ name: String, desc: String) -> NSImage? {

--- a/Sources/edmd/Views/FormatBarView.swift
+++ b/Sources/edmd/Views/FormatBarView.swift
@@ -1,0 +1,165 @@
+import AppKit
+import EdmundCore
+
+// MARK: - Format bar
+
+/// The always-available formatting button bar across the top of the editor,
+/// modelled on Apple Mail's format bar. A dumb view: every control's action is
+/// a nil-target `EditorTextView` `format…` action, so a click routes through
+/// the responder chain to the focused editor exactly like a Format-menu item.
+/// The two pulldowns are `NSPopUpButton`s in `.pullDown` mode whose menu items
+/// have a nil target and their own action — selecting one sends the action up
+/// the responder chain *with the `NSMenuItem` as sender*, which is what
+/// `formatHeading` (reads `tag`) and `formatCallout` (reads `representedObject`)
+/// need.
+final class FormatBarView: ChromeBarView {
+
+    /// The bar's fixed height. The accessory-bar buttons sit smaller than the
+    /// strip; `preferredHeight` drives the editor's top inset.
+    static let barHeight: CGFloat = 32
+    override var preferredHeight: CGFloat { Self.barHeight }
+
+    /// Each control paired with a private, unregistered menu item carrying its
+    /// selector — the input `EditorTextView.validateMenuItem` needs. Never
+    /// installed in a menu; exists only so a button's enabled state follows the
+    /// Format menu's own gate (Reading mode, Markdown-feature toggles) with no
+    /// new public API.
+    private var commandItems: [(button: NSButton, item: NSMenuItem)] = []
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        buildUI()
+    }
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    /// Re-runs the Format menu's validation for every control. The gate reads
+    /// only `viewMode` and `markdownFeatures`, so this is needed on show, on
+    /// view-mode change and when settings change — never per keystroke.
+    func refreshEnabledState(editor: EditorTextView) {
+        for (button, item) in commandItems {
+            button.isEnabled = editor.validateMenuItem(item)
+        }
+    }
+
+    // MARK: - Build
+
+    private func buildUI() {
+        let groups = [
+            makeGroup([
+                makePullDown(symbol: "textformat.size", title: "Heading",
+                             menu: FormatMenu.headingMenu(),
+                             action: #selector(EditorTextView.formatHeading(_:))),
+                makeButton(symbol: "minus", title: "Thematic Break",
+                           action: #selector(EditorTextView.formatThematicBreak(_:))),
+            ]),
+            makeGroup([
+                makeButton(symbol: "bold", title: "Bold",
+                           action: #selector(EditorTextView.formatBold(_:))),
+                makeButton(symbol: "italic", title: "Italic",
+                           action: #selector(EditorTextView.formatItalic(_:))),
+                makeButton(symbol: "underline", title: "Underline",
+                           action: #selector(EditorTextView.formatUnderline(_:))),
+                makeButton(symbol: "strikethrough", title: "Strikethrough",
+                           action: #selector(EditorTextView.formatStrikethrough(_:))),
+                makeButton(symbol: "textformat.subscript", title: "Subscript",
+                           action: #selector(EditorTextView.formatSubscript(_:))),
+                makeButton(symbol: "textformat.superscript", title: "Superscript",
+                           action: #selector(EditorTextView.formatSuperscript(_:))),
+            ]),
+            makeGroup([
+                makeButton(symbol: "highlighter", title: "Highlight",
+                           action: #selector(EditorTextView.formatHighlight(_:)),
+                           tint: .systemYellow),
+            ]),
+            makeGroup([
+                makeButton(symbol: "list.bullet", title: "Bulleted List",
+                           action: #selector(EditorTextView.formatBulletedList(_:))),
+                makeButton(symbol: "list.number", title: "Numbered List",
+                           action: #selector(EditorTextView.formatNumberedList(_:))),
+                makeButton(symbol: "checklist", title: "Checklist",
+                           action: #selector(EditorTextView.formatChecklist(_:))),
+            ]),
+            makeGroup([
+                makeButton(symbol: "quote.closing", title: "Block Quote",
+                           action: #selector(EditorTextView.formatBlockQuote(_:))),
+                makePullDown(symbol: "quote.bubble", title: "Alert / Callout",
+                             menu: FormatMenu.calloutMenu(),
+                             action: #selector(EditorTextView.formatCallout(_:))),
+            ]),
+        ]
+
+        let stack = NSStackView()
+        stack.orientation = .horizontal
+        stack.alignment = .centerY
+        for (i, group) in groups.enumerated() {
+            stack.addArrangedSubview(group)
+            if i < groups.count - 1 { stack.setCustomSpacing(16, after: group) }
+        }
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+        // Centred, so a narrow window clips the same reachable band on both
+        // sides rather than shoving the leading controls off-screen.
+        NSLayoutConstraint.activate([
+            stack.centerXAnchor.constraint(equalTo: centerXAnchor),
+            stack.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+    }
+
+    /// One control group: a sub-stack with the tight within-group spacing. The
+    /// wider between-group spacing is set on the top-level stack instead.
+    private func makeGroup(_ views: [NSView]) -> NSStackView {
+        let group = NSStackView(views: views)
+        group.orientation = .horizontal
+        group.spacing = 4
+        group.alignment = .centerY
+        return group
+    }
+
+    private func makeButton(symbol name: String, title: String,
+                            action: Selector, tint: NSColor? = nil) -> NSButton {
+        let button = NSButton(image: Self.symbol(name, desc: title) ?? NSImage(),
+                              target: nil, action: action)
+        button.bezelStyle = .accessoryBarAction
+        button.imagePosition = .imageOnly
+        // Out of the key-view loop entirely: `FindBarView` opts the whole
+        // window out of autorecalculating its key-view loop, so a Tab chain
+        // that included these buttons would fight that hand-managed chain.
+        button.refusesFirstResponder = true
+        button.setAccessibilityLabel(title)
+        button.toolTip = title
+        if let tint { button.contentTintColor = tint }
+        register(button, action: action, title: title)
+        return button
+    }
+
+    private func makePullDown(symbol name: String, title: String,
+                              menu: NSMenu, action: Selector) -> NSPopUpButton {
+        let pop = NSPopUpButton(frame: .zero, pullsDown: true)
+        pop.menu = menu
+        pop.bezelStyle = .accessoryBarAction
+        pop.refusesFirstResponder = true
+        pop.setAccessibilityLabel(title)
+        pop.toolTip = title
+        // Show the symbol, not the selected item's title, and never mark a
+        // selection in the open menu: the bar tracks no state, so a checkmark
+        // on the last-picked item would misread as "this is the caret's level".
+        if let cell = pop.cell as? NSPopUpButtonCell { cell.usesItemFromMenu = false }
+        for item in menu.items { item.onStateImage = nil }
+        if let image = Self.symbol(name, desc: title) {
+            pop.image = image
+            pop.imagePosition = .imageOnly
+        }
+        register(pop, action: action, title: title)
+        return pop
+    }
+
+    private func register(_ button: NSButton, action: Selector, title: String) {
+        commandItems.append((button: button,
+                             item: NSMenuItem(title: title, action: action, keyEquivalent: "")))
+    }
+
+    private static func symbol(_ name: String, desc: String) -> NSImage? {
+        NSImage(systemSymbolName: name, accessibilityDescription: desc)?
+            .withSymbolConfiguration(NSImage.SymbolConfiguration(pointSize: 13, weight: .regular))
+    }
+}

--- a/Sources/edmd/Views/FormatBarView.swift
+++ b/Sources/edmd/Views/FormatBarView.swift
@@ -16,13 +16,17 @@ final class FormatBarView: ChromeBarView {
 
     /// The bar's fixed height. The accessory-bar buttons sit smaller than the
     /// strip; `preferredHeight` drives the editor's top inset.
-    static let barHeight: CGFloat = 32
+    static let barHeight: CGFloat = 28
     override var preferredHeight: CGFloat { Self.barHeight }
 
-    /// The borderless controls' footprint — the same size the `.accessoryBarAction`
-    /// bezel gave them, so dropping the border doesn't shrink the hit area.
-    private static let controlWidth: CGFloat = 24
-    private static let controlHeight: CGFloat = 20
+    /// The borderless controls' footprint. Comfortably above the 20pt the HIG
+    /// asks for a pointer target even at this size.
+    private static let controlWidth: CGFloat = 22
+    private static let controlHeight: CGFloat = 18
+
+    /// Height of the hairline between two buttons of the same group — a little
+    /// shorter than the buttons, the way Mail draws it.
+    private static let dividerHeight: CGFloat = 13
 
     /// One bar control and everything needed to keep it in sync.
     ///
@@ -118,7 +122,7 @@ final class FormatBarView: ChromeBarView {
         stack.alignment = .centerY
         for (i, group) in groups.enumerated() {
             stack.addArrangedSubview(group)
-            if i < groups.count - 1 { stack.setCustomSpacing(16, after: group) }
+            if i < groups.count - 1 { stack.setCustomSpacing(14, after: group) }
         }
         stack.translatesAutoresizingMaskIntoConstraints = false
         addSubview(stack)
@@ -130,14 +134,37 @@ final class FormatBarView: ChromeBarView {
         ])
     }
 
-    /// One control group: a sub-stack with the tight within-group spacing. The
-    /// wider between-group spacing is set on the top-level stack instead.
+    /// One control group: the buttons run together with a hairline between each
+    /// adjacent pair, so the group reads as a single segmented unit. Group
+    /// boundaries get no divider — the wider spacing on the top-level stack is
+    /// what separates those, which is how Mail's bar is drawn.
     private func makeGroup(_ views: [NSView]) -> NSStackView {
-        let group = NSStackView(views: views)
+        var arranged: [NSView] = []
+        for (i, view) in views.enumerated() {
+            if i > 0 { arranged.append(Self.makeDivider()) }
+            arranged.append(view)
+        }
+        let group = NSStackView(views: arranged)
         group.orientation = .horizontal
-        group.spacing = 4
+        // Tight: the divider is the separation, so the buttons only need enough
+        // room that a hover chip doesn't crowd it.
+        group.spacing = 3
         group.alignment = .centerY
         return group
+    }
+
+    /// `NSBox` in separator mode rather than a layer-backed view: it is the
+    /// stock hairline and it tracks light/dark on its own, so there is no
+    /// `cgColor` snapshot to refresh on an appearance change.
+    private static func makeDivider() -> NSView {
+        let divider = NSBox()
+        divider.boxType = .separator
+        divider.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            divider.widthAnchor.constraint(equalToConstant: 1),
+            divider.heightAnchor.constraint(equalToConstant: dividerHeight),
+        ])
+        return divider
     }
 
     private func makeButton(symbol name: String, title: String,
@@ -206,6 +233,6 @@ final class FormatBarView: ChromeBarView {
 
     private static func symbol(_ name: String, desc: String) -> NSImage? {
         NSImage(systemSymbolName: name, accessibilityDescription: desc)?
-            .withSymbolConfiguration(NSImage.SymbolConfiguration(pointSize: 13, weight: .regular))
+            .withSymbolConfiguration(NSImage.SymbolConfiguration(pointSize: 12, weight: .regular))
     }
 }

--- a/Tests/EdmundTests/FormattingStateTests.swift
+++ b/Tests/EdmundTests/FormattingStateTests.swift
@@ -1,0 +1,134 @@
+import Testing
+import AppKit
+@testable import EdmundCore
+
+/// What the format bar lights up from: which formatting is in effect where the
+/// caret or selection currently sits.
+@MainActor @Suite("Formatting state")
+struct FormattingStateTests {
+
+    private func mk(_ content: String, _ sel: NSRange) -> EditorTextView {
+        let e = makeEditor()
+        e.loadContent(content)
+        e.setSelectedRange(sel)
+        return e
+    }
+
+    private func active(_ content: String, _ sel: NSRange) -> Set<Selector> {
+        mk(content, sel).activeFormattingActions()
+    }
+
+    private let bold = #selector(EditorTextView.formatBold(_:))
+    private let italic = #selector(EditorTextView.formatItalic(_:))
+    private let strike = #selector(EditorTextView.formatStrikethrough(_:))
+    private let highlight = #selector(EditorTextView.formatHighlight(_:))
+    private let sub = #selector(EditorTextView.formatSubscript(_:))
+    private let bullet = #selector(EditorTextView.formatBulletedList(_:))
+    private let checklist = #selector(EditorTextView.formatChecklist(_:))
+    private let numbered = #selector(EditorTextView.formatNumberedList(_:))
+    private let quote = #selector(EditorTextView.formatBlockQuote(_:))
+
+    // MARK: - Caret inside
+
+    @Test func caretInsideBoldIsBold() {
+        let a = active("a **word** b", NSRange(location: 5, length: 0))
+        #expect(a.contains(bold))
+        #expect(!a.contains(italic))
+    }
+
+    @Test func caretInsideItalicIsItalic() {
+        let a = active("a *word* b", NSRange(location: 4, length: 0))
+        #expect(a.contains(italic))
+        #expect(!a.contains(bold))
+    }
+
+    /// `***x***` is both, and the run length is the only thing that says so —
+    /// a plain search for `*` would find the inner star of the `**`.
+    @Test func tripleStarIsBoldAndItalic() {
+        let a = active("a ***word*** b", NSRange(location: 6, length: 0))
+        #expect(a.contains(bold))
+        #expect(a.contains(italic))
+    }
+
+    @Test func caretOutsideSpanIsNotActive() {
+        let a = active("a **word** b", NSRange(location: 0, length: 0))
+        #expect(!a.contains(bold))
+    }
+
+    /// The star pairing must not read `a **b** c **d** e` as one long span, or
+    /// the gap between the two bold words would report as bold.
+    @Test func caretBetweenTwoSpansIsNotActive() {
+        let a = active("**b** X **d**", NSRange(location: 6, length: 0))
+        #expect(!a.contains(bold))
+    }
+
+    // MARK: - Selection
+
+    @Test func selectionInsideSpanIsActive() {
+        let a = active("a **word** b", NSRange(location: 4, length: 4))
+        #expect(a.contains(bold))
+    }
+
+    /// Selecting the delimiters too still counts — pressing the button in that
+    /// state is what unwraps it.
+    @Test func selectionSwallowingTheWholeSpanIsActive() {
+        let a = active("a **word** b", NSRange(location: 2, length: 8))
+        #expect(a.contains(bold))
+    }
+
+    @Test func selectionSpillingPastTheSpanIsNotActive() {
+        let a = active("a **word** b", NSRange(location: 5, length: 6))
+        #expect(!a.contains(bold))
+    }
+
+    // MARK: - Other inline delimiters
+
+    @Test func strikeHighlightAndSubscriptEachReportThemselves() {
+        #expect(active("a ~~x~~ b", NSRange(location: 5, length: 0)).contains(strike))
+        #expect(active("a ==x== b", NSRange(location: 5, length: 0)).contains(highlight))
+        #expect(active("a <sub>x</sub> b", NSRange(location: 8, length: 0)).contains(sub))
+    }
+
+    @Test func highlightDoesNotLeakIntoStrikethrough() {
+        let a = active("a ==x== b", NSRange(location: 5, length: 0))
+        #expect(!a.contains(strike))
+        #expect(!a.contains(bold))
+    }
+
+    // MARK: - Line prefixes
+
+    @Test func listAndQuoteLinesReportTheirType() {
+        #expect(active("- item", NSRange(location: 3, length: 0)).contains(bullet))
+        #expect(active("1. item", NSRange(location: 4, length: 0)).contains(numbered))
+        #expect(active("- [ ] task", NSRange(location: 8, length: 0)).contains(checklist))
+        #expect(active("> quoted", NSRange(location: 4, length: 0)).contains(quote))
+    }
+
+    /// A checklist is not a plain bullet — the two buttons must not both light.
+    @Test func checklistIsNotABullet() {
+        let a = active("- [ ] task", NSRange(location: 8, length: 0))
+        #expect(a.contains(checklist))
+        #expect(!a.contains(bullet))
+    }
+
+    /// The toggles only clear a prefix when every selected line carries it, so
+    /// the on-state has to agree.
+    @Test func mixedSelectionIsNotActive() {
+        let a = active("- one\nplain\n", NSRange(location: 0, length: 11))
+        #expect(!a.contains(bullet))
+    }
+
+    // MARK: - Robustness
+
+    @Test func emptyDocumentAndDocumentEndAreSafe() {
+        #expect(active("", NSRange(location: 0, length: 0)).isEmpty)
+        #expect(!active("abc", NSRange(location: 3, length: 0)).contains(bold))
+    }
+
+    /// Emphasis does not carry across a blank line, and the scan is bounded by
+    /// the paragraph so a stray delimiter elsewhere cannot light the button.
+    @Test func unclosedDelimiterOnAnotherLineDoesNotLeak() {
+        let a = active("**open\n\nplain line", NSRange(location: 12, length: 0))
+        #expect(!a.contains(bold))
+    }
+}

--- a/Tests/EdmundTests/FormattingStateTests.swift
+++ b/Tests/EdmundTests/FormattingStateTests.swift
@@ -141,6 +141,14 @@ struct FormattingStateTests {
         #expect(mk("# One\n## Two\n", NSRange(location: 0, length: 12)).activeHeadingLevel() == nil)
     }
 
+    /// A callout is a block quote underneath, but only the callout should
+    /// report it — otherwise the bar claims the selection is two things.
+    @Test func calloutDoesNotAlsoLightBlockQuote() {
+        let a = active("> [!NOTE]", NSRange(location: 3, length: 0))
+        #expect(!a.contains(quote))
+        #expect(active("> plain quote", NSRange(location: 3, length: 0)).contains(quote))
+    }
+
     @Test func calloutTypeReportsTheHeaderLine() {
         #expect(mk("> [!NOTE]", NSRange(location: 3, length: 0)).activeCalloutType() == "note")
         #expect(mk("> [!tip]", NSRange(location: 3, length: 0)).activeCalloutType() == "tip")

--- a/Tests/EdmundTests/FormattingStateTests.swift
+++ b/Tests/EdmundTests/FormattingStateTests.swift
@@ -118,6 +118,43 @@ struct FormattingStateTests {
         #expect(!a.contains(bullet))
     }
 
+    // MARK: - Thematic break
+
+    @Test func thematicBreakLineReportsItself() {
+        let thematic = #selector(EditorTextView.formatThematicBreak(_:))
+        #expect(active("---", NSRange(location: 1, length: 0)).contains(thematic))
+        #expect(!active("- item", NSRange(location: 3, length: 0)).contains(thematic))
+        #expect(!active("--- trailing", NSRange(location: 1, length: 0)).contains(thematic))
+    }
+
+    // MARK: - Pulldown state
+
+    @Test func headingLevelReportsTheCaretsLine() {
+        #expect(mk("## Title", NSRange(location: 4, length: 0)).activeHeadingLevel() == 2)
+        #expect(mk("Body", NSRange(location: 2, length: 0)).activeHeadingLevel() == 0)
+        #expect(mk("###### Six", NSRange(location: 8, length: 0)).activeHeadingLevel() == 6)
+    }
+
+    /// Mixed levels have no single answer, so nothing is ticked — the same rule
+    /// `applyHeadingLevel` uses to decide a level is already applied.
+    @Test func mixedHeadingLevelsReportNothing() {
+        #expect(mk("# One\n## Two\n", NSRange(location: 0, length: 12)).activeHeadingLevel() == nil)
+    }
+
+    @Test func calloutTypeReportsTheHeaderLine() {
+        #expect(mk("> [!NOTE]", NSRange(location: 3, length: 0)).activeCalloutType() == "note")
+        #expect(mk("> [!tip]", NSRange(location: 3, length: 0)).activeCalloutType() == "tip")
+        #expect(mk("> plain quote", NSRange(location: 3, length: 0)).activeCalloutType() == nil)
+        #expect(mk("Body", NSRange(location: 2, length: 0)).activeCalloutType() == nil)
+    }
+
+    /// Obsidian's fold markers and a custom title still name the same type,
+    /// because parsing goes through the renderer's own matcher.
+    @Test func foldedAndTitledCalloutsStillReportTheirType() {
+        #expect(mk("> [!warning]-", NSRange(location: 3, length: 0)).activeCalloutType() == "warning")
+        #expect(mk("> [!info] Custom", NSRange(location: 3, length: 0)).activeCalloutType() == "info")
+    }
+
     // MARK: - Robustness
 
     @Test func emptyDocumentAndDocumentEndAreSafe() {

--- a/Tests/EdmundTests/FormattingTests.swift
+++ b/Tests/EdmundTests/FormattingTests.swift
@@ -14,6 +14,35 @@ private func mk(_ content: String, _ sel: NSRange) -> EditorTextView {
     return e
 }
 
+// MARK: - Format-bar routing
+
+/// The format bar's buttons and pulldowns carry their own selectors with a nil
+/// target, exactly like the Format-menu items, so selection routes through the
+/// responder chain to the focused editor — the same mechanism the whole Format
+/// menu relies on in the live app. That nil-target path needs a *key* window,
+/// which the headless test runner can't provide (`makeKeyAndOrderFront` yields a
+/// window that reports `isKeyWindow == false`), so it is pinned below at the
+/// explicit-target level: `formatHeading(_:)` reads `tag`, `formatCallout(_:)`
+/// reads `representedObject`. Live selection is verified by click-testing the
+/// bar against the running app.
+@MainActor @Suite struct FormatBarRoutingTests {
+
+    @Test func headingTagAndCalloutRepresentedObjectDriveActions() {
+        let e = mk("Body line one", NSRange(location: 0, length: 0))
+        let item = NSMenuItem(title: "Heading 2", action: #selector(EditorTextView.formatHeading(_:)),
+                              keyEquivalent: "")
+        item.tag = 2
+        _ = e.perform(item.action!, with: item)
+        #expect(e.rawSource.hasPrefix("## "))
+
+        let callout = NSMenuItem(title: "Note", action: #selector(EditorTextView.formatCallout(_:)),
+                                 keyEquivalent: "")
+        callout.representedObject = "NOTE"
+        _ = e.perform(callout.action!, with: callout)
+        #expect(e.rawSource.contains("[!NOTE]"))
+    }
+}
+
 // MARK: - Inline font styles
 
 @MainActor @Suite struct FormatInlineWrapTests {
@@ -91,6 +120,35 @@ private func mk(_ content: String, _ sel: NSRange) -> EditorTextView {
         e.formatMathBlock(nil)
         #expect(e.rawSource == "$$\nE=mc^2\n$$")
         #expect(e.selectedRange() == NSRange(location: 3, length: 0))  // caret on content line
+    }
+}
+
+// MARK: - Subscript / superscript
+
+@MainActor @Suite struct FormatSubSupTests {
+
+    @Test func subscriptWrapsSelectionAndInverts() {
+        let e = mk("2", NSRange(location: 0, length: 1))
+        e.formatSubscript(nil)
+        #expect(e.rawSource == "<sub>2</sub>")
+        e.formatSubscript(nil)
+        #expect(e.rawSource == "2")
+    }
+
+    @Test func superscriptWrapsSelectionAndInverts() {
+        let e = mk("2", NSRange(location: 0, length: 1))
+        e.formatSuperscript(nil)
+        #expect(e.rawSource == "<sup>2</sup>")
+        e.formatSuperscript(nil)
+        #expect(e.rawSource == "2")
+    }
+
+    @Test func subAndSuperscriptExpandToWordAtCaret() {
+        let e = mk("H2O", NSRange(location: 2, length: 0))  // caret inside "H2O"
+        e.formatSubscript(nil)
+        #expect(e.rawSource == "<sub>H2O</sub>")
+        e.formatSuperscript(nil)
+        #expect(e.rawSource == "<sub><sup>H2O</sup></sub>")
     }
 }
 
@@ -212,6 +270,18 @@ private func mk(_ content: String, _ sel: NSRange) -> EditorTextView {
         #expect(e.rawSource == "### Title")
         e.applyHeadingLevel(3)            // same level clears
         #expect(e.rawSource == "Title")
+    }
+
+    @Test func headingLevelZeroStripsPrefixToBody() {
+        let e = mk("### Title", NSRange(location: 0, length: 0))
+        e.applyHeadingLevel(0)
+        #expect(e.rawSource == "Title")
+    }
+
+    @Test func headingLevelZeroLeavesBodyLineUntouched() {
+        let e = mk("Plain", NSRange(location: 0, length: 0))
+        e.applyHeadingLevel(0)
+        #expect(e.rawSource == "Plain")
     }
 
     @Test func checklistAddsThenTogglesMark() {

--- a/Tests/EdmundTests/KeyBindingTests.swift
+++ b/Tests/EdmundTests/KeyBindingTests.swift
@@ -16,6 +16,42 @@ struct KeyBindingTests {
         KeyBindingStore.defaults = defaults
     }
 
+    // MARK: - Renamed ids
+
+    /// An override is filed under the command's id, so a rename has to carry it
+    /// across — otherwise the shortcut silently stops applying, which does not
+    /// even look like data loss to the user.
+    @Test("A renamed command keeps the shortcut set under its old id")
+    func migrationCarriesOverridesAcross() {
+        useFreshDefaults()
+        KeyBindingStore.setOverride(.cmdShift("t"), id: "view.typewriterScroll", default: nil)
+        KeyBindingStore.migrateRenamedIDs()
+
+        #expect(KeyBindingStore.effective(id: "edit.typewriterScroll", default: nil)
+                == .cmdShift("t"))
+        #expect(!KeyBindingStore.hasOverride(id: "view.typewriterScroll"))
+    }
+
+    /// A binding already set under the new id was chosen more recently than one
+    /// stranded under the old one.
+    @Test("Migration does not clobber a binding already set under the new id")
+    func migrationPrefersTheNewID() {
+        useFreshDefaults()
+        KeyBindingStore.setOverride(.cmdShift("t"), id: "view.focusMode", default: nil)
+        KeyBindingStore.setOverride(.cmdOpt("f"), id: "edit.focusMode", default: nil)
+        KeyBindingStore.migrateRenamedIDs()
+
+        #expect(KeyBindingStore.effective(id: "edit.focusMode", default: nil) == .cmdOpt("f"))
+        #expect(!KeyBindingStore.hasOverride(id: "view.focusMode"))
+    }
+
+    @Test("Migration is a no-op when nothing was rebound")
+    func migrationLeavesAnUntouchedStoreAlone() {
+        useFreshDefaults()
+        KeyBindingStore.migrateRenamedIDs()
+        #expect(!KeyBindingStore.hasAnyOverride)
+    }
+
     // MARK: - Shortcut coding
 
     @Test("Storage string round-trips every modifier combination")

--- a/Tests/EdmundTests/TopBarInsetTests.swift
+++ b/Tests/EdmundTests/TopBarInsetTests.swift
@@ -1,0 +1,105 @@
+import Testing
+import AppKit
+@testable import EdmundCore
+
+/// The top chrome bars (format bar, find bar) push the document down through the
+/// scroll view's `contentInsets.top` rather than by padding the text container.
+/// The distinction the tests below pin: a content inset moves the document and
+/// the scroll range together, while container padding would buy the same room as
+/// document height — scrollable emptiness above the first line that the reader
+/// can wander into and that stays behind once the bar closes.
+@Suite("Top bar inset")
+struct TopBarInsetTests {
+
+    @MainActor
+    private func makeWindowed(typewriter: Bool = false) -> (EditorTextView, NSScrollView) {
+        let editor = makeEditor()
+        let win = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
+                           styleMask: [.titled], backing: .buffered, defer: false)
+        let scroll = NSScrollView(frame: win.contentLayoutRect)
+        scroll.documentView = editor
+        win.contentView = scroll
+        win.makeFirstResponder(editor)
+        editor.isVerticallyResizable = true
+        editor.minSize = NSSize(width: 0, height: 0)
+        editor.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude,
+                                height: CGFloat.greatestFiniteMagnitude)
+        editor.autoresizingMask = [.width]
+        editor.textContainerInset = NSSize(width: 24,
+                                           height: EditorTextView.contentBaseVerticalInset)
+        editor.typewriterModeEnabled = typewriter
+        editor.updateContentInset()
+        editor.updateScrollOverscroll()
+        var doc = ""
+        for i in 1...100 { doc += "Line \(i) content here for the document body.\n" }
+        editor.loadContent(doc)
+        ensureFullLayout(editor); editor.sizeToFit(); editor.layoutSubtreeIfNeeded()
+        return (editor, scroll)
+    }
+
+    @Test("Bar height lands on contentInsets, not on document height")
+    @MainActor func insetNotOverscroll() {
+        let (editor, scroll) = makeWindowed()
+        let heightBefore = editor.frame.height
+        editor.additionalTopInset = 64
+        #expect(abs(scroll.contentInsets.top - 64) < 0.5,
+                "contentInsets.top = \(scroll.contentInsets.top), wanted 64")
+        #expect(abs(editor.frame.height - heightBefore) < 0.5,
+                "document grew \(editor.frame.height - heightBefore)pt — that is overscroll")
+    }
+
+    /// The point of the change: opening a bar pushes the text down out from
+    /// under it. Sitting at the top of the document, the resting scroll position
+    /// moves from 0 to -inset, which is the document sliding down by `inset`.
+    @Test("Opening a bar bumps the document down by its height")
+    @MainActor func barBumpsContentDown() {
+        let (editor, scroll) = makeWindowed()
+        scroll.contentView.scroll(to: .zero)
+        scroll.reflectScrolledClipView(scroll.contentView)
+        editor.additionalTopInset = 64
+        #expect(abs(scroll.contentView.bounds.origin.y + 64) < 0.5,
+                "origin.y = \(scroll.contentView.bounds.origin.y), wanted -64")
+    }
+
+    /// And closing it pulls the text back up — no residual gap.
+    @Test("Closing the bar restores the original position")
+    @MainActor func closingRestores() {
+        let (editor, scroll) = makeWindowed()
+        scroll.contentView.scroll(to: .zero)
+        scroll.reflectScrolledClipView(scroll.contentView)
+        editor.additionalTopInset = 64
+        editor.additionalTopInset = 0
+        #expect(abs(scroll.contentInsets.top) < 0.5)
+        #expect(abs(scroll.contentView.bounds.origin.y) < 0.5,
+                "origin.y = \(scroll.contentView.bounds.origin.y), wanted 0")
+    }
+
+    /// Nothing above the first line to scroll into: with the bars up, the top of
+    /// the scroll range is exactly the inset and no further.
+    @Test("No scrollable emptiness above the first line")
+    @MainActor func noRoomAboveTheTop() {
+        let (editor, _) = makeWindowed()
+        editor.additionalTopInset = 64
+        #expect(abs(editor.clampedScrollY(-9_999) + 64) < 0.5,
+                "top of range = \(editor.clampedScrollY(-9_999)), wanted -64")
+    }
+
+    /// Typewriter mode centres on what the reader can see. With a 64pt bar over
+    /// a 320pt clip the caret belongs at 64 + 128 = 192 from the clip top, not
+    /// at 160 — the old maths put it behind the bar.
+    @Test("Typewriter centres below the bars, not behind them")
+    @MainActor func typewriterCentresInVisibleBand() {
+        let (editor, scroll) = makeWindowed(typewriter: true)
+        editor.additionalTopInset = 64
+        editor.setSelectedRange(NSRange(location: 2_000, length: 0))
+        editor.centerViewportOnCaret()
+        guard let caret = editor.lineRect(forCharacterAt: 2_000) else {
+            Issue.record("no caret rect"); return
+        }
+        let caretOnScreen = caret.midY + editor.textContainerOrigin.y
+            - scroll.contentView.bounds.origin.y
+        let wanted = 64 + (scroll.contentView.bounds.height - 64) / 2
+        #expect(abs(caretOnScreen - wanted) < 4,
+                "caret sits \(caretOnScreen)pt from the clip top, wanted \(wanted)")
+    }
+}

--- a/Tests/EdmundTests/ViewMenuTitleTests.swift
+++ b/Tests/EdmundTests/ViewMenuTitleTests.swift
@@ -26,15 +26,32 @@ struct ViewMenuTitleTests {
     }
 
     /// The item ships titled for the default state, so it reads correctly
-    /// before the menu has ever been opened (validation only runs on open).
+    /// before the menu has ever been opened — validation only runs on open, and
+    /// until then the item wears whatever title it was built with.
+    ///
+    /// Asserted against validation rather than a literal, so flipping the
+    /// default cannot leave the shipped title behind.
     @Test func menuShipsTitledForTheDefaultState() {
-        let original = AppSettings.showFormatBar
-        defer { AppSettings.showFormatBar = original }
-        AppSettings.showFormatBar = true
+        let original = UserDefaults.standard.object(forKey: AppSettings.Key.showFormatBar)
+        defer { UserDefaults.standard.set(original, forKey: AppSettings.Key.showFormatBar) }
+        UserDefaults.standard.removeObject(forKey: AppSettings.Key.showFormatBar)
 
-        let item = ViewMenu.build().submenu?.items.first {
+        let shipped = ViewMenu.build().submenu?.items.first {
             $0.action == #selector(Document.toggleFormatBar(_:))
         }
-        #expect(item?.title == "Hide Format Bar")
+        let validated = NSMenuItem(title: "",
+                                   action: #selector(Document.toggleFormatBar(_:)),
+                                   keyEquivalent: "")
+        _ = Document().validateMenuItem(validated)
+        #expect(shipped?.title == validated.title)
+    }
+
+    /// The bar is opt-in: it costs a strip of the window and everything on it
+    /// is already on the Format menu.
+    @Test func formatBarDefaultsHidden() {
+        let original = UserDefaults.standard.object(forKey: AppSettings.Key.showFormatBar)
+        defer { UserDefaults.standard.set(original, forKey: AppSettings.Key.showFormatBar) }
+        UserDefaults.standard.removeObject(forKey: AppSettings.Key.showFormatBar)
+        #expect(AppSettings.showFormatBar == false)
     }
 }

--- a/Tests/EdmundTests/ViewMenuTitleTests.swift
+++ b/Tests/EdmundTests/ViewMenuTitleTests.swift
@@ -1,0 +1,40 @@
+import Testing
+import AppKit
+@testable import edmd
+
+/// The View menu's format-bar item names the action it will perform, flipping
+/// with the setting — the same idiom as Hide/Show Toolbar beside it, rather
+/// than a checkmark on a fixed title.
+@MainActor @Suite("View menu titles")
+struct ViewMenuTitleTests {
+
+    @Test func formatBarItemNamesTheActionItWillPerform() {
+        let document = Document()
+        let item = NSMenuItem(title: "",
+                              action: #selector(Document.toggleFormatBar(_:)),
+                              keyEquivalent: "")
+        let original = AppSettings.showFormatBar
+        defer { AppSettings.showFormatBar = original }
+
+        AppSettings.showFormatBar = true
+        _ = document.validateMenuItem(item)
+        #expect(item.title == "Hide Format Bar")
+
+        AppSettings.showFormatBar = false
+        _ = document.validateMenuItem(item)
+        #expect(item.title == "Show Format Bar")
+    }
+
+    /// The item ships titled for the default state, so it reads correctly
+    /// before the menu has ever been opened (validation only runs on open).
+    @Test func menuShipsTitledForTheDefaultState() {
+        let original = AppSettings.showFormatBar
+        defer { AppSettings.showFormatBar = original }
+        AppSettings.showFormatBar = true
+
+        let item = ViewMenu.build().submenu?.items.first {
+            $0.action == #selector(Document.toggleFormatBar(_:))
+        }
+        #expect(item?.title == "Hide Format Bar")
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -200,6 +200,7 @@ rawSource ─BlockParser─▶ [Block] ─SyntaxHighlighter─▶ spans ─style
 | Crash-log uploading | `EdmundCore/Diagnostics/CrashReporter.swift` (§7) |
 | Auto-update | Sparkle 2.x. `Info.plist`: `SUFeedURL` (raw GitHub URL to `appcast.xml`), `SUPublicEDKey`. `scripts/release.sh`: build → DMG (sindresorhus `create-dmg`, **npm** — not the homebrew tool) → EdDSA sign → update appcast → `gh release create`. The DMG is the Sparkle enclosure. CI: `.github/workflows/release.yml` (tag-triggered). Full pipeline + signing + `RELEASE_TOKEN`: §13. |
 | Find & Replace | `EdmundCore/Find/FindEngine.swift` (pure search), `TextView/EditorTextView+Find.swift` (match state, highlight drawing, pop animation, `EditorFindHandling`), `edmd/Views/FindBarView.swift` (the bar), `edmd/App/FindController.swift` (mediator); Edit ▸ Find menu in `main.swift` |
+| Format bar | `edmd/Views/FormatBarView.swift` + `ChromeBarView.swift` (titlebar-material + hairline base shared with the find bar), `edmd/App/FormatMenu.swift` (the two pulldowns are the same `headingMenu()`/`calloutMenu()` factories as the Format menu — one menu definition, three homes), `Document.formatBar` (owned by the document; shown/hidden by View ▸ Show Format Bar, `settings.edit.showFormatBar`, off in Reading mode). Stacks **above** the find bar; `Document.layoutTopBars()` is the sole writer of `editor.additionalTopInset`, so the two bars share the inset budget and a resize recomputing overscroll can't drop either bar's share. Bar is horizontally centred by design (a narrow window clips the same reachable band on both sides) |
 | Standard text menus | `edmd/App/main.swift` — Edit ▸ Spelling and Grammar, Transformations, Speech; stock `NSTextView` actions routed to the first responder. **Substitutions is deliberately excluded** (§8) |
 | Status bar | `edmd/Views/StatusBarView.swift` |
 | Build/packaging | `scripts/build-app.sh` (release build + Sparkle.framework embedding + signing), `Package.swift`, `Info.plist`, `Resources/` |
@@ -243,9 +244,10 @@ Notable subsystems:
   rather than hand-rolling a clamp; `preservingViewportAnchor` is the
   exception and floors at 0 only, since it runs mid-re-tile when the clip
   view's idea of the document height is stale (clamping there yanked the
-  viewport ~770pt). The find bar adds its height through
-  `editor.additionalTopInset` rather than writing the inset itself, so a
-  resize recomputing the overscroll can't drop the bar's share.
+  viewport ~770pt). The find and format bars both add their heights through
+  `Document.layoutTopBars()`, the sole writer of
+  `editor.additionalTopInset`, rather than each bar writing the inset itself,
+  so a resize recomputing the overscroll can't drop a bar's share.
 - **Content width** (`+ContentWidth.swift`): an **absolute physical**
   max-column width — set in cm/in in Settings, stored as cm, converted to
   points via the display's real PPI (`NSScreen.physicalPPI`, from
@@ -699,6 +701,14 @@ Notable subsystems:
   background, and refresh its `cgColor` on
   `viewDidChangeEffectiveAppearance` — a colour snapshot won't follow the
   appearance by itself.
+- **An `NSPopUpButton`'s AX menu hides the currently-selected item.** AX
+  enumeration reorders the menu so the selected item comes first *with a blank
+  title*, and the trailing separator reads as a blank non-menu element — so a
+  hand-count of `AXMenuItem`s is always one short of the true menu. When
+  verifying the format bar's two pulldowns by AX, read the items by title
+  against `FormatMenu.headingMenu()`/`calloutMenu()` (the same factories the
+  Format menu uses — one definition, three homes) rather than trusting a
+  count.
 
 ### Deliberate omissions
 
@@ -721,6 +731,11 @@ Notable subsystems:
   the parser chokes past it until the next `{`). Use `/* */`. Cost a whole
   round of "why doesn't this CSS change do anything" — see
   `docs/investigations/math-ratex-weight-investigation.md` Round 1.
+- **The format bar has no alignment buttons** (left/center/right/justify),
+  despite being the natural home for them, per an explicit decision with the
+  maintainer: block-alignment has no Markdown representation, so the buttons
+  would silently no-op or rewrite text. Text alignment stays out of the bar;
+  anything that can't round-trip through `rawSource` does not get a button.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,5 +1,5 @@
 # Roadmap
-Last updated: 2026-07-09
+Last updated: 2026-08-04
 
 ## v1.0.0
 
@@ -15,7 +15,7 @@ Basic editing experience
 Advanced editing features
 - [ ] File outline
 - [ ] Find and replace within file
-- [ ] Format bar
+- [x] Format bar
 - [ ] Advanced Code official extension
 - [ ] Advanced Math official extension
 


### PR DESCRIPTION
Adds the format bar from `docs/ROADMAP.md` ("Format bar", v1.0.0) — a horizontal
strip of formatting controls across the top of the editor, modelled on Apple Mail's.
Almost no new formatting logic: the bar is a new surface onto the 23 `@objc` actions
that `EditorTextView+FormattingCommands.swift` already exposes, which until now were
reachable only through the menu bar.

## What's on it

Heading pulldown · thematic break | bold · italic · underline · strikethrough ·
subscript · superscript | highlight | bulleted · numbered · checklist | block quote ·
callout pulldown.

Both pulldowns are `NSPopUpButton` in `.pullDown` mode, because that is the one
configuration where the menu item itself reaches the action as sender — which
`formatHeading` (reads `.tag`) and `formatCallout` (reads `.representedObject`)
require.

`formatSubscript` / `formatSuperscript` are new, one-liners over the existing
`toggleInlineWrap`; `<sub>`/`<sup>` were already rendered. `applyHeadingLevel(0)`
now means "strip to body" rather than producing a leading space.

## Chrome

`FindBarView`'s window-chrome behaviour moved into a shared `ChromeBarView` base
rather than being copied. Two details worth naming:

- Blending is `.withinWindow`. `.behindWindow` samples what is behind the *window* —
  the desktop — so the bar tracked the wallpaper. It happened to look right in light
  mode against this wallpaper; in dark mode it measured 40 levels lighter than the
  toolbar directly above it.
- `state = .followsWindowActiveState`, so the bar dims with the toolbar when the
  window stops being key. `.active` pinned it bright on inactive windows.

Controls sit in segmented groups with subtle dividers. Hover chips one control at a
time; a chip is a fixed 20pt box centred on the bar's interior rather than on the
control's own bounds, which is what made the chip heights vary with each symbol's
intrinsic size (measured spread 17.0–23.5pt, now a uniform 19.0pt, symmetric top and
bottom). A divider hides only when a chip next to it is *on*, not on hover.

## On-state

New `EditorTextView+FormattingState.swift` answers "what formatting is in effect
where the caret is". It scans **source delimiters**, not rendered attributes —
attributes are lossy here, since a heading is bold and `==mark==` and code spans are
both background fills. Star run length is what separates `*x*`, `**x**` and `***x***`.
A callout does not also light Block Quote: it is a block quote underneath, but the
callout pulldown already names the type, which is the more specific answer.

The two pulldowns tick the caret's current heading level and callout type.

## Top-bar inset

Previously the find bar reserved its height as overscroll. Now both bars are a real
`NSScrollView.contentInsets.top`, so content and viewport bump down and the document
gains no extra height. `Document.layoutTopBars()` is the sole writer, stacking format
bar above find bar — two independent writers of the old single scalar would have
clobbered each other.

One trap, covered by a test: AppKit re-clamps the clip view the instant the inset
shrinks, so the pre-change scroll origin has to be sampled *before* the assignment or
the delta is counted twice, and closing a bar leaves the document scrolled down.
Typewriter scroll, `scrollCharacterToTop` and `topmostVisibleCharacterOffset` all
account for the inset explicitly.

## Menus

The bar defaults **off** — it costs a strip of the window and every command on it is
already on the Format menu. The View item toggles its own title (Show/Hide Format
Bar), the same idiom as Hide Toolbar above it.

Typewriter Scroll and Focus Mode move from View to Edit, behind a separator. Their
ids follow (`view.*` → `edit.*`), and `KeyBindingStore.migrateRenamedIDs` re-files
stored overrides across the rename — an override is filed under the command id, so
the rename alone would strand a user's shortcut under a key nothing reads again. That
does not fall back to the default, it silently stops applying.

## Also

`.claude/hooks/guard-focus-steal.sh` gained a case it was waving through:
`ui-harness.sh raise` (and `open-find` / `replace` / `shot`) foreground the app from
*inside* the script, so the existing check only ever saw the script's own name.

## Testing

`swift test` — 1332 passing, including 20 new formatting-state tests, 5 top-inset
tests, 3 menu-title tests and 3 key-binding migration tests. Visuals verified live by
screencapture in light and dark, in and out of focus.

## Known, not fixed here

A callout that is the first block of a document draws ~3.5pt short of top padding
(14.5pt vs 18.0pt mid-document). Reproduced and localised to the callout draw
geometry, which predates this branch; left alone rather than guessing at it.
