### PR TITLE
docs(architecture): correct what the format bar changed under it

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -186,7 +186,7 @@ rawSource ─BlockParser─▶ [Block] ─SyntaxHighlighter─▶ spans ─style
 | Invisible characters | `TextView/EditorTextView+Invisibles.swift` — faint marks (· → ¬ ␣ ▯) overdrawn on laid-out whitespace, riding `DecoratedTextLayoutFragment.draw`. Pure display overlay: no characters inserted, TextKit 2 only. `EditorTextView.invisibles` ← `AppSettings.invisiblesConfig`; Settings ▸ Edit. Mechanism: [`architecture/editor-affordances.md`](architecture/editor-affordances.md). |
 | List indent guides | Faint vertical hairlines on list items: one per *ancestor* level spanning the item, plus the item's own column beside its wrapped continuation lines. Offsets from `listGuideOffsets(depth:slotWidth:)` (`Rendering/EditorTextView+ListRendering.swift`), written to `.listGuides` **whether or not the setting is on** — the fragment gates the drawing, so toggling is a re-vend, never a restyle. `EditorTextView.showListIndentGuides`; Settings ▸ Edit. Geometry traps (container-relative offsets, `lineFragmentPadding`): [`architecture/editor-affordances.md`](architecture/editor-affordances.md). |
 | Line numbers | `TextView/EditorTextView+LineNumbers.swift` — source line numbers (Settings ▸ Edit ▸ Lines, off by default), `EditorTextView.showLineNumbers`. **Two placements over one walk**, and the placement is **not** a setting: it follows whether the margin can hold them (beside the content by default, a `LineNumberRulerView` at the window edge otherwise). Also home to `line(forOffset:)`/`offset(forLine:)`, binary-searching the cached `lineStarts`. Editor-only; never printed. Placement rules, the macOS 14 SIGSEGV, draw rules and the tabular-figure face: [`architecture/editor-affordances.md`](architecture/editor-affordances.md). |
