### PR TITLE
fix(math): draw RaTeX Path and Rect display-list items (#265)

### DIFF
--- a/Sources/EdmundCore/Math/RaTeX/DisplayListRenderer.swift
+++ b/Sources/EdmundCore/Math/RaTeX/DisplayListRenderer.swift
@@ -25,13 +25,56 @@ struct RaTeXDisplayList: Decodable {
 
     struct RGBA: Decodable { let r, g, b, a: Double }
 
+    /// One segment of a `Path` item. Coordinates are offsets (em) from the
+    /// item's own origin, in the same top-down space as everything else.
+    enum PathCommand: Decodable {
+        case move(x: Double, y: Double)
+        case line(x: Double, y: Double)
+        case cubic(x1: Double, y1: Double, x2: Double, y2: Double, x: Double, y: Double)
+        case quad(x1: Double, y1: Double, x: Double, y: Double)
+        case close
+        case unknown
+
+        private enum Keys: String, CodingKey { case type, x, y, x1, y1, x2, y2 }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: Keys.self)
+            switch try c.decode(String.self, forKey: .type) {
+            case "MoveTo":
+                self = .move(x: try c.decode(Double.self, forKey: .x),
+                             y: try c.decode(Double.self, forKey: .y))
+            case "LineTo":
+                self = .line(x: try c.decode(Double.self, forKey: .x),
+                             y: try c.decode(Double.self, forKey: .y))
+            case "CubicTo":
+                self = .cubic(x1: try c.decode(Double.self, forKey: .x1),
+                              y1: try c.decode(Double.self, forKey: .y1),
+                              x2: try c.decode(Double.self, forKey: .x2),
+                              y2: try c.decode(Double.self, forKey: .y2),
+                              x: try c.decode(Double.self, forKey: .x),
+                              y: try c.decode(Double.self, forKey: .y))
+            case "QuadTo":
+                self = .quad(x1: try c.decode(Double.self, forKey: .x1),
+                             y1: try c.decode(Double.self, forKey: .y1),
+                             x: try c.decode(Double.self, forKey: .x),
+                             y: try c.decode(Double.self, forKey: .y))
+            case "Close":
+                self = .close
+            default:
+                self = .unknown
+            }
+        }
+    }
+
     enum Item: Decodable {
         case glyph(font: String, charCode: Int, x: Double, y: Double, scale: Double, color: RGBA)
         case line(x: Double, y: Double, width: Double, thickness: Double, color: RGBA)
+        case rect(x: Double, y: Double, width: Double, height: Double, color: RGBA)
+        case path(x: Double, y: Double, commands: [PathCommand], fill: Bool, color: RGBA)
         case unknown
 
         private enum Keys: String, CodingKey {
-            case type, font, char_code, x, y, scale, color, width, thickness
+            case type, font, char_code, x, y, scale, color, width, thickness, height, commands, fill
         }
 
         init(from decoder: Decoder) throws {
@@ -49,6 +92,18 @@ struct RaTeXDisplayList: Decodable {
                              y: try c.decode(Double.self, forKey: .y),
                              width: try c.decode(Double.self, forKey: .width),
                              thickness: try c.decode(Double.self, forKey: .thickness),
+                             color: try c.decode(RGBA.self, forKey: .color))
+            case "Rect":
+                self = .rect(x: try c.decode(Double.self, forKey: .x),
+                             y: try c.decode(Double.self, forKey: .y),
+                             width: try c.decode(Double.self, forKey: .width),
+                             height: try c.decode(Double.self, forKey: .height),
+                             color: try c.decode(RGBA.self, forKey: .color))
+            case "Path":
+                self = .path(x: try c.decode(Double.self, forKey: .x),
+                             y: try c.decode(Double.self, forKey: .y),
+                             commands: try c.decode([PathCommand].self, forKey: .commands),
+                             fill: try c.decodeIfPresent(Bool.self, forKey: .fill) ?? true,
                              color: try c.decode(RGBA.self, forKey: .color))
             default:
                 self = .unknown
@@ -131,6 +186,15 @@ final class RaTeXDisplayListRenderer {
                 ctx.fill(CGRect(x: CGFloat(x) * fs, y: boxH - CGFloat(y) * fs - th / 2,
                                 width: CGFloat(width) * fs, height: th))
 
+            case let .rect(x, y, width, height, _):
+                ctx.setFillColor(fill)
+                ctx.fill(CGRect(x: CGFloat(x) * fs, y: boxH - CGFloat(y + height) * fs,
+                                width: CGFloat(width) * fs, height: CGFloat(height) * fs))
+
+            case let .path(x, y, commands, filled, _):
+                drawPath(commands, originX: CGFloat(x) * fs, originY: CGFloat(y) * fs,
+                         filled: filled, fs: fs, boxH: boxH, color: fill, in: ctx)
+
             case .unknown:
                 continue
             }
@@ -150,5 +214,70 @@ final class RaTeXDisplayListRenderer {
         return RenderedMath(image: image,
                             ascent: CGFloat(dl.height) * fs + insetPad,
                             descent: CGFloat(dl.depth) * fs + insetPad)
+    }
+
+    /// Draws a `Path` item — the vector half of the display list, and the only
+    /// thing that draws a *stretchy* delimiter's connecting stem (a tall
+    /// `\begin{Bmatrix}` brace is Size4 glyph pieces bridged by path bars, and
+    /// a tall `\left(` is path outline only, no glyph at all). Command
+    /// coordinates are em offsets from the item's origin in the same top-down
+    /// space as everything else, so each point flips into the y-up context the
+    /// way a glyph baseline does.
+    ///
+    /// Each subpath (a run starting at a `MoveTo`) is filled on its own, with
+    /// the even-odd rule. Both quirks are copied from RaTeX's own reference
+    /// renderer, and both have a reason there: KaTeX assembles stretchy arrows
+    /// from components whose winding directions oppose, so one combined nonzero
+    /// fill cancels the shaft away, and a tall delimiter's stem is a second
+    /// subpath that nonzero would double-fill.
+    private func drawPath(_ commands: [RaTeXDisplayList.PathCommand],
+                          originX: CGFloat, originY: CGFloat,
+                          filled: Bool, fs: CGFloat, boxH: CGFloat,
+                          color: CGColor, in ctx: CGContext) {
+        func pt(_ x: Double, _ y: Double) -> CGPoint {
+            CGPoint(x: originX + CGFloat(x) * fs, y: boxH - originY - CGFloat(y) * fs)
+        }
+
+        ctx.saveGState()
+        defer { ctx.restoreGState() }
+        ctx.setFillColor(color)
+        ctx.setStrokeColor(color)
+        // RaTeX's renderers stroke with a device-pixel constant (1.5px); 0.04em
+        // is KaTeX's default rule thickness, so an unfilled path keeps the
+        // weight of `\frac`'s bar at every point size instead of thinning out.
+        ctx.setLineWidth(0.04 * fs)
+
+        var segment = CGMutablePath()
+        func flush() {
+            guard !segment.isEmpty else { return }
+            ctx.addPath(segment)
+            if filled { ctx.fillPath(using: .evenOdd) } else { ctx.strokePath() }
+            segment = CGMutablePath()
+        }
+
+        for cmd in commands {
+            switch cmd {
+            case let .move(x, y):
+                flush()
+                segment.move(to: pt(x, y))
+            // A subpath that never opened with a MoveTo has no current point;
+            // CoreGraphics treats that as a programming error, so skip it.
+            case let .line(x, y):
+                guard !segment.isEmpty else { continue }
+                segment.addLine(to: pt(x, y))
+            case let .cubic(x1, y1, x2, y2, x, y):
+                guard !segment.isEmpty else { continue }
+                segment.addCurve(to: pt(x, y), control1: pt(x1, y1), control2: pt(x2, y2))
+            case let .quad(x1, y1, x, y):
+                guard !segment.isEmpty else { continue }
+                segment.addQuadCurve(to: pt(x, y), control: pt(x1, y1))
+            case .close:
+                guard !segment.isEmpty else { continue }
+                segment.closeSubpath()
+            case .unknown:
+                continue
+            }
+        }
+        flush()
     }
 }

--- a/Tests/EdmundTests/RaTeXPathItemTests.swift
+++ b/Tests/EdmundTests/RaTeXPathItemTests.swift
@@ -1,0 +1,159 @@
+import Testing
+import AppKit
+import CoreText
+@testable import EdmundCore
+
+// RaTeX's display list has four item types (its
+// `docs/DISPLAYLIST_JSON_PROTOCOL.md`): GlyphPath, Line, Rect and Path. We used
+// to decode only the first two and silently skip the rest, which is what issue
+// #265 ("brackets are not rendering properly") actually was: a *stretchy*
+// delimiter is not one glyph. A tall `\begin{Bmatrix}` brace is Size4 glyph
+// pieces (U+23A7…U+23AD) bridged by Path bars, so it came out as disconnected
+// fragments; a tall `\left(` is Path outline with no glyph at all, so it came
+// out as nothing. Both are Edmund-side — RaTeX's JSON was correct all along.
+//
+// The JSON in these tests is real 0.1.14 output, not invented: the stem is the
+// first Path of `\begin{Bmatrix} a \\ b \\ c \\ d \end{Bmatrix}`, and the curve
+// is the shape of `\left(` around a 4-row matrix. No glyph items, so these need
+// no fonts and run everywhere — and on the pre-fix renderer every one of them
+// rasterizes to a completely blank image.
+
+@Suite("RaTeX display list — Path and Rect items")
+struct RaTeXPathItemTests {
+
+    /// These display lists contain no glyphs, so the loader is never consulted.
+    private func noFonts(_ name: String) -> CGFont? { nil }
+
+    private let fs: CGFloat = 16
+    private let insetPad: CGFloat = 2   // must match RaTeXDisplayListRenderer
+
+    /// Ink bounding box in image pixels, measured from the top-left. A
+    /// `CGBitmapContext`'s first memory row is the top of the image, so the row
+    /// index is already top-down — the same direction the display list uses.
+    private func inkBox(_ image: NSImage) throws -> (top: Int, bottom: Int, left: Int, right: Int, count: Int) {
+        let rep = try #require(image.representations.first as? NSBitmapImageRep)
+        let cg = try #require(rep.cgImage)
+        let w = cg.width, h = cg.height
+        var buf = [UInt8](repeating: 0, count: w * h * 4)
+        buf.withUnsafeMutableBytes { raw in
+            guard let ctx = CGContext(data: raw.baseAddress, width: w, height: h,
+                                      bitsPerComponent: 8, bytesPerRow: w * 4,
+                                      space: CGColorSpaceCreateDeviceRGB(),
+                                      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+            else { return }
+            ctx.draw(cg, in: CGRect(x: 0, y: 0, width: w, height: h))
+        }
+        var top = h, bottom = -1, left = w, right = -1, count = 0
+        for row in 0..<h {
+            for col in 0..<w where buf[(row * w + col) * 4 + 3] > 8 {
+                top = min(top, row); bottom = max(bottom, row)
+                left = min(left, col); right = max(right, col)
+                count += 1
+            }
+        }
+        return (top, bottom, left, right, count)
+    }
+
+    /// Where an em coordinate in the display list's top-down space lands, in
+    /// image pixels from the top, at `scale` 1.
+    private func expectedRow(_ yEm: Double, boxH: CGFloat, pxH: Int) -> Double {
+        Double(pxH) - (Double(boxH) - yEm * Double(fs) + Double(insetPad))
+    }
+
+    @Test("A filled Path draws, and lands where the display list puts it")
+    @MainActor func filledPathGeometry() throws {
+        // First stem of a 4-row `Bmatrix`: item origin y = 1.50799, commands
+        // spanning y −0.61598…0 and x 0.384…0.504 — so the bar occupies
+        // y 0.89201…1.50799 em, x 0.384…0.504 em, top-down.
+        let json = """
+            {"width":2.30637,"height":2.65,"depth":2.15,"items":[
+              {"type":"Path","x":0.0,"y":1.50799,"fill":true,
+               "color":{"r":0,"g":0,"b":0,"a":1},
+               "commands":[{"type":"MoveTo","x":0.384,"y":-0.61598},
+                           {"type":"LineTo","x":0.504,"y":-0.61598},
+                           {"type":"LineTo","x":0.504,"y":0.0},
+                           {"type":"LineTo","x":0.384,"y":0.0},
+                           {"type":"Close"}]}
+            ]}
+            """
+        let m = try #require(RaTeXDisplayListRenderer(fontLoader: noFonts)
+            .render(json: json, pointSize: fs, color: .black, scale: 1))
+        let box = try inkBox(m.image)
+        #expect(box.count > 0, "a Path item drew nothing — the item type is being skipped again")
+
+        let rep = try #require(m.image.representations.first as? NSBitmapImageRep)
+        let boxH = CGFloat(2.65 + 2.15) * fs
+        // Top-down: the smaller em y is the *upper* edge, i.e. the smaller row.
+        let wantTop = expectedRow(1.50799 - 0.61598, boxH: boxH, pxH: rep.pixelsHigh)
+        let wantBottom = expectedRow(1.50799, boxH: boxH, pxH: rep.pixelsHigh)
+        // A y-sign flip would mirror the bar to the far side of the box, which
+        // is ~10 px away here — 1.5 px of antialiasing slack cannot hide it.
+        #expect(abs(Double(box.top) - wantTop) < 1.5, "ink top \(box.top), expected ~\(wantTop)")
+        #expect(abs(Double(box.bottom) - wantBottom) < 1.5, "ink bottom \(box.bottom), expected ~\(wantBottom)")
+        #expect(abs(Double(box.left) - (0.384 * Double(fs) + Double(insetPad))) < 1.5)
+        #expect(abs(Double(box.right) - (0.504 * Double(fs) + Double(insetPad))) < 1.5)
+    }
+
+    @Test("A curved Path draws — a tall `\\left(` is outline only, no glyph")
+    @MainActor func cubicPathDraws() throws {
+        let json = """
+            {"width":2.279,"height":2.65,"depth":2.168,"items":[
+              {"type":"Path","x":0.0,"y":4.8,"fill":true,
+               "color":{"r":0,"g":0,"b":0,"a":1},
+               "commands":[{"type":"MoveTo","x":0.863,"y":-4.791},
+                           {"type":"CubicTo","x1":0.562,"y1":-4.487,"x2":0.409,"y2":-4.1,"x":0.347,"y":-3.62},
+                           {"type":"CubicTo","x1":0.313,"y1":-3.457,"x2":0.311,"y2":-3.063,"x":0.311,"y":-1.719},
+                           {"type":"CubicTo","x1":0.388,"y1":-0.737,"x2":0.545,"y2":-0.315,"x":0.805,"y":0.0},
+                           {"type":"LineTo","x":0.863,"y":-0.009},
+                           {"type":"Close"}]}
+            ]}
+            """
+        let m = try #require(RaTeXDisplayListRenderer(fontLoader: noFonts)
+            .render(json: json, pointSize: fs, color: .black, scale: 1))
+        let box = try inkBox(m.image)
+        #expect(box.count > 0, "a curved Path drew nothing")
+        // The delimiter spans nearly the whole box height; a stray flattening to
+        // a straight line or a dropped curve segment would collapse that.
+        #expect(box.bottom - box.top > Int(4.0 * fs))
+    }
+
+    @Test("A Rect item draws at its top-left origin")
+    @MainActor func rectDraws() throws {
+        let json = """
+            {"width":2.0,"height":1.0,"depth":0.5,"items":[
+              {"type":"Rect","x":0.25,"y":0.5,"width":1.0,"height":0.25,
+               "color":{"r":0,"g":0,"b":0,"a":1}}
+            ]}
+            """
+        let m = try #require(RaTeXDisplayListRenderer(fontLoader: noFonts)
+            .render(json: json, pointSize: fs, color: .black, scale: 1))
+        let box = try inkBox(m.image)
+        #expect(box.count > 0, "a Rect item drew nothing")
+
+        let rep = try #require(m.image.representations.first as? NSBitmapImageRep)
+        let boxH = CGFloat(1.0 + 0.5) * fs
+        #expect(abs(Double(box.top) - expectedRow(0.5, boxH: boxH, pxH: rep.pixelsHigh)) < 1.5)
+        #expect(abs(Double(box.bottom) - expectedRow(0.75, boxH: boxH, pxH: rep.pixelsHigh)) < 1.5)
+    }
+
+    @Test("An unknown item or path command is skipped, not fatal")
+    @MainActor func forwardCompatibility() throws {
+        // The protocol's own compatibility rule: decoders must ignore variants
+        // they don't know rather than hard-fail the whole equation.
+        let json = """
+            {"width":1.0,"height":1.0,"depth":0.0,"items":[
+              {"type":"SomethingNew","x":0.0,"y":0.0},
+              {"type":"Path","x":0.0,"y":1.0,"fill":true,
+               "color":{"r":0,"g":0,"b":0,"a":1},
+               "commands":[{"type":"MoveTo","x":0.1,"y":-0.9},
+                           {"type":"ArcTo","x":0.5,"y":-0.5},
+                           {"type":"LineTo","x":0.9,"y":-0.9},
+                           {"type":"LineTo","x":0.9,"y":0.0},
+                           {"type":"Close"}]}
+            ]}
+            """
+        let m = try #require(RaTeXDisplayListRenderer(fontLoader: noFonts)
+            .render(json: json, pointSize: fs, color: .black, scale: 1))
+        #expect(try inkBox(m.image).count > 0)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Fixed
 - Typewriter Scroll now centers the caret on every line, including the first and last ones and in documents shorter than the window — it reserves half a viewport of space at each end while the mode is on.