-| Focus mode | `TextView/EditorTextView+FocusMode.swift` — dims all but the lines the selection touches (Settings ▸ Edit ▸ Editor, View ▸ Focus Mode; off by default), `EditorTextView.focusMode`. **One transparency layer around `DecoratedTextLayoutFragment.draw`**, so text and its decorations fade as one composite; it cannot be a scrim (NSTextView composites fragments *after* `draw(_:)` returns). Editor-only. Why, and the measurements: [`architecture/editor-affordances.md`](architecture/editor-affordances.md). |
+| Focus mode | `TextView/EditorTextView+FocusMode.swift` — dims all but the lines the selection touches (Settings ▸ Edit ▸ Editor, Edit ▸ Focus Mode; off by default), `EditorTextView.focusMode`. **One transparency layer around `DecoratedTextLayoutFragment.draw`**, so text and its decorations fade as one composite; it cannot be a scrim (NSTextView composites fragments *after* `draw(_:)` returns). Editor-only. Why, and the measurements: [`architecture/editor-affordances.md`](architecture/editor-affordances.md). |
 | Read mode / Export | `Export/` — `HTMLRenderer` (MarkupVisitor → HTML; callout/checkbox icons are inline Lucide SVGs from `LucideIcons`), `HTMLTheme` (EditorTheme → CSS), `DocumentHTML` (assembly + asset inlining: math + local images → data URIs), `ReadModeWebView`, `MarkdownPrinter` (PDF/Print). `Document.refreshReadView()` keeps an open Read view in sync with edits and theme changes. |
 | Icons | `Model/LucideIcons.swift` — vendored [Lucide](https://lucide.dev) SVGs (ISC, `LICENSES/lucide.txt`). Callout headers use them in **both** modes: Read inlines the SVG (CSS-tinted via `currentColor`); Edit rasterizes to a tinted `NSImage` overlay. SF Symbols can't ship in exported PDFs (license); app-chrome SF Symbols are fine (in-app UI). Edit-mode task checkboxes still use SF Symbols (on-screen only); Read-mode checkboxes are a composed Lucide SVG. |
 | Edit behaviors | `Editing/EditorTextView+{List,Blockquote}Continuation.swift`, `+Indentation.swift`, `+AutoPairs.swift`, `+ListRenumbering.swift` |
@@ -196,11 +196,12 @@ rawSource ─BlockParser─▶ [Block] ─SyntaxHighlighter─▶ spans ─style
 | App shell | `edmd/App/{main,Document,DocumentController}.swift`; menu bar in `main.swift` `setupMenuBar()` + `FormatMenu.swift`; Sparkle `SPUStandardUpdaterController` in `AppDelegate` |
 | macOS integrations | Services menu (`edmd/App/ServicesProvider.swift` + `NSServices` in `Info.plist`), App Intents (`edmd/App/Intents.swift`), Quick Look preview (`EdmundQuickLook` target, hosts `ReadModeWebView`), AppleScript code-fence syntax (`EdmundCore/Resources/Syntaxes/applescript.json`). **Two shipped-but-not-live-verifiable limitations** (App Intents metadata needs an Xcode-project build; the Quick Look appex won't launch under ad-hoc signing): [`architecture/macos-integrations.md`](architecture/macos-integrations.md). |
 | Settings (SwiftUI) | `edmd/Settings/*` (AppSettings = UserDefaults keys; FontSettings; Appearance/General/Advanced views) |
-| Key bindings | `edmd/Settings/KeyBindingStore.swift` + `KeyBindingsSettingsView.swift`. Every rebindable command is a `MenuCommand` (`App/FormatMenu.swift`) with a stable `id`, a `group` (the menu it lives under) and a default `Shortcut`; `makeItem()` resolves the user's override from `KeyBindingStore` and registers the built `NSMenuItem` in `KeyBindingCatalog`, so the pane retunes shortcuts live without rebuilding the menu bar. Overrides live in one UserDefaults dict (`settings.keyBindings`, `id → "shift+cmd+e"`); an empty string means "user removed this shortcut", a missing key means "use the default". Conflicts are checked against the **live `NSApp.mainMenu`**, not the catalog, so system items (⌘S, ⌘C) count too; a chord without ⌘ or ⌃ is refused outright (it would fire while typing). Only Edmund's own commands are listed — the OS-standard items stay fixed. |
+| Key bindings | `edmd/Settings/KeyBindingStore.swift` + `KeyBindingsSettingsView.swift`. Every rebindable command is a `MenuCommand` (`App/FormatMenu.swift`) with a stable `id`, a `group` (the menu it lives under) and a default `Shortcut`; `makeItem()` resolves the user's override from `KeyBindingStore` and registers the built `NSMenuItem` in `KeyBindingCatalog`, so the pane retunes shortcuts live without rebuilding the menu bar. Overrides live in one UserDefaults dict (`settings.keyBindings`, `id → "shift+cmd+e"`); an empty string means "user removed this shortcut", a missing key means "use the default". **Moving a command between menus means renaming its id, and a rename must come with a migration** — an override is filed under the id, so renaming it alone strands the user's shortcut under a key nothing reads. That doesn't fall back to the default, it silently stops firing. `KeyBindingStore.migrateRenamedIDs` (called first thing in `setupMenuBar()`) re-files them, leaving alone any binding already set under the new id; add a pair to its `renamedIDs` table whenever you move one. Conflicts are checked against the **live `NSApp.mainMenu`**, not the catalog, so system items (⌘S, ⌘C) count too; a chord without ⌘ or ⌃ is refused outright (it would fire while typing). Only Edmund's own commands are listed — the OS-standard items stay fixed. |
 | Crash-log uploading | `EdmundCore/Diagnostics/CrashReporter.swift` (§7) |
 | Auto-update | Sparkle 2.x. `Info.plist`: `SUFeedURL` (raw GitHub URL to `appcast.xml`), `SUPublicEDKey`. `scripts/release.sh`: build → DMG (sindresorhus `create-dmg`, **npm** — not the homebrew tool) → EdDSA sign → update appcast → `gh release create`. The DMG is the Sparkle enclosure. CI: `.github/workflows/release.yml` (tag-triggered). Full pipeline + signing + `RELEASE_TOKEN`: §13. |
 | Find & Replace | `EdmundCore/Find/FindEngine.swift` (pure search), `TextView/EditorTextView+Find.swift` (match state, highlight drawing, pop animation, `EditorFindHandling`), `edmd/Views/FindBarView.swift` (the bar), `edmd/App/FindController.swift` (mediator); Edit ▸ Find menu in `main.swift` |
-| Format bar | `edmd/Views/FormatBarView.swift` + `ChromeBarView.swift` (titlebar-material + hairline base shared with the find bar), `edmd/App/FormatMenu.swift` (the two pulldowns are the same `headingMenu()`/`calloutMenu()` factories as the Format menu — one menu definition, three homes), `Document.formatBar` (owned by the document; shown/hidden by View ▸ Show Format Bar, `settings.edit.showFormatBar`, off in Reading mode). Stacks **above** the find bar; `Document.layoutTopBars()` is the sole writer of `editor.additionalTopInset`, so the two bars share the inset budget and a resize recomputing overscroll can't drop either bar's share. Bar is horizontally centred by design (a narrow window clips the same reachable band on both sides) |
+| Format bar | `edmd/Views/FormatBarView.swift` (layout + state refresh) and `FormatBarControls.swift` (the controls), on `ChromeBarView.swift` (titlebar-material + hairline base shared with the find bar), `edmd/App/FormatMenu.swift` (the two pulldowns are the same `headingMenu()`/`calloutMenu()` factories as the Format menu — one menu definition, three homes), `Document.formatBar` (owned by the document; **off by default**, toggled by View ▸ Show/Hide Format Bar, `settings.edit.showFormatBar`, force-hidden in Reading mode). Stacks **above** the find bar, both through `layoutTopBars()` (§6 top-bar insets). Bar is horizontally centred by design (a narrow window clips the same reachable band on both sides) |
+| Format-bar on-state | `EdmundCore/Editing/EditorTextView+FormattingState.swift` — the read-only counterpart to the toggles: `activeFormattingActions()`, `activeHeadingLevel()`, `activeCalloutType()`, refreshed from `editorDidChange` / `editorSelectionDidChange`. It scans **source delimiters, not rendered attributes**, because the attributes are lossy for this: a heading is also bold, and `==mark==` and a code span are both a background fill. Star *run length* is what separates `*x*` / `**x**` / `***x***`. A callout deliberately does not also light Block Quote (it is one underneath, but the callout pulldown gives the more specific answer). Hover/on chips live on `BarControlChip`; a chip is a fixed-height box centred on the bar's `interior`, **not** on the control's own bounds — sizing it per control made every symbol a different chip height. |
 | Standard text menus | `edmd/App/main.swift` — Edit ▸ Spelling and Grammar, Transformations, Speech; stock `NSTextView` actions routed to the first responder. **Substitutions is deliberately excluded** (§8) |
 | Status bar | `edmd/Views/StatusBarView.swift` |
 | Build/packaging | `scripts/build-app.sh` (release build + Sparkle.framework embedding + signing), `Package.swift`, `Info.plist`, `Resources/` |
@@ -244,10 +245,30 @@ Notable subsystems:
   rather than hand-rolling a clamp; `preservingViewportAnchor` is the
   exception and floors at 0 only, since it runs mid-re-tile when the clip
   view's idea of the document height is stale (clamping there yanked the
-  viewport ~770pt). The find and format bars both add their heights through
-  `Document.layoutTopBars()`, the sole writer of
-  `editor.additionalTopInset`, rather than each bar writing the inset itself,
-  so a resize recomputing the overscroll can't drop a bar's share.
+  viewport ~770pt).
+- **Top chrome bars are the one thing that *does* use `contentInsets`**
+  (`applyTopBarInset`, `+ContentWidth.swift`). The find and format bars stack
+  under the toolbar and hand their combined height to `editor.additionalTopInset`
+  via `Document.layoutTopBars()` — the sole writer, so a resize recomputing the
+  overscroll can't drop a bar's share. The hit-testing objection above does not
+  apply here: the band a top bar costs is the band it covers, so the live area
+  only loses what the reader could not click anyway.
+  - The inset does **not** shrink the clip view. The clip still spans the whole
+    scroll view and the document scrolls *under* the bar; what moves is the
+    scroll range's top end, from 0 to `-inset`. So the bars add no document
+    height — no overscroll, unlike the ends above.
+  - Every conversion between clip coordinates and "the top of what the reader
+    can see" must therefore add `viewportTopInset`, and use
+    `visibleContentHeight` (clip height *minus* the bars) where it used to use
+    the clip height. Typewriter centering, `scrollCharacterToTop` and
+    `topmostVisibleCharacterOffset` all do.
+  - **Sample the scroll origin *before* assigning the inset.** Shrinking it
+    re-clamps the clip view immediately, so an origin read afterwards has
+    already absorbed part of the delta — subtracting it again scrolled the
+    document *down* by a bar's height when a bar closed. Covered by
+    `TopBarInsetTests`.
+  - Set `automaticallyAdjustsContentInsets = false` first, or AppKit recomputes
+    the insets from the titlebar and stamps on the bars' value.
 - **Content width** (`+ContentWidth.swift`): an **absolute physical**
   max-column width — set in cm/in in Settings, stored as cm, converted to
   points via the display's real PPI (`NSScreen.physicalPPI`, from
@@ -417,17 +438,27 @@ Notable subsystems:
 
 ### Build, signing & packaging
 
-- **A green local `swift test` does not mean CI compiles.** The local CLI runs
-  a swift.org toolchain (`TOOLCHAINS` in `~/.zshrc` — 6.3.3); CI is macos-14 +
-  `latest-stable` Xcode (6.0.3). Concurrency *inference* differs between them:
-  SwiftUI's `View` is `@MainActor @preconcurrency`, so on 6.0.3 a `static func`
-  on a `View` is inferred main-actor-isolated and a synchronous test suite
-  cannot call it — an error 6.3.3 never emits (cost PR #249 a red `test` run).
-  Mark such helpers `nonisolated`. Before pushing anything that touches
-  isolation or a SwiftUI type's members, check parity:
-  `env -u TOOLCHAINS xcrun swift test --build-path .build-xcode`
-  (separate build path so it can't poison the normal `.build`; delete it after —
-  it is not gitignored).
+- **Build with the compiler CI builds with.** CI is macos-14 + `latest-stable`
+  Xcode, which is **Swift 6.0.3** (Xcode 16.2). Since 2026-08-10 the local CLI
+  matches it: the `TOOLCHAINS` export in `~/.zshrc` is commented out, so
+  `swift --version` reports 6.0.3 and a green local `swift test` means what it
+  says. The swift.org 6.3.3 toolchain is still installed for one-offs
+  (`TOOLCHAINS=org.swift.633202606251a swift build`) — but it is **newer than
+  CI**, and newer accepts what CI rejects. Two ways that has already cost a red
+  `test` run:
+  - SwiftUI's `View` is `@MainActor @preconcurrency`, so on 6.0.3 a `static
+    func` on a `View` is inferred main-actor-isolated and a synchronous test
+    suite cannot call it (PR #249). Mark such helpers `nonisolated`.
+  - An **unapplied method reference** is inferred on 6.0.3 as throwing *and* as
+    losing its actor isolation, so `forEach(removeTrackingArea)` and
+    `compactMap(Self.chip(of:))` failed to compile there and nowhere here
+    (PR #270). Spell the argument out: `forEach { removeTrackingArea($0) }`.
+  If you do run 6.3.3 for something, check parity before pushing with the
+  toolchain named explicitly, into a scratch path so it can't poison `.build`:
+  `TOOLCHAINS=com.apple.dt.toolchain.XcodeDefault swift test --scratch-path /tmp/ci-build`.
+  (Naming the toolchain beats `env -u TOOLCHAINS`: an agent in a worktree
+  session has its `env` wrappers refused, since the harness can't see what they
+  do to the command inside.)
 - **SwiftMath fonts**: `build-app.sh` must copy `*.bundle` into the `.app`
   root (it does). Without it the app **crashes the instant it renders any
   LaTeX**.
@@ -548,7 +579,10 @@ Notable subsystems:
   window, with nothing wrong in the mouse or selection code. Reserve blank
   space **inside the document view** instead, so every point of the window is
   still over the text view and a click in a blank band lands on the nearest
-  character.
+  character. The exception is a band that is *covered by chrome* — the top
+  bars (§6) do use `contentInsets`, because the clicks that inset costs are
+  clicks the bar was going to eat regardless. The test is not "is it an inset"
+  but "would the reader have been able to click there".
 - **`textContainerOrigin.y` is not the inset you set, and the default is
   OS-dependent.** AppKit splits the leftover space between the view's frame
   and the text container's own height, so the origin comes back as
@@ -680,7 +714,7 @@ Notable subsystems:
   only final then), so frame-in == frame-out (`windowDidResize` ↔
   `makeWindowControllers` in `Document.swift`).
 - **A frame-managed subview parked at the zero frame sets the window's
-  minimum width.** The find bar resizes by `autoresizingMask`, but its
+  minimum width.** A top chrome bar resizes by `autoresizingMask`, but its
   contents are Auto Layout, so its required constraints reach the window as
   a `contentMinSize`. A flexible-width autoresizing view only grows by the
   *delta* from the width it was added at — so a bar added at `.zero` first
@@ -690,7 +724,9 @@ Notable subsystems:
   opened at 1014 and would not shrink below it, `window.minSize` was
   inert (dropping it to 320 moved neither number), and the initial size and
   the minimum moved together. Fix: size the bar to the container when
-  parking it (`FindController.init`). Note this is invisible to headless
+  parking it — `FindController.init` for the find bar, and the `setFrameSize`
+  before `addSubview` in `Document.makeWindowControllers()` for the format bar,
+  which inherits the whole scar. Note this is invisible to headless
   tests — only the live window server applies `contentMinSize`, so verify by
   launching and asking AX to resize the window smaller than it can go.
 - **`NSSearchField`'s magnifier glyph can't be repositioned — draw your
@@ -818,6 +854,21 @@ Notable subsystems:
   exactly as edit mode reads by range. The `?? Self.plainText(of:)` fallback
   on that line is the mangled path — anything that makes `sourceText` return
   nil reintroduces the collapse.
+- **A callout that is the first block of a document is ~3.5pt short on top.**
+  Measured on a fresh open, caret moved off the block: 14.5pt above the title
+  vs 18.0pt for an identical callout mid-document (bands 80.0 / 83.0pt). Repro:
+  first line `> [!NOTE]`, a second callout further down, compare. (While the
+  caret is *inside* it the callout renders as raw source with no background —
+  that is live preview working, not the bug.) The top breathing room is not
+  paragraph spacing: it is reserved as *text* space by raising the header
+  line's `minimumLineHeight` in `calloutParagraphStyle`
+  (`+CalloutRendering.swift`), then painted by `decorationDrawHeight` /
+  `layoutFragmentFrame` (`+TextKit2.swift`). Check first whether the
+  *mid-document* callout is absorbing the blank line above it into its
+  fragment — `layoutFragmentFrame` already special-cases the trailing-empty-line
+  mirror of that — in which case 18.0pt is the inflated figure and the fix
+  belongs at the other end. Also reported and **not** reproduced: pushing such a
+  callout down with newlines loses its background entirely.
 - *(Add new ones here as you find them — with a one-line repro and a
   pointer to any deeper write-up in `docs/`.)*
 
@@ -921,7 +972,13 @@ only with reason):
    for `fix/foo`), so branches keep the normal `type/slug` naming and never
    get renamed to `worktree-*`. `.worktrees/` is gitignored. Distinct from
    `.claude/worktrees/`, which Claude Code's own EnterWorktree tool manages
-   automatically for agent isolation — don't hand-edit that one.
+   automatically for agent isolation — don't hand-edit that one. That tool
+   *does* name its branch `worktree-<name>`; rename it (`git branch -m
+   type/slug`) before committing, since the naming rule applies to what lands
+   in the history either way. An agent already pinned to one worktree cannot
+   `git -C` into another, and `guard-branch-create.sh` blocks `checkout -b` —
+   so the route to a second branch mid-session is ExitWorktree then
+   EnterWorktree, not a branch switch.
 7. **Reviewing someone else's PR uses `/edmund-pr-review <number>`**
    (`.claude/skills/edmund-pr-review/`). It gathers the PR, checks it against
    the invariants and the TextKit 2 estimate rule, verifies the claim the merge


### PR DESCRIPTION
Follow-up to #270. The format bar changed things ARCHITECTURE describes, and two
of its claims ended up contradicting the shipped code — the kind of doc error that
sends the next reader the wrong way rather than merely leaving them uninformed.

## Corrections

**`contentInsets` are no longer categorically banned.** §5 and §6 said to never use
them, on the strength of a real scar: reserving half a viewport at each end for
typewriter scroll shrank the hit-testing area to zero height and the caret stopped
following clicks anywhere in the window. The top bars now do use them. The rule that
actually holds is not "inset vs no inset" but *would the reader have been able to
click there* — what a top bar's inset costs is exactly the band the bar covers.

Both places now say so, and §6 documents the rest of the model, which was previously
only in code comments: the inset does not shrink the clip view (it moves the scroll
range's top end from 0 to `-inset`, which is why the bars add no document height and
no overscroll); every clip↔viewport conversion needs `viewportTopInset` /
`visibleContentHeight`; and the scroll origin must be sampled *before* the inset is
assigned, or a closing bar scrolls the document down by its own height.

**The toolchain bullet described a machine that no longer exists.** It said the local
CLI runs swift.org 6.3.3 and gave a parity command for it. Local is Xcode's 6.0.3 as
of 2026-08-10 — the same compiler CI uses — so a green local `swift test` now means
what it says. The two inference gaps stay documented as the reason not to drift newer
again, now including the one that cost #270 a red run: on 6.0.3 an unapplied method
reference is inferred as throwing *and* as losing its actor isolation, so
`forEach(removeTrackingArea)` compiles locally and fails on CI. The old parity command
also used `env -u TOOLCHAINS`, which an agent pinned to a worktree cannot run.

**Focus Mode moved to the Edit menu** in #270; §6 still said View.

## Additions

- The on-state scanner (`+FormattingState.swift`) and *why* it reads source
  delimiters rather than rendered attributes — the attributes are lossy for this
  question, since a heading is also bold and `==mark==` and a code span are both a
  background fill.
- The chip geometry rule: a chip is centred on the bar's `interior`, not on the
  control's own bounds, which is what made every symbol a different chip height.
- Renaming a command id needs `KeyBindingStore.migrateRenamedIDs`, because an
  override is filed under the id and a bare rename strands the user's shortcut
  under a key nothing reads — silently, without falling back to the default.
- The format bar inherits the `contentMinSize` scar, so §8's bullet now names both
  bars instead of just the find bar.
- Two worktree traps for agents: EnterWorktree names its branch `worktree-*`, which
  the project's own rule forbids, and a pinned session can neither `git -C` into
  another worktree nor `checkout -b` past `guard-branch-create.sh`.

## §9

The first-block callout top-padding bug: 14.5pt above the title versus 18.0pt for an
identical callout mid-document, with the repro, where the padding actually comes from
(a raised `minimumLineHeight`, not paragraph spacing), and the hypothesis worth
testing first — that the mid-document callout is absorbing the blank line above it,
making 18.0pt the wrong number rather than 14.5pt.

Docs only; `swift test` 1333 passing.