+- Advanced Math: tall brackets, braces and stretchy arrows now draw. A stretchy delimiter is part vector artwork, and the Advanced Math renderer was skipping that part — so a multi-row `\begin{Bmatrix}` came out as disconnected brace fragments, a tall `\left(` had no parentheses at all, and `\xrightarrow` lost its arrow (#265).
 
 ## [0.4.1] - 2026-08-01
 


### PR DESCRIPTION
Fixes #265.

## What was wrong

RaTeX's display list has four item types (its `DISPLAYLIST_JSON_PROTOCOL.md`): `GlyphPath`, `Line`, `Rect` and `Path`. `DisplayListRenderer` decoded only the first two and silently skipped the rest.

A stretchy delimiter is not one glyph, so this was very visible:

- a tall `\begin{Bmatrix}` is Size4 glyph pieces (U+23A7…U+23AD) **bridged by `Path` bars** → rendered as disconnected brace fragments
- a tall `\left(` is `Path` outline with **no glyph at all** → rendered as nothing
- `\xrightarrow` lost its arrow, `\overbrace` its brace, `\left\|` its bars — same mechanism

RaTeX's JSON was correct throughout. This is entirely our renderer, so no upstream change or version bump is involved.

## The fix

Decode and draw `Path` and `Rect`. Path commands (`MoveTo`/`LineTo`/`CubicTo`/`QuadTo`/`Close`) are em offsets from the item origin in the display list's top-down space — confirmed against the JSON itself (a 4-row `\left(` has item `y=4.800` with commands spanning `-4.800…+0.018`, reproducing the box's `0…4.818` exactly) and against RaTeX's own reference renderer.

Each subpath is filled separately with the even-odd rule. Both quirks are copied from that reference renderer and both have a reason there: KaTeX assembles stretchy arrows from components whose winding directions oppose, so a single nonzero fill cancels the shaft away, and a tall delimiter's stem is a second subpath that nonzero would double-fill. Unknown item and command types are still skipped rather than failing the equation, which is what the protocol's own compatibility rules ask of decoders.

## Verification

Nine equations rendered through the real wasm engine (0.1.14, pinned archive, hash verified) before and after:

- the six path-using ones are fixed — `Bmatrix`, `\left(`, `\left[`, `\left\|`, `\overbrace`, `\xrightarrow`
- glyph/`Line`-only output is **byte-identical** (`\int_0^\infty e^{-x^2}\,dx`, `\sqrt{\frac{a}{b}}`), so the blast radius is exactly the items that were previously dropped

`Tests/EdmundTests/RaTeXPathItemTests.swift` adds four tests built on real 0.1.14 JSON. They need no fonts (a path-only display list references none), so they run everywhere including CI, and all four fail on the pre-fix renderer — the image comes out completely blank. One of them pins the geometry, not just the presence of ink: a y-sign flip would mirror the brace stem to the far side of the box.

Full suite: 1299 tests, all green.