### PR TITLE
Populate the format toolbar and make its popup a popover

### DIFF
--- a/Sources/EdmundCore/Editing/EditorTextView+ActiveStyles.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+ActiveStyles.swift
@@ -1,0 +1,112 @@
+import AppKit
+
+// MARK: - What formatting applies at the caret
+//
+// The format popup shows which commands are already in effect, the way Apple
+// Notes lights up "I" inside italic text. Both answers are derived from the
+// same sources the renderer uses — `blocks` for the block kind and
+// `SyntaxHighlighter.parse` for the inline spans — so the popup can never
+// disagree with what is drawn.
+
+/// The inline styles in effect at the caret. An OptionSet because they nest:
+/// `***word***` inside `<u>` is bold + italic + underline at once.
+public struct ActiveInlineStyles: OptionSet, Sendable {
+    public let rawValue: Int
+    public init(rawValue: Int) { self.rawValue = rawValue }
+
+    public static let bold          = ActiveInlineStyles(rawValue: 1 << 0)
+    public static let italic        = ActiveInlineStyles(rawValue: 1 << 1)
+    public static let underline     = ActiveInlineStyles(rawValue: 1 << 2)
+    public static let strikethrough = ActiveInlineStyles(rawValue: 1 << 3)
+    public static let highlight     = ActiveInlineStyles(rawValue: 1 << 4)
+    public static let code          = ActiveInlineStyles(rawValue: 1 << 5)
+    public static let math          = ActiveInlineStyles(rawValue: 1 << 6)
+    public static let `subscript`   = ActiveInlineStyles(rawValue: 1 << 7)
+    public static let superscript   = ActiveInlineStyles(rawValue: 1 << 8)
+}
+
+/// The block the caret sits in, reduced to the cases the format popup offers.
+/// Deliberately coarser than `BlockKind`: the popup has one row per entry here.
+public enum ActiveBlockStyle: Equatable, Sendable {
+    case heading(level: Int)
+    case bulletedList
+    case numberedList
+    case checklist
+    case blockQuote
+    case callout
+    case codeBlock
+    case mathBlock
+    case body
+}
+
+extension EditorTextView {
+
+    /// The inline styles covering the caret (or the start of the selection).
+    ///
+    /// A style counts as active when the caret is anywhere within its *content*,
+    /// including hard against either edge — typing at the end of `**word**`
+    /// continues the bold run, so the button has to agree.
+    public func activeInlineStyles() -> ActiveInlineStyles {
+        let probe = selectedRange().location
+        guard let index = blockIndexForRawOffset(probe), index < blocks.count else { return [] }
+        let block = blocks[index]
+        let local = probe - block.range.location
+        guard local >= 0 else { return [] }
+
+        var styles: ActiveInlineStyles = []
+        for span in SyntaxHighlighter.parse(block.content,
+                                            linkDefinitions: linkDefState.defsText,
+                                            features: markdownFeatures) {
+            let r = span.contentRange
+            guard local >= r.location, local <= r.location + r.length else { continue }
+            switch span.kind {
+            case .bold:                  styles.insert(.bold)
+            case .italic:                styles.insert(.italic)
+            case .boldItalic:            styles.formUnion([.bold, .italic])
+            case .strikethrough:         styles.insert(.strikethrough)
+            case .highlight:             styles.insert(.highlight)
+            case .code:                  styles.insert(.code)
+            case .math(let display):     if !display { styles.insert(.math) }
+            case .htmlFormat(let tag):
+                switch tag {
+                case "u":   styles.insert(.underline)
+                case "sub": styles.insert(.subscript)
+                case "sup": styles.insert(.superscript)
+                default:    break
+                }
+            default: break
+            }
+        }
+        return styles
+    }
+
+    /// The block style at the caret. `body` when nothing more specific applies.
+    public func activeBlockStyle() -> ActiveBlockStyle {
+        let probe = selectedRange().location
+        guard let index = blockIndexForRawOffset(probe), index < blocks.count else { return .body }
+        let block = blocks[index]
+
+        switch block.kind {
+        case .heading(let level):        return .heading(level: level)
+        case .fence, .indentedCode:      return .codeBlock
+        case .mathDisplay:               return .mathBlock
+        case .quoteRun(let isCallout):   return isCallout ? .callout : .blockQuote
+        case .listItem:
+            // The marker distinguishes the three list flavours, and only the
+            // caret's own line counts — a multi-line block may mix them.
+            let line = lineAtCaret(in: block, probe: probe)
+            if isChecklistLine(line) { return .checklist }
+            if isBulletLine(line) { return .bulletedList }
+            return leadingListNumber(line) != nil ? .numberedList : .bulletedList
+        default:
+            return .body
+        }
+    }
+
+    /// The text of the caret's own line within `block`.
+    private func lineAtCaret(in block: Block, probe: Int) -> String {
+        let ns = rawSource as NSString
+        guard probe <= ns.length else { return block.content }
+        return ns.substring(with: ns.lineRange(for: NSRange(location: probe, length: 0)))
+    }
+}

--- a/Sources/EdmundCore/Editing/EditorTextView+FormattingCommands.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+FormattingCommands.swift
@@ -1,4 +1,5 @@
 import AppKit
+import UniformTypeIdentifiers
 
 // MARK: - Format-menu actions
 //
@@ -44,6 +45,16 @@ import AppKit
 // "** word **". Toggle-off detection also operates on the trimmed range, so
 // selecting " **word** " and pressing Cmd+B correctly unwraps.
 
+/// Toolbar items validate through `NSToolbarItemValidation`, not
+/// `validateMenuItem` — without this the format items would stay enabled in
+/// Read mode and for switched-off Markdown features.
+extension EditorTextView: NSToolbarItemValidation {
+    public func validateToolbarItem(_ item: NSToolbarItem) -> Bool {
+        guard let action = item.action, Self.formattingActions.contains(action) else { return true }
+        return isFormattingActionEnabled(action, representedObject: nil)
+    }
+}
+
 extension EditorTextView {
 
     // MARK: - Inline font styles
@@ -68,6 +79,8 @@ extension EditorTextView {
     @objc public func formatInlineMath(_ sender: Any?)    { toggleInlineWrap(open: "$", close: "$", expandToWord: true) }
     @objc public func formatKeyboard(_ sender: Any?)      { toggleInlineWrap(open: "<kbd>", close: "</kbd>", expandToWord: true) }
     @objc public func formatComment(_ sender: Any?)       { toggleInlineWrap(open: "<!-- ", close: " -->", expandToWord: true) }
+    @objc public func formatSubscript(_ sender: Any?)     { toggleInlineWrap(open: "<sub>", close: "</sub>", expandToWord: true) }
+    @objc public func formatSuperscript(_ sender: Any?)   { toggleInlineWrap(open: "<sup>", close: "</sup>", expandToWord: true) }
 
     // MARK: - Inline links
     // Link / Image: caret in `()` so URL can be typed next.
@@ -132,18 +145,26 @@ extension EditorTextView {
 
     public override func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         if let action = menuItem.action, Self.formattingActions.contains(action) {
-            if viewMode == .reading { return false }
-            // Gray out a command whose Markdown syntax is turned off in Settings
-            // (e.g. Highlight when highlights are disabled) so it can't insert
-            // markup the editor would render as plain text.
-            if let feature = Self.requiredFeature(forAction: action,
-                                                  representedObject: menuItem.representedObject),
-               !markdownFeatures.contains(feature) {
-                return false
-            }
-            return true
+            return isFormattingActionEnabled(action, representedObject: menuItem.representedObject)
         }
         return super.validateMenuItem(menuItem)
+    }
+
+    /// Whether a formatting command can run right now. The single predicate
+    /// behind menu validation, toolbar validation, and the format popup's icon
+    /// rows (whose buttons are not validated items at all and must ask directly).
+    /// One predicate, three callers — the enable rules must not drift apart.
+    public func isFormattingActionEnabled(_ action: Selector, representedObject: Any?) -> Bool {
+        if viewMode == .reading { return false }
+        // Gray out a command whose Markdown syntax is turned off in Settings
+        // (e.g. Highlight when highlights are disabled) so it can't insert
+        // markup the editor would render as plain text.
+        if let feature = Self.requiredFeature(forAction: action,
+                                              representedObject: representedObject),
+           !markdownFeatures.contains(feature) {
+            return false
+        }
+        return true
     }
 
     /// The Markdown feature a formatting command needs, or nil if it inserts
@@ -176,6 +197,8 @@ extension EditorTextView {
         #selector(formatChecklist(_:)), #selector(formatBlockQuote(_:)), #selector(formatThematicBreak(_:)),
         #selector(formatCodeBlock(_:)), #selector(formatMathBlock(_:)), #selector(formatTable(_:)),
         #selector(formatHeading(_:)), #selector(formatCallout(_:)),
+        #selector(formatSubscript(_:)), #selector(formatSuperscript(_:)),
+        #selector(formatAttachImage(_:)),
     ]
 
     // MARK: - Heading
@@ -366,6 +389,47 @@ extension EditorTextView {
         applyFormattingEdit(rawRange: NSRange(location: sel.location, length: 0),
                             replacement: "![]()",
                             select: NSRange(location: sel.location + 4, length: 0))
+    }
+
+    /// Image ▸ Attach File…: pick an image on disk and insert `![](path)` for it.
+    /// Unlike `formatImage`, which only lays down empty syntax, this one knows the
+    /// destination — so the caret lands in the *alt-text* slot, the part still
+    /// missing.
+    @objc public func formatAttachImage(_ sender: Any?) {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.image]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.prompt = "Attach"
+        panel.message = "Choose an image to insert."
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        insertImage(at: url)
+    }
+
+    /// Inserts `![](destination)` for `url` at the caret. Split from the panel
+    /// above so the path logic is testable without UI.
+    public func insertImage(at url: URL) {
+        let sel = selectedRange()
+        applyFormattingEdit(rawRange: sel,
+                            replacement: "![](" + imageDestination(for: url) + ")",
+                            select: NSRange(location: sel.location + 2, length: 0))
+    }
+
+    /// The destination to write into `![](…)`: relative to the document's own
+    /// directory when `url` sits at or below it (so the file stays portable
+    /// alongside its assets), absolute otherwise. Percent-encoded, since a raw
+    /// space or `)` in a filename would truncate the destination — which
+    /// `DocumentHTML.resolveLocalImage` decodes symmetrically on the way back.
+    func imageDestination(for url: URL) -> String {
+        let file = url.standardizedFileURL
+        var path = file.path
+        if let dir = document?.fileURL?.standardizedFileURL.deletingLastPathComponent() {
+            let prefix = dir.path.hasSuffix("/") ? dir.path : dir.path + "/"
+            if path.hasPrefix(prefix) { path = String(path.dropFirst(prefix.count)) }
+        }
+        var allowed = CharacterSet.urlPathAllowed
+        allowed.remove(charactersIn: "()")
+        return path.addingPercentEncoding(withAllowedCharacters: allowed) ?? path
     }
 
     /// Footnote (NOT invertible): inserts `[^n]` after the selection / end of

--- a/Sources/EdmundCore/Editing/EditorTextView+FormattingCommands.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+FormattingCommands.swift
@@ -188,7 +188,10 @@ extension EditorTextView {
         }
     }
 
-    static let formattingActions: Set<Selector> = [
+    /// Public because the toolbar decides from it which of its buttons the caret
+    /// may disable — an item whose action is not in here (Format, which only
+    /// opens a popover) must never be gated.
+    public static let formattingActions: Set<Selector> = [
         #selector(formatBold(_:)), #selector(formatItalic(_:)), #selector(formatUnderline(_:)),
         #selector(formatStrikethrough(_:)), #selector(formatHighlight(_:)), #selector(formatCode(_:)),
         #selector(formatInlineMath(_:)), #selector(formatKeyboard(_:)), #selector(formatComment(_:)),

--- a/Sources/EdmundCore/Model/Callout+Icon.swift
+++ b/Sources/EdmundCore/Model/Callout+Icon.swift
@@ -1,0 +1,17 @@
+import AppKit
+
+// Callout.swift stays Foundation-only — its fields are deliberately plain and
+// serializable — so the one AppKit-shaped accessor lives here.
+
+extension Callout {
+    /// A callout type's header icon, tinted to `color`, or nil for an unknown
+    /// type. Exists so the app module can draw the same glyph the editor draws
+    /// without `LucideIcons` (which is internal) leaking out of EdmundCore.
+    ///
+    /// The caller picks the tint: the editor uses the callout's own accent, the
+    /// format popover draws it monochrome so it sits with the other rows.
+    public static func icon(for type: String, color: NSColor, pointSize: CGFloat) -> NSImage? {
+        guard let style = style(for: type) else { return nil }
+        return LucideIcons.image(style.iconName, color: color, pointSize: pointSize)
+    }
+}

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -14,6 +14,9 @@ class Document: NSDocument, HeadingNavigable {
     private var viewModeButton: NSButton?
     private static let viewModeItemID = NSToolbarItem.Identifier("viewMode")
 
+    /// Builds and owns the formatting toolbar items (see `FormatToolbar`).
+    private var formatToolbar: FormatToolbar!
+
     /// Session-only zoom scale (View ▸ Actual Size/Zoom In/Zoom Out), applied on
     /// top of the persisted font size and content width. Not saved — each new
     /// window starts back at 100%.
@@ -157,22 +160,35 @@ class Document: NSDocument, HeadingNavigable {
             self?.readView?.setScrollPosition(line: line, fraction: 0)
         }
 
-        // Toolbar holds the right-aligned view-mode toggle (and gives the
-        // titlebar extra height for roomy traffic lights). Set it only after
-        // `editor` exists — assigning the toolbar synchronously vends its items.
-        let toolbar = NSToolbar(identifier: "MainToolbar")
+        // Toolbar holds the formatting items plus the right-aligned view-mode
+        // toggle (and gives the titlebar extra height for roomy traffic lights).
+        // Set it only after `editor` exists — assigning the toolbar synchronously
+        // vends its items.
+        //
+        // The identifier is versioned: `autosavesConfiguration` persists the item
+        // layout per identifier, so every window that ever ran the one-item
+        // toolbar has `[flexibleSpace, viewMode]` on disk, and that saved set
+        // wins over any new defaults. Bumping the identifier is what makes the
+        // format items appear for existing users; the only customization it
+        // discards is the ordering of a single item.
+        formatToolbar = FormatToolbar(document: self)
+        let toolbar = NSToolbar(identifier: "MainToolbar2")
         toolbar.delegate = self
         toolbar.displayMode = .iconOnly
         toolbar.allowsUserCustomization = true
-        toolbar.autosavesConfiguration = true   // persists layout per "MainToolbar"
+        toolbar.autosavesConfiguration = true   // persists layout per "MainToolbar2"
         window.toolbar = toolbar
         window.toolbarStyle = .unified
         window.titlebarSeparatorStyle = .line
 
-        // Wire the window's secondary-click interception now that the toolbar has
-        // synchronously vended the view-mode button (see DocumentWindow).
-        window.viewModeButton = viewModeButton
-        window.makeViewModeMenu = { [weak self] in self?.viewModeMenu() ?? NSMenu() }
+        // Wire the window's secondary-click interceptions now that the toolbar has
+        // synchronously vended its buttons (see DocumentWindow).
+        window.secondaryClickTargets = [
+            .init(viewModeButton) { [weak self] in self?.viewModeMenu() ?? NSMenu() },
+            .init(formatToolbar.linkButton) { [weak self] in
+                self?.formatToolbar.linkMenu() ?? NSMenu()
+            },
+        ]
 
         let statusBarHeight: CGFloat = 22
         let contentBounds = window.contentView!.bounds
@@ -472,8 +488,15 @@ class Document: NSDocument, HeadingNavigable {
     /// Shows the active mode's icon on the button and keeps the tooltip in sync.
     private func refreshViewModeButton() {
         guard let editor else { return }
+        // 15pt matches the formatting glyphs beside it (FormatToolbar.symbol).
+        // `book` is sized down from that: its intrinsic box is taller than
+        // `pencil`'s, so at a shared point size it draws visibly bigger (measured
+        // 17.5pt tall against the pencil's 15.0pt) and the button appears to
+        // change size when the mode flips. These two numbers are chosen so the
+        // *drawn* glyphs match, which is what the eye compares.
+        let pointSize: CGFloat = editor.viewMode == .reading ? 12.9 : 15
         viewModeButton?.image = icon(for: editor.viewMode)?
-            .withSymbolConfiguration(.init(pointSize: 13, weight: .regular))
+            .withSymbolConfiguration(.init(pointSize: pointSize, weight: .regular))
         viewModeButton?.toolTip = "View mode: \(label(for: editor.viewMode))"
     }
 
@@ -847,17 +870,20 @@ class Document: NSDocument, HeadingNavigable {
 
 extension Document: NSToolbarDelegate {
     func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        [.flexibleSpace, Self.viewModeItemID]
+        FormatToolbar.defaultIdentifiers(viewMode: Self.viewModeItemID)
     }
 
     func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        [.flexibleSpace, .space, Self.viewModeItemID]
+        FormatToolbar.allowedIdentifiers(viewMode: Self.viewModeItemID)
     }
 
     func toolbar(_ toolbar: NSToolbar,
                  itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
                  willBeInsertedIntoToolbar flag: Bool) -> NSToolbarItem? {
-        guard itemIdentifier == Self.viewModeItemID else { return nil }
+        // Everything but the view-mode toggle belongs to FormatToolbar.
+        guard itemIdentifier == Self.viewModeItemID else {
+            return formatToolbar.makeItem(itemIdentifier)
+        }
         let item = NSToolbarItem(itemIdentifier: itemIdentifier)
         item.label = "View Mode"
         item.visibilityPriority = .high
@@ -877,22 +903,40 @@ extension Document: NSToolbarDelegate {
     }
 }
 
-/// Document window that intercepts a secondary (right / control) click on the
-/// view-mode toolbar button and shows the mode menu itself. `sendEvent` is the
-/// single funnel all window events pass through *before* the toolbar/titlebar
-/// can turn the click into its own "Customize Toolbar…" context menu, so this is
-/// the one place the interception reliably wins.
+/// Document window that intercepts a secondary (right / control) click on a
+/// toolbar button and shows that button's own menu. `sendEvent` is the single
+/// funnel all window events pass through *before* the toolbar/titlebar can turn
+/// the click into its own "Customize Toolbar…" context menu, so this is the one
+/// place the interception reliably wins — the view's `menu`, a `rightMouseDown`
+/// override and a gesture recognizer all lose it.
+///
+/// Caveat: true full screen moves the toolbar into a separate window this
+/// main-window hook does not cover.
 final class DocumentWindow: NSWindow {
-    weak var viewModeButton: NSView?
-    var makeViewModeMenu: (() -> NSMenu)?
+    /// A button that claims its own secondary click, with the menu to show.
+    /// The view is weak: the toolbar owns it and may vend a replacement.
+    struct SecondaryClickTarget {
+        weak var view: NSView?
+        let makeMenu: () -> NSMenu
+
+        init(_ view: NSView?, makeMenu: @escaping () -> NSMenu) {
+            self.view = view
+            self.makeMenu = makeMenu
+        }
+    }
+
+    var secondaryClickTargets: [SecondaryClickTarget] = []
 
     override func sendEvent(_ event: NSEvent) {
-        if isSecondaryClick(event), let button = viewModeButton,
-           button.bounds.contains(button.convert(event.locationInWindow, from: nil)),
-           let menu = makeViewModeMenu?() {
-            menu.popUp(positioning: nil,
-                       at: NSPoint(x: 0, y: button.bounds.maxY + 4), in: button)
-            return
+        if isSecondaryClick(event) {
+            for target in secondaryClickTargets {
+                guard let button = target.view,
+                      button.bounds.contains(button.convert(event.locationInWindow, from: nil))
+                else { continue }
+                target.makeMenu().popUp(positioning: nil,
+                                        at: NSPoint(x: 0, y: button.bounds.maxY + 4), in: button)
+                return
+            }
         }
         super.sendEvent(event)
     }

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -501,7 +501,10 @@ class Document: NSDocument, HeadingNavigable {
         let pointSize: CGFloat = editor.viewMode == .reading ? 12.9 : 15
         viewModeButton?.image = icon(for: editor.viewMode)?
             .withSymbolConfiguration(.init(pointSize: pointSize, weight: .regular))
-        viewModeButton?.toolTip = "View mode: \(label(for: editor.viewMode))"
+        // Names what the click does, not what the mode is: the icon already shows
+        // the current mode, and AppKit's own toolbars read "Hide Sidebar" /
+        // "Show Sidebar" rather than stating the state back.
+        viewModeButton?.toolTip = "Switch to \(label(for: toggledViewMode)) View"
     }
 
     private func setViewMode(_ mode: EditorTextView.ViewMode) {
@@ -795,7 +798,13 @@ class Document: NSDocument, HeadingNavigable {
     /// button). With source mode on the editing view is Source, so this flips
     /// Source ↔ Read; otherwise Edit ↔ Read.
     @objc func toggleViewMode(_ sender: Any?) {
-        setViewMode(editor.viewMode == .reading ? editingMode : .reading)
+        setViewMode(toggledViewMode)
+    }
+
+    /// Where `toggleViewMode` would land — also what the button's tooltip names,
+    /// so the two can't say different things.
+    private var toggledViewMode: EditorTextView.ViewMode {
+        editor?.viewMode == .reading ? editingMode : .reading
     }
 
     /// "Inspect Reader" (⌥⌘I) — a semi-toggle, so one shortcut always gets you

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -177,6 +177,10 @@ class Document: NSDocument, HeadingNavigable {
         toolbar.displayMode = .iconOnly
         toolbar.allowsUserCustomization = true
         toolbar.autosavesConfiguration = true   // persists layout per "MainToolbar2"
+        // Flexible space alone does not centre the group: measured on a 1500pt
+        // window, the leading one absorbed all 1077pt of slack and the trailing
+        // one got nothing. This is the API that actually centres.
+        toolbar.centeredItemIdentifiers = FormatToolbar.centeredIdentifiers
         window.toolbar = toolbar
         window.toolbarStyle = .unified
         window.titlebarSeparatorStyle = .line

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -503,8 +503,12 @@ class Document: NSDocument, HeadingNavigable {
             .withSymbolConfiguration(.init(pointSize: pointSize, weight: .regular))
         // Names what the click does, not what the mode is: the icon already shows
         // the current mode, and AppKit's own toolbars read "Hide Sidebar" /
-        // "Show Sidebar" rather than stating the state back.
-        viewModeButton?.toolTip = "Switch to \(label(for: toggledViewMode)) View"
+        // "Show Sidebar" rather than stating the state back. Source is a display
+        // option *of* the editing view, not a third destination, so the toggle
+        // only ever has these two halves to name — even when `toggledViewMode`
+        // lands in `.source`.
+        viewModeButton?.toolTip = editor.viewMode == .reading
+            ? "Switch to Edit View" : "Switch to Read View"
     }
 
     private func setViewMode(_ mode: EditorTextView.ViewMode) {

--- a/Sources/edmd/App/FormatMenu.swift
+++ b/Sources/edmd/App/FormatMenu.swift
@@ -91,7 +91,7 @@ enum FormatMenu {
 
     // MARK: - Groups
 
-    private static let listCommands: [MenuCommand] = [
+    static let listCommands: [MenuCommand] = [
         MenuCommand(id: "format.bulletedList", title: "Bulleted List",
                     action: #selector(EditorTextView.formatBulletedList(_:)), shortcut: .cmdOpt("b")),
         MenuCommand(id: "format.numberedList", title: "Numbered List",
@@ -100,7 +100,7 @@ enum FormatMenu {
                     action: #selector(EditorTextView.formatChecklist(_:)), shortcut: .cmd("l")),
     ]
 
-    private static let linkCommands: [MenuCommand] = [
+    static let linkCommands: [MenuCommand] = [
         MenuCommand(id: "format.link", title: "Link",
                     action: #selector(EditorTextView.formatLink(_:)), shortcut: .cmd("k")),
         MenuCommand(id: "format.wikilink", title: "Wikilink",
@@ -109,13 +109,13 @@ enum FormatMenu {
                     action: #selector(EditorTextView.formatImage(_:))),
     ]
 
-    private static let thematicBreakCommand = MenuCommand(id: "format.thematicBreak", title: "Thematic Break",
+    static let thematicBreakCommand = MenuCommand(id: "format.thematicBreak", title: "Thematic Break",
                     action: #selector(EditorTextView.formatThematicBreak(_:)))
 
-    private static let footnoteCommand = MenuCommand(id: "format.footnote", title: "Footnote",
+    static let footnoteCommand = MenuCommand(id: "format.footnote", title: "Footnote",
                     action: #selector(EditorTextView.formatFootnote(_:)))
 
-    private static let blockCommands: [MenuCommand] = [
+    static let blockCommands: [MenuCommand] = [
         MenuCommand(id: "format.table", title: "Table",
                     action: #selector(EditorTextView.formatTable(_:))),
         MenuCommand(id: "format.codeBlock", title: "Code Block",
@@ -126,7 +126,7 @@ enum FormatMenu {
                     action: #selector(EditorTextView.formatBlockQuote(_:)), shortcut: .cmdShift("b")),
     ]
 
-    private static let fontCommands: [MenuCommand] = [
+    static let fontCommands: [MenuCommand] = [
         MenuCommand(id: "format.bold", submenu: "Font", title: "Bold",
                     action: #selector(EditorTextView.formatBold(_:)), shortcut: .cmd("b")),
         MenuCommand(id: "format.italic", submenu: "Font", title: "Italic",
@@ -145,6 +145,10 @@ enum FormatMenu {
                     action: #selector(EditorTextView.formatKeyboard(_:))),
         MenuCommand(id: "format.comment", submenu: "Font", title: "Comments",
                     action: #selector(EditorTextView.formatComment(_:))),
+        MenuCommand(id: "format.subscript", submenu: "Font", title: "Subscript",
+                    action: #selector(EditorTextView.formatSubscript(_:))),
+        MenuCommand(id: "format.superscript", submenu: "Font", title: "Superscript",
+                    action: #selector(EditorTextView.formatSuperscript(_:))),
     ]
 
     /// GitHub alert types (uppercase in source: `> [!NOTE]`).
@@ -159,7 +163,7 @@ enum FormatMenu {
 
     // MARK: - Submenus
 
-    private static func headingSubmenuItem() -> NSMenuItem {
+    static func headingSubmenuItem() -> NSMenuItem {
         let item = NSMenuItem(title: "Heading", action: nil, keyEquivalent: "")
         let menu = NSMenu(title: "Heading")
         for level in 1...6 {
@@ -172,7 +176,7 @@ enum FormatMenu {
         return item
     }
 
-    private static func calloutSubmenuItem() -> NSMenuItem {
+    static func calloutSubmenuItem() -> NSMenuItem {
         let item = NSMenuItem(title: "Alert / Callout", action: nil, keyEquivalent: "")
         let menu = NSMenu(title: "Alert / Callout")
         for type in githubCalloutTypes {

--- a/Sources/edmd/App/FormatPopover.swift
+++ b/Sources/edmd/App/FormatPopover.swift
@@ -97,8 +97,12 @@ final class FormatPopoverController: NSViewController {
         view = container
         // Sized to the widest row — usually the icon grid — rather than a fixed
         // width, so the popover fits its content snugly the way Notes' does.
+        // Exactly the fitting size: the stack's own edge insets are already in
+        // it, and any padding added on top is slack the stack stretches to fill,
+        // which the icon grid — the one band with no height of its own — absorbs
+        // whole. That is where the extra gap above the first divider came from.
         view.frame = NSRect(x: 0, y: 0, width: ceil(stack.fittingSize.width),
-                            height: stack.fittingSize.height + 12)
+                            height: stack.fittingSize.height)
     }
 
     /// Notes insets its dividers from the popover's sides rather than letting them
@@ -168,6 +172,14 @@ final class FormatPopoverRow: NSView {
     /// Uniform across every row. Exposed so the layout tests can assert it.
     static let rowHeight: CGFloat = 29
 
+    /// The three columns, as offsets from the row's leading edge. Notes puts its
+    /// checkmark at 17.5pt and its titles at 40pt, with nothing between; the
+    /// marker gutter is fitted into that same span rather than pushing the titles
+    /// right, by starting the checkmark closer in.
+    static let checkmarkX: CGFloat = 12
+    static let markerX: CGFloat = 25
+    static let titleX: CGFloat = 40
+
     let item: NSMenuItem
 
     var isEnabled = true { didSet { updateAppearance() } }
@@ -181,7 +193,10 @@ final class FormatPopoverRow: NSView {
     /// Not private: the layout tests read its frame and tint.
     let highlight = NSView()
     private let checkmark = NSImageView()
+    /// The callout row's glyph. Shares the marker gutter with `markerLabel` —
+    /// no row has both.
     private let iconView = NSImageView()
+    private let markerLabel = NSTextField(labelWithString: "")
     private let label = NSTextField(labelWithString: "")
     /// Not private so the offscreen render harness can exercise the hover look
     /// without synthesising mouse events.
@@ -196,39 +211,34 @@ final class FormatPopoverRow: NSView {
 
         checkmark.image = NSImage(systemSymbolName: "checkmark", accessibilityDescription: nil)?
             .withSymbolConfiguration(.init(pointSize: 10, weight: .semibold))
-        checkmark.contentTintColor = .labelColor
         checkmark.alphaValue = 0
 
         iconView.image = item.image
         iconView.isHidden = item.image == nil
 
-        if let attributed = item.attributedTitle {
-            label.attributedStringValue = attributed
-        } else {
-            label.stringValue = item.title
-            label.font = .menuFont(ofSize: 0)
+        let body = NSFont.menuFont(ofSize: 0)
+        if let marker = FormatToolbar.marker(for: item) {
+            markerLabel.stringValue = marker
+            // `$` is Markdown syntax, so it is shown in the face it is typed in.
+            markerLabel.font = marker == "$"
+                ? .monospacedSystemFont(ofSize: body.pointSize - 1, weight: .regular)
+                : body
         }
-        // Assigning an attributed string whose paragraph style is unset drops the
-        // cell back into wrapping mode, and a wrapping label has no intrinsic
-        // width to give the stack — every marked row laid out 4pt wide and drew
-        // nothing. Restore single line after the assignment, not before.
-        label.usesSingleLineMode = true
+        markerLabel.isHidden = markerLabel.stringValue.isEmpty
+        markerLabel.alignment = .left
+
+        label.stringValue = item.title
+        label.font = FormatToolbar.titleFont(for: item)
         label.lineBreakMode = .byTruncatingTail
         label.setContentCompressionResistancePriority(.required, for: .horizontal)
 
         highlight.wantsLayer = true
         highlight.translatesAutoresizingMaskIntoConstraints = false
         addSubview(highlight)          // behind the content
-
-        let stack = NSStackView(views: [checkmark, iconView, label])
-        stack.orientation = .horizontal
-        stack.spacing = 10
-        stack.alignment = .centerY
-        // Notes leaves the title 40pt clear of the popover's edge with the tick in
-        // the gutter before it: 16 + a 14pt checkmark + 10 lands on the same mark.
-        stack.edgeInsets = NSEdgeInsets(top: 0, left: 16, bottom: 0, right: 10)
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(stack)
+        for column in [checkmark, iconView, markerLabel, label] as [NSView] {
+            column.translatesAutoresizingMaskIntoConstraints = false
+            addSubview(column)
+        }
 
         NSLayoutConstraint.activate([
             highlight.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 6.5),
@@ -239,18 +249,37 @@ final class FormatPopoverRow: NSView {
             // previews do not tower over the plain rows. Notes' rows measure a
             // uniform 58px on a 2x screenshot — 29pt — at the same 13pt menu font.
             heightAnchor.constraint(equalToConstant: Self.rowHeight),
-            // A fixed checkmark gutter keeps every title on the same left edge
-            // whether or not its row is ticked.
-            checkmark.widthAnchor.constraint(equalToConstant: 14),
-            stack.topAnchor.constraint(equalTo: topAnchor),
-            stack.bottomAnchor.constraint(equalTo: bottomAnchor),
-            stack.leadingAnchor.constraint(equalTo: leadingAnchor),
-            stack.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
+            // Fixed columns rather than a stack: a stack would let each row's own
+            // marker width decide where its title starts.
+            checkmark.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Self.checkmarkX),
+            checkmark.centerYAnchor.constraint(equalTo: centerYAnchor),
+            iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Self.markerX),
+            iconView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            markerLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Self.markerX),
+            markerLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Self.titleX),
+            label.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -10),
+            // Plain centring is enough now that the title is a `font` + plain
+            // string: the previous rows set an `attributedTitle`, which dropped
+            // the cell into wrapping mode and gave the bigger heading previews
+            // different vertical metrics from the 13pt rows. Cap-band centring
+            // was tried on top and moved every label by under 0.5pt — below the
+            // half-point the layout quantises to, so it changed nothing.
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
         ])
 
         setAccessibilityRole(.button)
         setAccessibilityLabel(item.title)
         setAccessibilityElement(true)
+        updateAppearance()
+    }
+
+    /// The row is one button. A text field consumes the click that lands on it
+    /// and never passes it up, so the heading rows — whose labels are tall enough
+    /// to cover almost the whole row — could not be clicked at all.
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard let superview else { return nil }
+        return bounds.contains(convert(point, from: superview)) ? self : nil
     }
 
     required init?(coder: NSCoder) { fatalError("not used") }
@@ -295,9 +324,19 @@ final class FormatPopoverRow: NSView {
         // `.cgColor`, so the whole expression has to sit inside the block or the
         // tint comes out inverted (measured: black on a dark popover).
         effectiveAppearance.performAsCurrentDrawingAppearance {
-            highlight.layer?.backgroundColor = hovering
-                ? NSColor.controlAccentColor.withAlphaComponent(0.18).cgColor
-                : nil
+            // The accent at full strength, as Notes fills a hovered row with its
+            // yellow — so the row's contents flip to the colour AppKit already
+            // defines for text on an accent-filled menu row, in both appearances.
+            highlight.layer?.backgroundColor = hovering ? NSColor.controlAccentColor.cgColor : nil
+            let foreground: NSColor = hovering ? .selectedMenuItemTextColor : .labelColor
+            label.textColor = foreground
+            checkmark.contentTintColor = foreground
+            iconView.contentTintColor = foreground
+            // The quote bar is a rule, not a character: greyed so it does not
+            // read as part of the title — except on the accent, where grey muddies.
+            markerLabel.textColor = !hovering && item.action == #selector(EditorTextView.formatBlockQuote(_:))
+                ? .secondaryLabelColor
+                : foreground
         }
         alphaValue = isEnabled ? 1.0 : 0.35
     }

--- a/Sources/edmd/App/FormatPopover.swift
+++ b/Sources/edmd/App/FormatPopover.swift
@@ -1,0 +1,245 @@
+import AppKit
+import EdmundCore
+
+// MARK: - Format popover
+//
+// The Format toolbar item opens this instead of a menu. It is a *view* over the
+// same `NSMenuItem`s `FormatToolbar.formatPopupMenu()` builds — the items stay
+// the source of truth for title, action, tag and representedObject, and this
+// file only decides how they are drawn.
+//
+// Keeping the items matters for dispatch: `formatHeading` reads its level from
+// `(sender as? NSMenuItem)?.tag` and `formatCallout` reads its type from
+// `representedObject`. A row that sent itself as the sender would silently lose
+// both, so each row forwards its item.
+//
+// Mouse-first by design: no ⌘-shortcut hints, no type-to-select, no arrow-key
+// navigation. Esc and click-outside dismissal come free from `.transient`.
+
+@MainActor
+final class FormatPopoverController: NSViewController {
+
+    /// Where commands are sent. A popover's content view can take first
+    /// responder, so nil-target responder-chain dispatch — which is what the
+    /// menu bar and the old menu-based popup rely on — is not safe here. The
+    /// editor is captured explicitly instead.
+    weak var editor: EditorTextView?
+
+    private let items: [NSMenuItem]
+    private let iconRows: [NSStackView]
+    private var rows: [FormatPopoverRow] = []
+    private weak var popover: NSPopover?
+
+    /// The command rows, in display order. Exposed for tests.
+    var commandRows: [FormatPopoverRow] { rows }
+
+    init(iconRows: [NSStackView] = [], items: [NSMenuItem],
+         editor: EditorTextView?, popover: NSPopover?) {
+        self.iconRows = iconRows
+        self.items = items
+        self.editor = editor
+        self.popover = popover
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError("not used") }
+
+    override func loadView() {
+        let stack = NSStackView()
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 1
+        stack.edgeInsets = NSEdgeInsets(top: 6, left: 0, bottom: 6, right: 0)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        for row in iconRows { stack.addArrangedSubview(row) }
+        if !iconRows.isEmpty { stack.addArrangedSubview(Self.separator()) }
+
+        for item in items {
+            if item.isSeparatorItem {
+                stack.addArrangedSubview(Self.separator())
+            } else {
+                let row = FormatPopoverRow(item: item) { [weak self] in self?.fire($0) }
+                rows.append(row)
+                stack.addArrangedSubview(row)
+            }
+        }
+
+        // Rows fill the popover's width so their hover highlight spans it.
+        let container = NSView()
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: container.topAnchor),
+            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+        ])
+        for row in stack.arrangedSubviews {
+            row.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+        }
+        view = container
+        view.frame = NSRect(x: 0, y: 0, width: 240, height: stack.fittingSize.height + 12)
+    }
+
+    private static func separator() -> NSView {
+        let box = NSBox()
+        box.boxType = .separator
+        box.translatesAutoresizingMaskIntoConstraints = false
+        box.heightAnchor.constraint(equalToConstant: 9).isActive = true
+        return box
+    }
+
+    private func fire(_ item: NSMenuItem) {
+        popover?.performClose(nil)
+        guard let action = item.action else { return }
+        NSApp.sendAction(action, to: editor, from: item)
+    }
+
+    /// Re-reads the caret before each open: which inline styles are active, which
+    /// block the caret is in, and what is runnable at all. Mirrors what
+    /// `menuNeedsUpdate` did for the menu version.
+    func refresh() {
+        let active = editor?.activeInlineStyles() ?? []
+        let block = editor?.activeBlockStyle()
+
+        for row in rows {
+            let enabled = editor.map {
+                $0.isFormattingActionEnabled(row.item.action ?? Selector(("noop")),
+                                             representedObject: row.item.representedObject)
+            } ?? false
+            row.isEnabled = enabled
+            row.isChecked = FormatToolbar.blockStyle(for: row.item).map { $0 == block } ?? false
+        }
+
+        for stack in iconRows {
+            for case let button as FormatIconButton in stack.arrangedSubviews {
+                guard let target = button.target as? FormatIconTarget else { continue }
+                // Same explicit-editor reason as `fire`: the responder chain is
+                // not reliable once the popover's view can take first responder.
+                target.editor = editor
+                target.dismiss = { [weak self] in self?.popover?.performClose(nil) }
+                button.isActive = FormatToolbar.style(for: target.styleID).map(active.contains) ?? false
+                button.isEnabled = editor?.isFormattingActionEnabled(
+                    target.action, representedObject: nil) ?? false
+                // An explicit contentTintColor defeats AppKit's disabled dimming.
+                button.alphaValue = button.isEnabled ? 1.0 : 0.35
+            }
+        }
+    }
+}
+
+// MARK: - One row
+
+/// A popover row. `NSMenu` gave hover, highlighting and accessibility for free;
+/// a popover's content is a plain view hierarchy, so each is done by hand here.
+@MainActor
+final class FormatPopoverRow: NSView {
+
+    let item: NSMenuItem
+
+    var isEnabled = true { didSet { updateAppearance() } }
+    var isChecked = false { didSet { checkmark.isHidden = !isChecked } }
+
+    private let onFire: (NSMenuItem) -> Void
+    private let checkmark = NSImageView()
+    private let iconView = NSImageView()
+    private let label = NSTextField(labelWithString: "")
+    /// Not private so the offscreen render harness can exercise the hover look
+    /// without synthesising mouse events.
+    var isHovered = false { didSet { updateAppearance() } }
+    private var tracking: NSTrackingArea?
+
+    init(item: NSMenuItem, onFire: @escaping (NSMenuItem) -> Void) {
+        self.item = item
+        self.onFire = onFire
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+
+        checkmark.image = NSImage(systemSymbolName: "checkmark", accessibilityDescription: nil)?
+            .withSymbolConfiguration(.init(pointSize: 10, weight: .semibold))
+        checkmark.contentTintColor = .labelColor
+        checkmark.isHidden = true
+
+        iconView.image = item.image
+        iconView.isHidden = item.image == nil
+
+        if let attributed = item.attributedTitle {
+            label.attributedStringValue = attributed
+        } else {
+            label.stringValue = item.title
+            label.font = .menuFont(ofSize: 0)
+        }
+
+        let stack = NSStackView(views: [checkmark, iconView, label])
+        stack.orientation = .horizontal
+        stack.spacing = 5
+        stack.alignment = .centerY
+        stack.edgeInsets = NSEdgeInsets(top: 4, left: 10, bottom: 4, right: 10)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            // A fixed checkmark gutter keeps every title on the same left edge
+            // whether or not its row is ticked.
+            checkmark.widthAnchor.constraint(equalToConstant: 12),
+            stack.topAnchor.constraint(equalTo: topAnchor),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stack.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
+        ])
+
+        setAccessibilityRole(.button)
+        setAccessibilityLabel(item.title)
+        setAccessibilityElement(true)
+    }
+
+    required init?(coder: NSCoder) { fatalError("not used") }
+
+    // MARK: Hover
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let tracking { removeTrackingArea(tracking) }
+        let area = NSTrackingArea(rect: bounds,
+                                  options: [.mouseEnteredAndExited, .activeInActiveApp, .inVisibleRect],
+                                  owner: self)
+        addTrackingArea(area)
+        tracking = area
+    }
+
+    override func mouseEntered(with event: NSEvent) { if isEnabled { isHovered = true } }
+    override func mouseExited(with event: NSEvent)  { isHovered = false }
+
+    override func mouseUp(with event: NSEvent) {
+        guard isEnabled else { return }
+        onFire(item)
+    }
+
+    override func accessibilityPerformPress() -> Bool {
+        guard isEnabled else { return false }
+        onFire(item)
+        return true
+    }
+
+    /// Re-resolve the tint when the window flips between light and dark.
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateAppearance()
+    }
+
+    private func updateAppearance() {
+        wantsLayer = true
+        layer?.cornerRadius = 5
+        let hovering = isHovered && isEnabled
+        // A dynamic colour resolves against whatever appearance is current, not
+        // this view's — and it resolves at `withAlphaComponent` too, not only at
+        // `.cgColor`, so the whole expression has to sit inside the block or the
+        // tint comes out inverted (measured: black on a dark popover).
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            layer?.backgroundColor = hovering
+                ? NSColor.labelColor.withAlphaComponent(0.10).cgColor
+                : nil
+        }
+        alphaValue = isEnabled ? 1.0 : 0.35
+    }
+}

--- a/Sources/edmd/App/FormatPopover.swift
+++ b/Sources/edmd/App/FormatPopover.swift
@@ -47,13 +47,30 @@ final class FormatPopoverController: NSViewController {
     override func loadView() {
         let stack = NSStackView()
         stack.orientation = .vertical
-        stack.alignment = .leading
+        // Centred, so the icon grid — which keeps its own width — sits centred in
+        // the popover while the command rows still span it edge to edge.
+        stack.alignment = .centerX
         stack.spacing = 1
         stack.edgeInsets = NSEdgeInsets(top: 6, left: 0, bottom: 6, right: 0)
         stack.translatesAutoresizingMaskIntoConstraints = false
 
-        for row in iconRows { stack.addArrangedSubview(row) }
-        if !iconRows.isEmpty { stack.addArrangedSubview(Self.separator()) }
+        // One block, so the two icon rows share a left edge (centring them
+        // individually would indent the shorter one) while the block as a whole
+        // is centred in the popover by the outer stack's alignment.
+        var grid: NSView?
+        if !iconRows.isEmpty {
+            // Without this each row stretches to the block's width, and a row's
+            // trailing padding grows instead of the row keeping its own size.
+            for row in iconRows { row.setHuggingPriority(.required, for: .horizontal) }
+            let block = NSStackView(views: iconRows)
+            block.orientation = .vertical
+            block.alignment = .leading
+            block.spacing = 1
+            block.translatesAutoresizingMaskIntoConstraints = false
+            stack.addArrangedSubview(block)
+            stack.addArrangedSubview(Self.separator())
+            grid = block
+        }
 
         for item in items {
             if item.isSeparatorItem {
@@ -74,19 +91,33 @@ final class FormatPopoverController: NSViewController {
             stack.leadingAnchor.constraint(equalTo: container.leadingAnchor),
             stack.trailingAnchor.constraint(equalTo: container.trailingAnchor),
         ])
-        for row in stack.arrangedSubviews {
+        for row in stack.arrangedSubviews where row !== grid {
             row.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
         }
         view = container
-        view.frame = NSRect(x: 0, y: 0, width: 240, height: stack.fittingSize.height + 12)
+        // Sized to the widest row — usually the icon grid — rather than a fixed
+        // width, so the popover fits its content snugly the way Notes' does.
+        view.frame = NSRect(x: 0, y: 0, width: ceil(stack.fittingSize.width),
+                            height: stack.fittingSize.height + 12)
     }
 
+    /// Notes insets its dividers from the popover's sides rather than letting them
+    /// run into the rounded corners — 13px each side on a 2x screenshot of
+    /// misc/frontend-refs/notes-toolbar-format-menu.png, so 6.5pt.
     private static func separator() -> NSView {
+        let container = NSView()
+        container.translatesAutoresizingMaskIntoConstraints = false
         let box = NSBox()
         box.boxType = .separator
         box.translatesAutoresizingMaskIntoConstraints = false
-        box.heightAnchor.constraint(equalToConstant: 9).isActive = true
-        return box
+        container.addSubview(box)
+        NSLayoutConstraint.activate([
+            container.heightAnchor.constraint(equalToConstant: 9),
+            box.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 6.5),
+            box.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -6.5),
+            box.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+        ])
+        return container
     }
 
     private func fire(_ item: NSMenuItem) {
@@ -135,6 +166,9 @@ final class FormatPopoverController: NSViewController {
 @MainActor
 final class FormatPopoverRow: NSView {
 
+    /// Uniform across every row. Exposed so the layout tests can assert it.
+    static let rowHeight: CGFloat = 29
+
     let item: NSMenuItem
 
     var isEnabled = true { didSet { updateAppearance() } }
@@ -174,11 +208,15 @@ final class FormatPopoverRow: NSView {
         stack.orientation = .horizontal
         stack.spacing = 5
         stack.alignment = .centerY
-        stack.edgeInsets = NSEdgeInsets(top: 4, left: 10, bottom: 4, right: 10)
+        stack.edgeInsets = NSEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)
         stack.translatesAutoresizingMaskIntoConstraints = false
         addSubview(stack)
 
         NSLayoutConstraint.activate([
+            // Every row is the same height whatever its font, so the heading
+            // previews do not tower over the plain rows. Notes' rows measure a
+            // uniform 58px on a 2x screenshot — 29pt — at the same 13pt menu font.
+            heightAnchor.constraint(equalToConstant: Self.rowHeight),
             // A fixed checkmark gutter keeps every title on the same left edge
             // whether or not its row is ticked.
             checkmark.widthAnchor.constraint(equalToConstant: 12),

--- a/Sources/edmd/App/FormatPopover.swift
+++ b/Sources/edmd/App/FormatPopover.swift
@@ -172,13 +172,14 @@ final class FormatPopoverRow: NSView {
     /// Uniform across every row. Exposed so the layout tests can assert it.
     static let rowHeight: CGFloat = 29
 
-    /// The three columns, as offsets from the row's leading edge. Notes puts its
-    /// checkmark at 17.5pt and its titles at 40pt, with nothing between; the
-    /// marker gutter is fitted into that same span rather than pushing the titles
-    /// right, by starting the checkmark closer in.
-    static let checkmarkX: CGFloat = 12
-    static let markerX: CGFloat = 25
-    static let titleX: CGFloat = 40
+    /// The three columns, as offsets from the row's leading edge. Measured off
+    /// Notes' own popup, whose checkmark ink starts at 19pt and whose markers sit
+    /// at 37.5pt — scaled in to our narrower popover. A row with no marker puts
+    /// its title on the marker edge, not the title edge: that is what Notes does,
+    /// so "Subheading" and "• Bulleted List" start their glyphs at one mark.
+    static let checkmarkX: CGFloat = 15
+    static let markerX: CGFloat = 30
+    static let titleX: CGFloat = 45
 
     let item: NSMenuItem
 
@@ -224,6 +225,11 @@ final class FormatPopoverRow: NSView {
                 ? .monospacedSystemFont(ofSize: body.pointSize - 1, weight: .regular)
                 : body
         }
+        // A row with no marker of its own starts its title on the marker edge
+        // rather than the title edge, so unmarked and marked rows share one
+        // leading glyph column the way Notes' do.
+        let titleX = FormatToolbar.marker(for: item) == nil && item.image == nil
+            ? Self.markerX : Self.titleX
         markerLabel.isHidden = markerLabel.stringValue.isEmpty
         markerLabel.alignment = .left
 
@@ -257,7 +263,7 @@ final class FormatPopoverRow: NSView {
             iconView.centerYAnchor.constraint(equalTo: centerYAnchor),
             markerLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Self.markerX),
             markerLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
-            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Self.titleX),
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: titleX),
             label.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -10),
             // Plain centring is enough now that the title is a `font` + plain
             // string: the previous rows set an `attributedTitle`, which dropped
@@ -324,10 +330,12 @@ final class FormatPopoverRow: NSView {
         // `.cgColor`, so the whole expression has to sit inside the block or the
         // tint comes out inverted (measured: black on a dark popover).
         effectiveAppearance.performAsCurrentDrawingAppearance {
-            // The accent at full strength, as Notes fills a hovered row with its
-            // yellow — so the row's contents flip to the colour AppKit already
-            // defines for text on an accent-filled menu row, in both appearances.
-            highlight.layer?.backgroundColor = hovering ? NSColor.controlAccentColor.cgColor : nil
+            // The system's own selection fill, not a hand-mixed accent: Notes
+            // draws a hovered row exactly as it draws a selected one, so the
+            // row's contents flip to the colour AppKit already defines for text
+            // on that fill, in both appearances.
+            highlight.layer?.backgroundColor = hovering
+                ? NSColor.selectedContentBackgroundColor.cgColor : nil
             let foreground: NSColor = hovering ? .selectedMenuItemTextColor : .labelColor
             label.textColor = foreground
             checkmark.contentTintColor = foreground

--- a/Sources/edmd/App/FormatPopover.swift
+++ b/Sources/edmd/App/FormatPopover.swift
@@ -65,7 +65,7 @@ final class FormatPopoverController: NSViewController {
             let block = NSStackView(views: iconRows)
             block.orientation = .vertical
             block.alignment = .leading
-            block.spacing = 1
+            block.spacing = 4
             block.translatesAutoresizingMaskIntoConstraints = false
             stack.addArrangedSubview(block)
             stack.addArrangedSubview(Self.separator())
@@ -152,7 +152,6 @@ final class FormatPopoverController: NSViewController {
                 button.isActive = FormatToolbar.style(for: target.styleID).map(active.contains) ?? false
                 button.isEnabled = editor?.isFormattingActionEnabled(
                     target.action, representedObject: nil) ?? false
-                // An explicit contentTintColor defeats AppKit's disabled dimming.
                 button.alphaValue = button.isEnabled ? 1.0 : 0.35
             }
         }
@@ -172,9 +171,15 @@ final class FormatPopoverRow: NSView {
     let item: NSMenuItem
 
     var isEnabled = true { didSet { updateAppearance() } }
-    var isChecked = false { didSet { checkmark.isHidden = !isChecked } }
+    /// Faded rather than hidden: a hidden view drops out of the stack, and with it
+    /// the gutter that keeps every title on Notes' left edge, ticked or not.
+    var isChecked = false { didSet { checkmark.alphaValue = isChecked ? 1 : 0 } }
 
     private let onFire: (NSMenuItem) -> Void
+    /// The hover tint lives on its own inset view rather than on the row's layer,
+    /// so it stops short of the popover's rounded sides the way the dividers do.
+    /// Not private: the layout tests read its frame and tint.
+    let highlight = NSView()
     private let checkmark = NSImageView()
     private let iconView = NSImageView()
     private let label = NSTextField(labelWithString: "")
@@ -192,7 +197,7 @@ final class FormatPopoverRow: NSView {
         checkmark.image = NSImage(systemSymbolName: "checkmark", accessibilityDescription: nil)?
             .withSymbolConfiguration(.init(pointSize: 10, weight: .semibold))
         checkmark.contentTintColor = .labelColor
-        checkmark.isHidden = true
+        checkmark.alphaValue = 0
 
         iconView.image = item.image
         iconView.isHidden = item.image == nil
@@ -203,23 +208,40 @@ final class FormatPopoverRow: NSView {
             label.stringValue = item.title
             label.font = .menuFont(ofSize: 0)
         }
+        // Assigning an attributed string whose paragraph style is unset drops the
+        // cell back into wrapping mode, and a wrapping label has no intrinsic
+        // width to give the stack — every marked row laid out 4pt wide and drew
+        // nothing. Restore single line after the assignment, not before.
+        label.usesSingleLineMode = true
+        label.lineBreakMode = .byTruncatingTail
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        highlight.wantsLayer = true
+        highlight.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(highlight)          // behind the content
 
         let stack = NSStackView(views: [checkmark, iconView, label])
         stack.orientation = .horizontal
-        stack.spacing = 5
+        stack.spacing = 10
         stack.alignment = .centerY
-        stack.edgeInsets = NSEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)
+        // Notes leaves the title 40pt clear of the popover's edge with the tick in
+        // the gutter before it: 16 + a 14pt checkmark + 10 lands on the same mark.
+        stack.edgeInsets = NSEdgeInsets(top: 0, left: 16, bottom: 0, right: 10)
         stack.translatesAutoresizingMaskIntoConstraints = false
         addSubview(stack)
 
         NSLayoutConstraint.activate([
+            highlight.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 6.5),
+            highlight.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6.5),
+            highlight.topAnchor.constraint(equalTo: topAnchor, constant: 1),
+            highlight.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -1),
             // Every row is the same height whatever its font, so the heading
             // previews do not tower over the plain rows. Notes' rows measure a
             // uniform 58px on a 2x screenshot — 29pt — at the same 13pt menu font.
             heightAnchor.constraint(equalToConstant: Self.rowHeight),
             // A fixed checkmark gutter keeps every title on the same left edge
             // whether or not its row is ticked.
-            checkmark.widthAnchor.constraint(equalToConstant: 12),
+            checkmark.widthAnchor.constraint(equalToConstant: 14),
             stack.topAnchor.constraint(equalTo: topAnchor),
             stack.bottomAnchor.constraint(equalTo: bottomAnchor),
             stack.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -266,16 +288,15 @@ final class FormatPopoverRow: NSView {
     }
 
     private func updateAppearance() {
-        wantsLayer = true
-        layer?.cornerRadius = 5
+        highlight.layer?.cornerRadius = 5
         let hovering = isHovered && isEnabled
         // A dynamic colour resolves against whatever appearance is current, not
         // this view's — and it resolves at `withAlphaComponent` too, not only at
         // `.cgColor`, so the whole expression has to sit inside the block or the
         // tint comes out inverted (measured: black on a dark popover).
         effectiveAppearance.performAsCurrentDrawingAppearance {
-            layer?.backgroundColor = hovering
-                ? NSColor.labelColor.withAlphaComponent(0.10).cgColor
+            highlight.layer?.backgroundColor = hovering
+                ? NSColor.controlAccentColor.withAlphaComponent(0.18).cgColor
                 : nil
         }
         alphaValue = isEnabled ? 1.0 : 0.35

--- a/Sources/edmd/App/FormatToolbar.swift
+++ b/Sources/edmd/App/FormatToolbar.swift
@@ -144,6 +144,10 @@ final class FormatToolbar: NSObject {
         item.image = Self.symbol(symbol)
         item.target = nil
         item.action = action
+        // Without this a plain image item draws bare and never highlights under
+        // the pointer, unlike the custom-view items either side of it — which is
+        // what made Checklist and Table look dead next to Format and Link.
+        item.isBordered = true
         return item
     }
 
@@ -259,8 +263,10 @@ final class FormatToolbar: NSObject {
                                action: #selector(EditorTextView.formatCallout(_:)),
                                representedObject: "NOTE").makeItem()
         // Template so the row can tint it white on the accent highlight, the way
-        // it tints the checkmark and the text markers.
-        let icon = Callout.icon(for: "note", color: .labelColor, pointSize: 13)
+        // it tints the checkmark and the text markers. 10pt because a Lucide
+        // glyph fills its box: it draws 10pt of ink against the 9.2pt cap height
+        // of the text markers beside it, where 13pt towered over them.
+        let icon = Callout.icon(for: "note", color: .labelColor, pointSize: 10)
         icon?.isTemplate = true
         item.image = icon
         return item
@@ -277,6 +283,10 @@ final class FormatToolbar: NSObject {
         case #selector(EditorTextView.formatNumberedList(_:)): return "1."
         case #selector(EditorTextView.formatBlockQuote(_:)):   return "▎"
         case #selector(EditorTextView.formatMathBlock(_:)):    return "$"
+        // The printer's footnote mark rather than the `[^1]` it inserts: that
+        // preview measures 15pt against 7–9pt for every other marker, which is
+        // both lopsided in a shared gutter and wide enough to reach the titles.
+        case #selector(EditorTextView.formatFootnote(_:)):     return "†"
         default:                                               return nil
         }
     }

--- a/Sources/edmd/App/FormatToolbar.swift
+++ b/Sources/edmd/App/FormatToolbar.swift
@@ -1,0 +1,355 @@
+import AppKit
+import EdmundCore
+
+// MARK: - Format toolbar
+//
+// The window toolbar's formatting items. Every one of them drives the same
+// `EditorTextView.format…` selector the menu bar drives, through the same
+// nil-target responder-chain dispatch — there is deliberately no second
+// implementation of any command, and no second place the storage invariant has
+// to be upheld. Commands come from `FormatMenu`'s tables so a command defined
+// once shows up in the menu bar, in Settings ▸ Key Bindings, and here.
+//
+// Default order (misc/plans/prompts/format-bar.md):
+//   Format ▾ · Checklist · Table · Image ▾ · Link · (spacer) · View mode · Share
+//
+// `FormatToolbar` is an object rather than an enum because it has to *own*
+// things AppKit only holds weakly: the menu delegates that rebuild the popups on
+// open, and the icon-row buttons' action targets.
+
+@MainActor
+final class FormatToolbar: NSObject {
+
+    static let format     = NSToolbarItem.Identifier("format")
+    static let checklist  = NSToolbarItem.Identifier("checklist")
+    static let table      = NSToolbarItem.Identifier("table")
+    static let image      = NSToolbarItem.Identifier("image")
+    static let link       = NSToolbarItem.Identifier("link")
+    static let share      = NSToolbarItem.Identifier("share")
+
+    private weak var document: Document?
+
+    /// The Link item's button, so `DocumentWindow` can claim its secondary click
+    /// for the Link/Wikilink menu (see the note there — a custom item cannot win
+    /// that click by itself).
+    private(set) weak var linkButton: NSView?
+
+    init(document: Document) {
+        self.document = document
+        super.init()
+    }
+
+    static func defaultIdentifiers(viewMode: NSToolbarItem.Identifier) -> [NSToolbarItem.Identifier] {
+        [format, checklist, table, image, link, .flexibleSpace, viewMode, share]
+    }
+
+    static func allowedIdentifiers(viewMode: NSToolbarItem.Identifier) -> [NSToolbarItem.Identifier] {
+        [format, checklist, table, image, link, share, viewMode, .space, .flexibleSpace]
+    }
+
+    /// Builds one of the formatting items, or nil if `id` isn't ours (the
+    /// view-mode item stays with `Document`).
+    func makeItem(_ id: NSToolbarItem.Identifier) -> NSToolbarItem? {
+        switch id {
+        case Self.format:
+            return menuItem(id, label: "Format", symbol: "textformat",
+                            menu: formatPopupMenu())
+        case Self.image:
+            return menuItem(id, label: "Image", symbol: "photo.on.rectangle",
+                            menu: imagePopupMenu())
+        case Self.checklist:
+            return actionItem(id, label: "Checklist", symbol: "checklist",
+                              action: #selector(EditorTextView.formatChecklist(_:)))
+        case Self.table:
+            return actionItem(id, label: "Table", symbol: "tablecells",
+                              action: #selector(EditorTextView.formatTable(_:)))
+        case Self.link:
+            let item = FormatButtonItem(itemIdentifier: id)
+            item.label = "Link"
+            item.toolTip = "Link (right-click for Wikilink)"
+            let button = NSButton(image: Self.symbol("link.badge.plus") ?? NSImage(),
+                                  target: nil, action: #selector(EditorTextView.formatLink(_:)))
+            button.bezelStyle = .texturedRounded
+            button.imagePosition = .imageOnly
+            item.view = button
+            linkButton = button
+            return item
+        case Self.share:
+            // AppKit's own share item: it owns the picker, the anchoring and the
+            // standard icon, and asks the delegate below for what to share.
+            let item = NSSharingServicePickerToolbarItem(itemIdentifier: id)
+            item.label = "Share"
+            item.toolTip = "Share this document"
+            item.delegate = self
+            return item
+        default:
+            return nil
+        }
+    }
+
+    /// The Link item's secondary-click menu: Link and Wikilink.
+    func linkMenu() -> NSMenu {
+        let menu = NSMenu(title: "Link")
+        for cmd in FormatMenu.linkCommands where cmd.id != "format.image" {
+            menu.addItem(cmd.makeItem())
+        }
+        return menu
+    }
+
+    // MARK: - Item construction
+
+    /// A plain image item with a nil target: dispatch *and* validation both ride
+    /// the responder chain to the focused editor, which is why these get their
+    /// enabled state for free (see `EditorTextView.validateToolbarItem`).
+    private func actionItem(_ id: NSToolbarItem.Identifier, label: String,
+                            symbol: String, action: Selector) -> NSToolbarItem {
+        let item = NSToolbarItem(itemIdentifier: id)
+        item.label = label
+        item.toolTip = label
+        item.image = Self.symbol(symbol)
+        item.target = nil
+        item.action = action
+        return item
+    }
+
+    private func menuItem(_ id: NSToolbarItem.Identifier, label: String,
+                          symbol: String, menu: NSMenu) -> NSToolbarItem {
+        let item = FormatMenuToolbarItem(itemIdentifier: id)
+        item.label = label
+        item.toolTip = label
+        item.image = Self.symbol(symbol)
+        item.showsIndicator = true
+        menu.delegate = self
+        item.menu = menu
+        menus.append(menu)
+        return item
+    }
+
+    /// Menus we own. `NSMenu.delegate` is weak and `NSMenuToolbarItem` does not
+    /// keep the delegate alive, so the popups would stop rebuilding without this.
+    private var menus: [NSMenu] = []
+
+    /// Action targets for the icon-row buttons — `NSControl.target` is weak.
+    private var iconTargets: [FormatIconTarget] = []
+
+    /// One point size for every toolbar glyph, chosen to match the item AppKit
+    /// builds itself (the share item). Both extremes were measured and are
+    /// wrong: at 13pt our glyphs sit visibly smaller than share, and at their
+    /// *natural* size `checklist` and `tablecells` overshoot it — SF Symbols
+    /// carry different intrinsic boxes, so only a common point size makes the
+    /// row read as one set.
+    static func symbol(_ name: String) -> NSImage? {
+        NSImage(systemSymbolName: name, accessibilityDescription: nil)?
+            .withSymbolConfiguration(.init(pointSize: 15, weight: .regular))
+    }
+
+    /// The format popup's icon rows are ordinary buttons inside a menu, not
+    /// toolbar items, so they do need an explicit size.
+    static func rowSymbol(_ name: String) -> NSImage? {
+        NSImage(systemSymbolName: name, accessibilityDescription: nil)?
+            .withSymbolConfiguration(.init(pointSize: 14, weight: .regular))
+    }
+
+    // MARK: - Format popup
+
+    /// Apple Notes-style: two rows of icon buttons, then the block commands as
+    /// ordinary menu rows (which get dividers, submenus, hover, keyboard nav and
+    /// live shortcut display for free — the reason this is an `NSMenu` and not a
+    /// hand-built popover).
+    ///
+    /// Checklist and Table are absent on purpose: they are their own toolbar
+    /// items.
+    func formatPopupMenu() -> NSMenu {
+        let menu = NSMenu(title: "Format")
+        menu.addItem(iconRowItem(Self.inlineRow1))
+        menu.addItem(iconRowItem(Self.inlineRow2))
+        menu.addItem(.separator())
+
+        menu.addItem(FormatMenu.headingSubmenuItem())
+        menu.addItem(FormatMenu.thematicBreakCommand.makeItem())
+        for cmd in FormatMenu.listCommands where cmd.id != "format.checklist" {
+            menu.addItem(cmd.makeItem())
+        }
+        menu.addItem(.separator())
+
+        for cmd in FormatMenu.blockCommands where cmd.id != "format.table" {
+            menu.addItem(cmd.makeItem())
+        }
+        menu.addItem(FormatMenu.calloutSubmenuItem())
+        menu.addItem(FormatMenu.footnoteCommand.makeItem())
+        return menu
+    }
+
+    /// (SF Symbol, command id) for the popup's first row.
+    private static let inlineRow1: [(String, String)] = [
+        ("bold", "format.bold"),
+        ("italic", "format.italic"),
+        ("underline", "format.underline"),
+        ("strikethrough", "format.strikethrough"),
+        ("highlighter", "format.highlight"),
+    ]
+
+    /// …and its second row. There is no alignment control: a `<div align>`
+    /// wrapper splits across blocks in Edit mode, so alignment cannot be shown
+    /// faithfully, and Markdown has no alignment concept outside table columns.
+    private static let inlineRow2: [(String, String)] = [
+        ("chevron.left.forwardslash.chevron.right", "format.code"),
+        ("function", "format.math"),
+        ("textformat.subscript", "format.subscript"),
+        ("textformat.superscript", "format.superscript"),
+    ]
+
+    private func iconRowItem(_ row: [(String, String)]) -> NSMenuItem {
+        let stack = NSStackView()
+        stack.orientation = .horizontal
+        stack.spacing = 2
+        stack.edgeInsets = NSEdgeInsets(top: 4, left: 12, bottom: 4, right: 12)
+
+        for (symbol, id) in row {
+            guard let cmd = FormatMenu.fontCommands.first(where: { $0.id == id }) else { continue }
+            let target = FormatIconTarget(action: cmd.action)
+            iconTargets.append(target)
+
+            let button = NSButton(image: Self.rowSymbol(symbol) ?? NSImage(),
+                                  target: target, action: #selector(FormatIconTarget.fire(_:)))
+            button.bezelStyle = .accessoryBar
+            button.setButtonType(.momentaryPushIn)
+            button.imagePosition = .imageOnly
+            button.toolTip = cmd.title
+            button.setAccessibilityLabel(cmd.title)
+            // The highlighter reads as its ink colour, matching the mark it makes.
+            if id == "format.highlight" { button.contentTintColor = .systemYellow }
+            stack.addArrangedSubview(button)
+        }
+
+        let item = NSMenuItem()
+        item.title = ""   // NSMenuItem defaults to "NSMenuItem", which VoiceOver reads out
+        item.view = stack
+        return item
+    }
+
+    // MARK: - Image popup
+
+    /// Attach File… works today; the remaining sources are visible but disabled,
+    /// so the finished shape of the feature is legible without pretending the
+    /// pieces exist. See `ImageSource`.
+    func imagePopupMenu() -> NSMenu {
+        let menu = NSMenu(title: "Image")
+        for source in ImageSource.allCases {
+            if source == .camera { menu.addItem(.separator()) }
+            let item = NSMenuItem(title: source.title,
+                                  action: #selector(EditorTextView.formatAttachImage(_:)),
+                                  keyEquivalent: "")
+            item.isEnabled = source.isAvailable
+            // A disabled placeholder must not dispatch if AppKit ever enables it.
+            if !source.isAvailable { item.action = nil }
+            menu.addItem(item)
+        }
+        return menu
+    }
+}
+
+// MARK: - Menu delegate
+
+extension FormatToolbar: NSMenuDelegate {
+    /// Rebuild the format popup on every open so a shortcut changed in Settings ▸
+    /// Key Bindings shows through, and so the icon rows re-evaluate enablement.
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        guard menu.title == "Format" else { return }
+        menu.removeAllItems()
+        iconTargets.removeAll()
+        let fresh = formatPopupMenu()
+        for item in fresh.items {
+            fresh.removeItem(item)
+            menu.addItem(item)
+        }
+        refreshIconRows(in: menu)
+    }
+
+    /// Icon-row buttons are not validated items, so they have to ask the focused
+    /// editor directly.
+    private func refreshIconRows(in menu: NSMenu) {
+        let editor = document?.editor
+        for item in menu.items {
+            guard let stack = item.view as? NSStackView else { continue }
+            for case let button as NSButton in stack.arrangedSubviews {
+                guard let target = button.target as? FormatIconTarget else { continue }
+                button.isEnabled = editor?.isFormattingActionEnabled(
+                    target.action, representedObject: nil) ?? false
+            }
+        }
+    }
+}
+
+// MARK: - Share
+
+extension FormatToolbar: NSSharingServicePickerToolbarItemDelegate {
+    /// Shares the document's *file*, so the recipient gets a `.md` document
+    /// rather than a wall of pasted text. An unsaved document has no file yet;
+    /// returning nothing leaves the picker with no services to offer.
+    func items(for pickerToolbarItem: NSSharingServicePickerToolbarItem) -> [Any] {
+        document?.fileURL.map { [$0] } ?? []
+    }
+}
+
+// MARK: - Supporting types
+
+/// Forwards an icon-row button's click to the focused editor. A menu item's
+/// custom view gets none of a real menu item's behaviour, so the menu is
+/// dismissed by hand before the action is sent — otherwise the popup stays open
+/// over the edit the user just made.
+@MainActor
+final class FormatIconTarget: NSObject {
+    let action: Selector
+
+    init(action: Selector) {
+        self.action = action
+        super.init()
+    }
+
+    @objc func fire(_ sender: NSButton) {
+        sender.enclosingMenuItem?.menu?.cancelTracking()
+        NSApp.sendAction(action, to: nil, from: sender)
+    }
+}
+
+/// `NSMenuToolbarItem` whose enabled state follows the editor: without this the
+/// Format and Image popups stay live in Read mode, where nothing they contain
+/// can run.
+final class FormatMenuToolbarItem: NSMenuToolbarItem {
+    override func validate() {
+        isEnabled = (NSApp.target(forAction: #selector(EditorTextView.formatBold(_:)))
+            as? EditorTextView)?
+            .isFormattingActionEnabled(#selector(EditorTextView.formatBold(_:)),
+                                       representedObject: nil) ?? false
+    }
+}
+
+/// A toolbar item with a custom view. AppKit skips validation entirely for those,
+/// so the enabled state is pushed onto the button by hand.
+final class FormatButtonItem: NSToolbarItem {
+    override func validate() {
+        guard let action, let button = view as? NSButton else { return }
+        button.isEnabled = (NSApp.target(forAction: action) as? EditorTextView)?
+            .isFormattingActionEnabled(action, representedObject: nil) ?? false
+    }
+}
+
+/// Where an attached image comes from. Only `.file` is wired up; the rest are
+/// the extension points for Photos and Continuity Camera, which need a PhotoKit
+/// dependency, an `NSPhotoLibraryUsageDescription`, and `NSServicesMenuRequestor`
+/// plumbing respectively.
+enum ImageSource: CaseIterable {
+    case file, photos, camera, scan
+
+    var title: String {
+        switch self {
+        case .file:   return "Attach File…"
+        case .photos: return "Photos…"
+        case .camera: return "Take Photo"
+        case .scan:   return "Scan Documents"
+        }
+    }
+
+    var isAvailable: Bool { self == .file }
+}

--- a/Sources/edmd/App/FormatToolbar.swift
+++ b/Sources/edmd/App/FormatToolbar.swift
@@ -39,6 +39,11 @@ final class FormatToolbar: NSObject {
         super.init()
     }
 
+    /// The formatting group, centred in the window by `centeredItemIdentifiers`.
+    static let centeredIdentifiers: Set<NSToolbarItem.Identifier> =
+        [format, checklist, table, image, link]
+
+    /// The centred group, then flexible space pushing view-mode and share right.
     static func defaultIdentifiers(viewMode: NSToolbarItem.Identifier) -> [NSToolbarItem.Identifier] {
         [format, checklist, table, image, link, .flexibleSpace, viewMode, share]
     }
@@ -52,8 +57,16 @@ final class FormatToolbar: NSObject {
     func makeItem(_ id: NSToolbarItem.Identifier) -> NSToolbarItem? {
         switch id {
         case Self.format:
-            return menuItem(id, label: "Format", symbol: "textformat",
-                            menu: formatPopupMenu())
+            let item = FormatButtonItem(itemIdentifier: id)
+            item.label = "Format"
+            item.toolTip = "Format"
+            let button = NSButton(image: Self.symbol("textformat") ?? NSImage(),
+                                  target: self, action: #selector(showFormatPopover(_:)))
+            button.bezelStyle = .texturedRounded
+            button.imagePosition = .imageOnly
+            item.view = button
+            formatButton = button
+            return item
         case Self.image:
             return menuItem(id, label: "Image", symbol: "photo.on.rectangle",
                             menu: imagePopupMenu())
@@ -85,6 +98,28 @@ final class FormatToolbar: NSObject {
         default:
             return nil
         }
+    }
+
+    /// The Format item's button, so the popover has something to hang off.
+    private weak var formatButton: NSView?
+    private var formatPopover: NSPopover?
+
+    /// Opens (or closes) the format panel. Rebuilt each time so the rows reflect
+    /// the current caret and any shortcut changed in Settings ▸ Key Bindings.
+    @objc func showFormatPopover(_ sender: Any?) {
+        if let open = formatPopover, open.isShown { open.performClose(sender); return }
+        guard let anchor = formatButton else { return }
+
+        let popover = NSPopover()
+        popover.behavior = .transient        // Esc + click-outside dismissal, free
+        let controller = FormatPopoverController(iconRows: iconRowViews(),
+                                                 items: Array(formatPopupMenu().items),
+                                                 editor: document?.editor,
+                                                 popover: popover)
+        popover.contentViewController = controller
+        formatPopover = popover
+        popover.show(relativeTo: anchor.bounds, of: anchor, preferredEdge: .maxY)
+        controller.refresh()
     }
 
     /// The Link item's secondary-click menu: Link and Wikilink.
@@ -132,15 +167,25 @@ final class FormatToolbar: NSObject {
     /// Action targets for the icon-row buttons — `NSControl.target` is weak.
     private var iconTargets: [FormatIconTarget] = []
 
-    /// One point size for every toolbar glyph, chosen to match the item AppKit
-    /// builds itself (the share item). Both extremes were measured and are
-    /// wrong: at 13pt our glyphs sit visibly smaller than share, and at their
-    /// *natural* size `checklist` and `tablecells` overshoot it — SF Symbols
-    /// carry different intrinsic boxes, so only a common point size makes the
-    /// row read as one set.
+    /// Point size per symbol, because SF Symbols do not share a bounding box: one
+    /// common size renders `textformat` and `link.badge.plus` visibly larger than
+    /// `checklist` and `tablecells`, which is what made the row read as ragged.
+    ///
+    /// The target is a ~19pt drawn extent for every glyph — the size of the share
+    /// item AppKit builds itself, the one fixed reference in the row. These
+    /// numbers were derived by measuring each glyph's rendered extent and scaling
+    /// from it, then re-measured; do not collapse them back to a single constant.
+    private static let symbolPointSizes: [String: CGFloat] = [
+        "textformat": 13,                 // "Aa" is wide and short — 15 read oversized
+        "checklist": 17,
+        "tablecells": 16,
+        "link.badge.plus": 13,
+    ]
+
     static func symbol(_ name: String) -> NSImage? {
         NSImage(systemSymbolName: name, accessibilityDescription: nil)?
-            .withSymbolConfiguration(.init(pointSize: 15, weight: .regular))
+            .withSymbolConfiguration(.init(pointSize: symbolPointSizes[name] ?? 15,
+                                           weight: .regular))
     }
 
     /// The format popup's icon rows are ordinary buttons inside a menu, not
@@ -164,12 +209,17 @@ final class FormatToolbar: NSObject {
     ///
     /// Checklist and Table are absent on purpose: they are their own toolbar
     /// items.
+    /// The popover's two icon rows. Kept out of `formatPopupMenu()` on purpose:
+    /// wrapping them in `NSMenuItem.view` (which the menu version needed) leaves
+    /// AppKit owning the view, and re-parenting it into the popover's stack left
+    /// it unmanaged — laid out at the container origin, i.e. drawn over the last
+    /// row. They are plain views now.
+    func iconRowViews() -> [NSStackView] {
+        [iconRow(Self.inlineRow1), iconRow(Self.inlineRow2)]
+    }
+
     func formatPopupMenu() -> NSMenu {
         let menu = NSMenu(title: "Format")
-        menu.addItem(iconRowItem(Self.inlineRow1))
-        menu.addItem(iconRowItem(Self.inlineRow2))
-        menu.addItem(.separator())
-
         for level in 1...3 { menu.addItem(headingRow(level)) }
         menu.addItem(FormatMenu.thematicBreakCommand.makeItem())
         for cmd in FormatMenu.listCommands where cmd.id != "format.checklist" {
@@ -201,13 +251,16 @@ final class FormatToolbar: NSObject {
         return item
     }
 
-    /// The single callout row. The label is the syntax it writes, matching how
-    /// the list rows show their own markers.
+    /// The single callout row, carrying the same Lucide glyph the editor draws in
+    /// a NOTE callout's header — drawn monochrome so it sits with the other rows
+    /// rather than announcing itself in the callout's blue.
     private func calloutRow() -> NSMenuItem {
-        MenuCommand(id: "format.callout.NOTE", submenu: "Alert / Callout",
-                    title: "> [!NOTE]",
-                    action: #selector(EditorTextView.formatCallout(_:)),
-                    representedObject: "NOTE").makeItem()
+        let item = MenuCommand(id: "format.callout.NOTE", submenu: "Alert / Callout",
+                               title: "Alert / Callout",
+                               action: #selector(EditorTextView.formatCallout(_:)),
+                               representedObject: "NOTE").makeItem()
+        item.image = Callout.icon(for: "note", color: .labelColor, pointSize: 14)
+        return item
     }
 
     /// Prefixes a row with the marker it inserts (`•`, `1.`, `▎`), so the menu
@@ -277,11 +330,16 @@ final class FormatToolbar: NSObject {
         }
     }
 
-    private func iconRowItem(_ row: [(String, String)]) -> NSMenuItem {
+    private func iconRow(_ row: [(String, String)]) -> NSStackView {
         let stack = NSStackView()
         stack.orientation = .horizontal
         stack.spacing = 2
-        stack.edgeInsets = NSEdgeInsets(top: 4, left: 12, bottom: 4, right: 12)
+        stack.edgeInsets = NSEdgeInsets(top: 4, left: 8, bottom: 4, right: 8)
+        // The popover lays its rows out with Auto Layout. Left on, the default
+        // autoresizing frame puts this row at the container's origin — the
+        // *bottom* in AppKit's unflipped coordinates — where it drew on top of
+        // the last row.
+        stack.translatesAutoresizingMaskIntoConstraints = false
 
         for (symbol, id) in row {
             guard let cmd = FormatMenu.fontCommands.first(where: { $0.id == id }) else { continue }
@@ -307,11 +365,7 @@ final class FormatToolbar: NSObject {
             ])
             stack.addArrangedSubview(button)
         }
-
-        let item = NSMenuItem()
-        item.title = ""   // NSMenuItem defaults to "NSMenuItem", which VoiceOver reads out
-        item.view = stack
-        return item
+        return stack
     }
 
     // MARK: - Image popup
@@ -410,6 +464,13 @@ final class FormatIconTarget: NSObject {
     /// reflects when the popup refreshes.
     let styleID: String
 
+    /// Where to send the command. Set by the popover, which cannot rely on the
+    /// responder chain: its content view can take first responder, unlike a
+    /// menu, so a nil target may never reach the editor.
+    weak var editor: EditorTextView?
+    /// How to close the container once the command has fired.
+    var dismiss: (() -> Void)?
+
     init(action: Selector, styleID: String) {
         self.action = action
         self.styleID = styleID
@@ -417,8 +478,8 @@ final class FormatIconTarget: NSObject {
     }
 
     @objc func fire(_ sender: NSButton) {
-        sender.enclosingMenuItem?.menu?.cancelTracking()
-        NSApp.sendAction(action, to: nil, from: sender)
+        dismiss?()
+        NSApp.sendAction(action, to: editor, from: sender)
     }
 }
 
@@ -448,15 +509,26 @@ final class FormatIconButton: NSButton {
         didSet { if !isEnabled { isHovered = false } else { updateBackground() } }
     }
 
+    /// Re-resolve the tint when the window flips between light and dark.
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateBackground()
+    }
+
     private func updateBackground() {
         wantsLayer = true
         layer?.cornerRadius = 5
-        let color: NSColor? =
-            !isEnabled ? nil
-            : isActive ? .controlAccentColor.withAlphaComponent(isHovered ? 0.32 : 0.22)
-            : isHovered ? .labelColor.withAlphaComponent(0.10)
-            : nil
-        layer?.backgroundColor = color?.cgColor
+        // See FormatPopoverRow: a dynamic colour resolves against the current
+        // appearance, not this view's, and it resolves at `withAlphaComponent`
+        // as well as at `.cgColor` — so the whole expression is pinned to ours.
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            let color: NSColor? =
+                !isEnabled ? nil
+                : isActive ? .controlAccentColor.withAlphaComponent(isHovered ? 0.32 : 0.22)
+                : isHovered ? .labelColor.withAlphaComponent(0.10)
+                : nil
+            layer?.backgroundColor = color?.cgColor
+        }
     }
 }
 

--- a/Sources/edmd/App/FormatToolbar.swift
+++ b/Sources/edmd/App/FormatToolbar.swift
@@ -153,9 +153,14 @@ final class FormatToolbar: NSObject {
     // MARK: - Format popup
 
     /// Apple Notes-style: two rows of icon buttons, then the block commands as
-    /// ordinary menu rows (which get dividers, submenus, hover, keyboard nav and
-    /// live shortcut display for free — the reason this is an `NSMenu` and not a
+    /// ordinary menu rows (which get dividers, hover, keyboard nav and live
+    /// shortcut display for free — the reason this is an `NSMenu` and not a
     /// hand-built popover).
+    ///
+    /// Entirely flat: no submenus. Headings stop at 3 and callouts collapse to
+    /// the single `> [!NOTE]` form. The full range stays in the menu bar's
+    /// Format menu (H1–H6, 20 callout types) — this is the quick path, not a
+    /// mirror of it.
     ///
     /// Checklist and Table are absent on purpose: they are their own toolbar
     /// items.
@@ -165,19 +170,60 @@ final class FormatToolbar: NSObject {
         menu.addItem(iconRowItem(Self.inlineRow2))
         menu.addItem(.separator())
 
-        menu.addItem(FormatMenu.headingSubmenuItem())
+        for level in 1...3 { menu.addItem(headingRow(level)) }
         menu.addItem(FormatMenu.thematicBreakCommand.makeItem())
         for cmd in FormatMenu.listCommands where cmd.id != "format.checklist" {
-            menu.addItem(cmd.makeItem())
+            menu.addItem(marked(cmd.makeItem()))
         }
         menu.addItem(.separator())
 
         for cmd in FormatMenu.blockCommands where cmd.id != "format.table" {
-            menu.addItem(cmd.makeItem())
+            menu.addItem(marked(cmd.makeItem()))
         }
-        menu.addItem(FormatMenu.calloutSubmenuItem())
+        menu.addItem(calloutRow())
         menu.addItem(FormatMenu.footnoteCommand.makeItem())
         return menu
+    }
+
+    /// A heading row rendered at the weight it applies, the way Notes previews
+    /// Title / Heading / Subheading.
+    private func headingRow(_ level: Int) -> NSMenuItem {
+        let item = MenuCommand(id: "format.heading\(level)", submenu: "Heading",
+                               title: "Heading \(level)",
+                               action: #selector(EditorTextView.formatHeading(_:)),
+                               tag: level).makeItem()
+        // H1 18pt, H2 15.5pt, H3 13pt — a visible step down without overwhelming
+        // the plain rows beneath.
+        let size = [18.0, 15.5, 13.0][level - 1]
+        item.attributedTitle = NSAttributedString(
+            string: item.title,
+            attributes: [.font: NSFont.systemFont(ofSize: size, weight: .semibold)])
+        return item
+    }
+
+    /// The single callout row. The label is the syntax it writes, matching how
+    /// the list rows show their own markers.
+    private func calloutRow() -> NSMenuItem {
+        MenuCommand(id: "format.callout.NOTE", submenu: "Alert / Callout",
+                    title: "> [!NOTE]",
+                    action: #selector(EditorTextView.formatCallout(_:)),
+                    representedObject: "NOTE").makeItem()
+    }
+
+    /// Prefixes a row with the marker it inserts (`•`, `1.`, `▎`), so the menu
+    /// previews its own effect.
+    private func marked(_ item: NSMenuItem) -> NSMenuItem {
+        let marker: String
+        switch item.action {
+        case #selector(EditorTextView.formatBulletedList(_:)): marker = "•  "
+        case #selector(EditorTextView.formatNumberedList(_:)): marker = "1.  "
+        case #selector(EditorTextView.formatBlockQuote(_:)):   marker = "▎ "
+        default: return item
+        }
+        item.attributedTitle = NSAttributedString(
+            string: marker + item.title,
+            attributes: [.font: NSFont.menuFont(ofSize: 0)])
+        return item
     }
 
     /// (SF Symbol, command id) for the popup's first row.
@@ -199,6 +245,38 @@ final class FormatToolbar: NSObject {
         ("textformat.superscript", "format.superscript"),
     ]
 
+    /// Which inline style a row button reflects. Nil for commands that have no
+    /// detectable on/off state at the caret.
+    static func style(for commandID: String) -> ActiveInlineStyles? {
+        switch commandID {
+        case "format.bold":          return .bold
+        case "format.italic":        return .italic
+        case "format.underline":     return .underline
+        case "format.strikethrough": return .strikethrough
+        case "format.highlight":     return .highlight
+        case "format.code":          return .code
+        case "format.math":          return .math
+        case "format.subscript":     return .subscript
+        case "format.superscript":   return .superscript
+        default:                     return nil
+        }
+    }
+
+    /// The block style a popup row applies, so the row matching the caret's own
+    /// block can be checkmarked.
+    static func blockStyle(for item: NSMenuItem) -> ActiveBlockStyle? {
+        switch item.action {
+        case #selector(EditorTextView.formatHeading(_:)):     return .heading(level: item.tag)
+        case #selector(EditorTextView.formatBulletedList(_:)): return .bulletedList
+        case #selector(EditorTextView.formatNumberedList(_:)): return .numberedList
+        case #selector(EditorTextView.formatBlockQuote(_:)):   return .blockQuote
+        case #selector(EditorTextView.formatCodeBlock(_:)):    return .codeBlock
+        case #selector(EditorTextView.formatMathBlock(_:)):    return .mathBlock
+        case #selector(EditorTextView.formatCallout(_:)):      return .callout
+        default:                                               return nil
+        }
+    }
+
     private func iconRowItem(_ row: [(String, String)]) -> NSMenuItem {
         let stack = NSStackView()
         stack.orientation = .horizontal
@@ -207,18 +285,26 @@ final class FormatToolbar: NSObject {
 
         for (symbol, id) in row {
             guard let cmd = FormatMenu.fontCommands.first(where: { $0.id == id }) else { continue }
-            let target = FormatIconTarget(action: cmd.action)
+            let target = FormatIconTarget(action: cmd.action, styleID: id)
             iconTargets.append(target)
 
-            let button = NSButton(image: Self.rowSymbol(symbol) ?? NSImage(),
-                                  target: target, action: #selector(FormatIconTarget.fire(_:)))
-            button.bezelStyle = .accessoryBar
-            button.setButtonType(.momentaryPushIn)
+            let button = FormatIconButton(image: Self.rowSymbol(symbol) ?? NSImage(),
+                                          target: target, action: #selector(FormatIconTarget.fire(_:)))
+            button.isBordered = false          // our own hover/active background shows instead
+            button.setButtonType(.momentaryChange)
             button.imagePosition = .imageOnly
             button.toolTip = cmd.title
             button.setAccessibilityLabel(cmd.title)
             // The highlighter reads as its ink colour, matching the mark it makes.
             if id == "format.highlight" { button.contentTintColor = .systemYellow }
+            // Explicit metrics: an image-only borderless button has a slim
+            // intrinsic size, which leaves the row cramped and its hover targets
+            // overlapping. These give every icon the same square hit area.
+            button.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                button.widthAnchor.constraint(equalToConstant: 28),
+                button.heightAnchor.constraint(equalToConstant: 24),
+            ])
             stack.addArrangedSubview(button)
         }
 
@@ -264,18 +350,37 @@ extension FormatToolbar: NSMenuDelegate {
             menu.addItem(item)
         }
         refreshIconRows(in: menu)
+        refreshBlockRows(in: menu)
+    }
+
+    /// Checkmarks the row matching the caret's own block, the way Notes ticks the
+    /// current paragraph style.
+    private func refreshBlockRows(in menu: NSMenu) {
+        guard let editor = document?.editor else { return }
+        let active = editor.activeBlockStyle()
+        for item in menu.items {
+            guard let style = Self.blockStyle(for: item) else { continue }
+            item.state = style == active ? .on : .off
+        }
     }
 
     /// Icon-row buttons are not validated items, so they have to ask the focused
-    /// editor directly.
+    /// editor directly — for both their enabled state and whether the style they
+    /// apply is already in effect at the caret.
     private func refreshIconRows(in menu: NSMenu) {
         let editor = document?.editor
+        let active = editor?.activeInlineStyles() ?? []
         for item in menu.items {
             guard let stack = item.view as? NSStackView else { continue }
             for case let button as NSButton in stack.arrangedSubviews {
                 guard let target = button.target as? FormatIconTarget else { continue }
+                (button as? FormatIconButton)?.isActive =
+                    Self.style(for: target.styleID).map(active.contains) ?? false
                 button.isEnabled = editor?.isFormattingActionEnabled(
                     target.action, representedObject: nil) ?? false
+                // An explicit contentTintColor (the highlighter's yellow) defeats
+                // AppKit's automatic dimming, so fade the whole button instead.
+                button.alphaValue = button.isEnabled ? 1.0 : 0.35
             }
         }
     }
@@ -301,15 +406,57 @@ extension FormatToolbar: NSSharingServicePickerToolbarItemDelegate {
 @MainActor
 final class FormatIconTarget: NSObject {
     let action: Selector
+    /// The `MenuCommand` id, used to look up which inline style this button
+    /// reflects when the popup refreshes.
+    let styleID: String
 
-    init(action: Selector) {
+    init(action: Selector, styleID: String) {
         self.action = action
+        self.styleID = styleID
         super.init()
     }
 
     @objc func fire(_ sender: NSButton) {
         sender.enclosingMenuItem?.menu?.cancelTracking()
         NSApp.sendAction(action, to: nil, from: sender)
+    }
+}
+
+/// An icon-row button. A menu item's custom view gets none of a real row's
+/// behaviour, so hover highlighting is drawn here by hand; `isActive` is the
+/// same affordance for "this style is already on at the caret".
+final class FormatIconButton: NSButton {
+    var isActive = false { didSet { updateBackground() } }
+    private var isHovered = false { didSet { updateBackground() } }
+    private var tracking: NSTrackingArea?
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let tracking { removeTrackingArea(tracking) }
+        let area = NSTrackingArea(rect: bounds,
+                                  options: [.mouseEnteredAndExited, .activeInActiveApp, .inVisibleRect],
+                                  owner: self)
+        addTrackingArea(area)
+        tracking = area
+    }
+
+    override func mouseEntered(with event: NSEvent) { isHovered = true }
+    override func mouseExited(with event: NSEvent)  { isHovered = false }
+
+    /// A disabled button must not look hoverable.
+    override var isEnabled: Bool {
+        didSet { if !isEnabled { isHovered = false } else { updateBackground() } }
+    }
+
+    private func updateBackground() {
+        wantsLayer = true
+        layer?.cornerRadius = 5
+        let color: NSColor? =
+            !isEnabled ? nil
+            : isActive ? .controlAccentColor.withAlphaComponent(isHovered ? 0.32 : 0.22)
+            : isHovered ? .labelColor.withAlphaComponent(0.10)
+            : nil
+        layer?.backgroundColor = color?.cgColor
     }
 }
 

--- a/Sources/edmd/App/FormatToolbar.swift
+++ b/Sources/edmd/App/FormatToolbar.swift
@@ -269,19 +269,33 @@ final class FormatToolbar: NSObject {
         return item
     }
 
-    /// Prefixes a row with the marker it inserts (`•`, `1.`, `▎`), so the menu
-    /// previews its own effect.
+    /// Prefixes a row with the marker it inserts, so the menu previews its own
+    /// effect. Markers that are literal Markdown syntax are set in the mono font
+    /// they will be typed in; the block quote's bar is a rule rather than a
+    /// character, so it is greyed to keep it from reading as part of the title.
     private func marked(_ item: NSMenuItem) -> NSMenuItem {
+        let body = NSFont.menuFont(ofSize: 0)
+        let mono = NSFont.monospacedSystemFont(ofSize: body.pointSize - 1, weight: .regular)
+
         let marker: String
+        var attributes: [NSAttributedString.Key: Any] = [.font: body]
         switch item.action {
         case #selector(EditorTextView.formatBulletedList(_:)): marker = "•  "
         case #selector(EditorTextView.formatNumberedList(_:)): marker = "1.  "
-        case #selector(EditorTextView.formatBlockQuote(_:)):   marker = "▎ "
+        case #selector(EditorTextView.formatBlockQuote(_:)):
+            marker = "▎ "
+            attributes[.foregroundColor] = NSColor.secondaryLabelColor
+        case #selector(EditorTextView.formatCodeBlock(_:)):
+            marker = "```  "
+            attributes[.font] = mono
+        case #selector(EditorTextView.formatMathBlock(_:)):
+            marker = "$  "
+            attributes[.font] = mono
         default: return item
         }
-        item.attributedTitle = NSAttributedString(
-            string: marker + item.title,
-            attributes: [.font: NSFont.menuFont(ofSize: 0)])
+        let title = NSMutableAttributedString(string: marker, attributes: attributes)
+        title.append(NSAttributedString(string: item.title, attributes: [.font: body]))
+        item.attributedTitle = title
         return item
     }
 
@@ -340,7 +354,9 @@ final class FormatToolbar: NSObject {
         let stack = NSStackView()
         stack.orientation = .horizontal
         stack.spacing = 2
-        stack.edgeInsets = NSEdgeInsets(top: 4, left: 8, bottom: 4, right: 8)
+        // No vertical inset: it sat between the last icon row and the divider
+        // below it, so the gap there read wider than every other section gap.
+        stack.edgeInsets = NSEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
         // The popover lays its rows out with Auto Layout. Left on, the default
         // autoresizing frame puts this row at the container's origin — the
         // *bottom* in AppKit's unflipped coordinates — where it drew on top of
@@ -359,8 +375,10 @@ final class FormatToolbar: NSObject {
             button.imagePosition = .imageOnly
             button.toolTip = cmd.title
             button.setAccessibilityLabel(cmd.title)
-            // The highlighter reads as its ink colour, matching the mark it makes.
-            if id == "format.highlight" { button.contentTintColor = .systemYellow }
+            // A mouse-first panel: arrow-key navigation was explicitly not wanted,
+            // so nothing here joins the key view loop or draws a focus ring.
+            button.focusRingType = .none
+            button.refusesFirstResponder = true
             // Explicit metrics: an image-only borderless button has a slim
             // intrinsic size, which leaves the row cramped and its hover targets
             // overlapping. These give every icon the same square hit area.
@@ -438,8 +456,6 @@ extension FormatToolbar: NSMenuDelegate {
                     Self.style(for: target.styleID).map(active.contains) ?? false
                 button.isEnabled = editor?.isFormattingActionEnabled(
                     target.action, representedObject: nil) ?? false
-                // An explicit contentTintColor (the highlighter's yellow) defeats
-                // AppKit's automatic dimming, so fade the whole button instead.
                 button.alphaValue = button.isEnabled ? 1.0 : 0.35
             }
         }
@@ -530,8 +546,8 @@ final class FormatIconButton: NSButton {
         effectiveAppearance.performAsCurrentDrawingAppearance {
             let color: NSColor? =
                 !isEnabled ? nil
-                : isActive ? .controlAccentColor.withAlphaComponent(isHovered ? 0.32 : 0.22)
-                : isHovered ? .labelColor.withAlphaComponent(0.10)
+                : isActive ? .controlAccentColor.withAlphaComponent(isHovered ? 0.45 : 0.35)
+                : isHovered ? .controlAccentColor.withAlphaComponent(0.18)
                 : nil
             layer?.backgroundColor = color?.cgColor
         }

--- a/Sources/edmd/App/FormatToolbar.swift
+++ b/Sources/edmd/App/FormatToolbar.swift
@@ -43,9 +43,11 @@ final class FormatToolbar: NSObject {
     static let centeredIdentifiers: Set<NSToolbarItem.Identifier> =
         [format, checklist, table, image, link]
 
-    /// The centred group, then flexible space pushing view-mode and share right.
+    /// Just the view-mode button, right-aligned — the toolbar as it shipped. The
+    /// formatting group stays *allowed*, so it can be dragged in from Customize
+    /// Toolbar, but the default bar is bare.
     static func defaultIdentifiers(viewMode: NSToolbarItem.Identifier) -> [NSToolbarItem.Identifier] {
-        [format, checklist, table, image, link, .flexibleSpace, viewMode, share]
+        [.flexibleSpace, viewMode]
     }
 
     static func allowedIdentifiers(viewMode: NSToolbarItem.Identifier) -> [NSToolbarItem.Identifier] {
@@ -186,8 +188,12 @@ final class FormatToolbar: NSObject {
     /// screenshot, so the two sets of numbers are not interchangeable.
     private static let symbolPointSizes: [String: CGFloat] = [
         "textformat": 14,                 // "Aa" is wide and short — 15 read oversized
-        "checklist": 17.5,
-        "tablecells": 17,
+        // Notes' own extents put these two at 18.5 and 19.5, but its toolbar
+        // draws them against a taller bar; here they came out at 19.2 and 20.0
+        // against 15.0–16.5 for everything else and read plainly oversized, so
+        // they are matched to the rest of the row rather than to Notes.
+        "checklist": 14,
+        "tablecells": 14,
         "photo.on.rectangle": 13.5,
         "link.badge.plus": 13.5,
     ]

--- a/Sources/edmd/App/FormatToolbar.swift
+++ b/Sources/edmd/App/FormatToolbar.swift
@@ -204,9 +204,35 @@ final class FormatToolbar: NSObject {
 
     /// The format popup's icon rows are ordinary buttons inside a menu, not
     /// toolbar items, so they do need an explicit size.
+    ///
+    /// `pi` is drawn rather than looked up: the SF Symbol of that name is only in
+    /// SF Symbols 6, so on macOS 14 — which this app still supports — the lookup
+    /// returns nil and the Math button draws blank. Rendering the glyph from the
+    /// system font is one image on every supported version, and the only one that
+    /// can be checked from here.
     static func rowSymbol(_ name: String) -> NSImage? {
-        NSImage(systemSymbolName: name, accessibilityDescription: nil)?
+        if name == "pi" { return mathGlyph() }
+        return NSImage(systemSymbolName: name, accessibilityDescription: nil)?
             .withSymbolConfiguration(.init(pointSize: 14, weight: .regular))
+    }
+
+    /// "π" as a template image, sized so its ink matches the SF Symbols beside it.
+    private static func mathGlyph() -> NSImage {
+        let text = "π" as NSString
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 15, weight: .regular),
+            .foregroundColor: NSColor.black,
+        ]
+        let size = text.size(withAttributes: attributes)
+        let image = NSImage(size: NSSize(width: ceil(size.width), height: ceil(size.height)),
+                            flipped: false) { rect in
+            text.draw(in: rect, withAttributes: attributes)
+            return true
+        }
+        // Template so the row tints it like every other glyph — including white
+        // on the accent fill when the style is active.
+        image.isTemplate = true
+        return image
     }
 
     // MARK: - Format popup

--- a/Sources/edmd/App/FormatToolbar.swift
+++ b/Sources/edmd/App/FormatToolbar.swift
@@ -171,15 +171,21 @@ final class FormatToolbar: NSObject {
     /// common size renders `textformat` and `link.badge.plus` visibly larger than
     /// `checklist` and `tablecells`, which is what made the row read as ragged.
     ///
-    /// The target is a ~19pt drawn extent for every glyph — the size of the share
-    /// item AppKit builds itself, the one fixed reference in the row. These
-    /// numbers were derived by measuring each glyph's rendered extent and scaling
-    /// from it, then re-measured; do not collapse them back to a single constant.
+    /// The targets are Apple Notes', glyph for glyph. Both toolbars are 52pt tall,
+    /// so the point sizes compare directly; Notes' drawn extents, measured off
+    /// misc/frontend-refs/notes-toolbar-format-menu.png at 2x (traffic lights are
+    /// a fixed 12pt, which gives the scale), are Aa 20.0, checklist 18.5, table
+    /// 19.5, image 20.5, link 19.0. Each point size below is its target divided by
+    /// what that symbol drew here at the default 15 — which put the photo glyph at
+    /// 23.0pt, well over Notes'. Measure both sides the same way before touching
+    /// these: an offscreen `NSImage` draw has a different baseline than a
+    /// screenshot, so the two sets of numbers are not interchangeable.
     private static let symbolPointSizes: [String: CGFloat] = [
-        "textformat": 13,                 // "Aa" is wide and short — 15 read oversized
-        "checklist": 17,
-        "tablecells": 16,
-        "link.badge.plus": 13,
+        "textformat": 14,                 // "Aa" is wide and short — 15 read oversized
+        "checklist": 17.5,
+        "tablecells": 17,
+        "photo.on.rectangle": 13.5,
+        "link.badge.plus": 13.5,
     ]
 
     static func symbol(_ name: String) -> NSImage? {
@@ -549,7 +555,17 @@ final class FormatMenuToolbarItem: NSMenuToolbarItem {
 final class FormatButtonItem: NSToolbarItem {
     override func validate() {
         guard let action, let button = view as? NSButton else { return }
-        button.isEnabled = (NSApp.target(forAction: action) as? EditorTextView)?
+        // Only commands the editor runs are gated by the caret. The Format item
+        // opens a popover — it is not a formatting action, nothing in the
+        // responder chain answers it, and gating it here left it permanently
+        // disabled. The popover disables its own inapplicable rows.
+        guard EditorTextView.formattingActions.contains(action) else {
+            button.isEnabled = true
+            return
+        }
+        // `NSApp` is an implicitly-unwrapped optional and is genuinely nil in a
+        // test process, so chain it rather than trusting the declaration.
+        button.isEnabled = (NSApp?.target(forAction: action) as? EditorTextView)?
             .isFormattingActionEnabled(action, representedObject: nil) ?? false
     }
 }

--- a/Sources/edmd/App/FormatToolbar.swift
+++ b/Sources/edmd/App/FormatToolbar.swift
@@ -229,32 +229,25 @@ final class FormatToolbar: NSObject {
         for level in 1...3 { menu.addItem(headingRow(level)) }
         menu.addItem(FormatMenu.thematicBreakCommand.makeItem())
         for cmd in FormatMenu.listCommands where cmd.id != "format.checklist" {
-            menu.addItem(marked(cmd.makeItem()))
+            menu.addItem(cmd.makeItem())
         }
         menu.addItem(.separator())
 
         for cmd in FormatMenu.blockCommands where cmd.id != "format.table" {
-            menu.addItem(marked(cmd.makeItem()))
+            menu.addItem(cmd.makeItem())
         }
         menu.addItem(calloutRow())
         menu.addItem(FormatMenu.footnoteCommand.makeItem())
         return menu
     }
 
-    /// A heading row rendered at the weight it applies, the way Notes previews
-    /// Title / Heading / Subheading.
+    /// A heading row. It is drawn at the weight it applies — see `titleFont(for:)`
+    /// — the way Notes previews Title / Heading / Subheading.
     private func headingRow(_ level: Int) -> NSMenuItem {
-        let item = MenuCommand(id: "format.heading\(level)", submenu: "Heading",
-                               title: "Heading \(level)",
-                               action: #selector(EditorTextView.formatHeading(_:)),
-                               tag: level).makeItem()
-        // H1 18pt, H2 15.5pt, H3 13pt — a visible step down without overwhelming
-        // the plain rows beneath.
-        let size = [18.0, 15.5, 13.0][level - 1]
-        item.attributedTitle = NSAttributedString(
-            string: item.title,
-            attributes: [.font: NSFont.systemFont(ofSize: size, weight: .semibold)])
-        return item
+        MenuCommand(id: "format.heading\(level)", submenu: "Heading",
+                    title: "Heading \(level)",
+                    action: #selector(EditorTextView.formatHeading(_:)),
+                    tag: level).makeItem()
     }
 
     /// The single callout row, carrying the same Lucide glyph the editor draws in
@@ -265,38 +258,45 @@ final class FormatToolbar: NSObject {
                                title: "Alert / Callout",
                                action: #selector(EditorTextView.formatCallout(_:)),
                                representedObject: "NOTE").makeItem()
-        item.image = Callout.icon(for: "note", color: .labelColor, pointSize: 14)
+        // Template so the row can tint it white on the accent highlight, the way
+        // it tints the checkmark and the text markers.
+        let icon = Callout.icon(for: "note", color: .labelColor, pointSize: 13)
+        icon?.isTemplate = true
+        item.image = icon
         return item
     }
 
-    /// Prefixes a row with the marker it inserts, so the menu previews its own
-    /// effect. Markers that are literal Markdown syntax are set in the mono font
-    /// they will be typed in; the block quote's bar is a rule rather than a
-    /// character, so it is greyed to keep it from reading as part of the title.
-    private func marked(_ item: NSMenuItem) -> NSMenuItem {
-        let body = NSFont.menuFont(ofSize: 0)
-        let mono = NSFont.monospacedSystemFont(ofSize: body.pointSize - 1, weight: .regular)
-
-        let marker: String
-        var attributes: [NSAttributedString.Key: Any] = [.font: body]
+    /// The mini marker previewing what a row inserts. `FormatPopoverRow` draws it
+    /// in a gutter of its own so `•`, `1.`, `▎`, `$` and the callout glyph all
+    /// share a left edge however wide each one is — inline prefixes could not,
+    /// since each shifted its own title. Code Block has no marker: it previews
+    /// itself through the mono face of its title instead (see `titleFont`).
+    static func marker(for item: NSMenuItem) -> String? {
         switch item.action {
-        case #selector(EditorTextView.formatBulletedList(_:)): marker = "•  "
-        case #selector(EditorTextView.formatNumberedList(_:)): marker = "1.  "
-        case #selector(EditorTextView.formatBlockQuote(_:)):
-            marker = "▎ "
-            attributes[.foregroundColor] = NSColor.secondaryLabelColor
-        case #selector(EditorTextView.formatCodeBlock(_:)):
-            marker = "```  "
-            attributes[.font] = mono
-        case #selector(EditorTextView.formatMathBlock(_:)):
-            marker = "$  "
-            attributes[.font] = mono
-        default: return item
+        case #selector(EditorTextView.formatBulletedList(_:)): return "•"
+        case #selector(EditorTextView.formatNumberedList(_:)): return "1."
+        case #selector(EditorTextView.formatBlockQuote(_:)):   return "▎"
+        case #selector(EditorTextView.formatMathBlock(_:)):    return "$"
+        default:                                               return nil
         }
-        let title = NSMutableAttributedString(string: marker, attributes: attributes)
-        title.append(NSAttributedString(string: item.title, attributes: [.font: body]))
-        item.attributedTitle = title
-        return item
+    }
+
+    /// The face a row's title is drawn in. Headings step down in size the way
+    /// Notes previews Title / Heading / Subheading; Code Block is set in the mono
+    /// face its content is typed in, which is what it previews instead of a
+    /// marker.
+    static func titleFont(for item: NSMenuItem) -> NSFont {
+        let body = NSFont.menuFont(ofSize: 0)
+        switch item.action {
+        case #selector(EditorTextView.formatHeading(_:)):
+            let sizes = [18.0, 15.5, 13.0]
+            return .systemFont(ofSize: sizes[min(max(item.tag, 1), sizes.count) - 1],
+                               weight: .semibold)
+        case #selector(EditorTextView.formatCodeBlock(_:)):
+            return .monospacedSystemFont(ofSize: body.pointSize - 1, weight: .regular)
+        default:
+            return body
+        }
     }
 
     /// (SF Symbol, command id) for the popup's first row.
@@ -313,7 +313,9 @@ final class FormatToolbar: NSObject {
     /// faithfully, and Markdown has no alignment concept outside table columns.
     private static let inlineRow2: [(String, String)] = [
         ("chevron.left.forwardslash.chevron.right", "format.code"),
-        ("function", "format.math"),
+        // `pi` rather than `function`: ƒ(x) is far wider than every other glyph
+        // in the grid, so the row read ragged.
+        ("pi", "format.math"),
         ("textformat.subscript", "format.subscript"),
         ("textformat.superscript", "format.superscript"),
     ]
@@ -526,6 +528,14 @@ final class FormatIconButton: NSButton {
     override func mouseEntered(with event: NSEvent) { isHovered = true }
     override func mouseExited(with event: NSEvent)  { isHovered = false }
 
+    /// The frame is the hover chip and the hit area, so it has to be exactly what
+    /// the size constraints say. Left to AppKit a borderless image button insets
+    /// its alignment rect from its frame by a bezel it never draws, and by a
+    /// different amount per symbol: equal 24pt height constraints produced chips
+    /// from 26 to 31pt tall, and left the grid's wrapper 12pt taller than its
+    /// rows — which is where the extra gap above the first divider came from.
+    override var alignmentRectInsets: NSEdgeInsets { NSEdgeInsets() }
+
     /// A disabled button must not look hoverable.
     override var isEnabled: Bool {
         didSet { if !isEnabled { isHovered = false } else { updateBackground() } }
@@ -544,12 +554,16 @@ final class FormatIconButton: NSButton {
         // appearance, not this view's, and it resolves at `withAlphaComponent`
         // as well as at `.cgColor` — so the whole expression is pinned to ours.
         effectiveAppearance.performAsCurrentDrawingAppearance {
+            // On is the accent at full strength, the way Notes fills an active
+            // grid button with its yellow. Hover stays a wash: a hover that
+            // looked identical to on would say the style had been applied.
             let color: NSColor? =
                 !isEnabled ? nil
-                : isActive ? .controlAccentColor.withAlphaComponent(isHovered ? 0.45 : 0.35)
+                : isActive ? .controlAccentColor
                 : isHovered ? .controlAccentColor.withAlphaComponent(0.18)
                 : nil
             layer?.backgroundColor = color?.cgColor
+            contentTintColor = isActive && isEnabled ? .selectedMenuItemTextColor : .labelColor
         }
     }
 }

--- a/Sources/edmd/App/FormatToolbar.swift
+++ b/Sources/edmd/App/FormatToolbar.swift
@@ -81,7 +81,12 @@ final class FormatToolbar: NSObject {
         case Self.link:
             let item = FormatButtonItem(itemIdentifier: id)
             item.label = "Link"
-            item.toolTip = "Link (right-click for Wikilink)"
+            // No "right-click for Wikilink" hint: AppKit never advertises a
+            // secondary-click menu in a tooltip (Safari's back button holds a
+            // history menu and says only "Show the previous page"), and a tooltip
+            // is seen only after hovering the thing whose menu you didn't know
+            // about. Wikilink stays discoverable through the Format menu.
+            item.toolTip = "Link"
             let button = NSButton(image: Self.symbol("link.badge.plus") ?? NSImage(),
                                   target: nil, action: #selector(EditorTextView.formatLink(_:)))
             button.bezelStyle = .texturedRounded

--- a/Sources/edmd/App/ReproScript.swift
+++ b/Sources/edmd/App/ReproScript.swift
@@ -23,6 +23,11 @@ import WebKit
 ///   readscroll <y>    raw-scroll the Read-mode webview to y
 ///   logstate          NSLog view-swap state (mode, hidden flags, clip y,
 ///                     webview scrollTop) for mode-switch harness debugging
+///   logtoolbar        log every toolbar item's identifier and enabled state
+///   clicktoolbar <id> click a toolbar item by identifier (real target/action)
+///   clickrow <title>  press a format-popover row by its title
+///   clickicon <id>    press a format-popover icon button by its style id
+///   assertsource <s>  PASS iff <s> appears in the document
 @MainActor
 enum ReproScript {
 
@@ -30,6 +35,8 @@ enum ReproScript {
         guard let path = UserDefaults.standard.string(forKey: "debug.reproScript"),
               let script = try? String(contentsOfFile: path, encoding: .utf8) else { return }
         Log.info("repro script: \(path)", category: .app)
+        reportPath = path + ".log"
+        try? "".write(toFile: path + ".log", atomically: true, encoding: .utf8)
         var delay: TimeInterval = 1.5   // let the document finish opening
         for line in script.split(separator: "\n") {
             let parts = line.split(separator: " ", maxSplits: 1).map(String.init)
@@ -173,10 +180,9 @@ enum ReproScript {
                 }
             case "logsel":
                 schedule(after: delay) { editor in
-                    Log.info("repro logsel sel=\(editor.selectedRange()) " +
-                             "rawLen=\((editor.rawSource as NSString).length) " +
-                             "docs=\(NSDocumentController.shared.documents.count)",
-                             category: .app)
+                    report("repro logsel sel=\(editor.selectedRange()) " +
+                           "rawLen=\((editor.rawSource as NSString).length) " +
+                           "docs=\(NSDocumentController.shared.documents.count)")
                 }
             case "scroll":
                 // Scrolls the clip view directly (bypassing the caret, so the
@@ -240,6 +246,80 @@ enum ReproScript {
                         NSLog("WEBSTATE \(v.map(String.init(describing:)) ?? "nil") err=\(e.map(String.init(describing:)) ?? "none")")
                     }
                 }
+            case "logtoolbar":
+                scheduleDoc(after: delay) { doc in
+                    let window = doc.windowControllers.first?.window
+                    let target = NSApp?.target(forAction: #selector(EditorTextView.formatChecklist(_:)))
+                    report("repro responders active=\(NSApp?.isActive ?? false) " +
+                           "keyIsDoc=\(NSApp?.keyWindow === window) " +
+                           "key=\(NSApp?.keyWindow.map { String(describing: type(of: $0)) } ?? "nil") " +
+                           "first=\(window?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil") " +
+                           "target=\(target.map { String(describing: type(of: $0)) } ?? "nil")")
+                    for item in window?.toolbar?.items ?? [] {
+                        item.validate()
+                        // A custom-view item's own `isEnabled` is not what draws;
+                        // the button inside it is. Nil-target items validate off the
+                        // key window, which a script-launched app never has, so ask
+                        // this window's first responder instead.
+                        let on: Bool
+                        if let control = item.view as? NSControl {
+                            on = control.isEnabled
+                        } else if let validator = window?.firstResponder as? NSToolbarItemValidation {
+                            on = validator.validateToolbarItem(item)
+                        } else {
+                            on = item.isEnabled
+                        }
+                        report("repro toolbar \(item.itemIdentifier.rawValue) enabled=\(on)")
+                    }
+                }
+            case "clicktoolbar":
+                scheduleDoc(after: delay) { doc in
+                    guard let item = doc.windowControllers.first?.window?.toolbar?
+                        .items.first(where: { $0.itemIdentifier.rawValue == arg }) else {
+                        report("repro clicktoolbar: no item \(arg)"); return
+                    }
+                    item.validate()
+                    if let button = item.view as? NSButton {
+                        report("repro clicktoolbar \(arg) enabled=\(button.isEnabled)")
+                        button.performClick(nil)
+                    } else if let action = item.action {
+                        // A script-launched binary never becomes the active app, so
+                        // `NSApp.keyWindow` is nil and `sendAction` — which starts
+                        // from the key window — finds nobody. Walking this window's
+                        // own responder chain is what a real click would reach.
+                        // …and the chain starts at the first responder, not at the
+                        // window: `NSWindow.tryToPerform` walks its own nextResponder.
+                        let window = doc.windowControllers.first?.window
+                        let sent = window?.firstResponder?.tryToPerform(action, with: item) ?? false
+                        report("repro clicktoolbar \(arg) sent=\(sent)")
+                    } else {
+                        report("repro clicktoolbar \(arg) has no button and no action")
+                    }
+                }
+            case "clickrow":
+                scheduleDoc(after: delay) { _ in
+                    guard let row = findInPopover({ ($0 as? FormatPopoverRow)?.item.title == arg })
+                            as? FormatPopoverRow else {
+                        report("repro clickrow: no row titled \(arg)"); return
+                    }
+                    report("repro clickrow \(arg) enabled=\(row.isEnabled)")
+                    _ = row.accessibilityPerformPress()
+                }
+            case "clickicon":
+                scheduleDoc(after: delay) { _ in
+                    guard let button = findInPopover({
+                        (($0 as? FormatIconButton)?.target as? FormatIconTarget)?.styleID == arg
+                    }) as? FormatIconButton else {
+                        report("repro clickicon: no button for \(arg)"); return
+                    }
+                    report("repro clickicon \(arg) enabled=\(button.isEnabled)")
+                    button.performClick(nil)
+                }
+            case "assertsource":
+                schedule(after: delay) { editor in
+                    let ok = (editor.rawSource as NSString).range(of: arg).location != NSNotFound
+                    report("repro assertsource \(ok ? "PASS" : "FAIL") needle=\(arg)")
+                }
             default:
                 break
             }
@@ -247,12 +327,46 @@ enum ReproScript {
         }
     }
 
+    /// Where a run's results are written: `<script>.log`, next to the script.
+    private static var reportPath: String?
+
+    /// Results go to a file of their own. The daily log is shared with every
+    /// other running instance, and NSLog does not reach the redirected stderr of
+    /// a bundle-less binary — so neither can be relied on to read a run back.
+    private static func report(_ line: String) {
+        Log.info(line, category: .app)
+        guard let path = reportPath else { return }
+        let data = Data((line + "\n").utf8)
+        if let handle = FileHandle(forWritingAtPath: path) {
+            handle.seekToEndOfFile()
+            handle.write(data)
+            try? handle.close()
+        }
+    }
+
     private static func scheduleDoc(after: TimeInterval,
                                     _ body: @escaping @MainActor (Document) -> Void) {
         DispatchQueue.main.asyncAfter(deadline: .now() + after) {
-            guard let doc = NSDocumentController.shared.documents.first as? Document else { return }
+            guard let doc = NSDocumentController.shared.documents.first as? Document else {
+                report("repro: no document yet"); return
+            }
             body(doc)
         }
+    }
+
+    /// First view in any open popover satisfying `match`. The popover keeps its
+    /// own window, so it is reachable from `NSApp.windows` without the toolbar
+    /// having to hand out a reference to it.
+    private static func findInPopover(_ match: (NSView) -> Bool) -> NSView? {
+        func search(_ view: NSView) -> NSView? {
+            if match(view) { return view }
+            for sub in view.subviews { if let hit = search(sub) { return hit } }
+            return nil
+        }
+        for window in NSApp?.windows ?? [] {
+            if let content = window.contentView, let hit = search(content) { return hit }
+        }
+        return nil
     }
 
     private static func firstWebView(in view: NSView) -> WKWebView? {

--- a/Sources/edmd/App/ReproScript.swift
+++ b/Sources/edmd/App/ReproScript.swift
@@ -24,6 +24,7 @@ import WebKit
 ///   logstate          NSLog view-swap state (mode, hidden flags, clip y,
 ///                     webview scrollTop) for mode-switch harness debugging
 ///   logtoolbar        log every toolbar item's identifier and enabled state
+///   logwindows        log each visible window's id, for `screencapture -l`
 ///   clicktoolbar <id> click a toolbar item by identifier (real target/action)
 ///   clickrow <title>  press a format-popover row by its title
 ///   clickicon <id>    press a format-popover icon button by its style id
@@ -244,6 +245,17 @@ enum ReproScript {
                     }
                     web?.evaluateJavaScript("document.scrollingElement.scrollTop + ',' + document.body.childElementCount") { v, e in
                         NSLog("WEBSTATE \(v.map(String.init(describing:)) ?? "nil") err=\(e.map(String.init(describing:)) ?? "none")")
+                    }
+                }
+            case "logwindows":
+                // `NSWindow.windowNumber` is the CGWindowID `screencapture -l`
+                // takes. Reporting it is the only way to grab a window from a
+                // script here: a freshly built tool has no Screen Recording grant
+                // of its own, so it cannot look the id up from outside.
+                schedule(after: delay) { _ in
+                    for window in NSApp?.windows ?? [] where window.isVisible {
+                        report("repro window \(window.windowNumber) " +
+                               "\(type(of: window)) frame=\(window.frame)")
                     }
                 }
             case "logtoolbar":

--- a/Sources/edmd/App/ReproScript.swift
+++ b/Sources/edmd/App/ReproScript.swift
@@ -281,7 +281,11 @@ enum ReproScript {
                         } else {
                             on = item.isEnabled
                         }
-                        report("repro toolbar \(item.itemIdentifier.rawValue) enabled=\(on)")
+                        // The tooltip too: hovering an item to read one cannot be
+                        // driven from here, so this is the only way to check it.
+                        let tip = (item.view as? NSView)?.toolTip ?? item.toolTip
+                        report("repro toolbar \(item.itemIdentifier.rawValue) " +
+                               "enabled=\(on) tip=\(tip ?? "nil")")
                     }
                 }
             case "clicktoolbar":

--- a/Tests/EdmundTests/ActiveStylesTests.swift
+++ b/Tests/EdmundTests/ActiveStylesTests.swift
@@ -1,0 +1,109 @@
+import Testing
+import AppKit
+@testable import EdmundCore
+
+// What the format popup reads to decide which rows show as already-applied.
+
+@MainActor
+private func mk(_ content: String, _ caret: Int) -> EditorTextView {
+    let e = makeEditor()
+    e.loadContent(content)
+    e.setSelectedRange(NSRange(location: caret, length: 0))
+    return e
+}
+
+@MainActor @Suite struct ActiveInlineStyleTests {
+
+    @Test func detectsBoldInsideDelimiters() {
+        #expect(mk("a **word** b", 6).activeInlineStyles().contains(.bold))
+    }
+
+    @Test func plainTextHasNoStyles() {
+        #expect(mk("a word b", 3).activeInlineStyles().isEmpty)
+    }
+
+    /// Typing at either edge of a run continues it, so the button must agree.
+    @Test func detectsBoldAtBothEdgesOfTheContent() {
+        #expect(mk("a **word** b", 4).activeInlineStyles().contains(.bold))   // before "w"
+        #expect(mk("a **word** b", 8).activeInlineStyles().contains(.bold))   // after "d"
+    }
+
+    @Test func doesNotLeakOutsideTheRun() {
+        #expect(!mk("a **word** b", 0).activeInlineStyles().contains(.bold))
+        #expect(!mk("a **word** b", 12).activeInlineStyles().contains(.bold))
+    }
+
+    @Test func boldItalicReportsBoth() {
+        let s = mk("***word***", 5).activeInlineStyles()
+        #expect(s.contains(.bold))
+        #expect(s.contains(.italic))
+    }
+
+    @Test func detectsItalicStrikethroughHighlightAndCode() {
+        #expect(mk("*w* x", 1).activeInlineStyles().contains(.italic))
+        #expect(mk("~~w~~ x", 2).activeInlineStyles().contains(.strikethrough))
+        #expect(mk("==w== x", 2).activeInlineStyles().contains(.highlight))
+        #expect(mk("`w` x", 1).activeInlineStyles().contains(.code))
+    }
+
+    @Test func detectsInlineMathButNotDisplayMath() {
+        #expect(mk("$x^2$ t", 1).activeInlineStyles().contains(.math))
+        #expect(!mk("$$\nx^2\n$$", 3).activeInlineStyles().contains(.math))
+    }
+
+    @Test func detectsHTMLFormatTags() {
+        #expect(mk("<u>w</u>", 4).activeInlineStyles().contains(.underline))
+        #expect(mk("H<sub>2</sub>O", 6).activeInlineStyles().contains(.subscript))
+        #expect(mk("x<sup>2</sup>", 6).activeInlineStyles().contains(.superscript))
+    }
+
+    /// The popup's own commands must round-trip: apply, then detect.
+    @Test func detectsWhatTheCommandsJustInserted() {
+        let e = mk("word", 0)
+        e.setSelectedRange(NSRange(location: 0, length: 4))
+        e.formatBold(nil)
+        e.setSelectedRange(NSRange(location: 3, length: 0))   // inside "**wo|rd**"
+        #expect(e.activeInlineStyles().contains(.bold))
+    }
+
+    @Test func detectsStylesOnLaterBlocks() {
+        // Offsets are block-relative internally; a second block must still work.
+        #expect(mk("first\n\nsecond **bold** here", 17).activeInlineStyles().contains(.bold))
+    }
+}
+
+@MainActor @Suite struct ActiveBlockStyleTests {
+
+    @Test func plainParagraphIsBody() {
+        #expect(mk("just text", 4).activeBlockStyle() == .body)
+    }
+
+    @Test func detectsHeadingLevels() {
+        #expect(mk("# One", 3).activeBlockStyle() == .heading(level: 1))
+        #expect(mk("## Two", 4).activeBlockStyle() == .heading(level: 2))
+        #expect(mk("### Three", 5).activeBlockStyle() == .heading(level: 3))
+    }
+
+    @Test func distinguishesTheThreeListFlavours() {
+        #expect(mk("- item", 3).activeBlockStyle() == .bulletedList)
+        #expect(mk("1. item", 4).activeBlockStyle() == .numberedList)
+        #expect(mk("- [ ] task", 8).activeBlockStyle() == .checklist)
+    }
+
+    @Test func distinguishesQuoteFromCallout() {
+        #expect(mk("> quoted", 4).activeBlockStyle() == .blockQuote)
+        #expect(mk("> [!NOTE]\n> body", 13).activeBlockStyle() == .callout)
+    }
+
+    @Test func detectsCodeAndMathBlocks() {
+        #expect(mk("```\ncode\n```", 5).activeBlockStyle() == .codeBlock)
+        #expect(mk("$$\nx^2\n$$", 4).activeBlockStyle() == .mathBlock)
+    }
+
+    /// A block may mix list markers line by line, so the caret's own line wins.
+    @Test func usesTheCaretsOwnLineInAMixedList() {
+        let content = "- bullet\n- [ ] task"
+        #expect(mk(content, 4).activeBlockStyle() == .bulletedList)
+        #expect(mk(content, 16).activeBlockStyle() == .checklist)
+    }
+}

--- a/Tests/EdmundTests/FormatToolbarTests.swift
+++ b/Tests/EdmundTests/FormatToolbarTests.swift
@@ -1,0 +1,215 @@
+import Testing
+import AppKit
+@testable import edmd
+@testable import EdmundCore
+
+// The toolbar's *composition*: that it offers the documented items in the
+// documented order, and that every command in its popups is one of the existing
+// Format commands rather than a second implementation. Interaction (clicking a
+// row, the Link item's secondary click) is not reachable headlessly — see the
+// live checks in the PR description.
+
+@MainActor private func toolbar() -> (FormatToolbar, Document) {
+    let doc = Document()
+    return (FormatToolbar(document: doc), doc)
+}
+
+/// Titles of a menu's real items, separators rendered as "-".
+@MainActor private func titles(_ menu: NSMenu) -> [String] {
+    menu.items.map { $0.isSeparatorItem ? "-" : $0.title }
+}
+
+@MainActor @Suite struct FormatToolbarLayoutTests {
+
+    private let viewMode = NSToolbarItem.Identifier("viewMode")
+
+    @Test func defaultOrderMatchesTheSpec() {
+        let ids = FormatToolbar.defaultIdentifiers(viewMode: viewMode).map(\.rawValue)
+        #expect(ids == ["format", "checklist", "table", "image", "link",
+                        "NSToolbarFlexibleSpaceItem", "viewMode", "share"])
+    }
+
+    @Test func everyDefaultItemIsAlsoAllowed() {
+        let allowed = Set(FormatToolbar.allowedIdentifiers(viewMode: viewMode))
+        for id in FormatToolbar.defaultIdentifiers(viewMode: viewMode) {
+            #expect(allowed.contains(id), "\(id.rawValue) is a default but not allowed")
+        }
+    }
+
+    @Test func vendsEveryItemItDeclares() {
+        let (bar, doc) = toolbar()
+        for id in FormatToolbar.allowedIdentifiers(viewMode: viewMode)
+        where id != viewMode && id != .space && id != .flexibleSpace {
+            #expect(bar.makeItem(id) != nil, "no item vended for \(id.rawValue)")
+        }
+        _ = doc
+    }
+
+    /// The view-mode item stays with `Document`; FormatToolbar must decline it
+    /// rather than vend an empty replacement.
+    @Test func declinesTheViewModeItem() {
+        let (bar, doc) = toolbar()
+        #expect(bar.makeItem(viewMode) == nil)
+        _ = doc
+    }
+}
+
+@MainActor @Suite struct FormatPopupTests {
+
+    @Test func rowOrderMatchesTheSpec() {
+        let (bar, doc) = toolbar()
+        #expect(titles(bar.formatPopupMenu()) == [
+            "", "", "-",
+            "Heading", "Thematic Break", "Bulleted List", "Numbered List", "-",
+            "Code Block", "Math Block", "Block Quote", "Alert / Callout", "Footnote",
+        ])
+        _ = doc
+    }
+
+    /// Checklist and Table are top-level toolbar items, so listing them in the
+    /// popup too would be a second route to the same command.
+    @Test func popupOmitsChecklistAndTable() {
+        let (bar, doc) = toolbar()
+        let names = titles(bar.formatPopupMenu())
+        #expect(!names.contains("Checklist"))
+        #expect(!names.contains("Table"))
+        _ = doc
+    }
+
+    @Test func headingAndCalloutKeepTheirSubmenus() {
+        let (bar, doc) = toolbar()
+        let menu = bar.formatPopupMenu()
+        let heading = menu.items.first { $0.title == "Heading" }
+        let callout = menu.items.first { $0.title == "Alert / Callout" }
+        #expect(heading?.submenu?.items.count == 6)          // H1–H6
+        #expect((callout?.submenu?.items.count ?? 0) > 5)    // GFM alerts + Obsidian types
+        _ = doc
+    }
+
+    @Test func iconRowsCarryTheDocumentedCommands() {
+        let (bar, doc) = toolbar()
+        let rows = bar.formatPopupMenu().items.prefix(2).compactMap { $0.view as? NSStackView }
+        #expect(rows.count == 2)
+
+        // Every row button funnels through the same forwarding target…
+        let buttons = rows.map { $0.arrangedSubviews.compactMap { $0 as? NSButton } }
+        #expect(buttons.allSatisfy { $0.allSatisfy { NSStringFromSelector($0.action!) == "fire:" } })
+        // …so the real command lives on the target, not the button.
+        let targets = rows.map { row in
+            row.arrangedSubviews.compactMap { ($0 as? NSButton)?.target as? FormatIconTarget }
+                .map { NSStringFromSelector($0.action) }
+        }
+        #expect(targets[0] == ["formatBold:", "formatItalic:", "formatUnderline:",
+                               "formatStrikethrough:", "formatHighlight:"])
+        #expect(targets[1] == ["formatCode:", "formatInlineMath:",
+                               "formatSubscript:", "formatSuperscript:"])
+        _ = doc
+    }
+
+    /// Every command the popup offers must be a known formatting action —
+    /// the guard against the toolbar growing its own private commands.
+    @Test func everyPopupCommandIsAKnownFormattingAction() {
+        let (bar, doc) = toolbar()
+        func check(_ menu: NSMenu) {
+            for item in menu.items {
+                if let sub = item.submenu { check(sub); continue }
+                guard let action = item.action else { continue }
+                #expect(EditorTextView.formattingActions.contains(action),
+                        "\(item.title) uses unregistered action \(action)")
+            }
+        }
+        check(bar.formatPopupMenu())
+        _ = doc
+    }
+}
+
+// MARK: - View-mode glyph sizing
+//
+// `pencil` and `book` have different intrinsic boxes, so a shared point size
+// draws the book visibly larger and the toolbar button appears to resize when
+// the mode flips. Document compensates with a smaller point size for the book;
+// these lock the two constants to the property that actually matters — the
+// height of the *drawn* glyph, which is what the eye compares.
+
+/// Height in points of the ink in `image` (its drawn extent, not its layout box).
+@MainActor private func inkHeight(_ image: NSImage) -> Int {
+    let side = 64
+    let rep = NSBitmapImageRep(bitmapDataPlanes: nil, pixelsWide: side, pixelsHigh: side,
+                               bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true,
+                               isPlanar: false, colorSpaceName: .deviceRGB,
+                               bytesPerRow: 0, bitsPerPixel: 0)!
+    NSGraphicsContext.saveGraphicsState()
+    NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
+    let size = image.size
+    image.draw(in: NSRect(x: (CGFloat(side) - size.width) / 2,
+                          y: (CGFloat(side) - size.height) / 2,
+                          width: size.width, height: size.height))
+    NSGraphicsContext.restoreGraphicsState()
+
+    var top: Int?, bottom: Int?
+    for y in 0..<side {
+        var inked = false
+        for x in 0..<side where (rep.colorAt(x: x, y: y)?.alphaComponent ?? 0) > 0.1 {
+            inked = true; break
+        }
+        if inked { if top == nil { top = y }; bottom = y }
+    }
+    guard let t = top, let b = bottom else { return 0 }
+    return b - t + 1
+}
+
+@MainActor @Suite struct ViewModeGlyphSizeTests {
+
+    private func symbol(_ name: String, _ pointSize: CGFloat) throws -> NSImage {
+        try #require(NSImage(systemSymbolName: name, accessibilityDescription: nil)?
+            .withSymbolConfiguration(.init(pointSize: pointSize, weight: .regular)))
+    }
+
+    /// The pair Document actually uses. Tolerance of 1pt: they only have to look
+    /// the same, and SF Symbol outlines will never match to the pixel.
+    @Test func pencilAndBookDrawTheSameHeight() throws {
+        let pencil = inkHeight(try symbol("pencil", 15))
+        let book = inkHeight(try symbol("book", 12.9))
+        #expect(abs(pencil - book) <= 1, "pencil \(pencil)pt vs book \(book)pt")
+    }
+
+    /// The reason the compensation exists — guards against someone "simplifying"
+    /// the two constants back into one.
+    @Test func aSharedPointSizeWouldDrawTheBookLarger() throws {
+        let pencil = inkHeight(try symbol("pencil", 15))
+        let book = inkHeight(try symbol("book", 15))
+        #expect(book > pencil + 1, "book \(book)pt vs pencil \(pencil)pt")
+    }
+}
+
+@MainActor @Suite struct ImageAndLinkMenuTests {
+
+    @Test func imageMenuOffersEverySourceWithOnlyFileEnabled() {
+        let (bar, doc) = toolbar()
+        let menu = bar.imagePopupMenu()
+        #expect(titles(menu) == ["Attach File…", "Photos…", "-", "Take Photo", "Scan Documents"])
+
+        let attach = menu.items.first { $0.title == "Attach File…" }
+        #expect(attach?.action == #selector(EditorTextView.formatAttachImage(_:)))
+
+        // Placeholders must not dispatch even if AppKit enables them.
+        for item in menu.items where !item.isSeparatorItem && item.title != "Attach File…" {
+            #expect(item.action == nil, "\(item.title) is a placeholder but has an action")
+        }
+        _ = doc
+    }
+
+    @Test func onlyFileSourceIsAvailable() {
+        #expect(ImageSource.allCases.filter(\.isAvailable) == [.file])
+    }
+
+    /// The Link item's secondary-click menu — Image has its own toolbar item.
+    @Test func linkMenuIsLinkAndWikilink() {
+        let (bar, doc) = toolbar()
+        let menu = bar.linkMenu()
+        #expect(titles(menu) == ["Link", "Wikilink"])
+        #expect(menu.items[0].action == #selector(EditorTextView.formatLink(_:)))
+        #expect(menu.items[1].action == #selector(EditorTextView.formatWikilink(_:)))
+        _ = doc
+    }
+}

--- a/Tests/EdmundTests/FormatToolbarTests.swift
+++ b/Tests/EdmundTests/FormatToolbarTests.swift
@@ -96,7 +96,8 @@ import AppKit
         #expect(titles(bar.formatPopupMenu()) == [
             "Heading 1", "Heading 2", "Heading 3", "Thematic Break",
             "•  Bulleted List", "1.  Numbered List", "-",
-            "Code Block", "Math Block", "▎ Block Quote", "Alert / Callout", "Footnote",
+            "```  Code Block", "$  Math Block", "▎ Block Quote",
+            "Alert / Callout", "Footnote",
         ])
         _ = doc
     }
@@ -277,6 +278,99 @@ import AppKit
         _ = doc
     }
 
+    /// The hover tint is the accent colour on an inset view, so it stops short of
+    /// the popover's rounded sides the way the dividers do.
+    @Test func theHoverHighlightIsInsetAndAccentTinted() {
+        let (bar, doc) = toolbar()
+        let controller = FormatPopoverController(items: Array(bar.formatPopupMenu().items),
+                                                 editor: nil, popover: nil)
+        controller.loadView()
+        controller.view.layoutSubtreeIfNeeded()
+
+        let row = try! #require(controller.commandRows.first)
+        #expect(row.highlight.layer?.backgroundColor == nil, "tinted before hover")
+
+        row.isHovered = true
+        controller.view.layoutSubtreeIfNeeded()
+        var accent: CGColor?
+        row.effectiveAppearance.performAsCurrentDrawingAppearance {
+            accent = NSColor.controlAccentColor.withAlphaComponent(0.18).cgColor
+        }
+        #expect(row.highlight.layer?.backgroundColor == accent)
+        #expect(row.highlight.frame.minX > row.frame.minX)
+        #expect(row.highlight.frame.maxX < row.frame.maxX)
+        _ = doc
+    }
+
+    /// Notes reserves the tick's gutter whether or not a row is ticked. Hiding the
+    /// checkmark instead dropped it out of the stack and the titles slid left.
+    @Test func everyTitleSitsOnTheSameLeftEdgeUnticked() {
+        let (bar, doc) = toolbar()
+        let controller = FormatPopoverController(items: Array(bar.formatPopupMenu().items),
+                                                 editor: nil, popover: nil)
+        controller.loadView()
+        controller.view.layoutSubtreeIfNeeded()
+
+        // The callout row carries an icon of its own, so it is legitimately inset
+        // further; every other title shares one edge.
+        let edges = Set(controller.commandRows
+            .filter { $0.item.image == nil }
+            .compactMap { row in
+                row.subviews.compactMap { $0 as? NSStackView }.first?
+                    .arrangedSubviews.compactMap { $0 as? NSTextField }.first?.frame.minX
+            })
+        #expect(edges.count == 1, "titles do not share a left edge: \(edges.sorted())")
+
+        // A wrapping label reports no intrinsic width; the marked rows laid out
+        // 4pt wide and drew nothing until the cell was forced back to one line.
+        for row in controller.commandRows {
+            let label = row.subviews.compactMap { $0 as? NSStackView }.first?
+                .arrangedSubviews.compactMap { $0 as? NSTextField }.first
+            #expect((label?.frame.width ?? 0) >= (label?.intrinsicContentSize.width ?? 0),
+                    "'\(row.item.title)' is squeezed below its intrinsic width")
+        }
+        _ = doc
+    }
+
+    /// Markers that are literal Markdown syntax are set in the mono font they will
+    /// be typed in; the block quote's bar is greyed so it reads as a rule.
+    @Test func syntaxMarkersAreMonoAndTheQuoteBarIsGrey() {
+        let (bar, doc) = toolbar()
+        let items = bar.formatPopupMenu().items
+
+        func marker(_ suffix: String) -> (NSFont?, NSColor?) {
+            let item = items.first { $0.title.hasSuffix(suffix) }
+            let title = item?.attributedTitle
+            let attributes = title?.attributes(at: 0, effectiveRange: nil)
+            return (attributes?[.font] as? NSFont, attributes?[.foregroundColor] as? NSColor)
+        }
+
+        #expect(items.first { $0.title.hasSuffix("Code Block") }?.title.hasPrefix("```") == true)
+        #expect(items.first { $0.title.hasSuffix("Math Block") }?.title.hasPrefix("$") == true)
+        #expect(marker("Code Block").0?.isFixedPitch == true)
+        #expect(marker("Math Block").0?.isFixedPitch == true)
+        #expect(marker("Block Quote").1 == .secondaryLabelColor)
+        // The title itself stays in the menu font whatever its marker is.
+        let code = items.first { $0.title.hasSuffix("Code Block") }?.attributedTitle
+        let tail = code?.attributes(at: (code?.length ?? 1) - 1, effectiveRange: nil)
+        #expect((tail?[.font] as? NSFont)?.isFixedPitch == false)
+        _ = doc
+    }
+
+    /// Mouse-first panel: no key view loop, no focus rings, and no button carries
+    /// a tint of its own (the highlighter used to be drawn in yellow).
+    @Test func theIconRowIsMouseOnlyAndUntinted() {
+        let (bar, doc) = toolbar()
+        for row in bar.iconRowViews() {
+            for case let button as NSButton in row.arrangedSubviews {
+                #expect(button.focusRingType == .none)
+                #expect(button.refusesFirstResponder)
+                #expect(button.contentTintColor == nil, "\(button.toolTip ?? "?") is tinted")
+            }
+        }
+        _ = doc
+    }
+
     /// `formatHeading` reads its level from `(sender as? NSMenuItem)?.tag` and
     /// `formatCallout` its type from `representedObject`. Rows forward their
     /// item as the sender precisely so those survive — a row sending itself
@@ -354,8 +448,10 @@ import AppKit
     @Test func blockRowsMapToTheStyleTheyApply() {
         let (bar, doc) = toolbar()
         let menu = bar.formatPopupMenu()
+        // Matched on the suffix: a marked row's `title` carries its marker, since
+        // AppKit syncs `title` from whatever `attributedTitle` is set to.
         func style(ofRowTitled title: String) -> ActiveBlockStyle? {
-            menu.items.first { $0.title == title }.flatMap(FormatToolbar.blockStyle(for:))
+            menu.items.first { $0.title.hasSuffix(title) }.flatMap(FormatToolbar.blockStyle(for:))
         }
         #expect(style(ofRowTitled: "Heading 2") == .heading(level: 2))
         #expect(style(ofRowTitled: "•  Bulleted List") == .bulletedList)

--- a/Tests/EdmundTests/FormatToolbarTests.swift
+++ b/Tests/EdmundTests/FormatToolbarTests.swift
@@ -92,6 +92,15 @@ import AppKit
         _ = doc
     }
 
+    /// A tooltip names the command, never the secondary-click menu behind it —
+    /// AppKit does not advertise those, and the hint only shows once you are
+    /// already hovering the item you would have had to know about.
+    @Test func tooltipsDoNotAdvertiseTheSecondaryClickMenu() {
+        let (bar, doc) = toolbar()
+        #expect(bar.makeItem(FormatToolbar.link)?.toolTip == "Link")
+        _ = doc
+    }
+
     /// The other custom-view item is a real command and must still be gated,
     /// or the fix above would have blanket-enabled everything.
     @Test func theLinkButtonIsStillGated() {

--- a/Tests/EdmundTests/FormatToolbarTests.swift
+++ b/Tests/EdmundTests/FormatToolbarTests.swift
@@ -60,8 +60,9 @@ import AppKit
         let (bar, doc) = toolbar()
         #expect(titles(bar.formatPopupMenu()) == [
             "", "", "-",
-            "Heading", "Thematic Break", "Bulleted List", "Numbered List", "-",
-            "Code Block", "Math Block", "Block Quote", "Alert / Callout", "Footnote",
+            "Heading 1", "Heading 2", "Heading 3", "Thematic Break",
+            "•  Bulleted List", "1.  Numbered List", "-",
+            "Code Block", "Math Block", "▎ Block Quote", "> [!NOTE]", "Footnote",
         ])
         _ = doc
     }
@@ -76,14 +77,42 @@ import AppKit
         _ = doc
     }
 
-    @Test func headingAndCalloutKeepTheirSubmenus() {
+    /// The popup is the quick path, not a mirror of the Format menu: flat, with
+    /// headings stopping at 3 and one callout form.
+    @Test func popupIsEntirelyFlat() {
         let (bar, doc) = toolbar()
-        let menu = bar.formatPopupMenu()
-        let heading = menu.items.first { $0.title == "Heading" }
-        let callout = menu.items.first { $0.title == "Alert / Callout" }
-        #expect(heading?.submenu?.items.count == 6)          // H1–H6
-        #expect((callout?.submenu?.items.count ?? 0) > 5)    // GFM alerts + Obsidian types
+        for item in bar.formatPopupMenu().items {
+            #expect(item.submenu == nil, "\(item.title) still has a submenu")
+        }
         _ = doc
+    }
+
+    @Test func headingRowsCarryTheirLevelAndStopAtThree() {
+        let (bar, doc) = toolbar()
+        let headings = bar.formatPopupMenu().items.filter {
+            $0.action == #selector(EditorTextView.formatHeading(_:))
+        }
+        #expect(headings.map(\.tag) == [1, 2, 3])
+        // formatHeading reads the level off the sender's tag, so it must survive
+        // the attributedTitle styling.
+        #expect(headings.allSatisfy { $0.attributedTitle != nil })
+        _ = doc
+    }
+
+    @Test func theSingleCalloutRowInsertsANote() {
+        let (bar, doc) = toolbar()
+        let callout = bar.formatPopupMenu().items.first {
+            $0.action == #selector(EditorTextView.formatCallout(_:))
+        }
+        #expect(callout?.representedObject as? String == "NOTE")
+        _ = doc
+    }
+
+    /// The full H1–H6 range and all 20 callout types stay reachable in the menu
+    /// bar — the popup trimming them must not have trimmed those too.
+    @Test func theMenuBarStillOffersTheFullRange() {
+        #expect(FormatMenu.headingSubmenuItem().submenu?.items.count == 6)
+        #expect((FormatMenu.calloutSubmenuItem().submenu?.items.count ?? 0) > 15)
     }
 
     @Test func iconRowsCarryTheDocumentedCommands() {
@@ -119,6 +148,40 @@ import AppKit
             }
         }
         check(bar.formatPopupMenu())
+        _ = doc
+    }
+}
+
+@MainActor @Suite struct ActiveStateWiringTests {
+
+    /// Every icon-row button must map to a detectable style, or it can never
+    /// light up and the affordance silently lies.
+    @Test func everyIconRowButtonMapsToAStyle() {
+        let (bar, doc) = toolbar()
+        let rows = bar.formatPopupMenu().items.prefix(2).compactMap { $0.view as? NSStackView }
+        for row in rows {
+            for case let button as NSButton in row.arrangedSubviews {
+                let target = button.target as? FormatIconTarget
+                #expect(target.flatMap { FormatToolbar.style(for: $0.styleID) } != nil,
+                        "\(target?.styleID ?? "?") has no ActiveInlineStyles mapping")
+            }
+        }
+        _ = doc
+    }
+
+    @Test func blockRowsMapToTheStyleTheyApply() {
+        let (bar, doc) = toolbar()
+        let menu = bar.formatPopupMenu()
+        func style(ofRowTitled title: String) -> ActiveBlockStyle? {
+            menu.items.first { $0.title == title }.flatMap(FormatToolbar.blockStyle(for:))
+        }
+        #expect(style(ofRowTitled: "Heading 2") == .heading(level: 2))
+        #expect(style(ofRowTitled: "•  Bulleted List") == .bulletedList)
+        #expect(style(ofRowTitled: "▎ Block Quote") == .blockQuote)
+        #expect(style(ofRowTitled: "> [!NOTE]") == .callout)
+        #expect(style(ofRowTitled: "Code Block") == .codeBlock)
+        // Footnote is not a block style — it must not claim a checkmark.
+        #expect(style(ofRowTitled: "Footnote") == nil)
         _ = doc
     }
 }

--- a/Tests/EdmundTests/FormatToolbarTests.swift
+++ b/Tests/EdmundTests/FormatToolbarTests.swift
@@ -79,6 +79,17 @@ import AppKit
         _ = doc
     }
 
+    /// A plain image item draws bare and never highlights under the pointer
+    /// unless it is bordered, which left Checklist and Table looking dead beside
+    /// the custom-view items either side of them.
+    @Test func plainItemsAreBorderedSoTheyHighlightOnHover() {
+        let (bar, doc) = toolbar()
+        for id in [FormatToolbar.checklist, FormatToolbar.table] {
+            #expect(bar.makeItem(id)?.isBordered == true, "\(id.rawValue) will not highlight")
+        }
+        _ = doc
+    }
+
     /// The view-mode item stays with `Document`; FormatToolbar must decline it
     /// rather than vend an empty replacement.
     @Test func declinesTheViewModeItem() {
@@ -301,7 +312,7 @@ import AppKit
         controller.view.layoutSubtreeIfNeeded()
         var accent: CGColor?
         row.effectiveAppearance.performAsCurrentDrawingAppearance {
-            accent = NSColor.controlAccentColor.cgColor
+            accent = NSColor.selectedContentBackgroundColor.cgColor
         }
         #expect(row.highlight.layer?.backgroundColor == accent)
         #expect(label.textColor == .selectedMenuItemTextColor)
@@ -322,10 +333,13 @@ import AppKit
 
         var titleEdges: Set<CGFloat> = []
         var markerEdges: Set<CGFloat> = []
+        var unmarkedEdges: Set<CGFloat> = []
         for row in controller.commandRows {
             let fields = row.subviews.compactMap { $0 as? NSTextField }
             let title = try! #require(fields.first { $0.stringValue == row.item.title })
-            titleEdges.insert(title.alignmentRect(forFrame: title.frame).minX)
+            let hasMarker = FormatToolbar.marker(for: row.item) != nil || row.item.image != nil
+            let edge = title.alignmentRect(forFrame: title.frame).minX
+            if hasMarker { titleEdges.insert(edge) } else { unmarkedEdges.insert(edge) }
             // A wrapping label reports no intrinsic width; the styled rows once
             // laid out 4pt wide and drew nothing at all.
             #expect(title.frame.width >= title.intrinsicContentSize.width,
@@ -341,9 +355,13 @@ import AppKit
             }
         }
         #expect(titleEdges == [FormatPopoverRow.titleX],
-                "titles do not share a left edge: \(titleEdges.sorted())")
+                "marked titles do not share a left edge: \(titleEdges.sorted())")
         #expect(markerEdges == [FormatPopoverRow.markerX],
                 "markers do not share a left edge: \(markerEdges.sorted())")
+        // Notes starts an unmarked row's title on the marker edge, so the first
+        // glyph of every row — marker or letter — lands on one column.
+        #expect(unmarkedEdges == [FormatPopoverRow.markerX],
+                "unmarked titles are not on the marker edge: \(unmarkedEdges.sorted())")
         _ = doc
     }
 
@@ -382,6 +400,7 @@ import AppKit
         #expect(FormatToolbar.marker(for: item("Block Quote")) == "▎")
         #expect(FormatToolbar.marker(for: item("Bulleted List")) == "•")
         #expect(FormatToolbar.marker(for: item("Numbered List")) == "1.")
+        #expect(FormatToolbar.marker(for: item("Footnote")) == "†")
         // Titles are plain, so nothing a row draws leaks into its VoiceOver label.
         #expect(items.allSatisfy { $0.attributedTitle == nil })
         _ = doc

--- a/Tests/EdmundTests/FormatToolbarTests.swift
+++ b/Tests/EdmundTests/FormatToolbarTests.swift
@@ -29,6 +29,15 @@ import AppKit
                         "NSToolbarFlexibleSpaceItem", "viewMode", "share"])
     }
 
+    /// Centring is `centeredItemIdentifiers`, not flexible space — measured, a
+    /// leading flexible space swallowed all the slack and the group stayed right.
+    @Test func theFormattingGroupIsTheCentredSet() {
+        let ids = FormatToolbar.defaultIdentifiers(viewMode: viewMode)
+        #expect(FormatToolbar.centeredIdentifiers == Set(ids.prefix(5)))
+        #expect(!FormatToolbar.centeredIdentifiers.contains(viewMode))
+        #expect(!FormatToolbar.centeredIdentifiers.contains(FormatToolbar.share))
+    }
+
     @Test func everyDefaultItemIsAlsoAllowed() {
         let allowed = Set(FormatToolbar.allowedIdentifiers(viewMode: viewMode))
         for id in FormatToolbar.defaultIdentifiers(viewMode: viewMode) {
@@ -58,11 +67,11 @@ import AppKit
 
     @Test func rowOrderMatchesTheSpec() {
         let (bar, doc) = toolbar()
+        // Icon rows are views, not items — the popover stacks them above these.
         #expect(titles(bar.formatPopupMenu()) == [
-            "", "", "-",
             "Heading 1", "Heading 2", "Heading 3", "Thematic Break",
             "•  Bulleted List", "1.  Numbered List", "-",
-            "Code Block", "Math Block", "▎ Block Quote", "> [!NOTE]", "Footnote",
+            "Code Block", "Math Block", "▎ Block Quote", "Alert / Callout", "Footnote",
         ])
         _ = doc
     }
@@ -117,7 +126,7 @@ import AppKit
 
     @Test func iconRowsCarryTheDocumentedCommands() {
         let (bar, doc) = toolbar()
-        let rows = bar.formatPopupMenu().items.prefix(2).compactMap { $0.view as? NSStackView }
+        let rows = bar.iconRowViews()
         #expect(rows.count == 2)
 
         // Every row button funnels through the same forwarding target…
@@ -152,13 +161,109 @@ import AppKit
     }
 }
 
+@MainActor @Suite struct FormatPopoverTests {
+
+    /// The popover renders the same items the command table produces — the rows
+    /// are a view over them, not a second declaration.
+    @Test func buildsARowForEveryCommandItem() {
+        let (bar, doc) = toolbar()
+        let items = Array(bar.formatPopupMenu().items)
+        let controller = FormatPopoverController(items: items, editor: nil, popover: nil)
+        controller.loadView()
+
+        let rows = controller.commandRows
+        let expected = items.filter { !$0.isSeparatorItem }
+        #expect(rows.count == expected.count)
+        #expect(rows.map(\.item.title) == expected.map(\.title))
+        _ = doc
+    }
+
+    /// The icon rows are passed in as views. Routing them through
+    /// `NSMenuItem.view` instead left AppKit owning their layout and they
+    /// stacked at y=0 on top of the last command row.
+    @Test func iconRowsAreLaidOutAboveTheCommandRows() {
+        let (bar, doc) = toolbar()
+        let iconRows = bar.iconRowViews()
+        let controller = FormatPopoverController(iconRows: iconRows,
+                                                 items: Array(bar.formatPopupMenu().items),
+                                                 editor: nil, popover: nil)
+        controller.loadView()
+        controller.view.layoutSubtreeIfNeeded()
+
+        // Every row occupies its own vertical band — no two overlap.
+        let bands = (iconRows.map(\.self) as [NSView] + controller.commandRows)
+            .map { ($0.frame.minY, $0.frame.maxY) }
+            .sorted { $0.0 < $1.0 }
+        #expect(bands.allSatisfy { $0.1 > $0.0 }, "a row has zero height")
+        #expect(zip(bands, bands.dropFirst()).allSatisfy { $0.1 <= $1.0 },
+                "rows overlap: \(bands)")
+        _ = doc
+    }
+
+    /// `formatHeading` reads its level from `(sender as? NSMenuItem)?.tag` and
+    /// `formatCallout` its type from `representedObject`. Rows forward their
+    /// item as the sender precisely so those survive — a row sending itself
+    /// would silently apply Heading 1 and no callout at all.
+    @Test func rowsCarryTheMenuItemSoSenderStateSurvives() {
+        let (bar, doc) = toolbar()
+        let controller = FormatPopoverController(items: Array(bar.formatPopupMenu().items),
+                                                 editor: nil, popover: nil)
+        controller.loadView()
+
+        let heading2 = controller.commandRows.first { $0.item.title == "Heading 2" }
+        #expect(heading2?.item.tag == 2)
+
+        let callout = controller.commandRows.first { $0.item.title == "Alert / Callout" }
+        #expect(callout?.item.representedObject as? String == "NOTE")
+        _ = doc
+    }
+
+    @Test func rowsAreAccessibleAsButtons() {
+        let (bar, doc) = toolbar()
+        let controller = FormatPopoverController(items: Array(bar.formatPopupMenu().items),
+                                                 editor: nil, popover: nil)
+        controller.loadView()
+        for row in controller.commandRows {
+            #expect(row.accessibilityRole() == .button)
+            #expect(row.accessibilityLabel() == row.item.title)
+        }
+        _ = doc
+    }
+
+    @Test func theCalloutRowCarriesTheNoteIcon() {
+        let (bar, doc) = toolbar()
+        let callout = bar.formatPopupMenu().items.first {
+            $0.action == #selector(EditorTextView.formatCallout(_:))
+        }
+        #expect(callout?.image != nil)
+        _ = doc
+    }
+}
+
+@MainActor @Suite struct CalloutIconTests {
+
+    @Test func noteResolvesToAnIcon() {
+        #expect(Callout.icon(for: "note", color: .labelColor, pointSize: 14) != nil)
+    }
+
+    /// Case-insensitive, since the toolbar writes `[!NOTE]` uppercase.
+    @Test func lookupIsCaseInsensitive() {
+        #expect(Callout.icon(for: "NOTE", color: .labelColor, pointSize: 14) != nil)
+    }
+
+    @Test func unknownTypeHasNoIcon() {
+        #expect(Callout.icon(for: "not-a-callout", color: .labelColor, pointSize: 14) == nil)
+    }
+}
+
 @MainActor @Suite struct ActiveStateWiringTests {
 
     /// Every icon-row button must map to a detectable style, or it can never
     /// light up and the affordance silently lies.
     @Test func everyIconRowButtonMapsToAStyle() {
         let (bar, doc) = toolbar()
-        let rows = bar.formatPopupMenu().items.prefix(2).compactMap { $0.view as? NSStackView }
+        let rows = bar.iconRowViews()
+        #expect(rows.count == 2)
         for row in rows {
             for case let button as NSButton in row.arrangedSubviews {
                 let target = button.target as? FormatIconTarget
@@ -178,7 +283,7 @@ import AppKit
         #expect(style(ofRowTitled: "Heading 2") == .heading(level: 2))
         #expect(style(ofRowTitled: "•  Bulleted List") == .bulletedList)
         #expect(style(ofRowTitled: "▎ Block Quote") == .blockQuote)
-        #expect(style(ofRowTitled: "> [!NOTE]") == .callout)
+        #expect(style(ofRowTitled: "Alert / Callout") == .callout)
         #expect(style(ofRowTitled: "Code Block") == .codeBlock)
         // Footnote is not a block style — it must not claim a checkmark.
         #expect(style(ofRowTitled: "Footnote") == nil)

--- a/Tests/EdmundTests/FormatToolbarTests.swift
+++ b/Tests/EdmundTests/FormatToolbarTests.swift
@@ -215,13 +215,65 @@ import AppKit
         controller.loadView()
         controller.view.layoutSubtreeIfNeeded()
 
-        // Every row occupies its own vertical band — no two overlap.
-        let bands = (iconRows.map(\.self) as [NSView] + controller.commandRows)
-            .map { ($0.frame.minY, $0.frame.maxY) }
+        // Every row occupies its own vertical band — no two overlap. The icon rows
+        // sit inside the grid block, so their frames need converting first.
+        let bands = ((iconRows.map(\.self) as [NSView]) + controller.commandRows)
+            .map { $0.convert($0.bounds, to: controller.view) }
+            .map { ($0.minY, $0.maxY) }
             .sorted { $0.0 < $1.0 }
         #expect(bands.allSatisfy { $0.1 > $0.0 }, "a row has zero height")
         #expect(zip(bands, bands.dropFirst()).allSatisfy { $0.1 <= $1.0 },
                 "rows overlap: \(bands)")
+        _ = doc
+    }
+
+    /// Notes gives every row the same height whatever type it previews; ours used
+    /// to size each row to its own font, so the heading rows towered over the rest.
+    @Test func everyCommandRowIsTheSameHeight() {
+        let (bar, doc) = toolbar()
+        let controller = FormatPopoverController(iconRows: bar.iconRowViews(),
+                                                 items: Array(bar.formatPopupMenu().items),
+                                                 editor: nil, popover: nil)
+        controller.loadView()
+        controller.view.layoutSubtreeIfNeeded()
+
+        let heights = Set(controller.commandRows.map(\.frame.height))
+        #expect(heights == [FormatPopoverRow.rowHeight], "ragged rows: \(heights.sorted())")
+        _ = doc
+    }
+
+    /// The popover is as wide as its widest band and no wider, the dividers stop
+    /// short of both sides, and the icon grid — which is that widest band — keeps
+    /// its two rows on a shared left edge.
+    @Test func thePopoverFitsItsContentAndInsetsItsDividers() {
+        let (bar, doc) = toolbar()
+        let iconRows = bar.iconRowViews()
+        let controller = FormatPopoverController(iconRows: iconRows,
+                                                 items: Array(bar.formatPopupMenu().items),
+                                                 editor: nil, popover: nil)
+        controller.loadView()
+        controller.view.layoutSubtreeIfNeeded()
+
+        let stack = controller.view.subviews.first as? NSStackView
+        let bands = stack?.arrangedSubviews ?? []
+        // Snug: no band is cut off, and none of the width is unclaimed either.
+        let widest = bands.map(\.fittingSize.width).max() ?? 0
+        #expect(controller.view.frame.width == ceil(widest),
+                "popover is \(controller.view.frame.width) for a \(widest) widest band")
+        #expect(widest >= (controller.commandRows.map(\.fittingSize.width).max() ?? 0))
+
+        // Separator containers span the popover; the hairline inside does not.
+        let separators = bands
+            .filter { $0.subviews.first is NSBox }
+        #expect(separators.count == 2)
+        for separator in separators {
+            let box = separator.subviews[0]
+            #expect(box.frame.minX > separator.frame.minX)
+            #expect(box.frame.maxX < separator.frame.maxX)
+        }
+
+        #expect(Set(iconRows.map(\.frame.minX)).count == 1,
+                "icon rows are not on a shared left edge")
         _ = doc
     }
 

--- a/Tests/EdmundTests/FormatToolbarTests.swift
+++ b/Tests/EdmundTests/FormatToolbarTests.swift
@@ -54,6 +54,31 @@ import AppKit
         _ = doc
     }
 
+    /// `validate()` gates formatting commands on the caret. The Format item's
+    /// action only opens a popover, so nothing in the responder chain answers it
+    /// — gating it there disabled the button permanently.
+    @Test func theFormatButtonIsNotGatedOnAFormattingAction() {
+        let (bar, doc) = toolbar()
+        let item = bar.makeItem(FormatToolbar.format) as? FormatButtonItem
+        let button = item?.view as? NSButton
+        button?.isEnabled = false
+        item?.validate()
+        #expect(button?.isEnabled == true)
+        _ = doc
+    }
+
+    /// The other custom-view item is a real command and must still be gated,
+    /// or the fix above would have blanket-enabled everything.
+    @Test func theLinkButtonIsStillGated() {
+        let (bar, doc) = toolbar()
+        let item = bar.makeItem(FormatToolbar.link) as? FormatButtonItem
+        let button = item?.view as? NSButton
+        button?.isEnabled = true
+        item?.validate()   // no editor is first responder here
+        #expect(button?.isEnabled == false)
+        _ = doc
+    }
+
     /// The view-mode item stays with `Document`; FormatToolbar must decline it
     /// rather than vend an empty replacement.
     @Test func declinesTheViewModeItem() {

--- a/Tests/EdmundTests/FormatToolbarTests.swift
+++ b/Tests/EdmundTests/FormatToolbarTests.swift
@@ -23,17 +23,42 @@ import AppKit
 
     private let viewMode = NSToolbarItem.Identifier("viewMode")
 
+    /// The default bar is the one that shipped: view-mode alone, on the right.
     @Test func defaultOrderMatchesTheSpec() {
         let ids = FormatToolbar.defaultIdentifiers(viewMode: viewMode).map(\.rawValue)
-        #expect(ids == ["format", "checklist", "table", "image", "link",
-                        "NSToolbarFlexibleSpaceItem", "viewMode", "share"])
+        #expect(ids == ["NSToolbarFlexibleSpaceItem", "viewMode"])
+    }
+
+    /// The point sizes are per symbol precisely so the drawn glyphs match; a
+    /// single shared size is what left checklist and tablecells 3–5pt bigger than
+    /// the rest. `textformat` is exempt: "Aa" is wide and short, and matching its
+    /// width to the others made it read oversized.
+    @Test func everyToolbarSymbolDrawsTheSameSize() throws {
+        let extents = try ["checklist", "tablecells", "photo.on.rectangle",
+                           "link.badge.plus"].map {
+            ($0, inkExtent(try #require(FormatToolbar.symbol($0))))
+        }
+        let sizes = extents.map(\.1)
+        #expect(sizes.max()! - sizes.min()! <= 2,
+                "uneven row: \(extents.map { "\($0.0) \($0.1)pt" }.joined(separator: ", "))")
+    }
+
+    /// Off the default bar but still draggable in from Customize Toolbar.
+    @Test func theFormattingItemsStayAvailable() {
+        let allowed = Set(FormatToolbar.allowedIdentifiers(viewMode: viewMode))
+        for id in [FormatToolbar.format, FormatToolbar.checklist, FormatToolbar.table,
+                   FormatToolbar.image, FormatToolbar.link, FormatToolbar.share] {
+            #expect(allowed.contains(id), "\(id.rawValue) is not offered any more")
+        }
     }
 
     /// Centring is `centeredItemIdentifiers`, not flexible space — measured, a
     /// leading flexible space swallowed all the slack and the group stayed right.
+    /// It applies to whatever the user drags in, so it outlives the default bar.
     @Test func theFormattingGroupIsTheCentredSet() {
-        let ids = FormatToolbar.defaultIdentifiers(viewMode: viewMode)
-        #expect(FormatToolbar.centeredIdentifiers == Set(ids.prefix(5)))
+        #expect(FormatToolbar.centeredIdentifiers ==
+                [FormatToolbar.format, FormatToolbar.checklist, FormatToolbar.table,
+                 FormatToolbar.image, FormatToolbar.link])
         #expect(!FormatToolbar.centeredIdentifiers.contains(viewMode))
         #expect(!FormatToolbar.centeredIdentifiers.contains(FormatToolbar.share))
     }
@@ -593,6 +618,33 @@ import AppKit
     }
     guard let t = top, let b = bottom else { return 0 }
     return b - t + 1
+}
+
+/// The longer side of the ink in `image` — what the eye compares across a row of
+/// symbols whose bounding boxes differ (`tablecells` is wide, `checklist` tall).
+@MainActor private func inkExtent(_ image: NSImage) -> Int {
+    let side = 64
+    let rep = NSBitmapImageRep(bitmapDataPlanes: nil, pixelsWide: side, pixelsHigh: side,
+                               bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true,
+                               isPlanar: false, colorSpaceName: .deviceRGB,
+                               bytesPerRow: 0, bitsPerPixel: 0)!
+    NSGraphicsContext.saveGraphicsState()
+    NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
+    let size = image.size
+    image.draw(in: NSRect(x: (CGFloat(side) - size.width) / 2,
+                          y: (CGFloat(side) - size.height) / 2,
+                          width: size.width, height: size.height))
+    NSGraphicsContext.restoreGraphicsState()
+
+    var minX = side, maxX = -1, minY = side, maxY = -1
+    for y in 0..<side {
+        for x in 0..<side where (rep.colorAt(x: x, y: y)?.alphaComponent ?? 0) > 0.1 {
+            minX = min(minX, x); maxX = max(maxX, x)
+            minY = min(minY, y); maxY = max(maxY, y)
+        }
+    }
+    guard maxX >= 0 else { return 0 }
+    return max(maxX - minX, maxY - minY) + 1
 }
 
 @MainActor @Suite struct ViewModeGlyphSizeTests {

--- a/Tests/EdmundTests/FormatToolbarTests.swift
+++ b/Tests/EdmundTests/FormatToolbarTests.swift
@@ -95,8 +95,8 @@ import AppKit
         // Icon rows are views, not items — the popover stacks them above these.
         #expect(titles(bar.formatPopupMenu()) == [
             "Heading 1", "Heading 2", "Heading 3", "Thematic Break",
-            "•  Bulleted List", "1.  Numbered List", "-",
-            "```  Code Block", "$  Math Block", "▎ Block Quote",
+            "Bulleted List", "Numbered List", "-",
+            "Code Block", "Math Block", "Block Quote",
             "Alert / Callout", "Footnote",
         ])
         _ = doc
@@ -128,9 +128,12 @@ import AppKit
             $0.action == #selector(EditorTextView.formatHeading(_:))
         }
         #expect(headings.map(\.tag) == [1, 2, 3])
-        // formatHeading reads the level off the sender's tag, so it must survive
-        // the attributedTitle styling.
-        #expect(headings.allSatisfy { $0.attributedTitle != nil })
+        // The row's font previews the level, and it is read off that same tag —
+        // so a heading whose tag was lost would also lose its preview.
+        #expect(headings.map { FormatToolbar.titleFont(for: $0).pointSize } == [18, 15.5, 13])
+        // Plain titles: a marker or a weight baked into an `attributedTitle`
+        // becomes the item's `title`, and from there its VoiceOver label.
+        #expect(headings.allSatisfy { $0.attributedTitle == nil })
         _ = doc
     }
 
@@ -278,9 +281,10 @@ import AppKit
         _ = doc
     }
 
-    /// The hover tint is the accent colour on an inset view, so it stops short of
-    /// the popover's rounded sides the way the dividers do.
-    @Test func theHoverHighlightIsInsetAndAccentTinted() {
+    /// The hover tint is the accent colour at full strength on an inset view, so
+    /// it stops short of the popover's rounded sides the way the dividers do, and
+    /// the row's contents flip to the colour AppKit uses on an accent-filled row.
+    @Test func theHoverHighlightIsInsetAccentFilledAndFlipsTheText() {
         let (bar, doc) = toolbar()
         let controller = FormatPopoverController(items: Array(bar.formatPopupMenu().items),
                                                  editor: nil, popover: nil)
@@ -288,86 +292,161 @@ import AppKit
         controller.view.layoutSubtreeIfNeeded()
 
         let row = try! #require(controller.commandRows.first)
+        let label = try! #require(row.subviews.compactMap { $0 as? NSTextField }
+            .first { $0.stringValue == row.item.title })
         #expect(row.highlight.layer?.backgroundColor == nil, "tinted before hover")
+        #expect(label.textColor == .labelColor)
 
         row.isHovered = true
         controller.view.layoutSubtreeIfNeeded()
         var accent: CGColor?
         row.effectiveAppearance.performAsCurrentDrawingAppearance {
-            accent = NSColor.controlAccentColor.withAlphaComponent(0.18).cgColor
+            accent = NSColor.controlAccentColor.cgColor
         }
         #expect(row.highlight.layer?.backgroundColor == accent)
+        #expect(label.textColor == .selectedMenuItemTextColor)
         #expect(row.highlight.frame.minX > row.frame.minX)
         #expect(row.highlight.frame.maxX < row.frame.maxX)
         _ = doc
     }
 
-    /// Notes reserves the tick's gutter whether or not a row is ticked. Hiding the
-    /// checkmark instead dropped it out of the stack and the titles slid left.
-    @Test func everyTitleSitsOnTheSameLeftEdgeUnticked() {
+    /// Three fixed columns — tick, marker, title — so a `1.` no more shifts its
+    /// own title than a bare row does, and the markers share an edge with each
+    /// other instead of each hanging off the front of its own text.
+    @Test func everyRowSharesTheSameThreeColumns() {
         let (bar, doc) = toolbar()
         let controller = FormatPopoverController(items: Array(bar.formatPopupMenu().items),
                                                  editor: nil, popover: nil)
         controller.loadView()
         controller.view.layoutSubtreeIfNeeded()
 
-        // The callout row carries an icon of its own, so it is legitimately inset
-        // further; every other title shares one edge.
-        let edges = Set(controller.commandRows
-            .filter { $0.item.image == nil }
-            .compactMap { row in
-                row.subviews.compactMap { $0 as? NSStackView }.first?
-                    .arrangedSubviews.compactMap { $0 as? NSTextField }.first?.frame.minX
-            })
-        #expect(edges.count == 1, "titles do not share a left edge: \(edges.sorted())")
-
-        // A wrapping label reports no intrinsic width; the marked rows laid out
-        // 4pt wide and drew nothing until the cell was forced back to one line.
+        var titleEdges: Set<CGFloat> = []
+        var markerEdges: Set<CGFloat> = []
         for row in controller.commandRows {
-            let label = row.subviews.compactMap { $0 as? NSStackView }.first?
-                .arrangedSubviews.compactMap { $0 as? NSTextField }.first
-            #expect((label?.frame.width ?? 0) >= (label?.intrinsicContentSize.width ?? 0),
+            let fields = row.subviews.compactMap { $0 as? NSTextField }
+            let title = try! #require(fields.first { $0.stringValue == row.item.title })
+            titleEdges.insert(title.alignmentRect(forFrame: title.frame).minX)
+            // A wrapping label reports no intrinsic width; the styled rows once
+            // laid out 4pt wide and drew nothing at all.
+            #expect(title.frame.width >= title.intrinsicContentSize.width,
                     "'\(row.item.title)' is squeezed below its intrinsic width")
+
+            for marker in fields where marker !== title && !marker.stringValue.isEmpty {
+                markerEdges.insert(marker.alignmentRect(forFrame: marker.frame).minX)
+            }
+            // The callout's glyph shares the marker gutter — no row has both.
+            if let icon = row.subviews.compactMap({ $0 as? NSImageView })
+                .first(where: { !$0.isHidden && $0.image === row.item.image }) {
+                markerEdges.insert(icon.frame.minX)
+            }
+        }
+        #expect(titleEdges == [FormatPopoverRow.titleX],
+                "titles do not share a left edge: \(titleEdges.sorted())")
+        #expect(markerEdges == [FormatPopoverRow.markerX],
+                "markers do not share a left edge: \(markerEdges.sorted())")
+        _ = doc
+    }
+
+    /// The row is one button. A text field consumes the click that lands on it,
+    /// and the heading previews are tall enough to cover almost their whole row —
+    /// so before the hit test was overridden those rows could not be clicked.
+    @Test func aClickOnATitleReachesTheRow() {
+        let (bar, doc) = toolbar()
+        let controller = FormatPopoverController(items: Array(bar.formatPopupMenu().items),
+                                                 editor: nil, popover: nil)
+        controller.loadView()
+        controller.view.layoutSubtreeIfNeeded()
+
+        for row in controller.commandRows {
+            for field in row.subviews.compactMap({ $0 as? NSTextField })
+            where !field.stringValue.isEmpty {
+                let point = row.convert(NSPoint(x: field.frame.midX, y: field.frame.midY),
+                                        to: row.superview)
+                #expect(row.hitTest(point) === row,
+                        "'\(row.item.title)' swallows the click on '\(field.stringValue)'")
+            }
         }
         _ = doc
     }
 
-    /// Markers that are literal Markdown syntax are set in the mono font they will
-    /// be typed in; the block quote's bar is greyed so it reads as a rule.
-    @Test func syntaxMarkersAreMonoAndTheQuoteBarIsGrey() {
+    /// `$` is Markdown syntax and is shown in the face it is typed in; Code Block
+    /// previews itself through its whole title instead of a ``` prefix.
+    @Test func syntaxIsPreviewedInTheMonoFace() {
         let (bar, doc) = toolbar()
         let items = bar.formatPopupMenu().items
 
-        func marker(_ suffix: String) -> (NSFont?, NSColor?) {
-            let item = items.first { $0.title.hasSuffix(suffix) }
-            let title = item?.attributedTitle
-            let attributes = title?.attributes(at: 0, effectiveRange: nil)
-            return (attributes?[.font] as? NSFont, attributes?[.foregroundColor] as? NSColor)
-        }
-
-        #expect(items.first { $0.title.hasSuffix("Code Block") }?.title.hasPrefix("```") == true)
-        #expect(items.first { $0.title.hasSuffix("Math Block") }?.title.hasPrefix("$") == true)
-        #expect(marker("Code Block").0?.isFixedPitch == true)
-        #expect(marker("Math Block").0?.isFixedPitch == true)
-        #expect(marker("Block Quote").1 == .secondaryLabelColor)
-        // The title itself stays in the menu font whatever its marker is.
-        let code = items.first { $0.title.hasSuffix("Code Block") }?.attributedTitle
-        let tail = code?.attributes(at: (code?.length ?? 1) - 1, effectiveRange: nil)
-        #expect((tail?[.font] as? NSFont)?.isFixedPitch == false)
+        func item(_ title: String) -> NSMenuItem { items.first { $0.title == title }! }
+        #expect(FormatToolbar.titleFont(for: item("Code Block")).isFixedPitch)
+        #expect(FormatToolbar.marker(for: item("Code Block")) == nil)
+        #expect(FormatToolbar.marker(for: item("Math Block")) == "$")
+        #expect(FormatToolbar.marker(for: item("Block Quote")) == "▎")
+        #expect(FormatToolbar.marker(for: item("Bulleted List")) == "•")
+        #expect(FormatToolbar.marker(for: item("Numbered List")) == "1.")
+        // Titles are plain, so nothing a row draws leaks into its VoiceOver label.
+        #expect(items.allSatisfy { $0.attributedTitle == nil })
         _ = doc
     }
 
-    /// Mouse-first panel: no key view loop, no focus rings, and no button carries
-    /// a tint of its own (the highlighter used to be drawn in yellow).
-    @Test func theIconRowIsMouseOnlyAndUntinted() {
+    /// The grid is one band among the others: its gap to the divider beneath has
+    /// to be the gap every other section has. It came out 12pt wider because the
+    /// popover was sized taller than its own content, and the grid — the one band
+    /// with no height of its own — absorbed all the slack.
+    @Test func theGridSitsAsCloseToItsDividerAsAnyRow() {
         let (bar, doc) = toolbar()
-        for row in bar.iconRowViews() {
-            for case let button as NSButton in row.arrangedSubviews {
+        let controller = FormatPopoverController(iconRows: bar.iconRowViews(),
+                                                 items: Array(bar.formatPopupMenu().items),
+                                                 editor: nil, popover: nil)
+        controller.loadView()
+        controller.view.layoutSubtreeIfNeeded()
+
+        let stack = try! #require(controller.view.subviews.first as? NSStackView)
+        #expect(controller.view.frame.height == stack.fittingSize.height,
+                "the popover is taller than its content, so a band is being stretched")
+
+        // Every band sitting above a divider must clear it by the same amount.
+        let bands = stack.arrangedSubviews
+        var gaps: Set<CGFloat> = []
+        for (band, next) in zip(bands, bands.dropFirst()) where next.subviews.first is NSBox {
+            gaps.insert(band.frame.minY - next.convert(next.subviews[0].frame, to: stack).maxY)
+        }
+        #expect(gaps.count == 1, "uneven gaps above the dividers: \(gaps.sorted())")
+        _ = doc
+    }
+
+    /// Mouse-first panel: no key view loop and no focus rings. Every button draws
+    /// in the label colour until it is on — the highlighter used to carry a
+    /// yellow of its own — and every hover chip is the size the constraints say,
+    /// which needs the bezel insets AppKit varies per symbol zeroed out.
+    @Test func theIconRowIsMouseOnlyUntintedAndEvenlySized() {
+        let (bar, doc) = toolbar()
+        let rows = bar.iconRowViews()
+        for row in rows {
+            for case let button as FormatIconButton in row.arrangedSubviews {
                 #expect(button.focusRingType == .none)
                 #expect(button.refusesFirstResponder)
-                #expect(button.contentTintColor == nil, "\(button.toolTip ?? "?") is tinted")
+                #expect(button.contentTintColor == .labelColor,
+                        "\(button.toolTip ?? "?") is tinted")
+                let insets = button.alignmentRectInsets
+                #expect(insets.top == 0 && insets.bottom == 0
+                        && insets.left == 0 && insets.right == 0)
             }
+            row.layoutSubtreeIfNeeded()
         }
+        let sizes = Set(rows.flatMap { $0.arrangedSubviews.map { NSStringFromSize($0.frame.size) } })
+        #expect(sizes.count == 1, "ragged buttons: \(sizes.sorted())")
+        _ = doc
+    }
+
+    /// `function` draws ƒ(x), far wider than anything else in the grid.
+    @Test func theMathButtonUsesTheNarrowPiGlyph() {
+        let (bar, doc) = toolbar()
+        let math = bar.iconRowViews()[1].arrangedSubviews
+            .compactMap { $0 as? NSButton }
+            .first { (($0.target as? FormatIconTarget)?.styleID) == "format.math" }
+        // A symbol image loses its name once configured, so it is identified by
+        // the extent it draws: `function` is the wide one this replaced.
+        #expect(math?.image?.size == FormatToolbar.rowSymbol("pi")?.size)
+        #expect(math?.image?.size != FormatToolbar.rowSymbol("function")?.size)
         _ = doc
     }
 
@@ -448,14 +527,12 @@ import AppKit
     @Test func blockRowsMapToTheStyleTheyApply() {
         let (bar, doc) = toolbar()
         let menu = bar.formatPopupMenu()
-        // Matched on the suffix: a marked row's `title` carries its marker, since
-        // AppKit syncs `title` from whatever `attributedTitle` is set to.
         func style(ofRowTitled title: String) -> ActiveBlockStyle? {
-            menu.items.first { $0.title.hasSuffix(title) }.flatMap(FormatToolbar.blockStyle(for:))
+            menu.items.first { $0.title == title }.flatMap(FormatToolbar.blockStyle(for:))
         }
         #expect(style(ofRowTitled: "Heading 2") == .heading(level: 2))
-        #expect(style(ofRowTitled: "•  Bulleted List") == .bulletedList)
-        #expect(style(ofRowTitled: "▎ Block Quote") == .blockQuote)
+        #expect(style(ofRowTitled: "Bulleted List") == .bulletedList)
+        #expect(style(ofRowTitled: "Block Quote") == .blockQuote)
         #expect(style(ofRowTitled: "Alert / Callout") == .callout)
         #expect(style(ofRowTitled: "Code Block") == .codeBlock)
         // Footnote is not a block style — it must not claim a checkmark.

--- a/Tests/EdmundTests/FormatToolbarTests.swift
+++ b/Tests/EdmundTests/FormatToolbarTests.swift
@@ -493,6 +493,30 @@ import AppKit
         _ = doc
     }
 
+    /// Every glyph the toolbar and the icon rows ask for has to exist on the
+    /// oldest macOS this app supports, or the control draws blank there. Nothing
+    /// local catches that — the dev machine has the newer symbol set — so this
+    /// runs the lookup for all of them and CI, which is macos-14, is the check.
+    @Test func everyGlyphResolvesOnTheOldestSupportedOS() {
+        let (bar, doc) = toolbar()
+        let viewMode = NSToolbarItem.Identifier("viewMode")
+        // Share draws AppKit's own icon and view-mode belongs to `Document`, so
+        // neither has a glyph of ours to check.
+        for id in FormatToolbar.allowedIdentifiers(viewMode: viewMode)
+        where id != .space && id != .flexibleSpace && id != FormatToolbar.share && id != viewMode {
+            let item = bar.makeItem(id)
+            let image = item?.image ?? (item?.view as? NSButton)?.image
+            #expect((image?.size.width ?? 0) > 0, "\(id.rawValue) has no glyph")
+        }
+        for row in bar.iconRowViews() {
+            for case let button as NSButton in row.arrangedSubviews {
+                let label = button.toolTip ?? "?"
+                #expect((button.image?.size.width ?? 0) > 0, "\(label) has no glyph")
+            }
+        }
+        _ = doc
+    }
+
     /// `function` draws ƒ(x), far wider than anything else in the grid.
     @Test func theMathButtonUsesTheNarrowPiGlyph() {
         let (bar, doc) = toolbar()
@@ -503,6 +527,12 @@ import AppKit
         // the extent it draws: `function` is the wide one this replaced.
         #expect(math?.image?.size == FormatToolbar.rowSymbol("pi")?.size)
         #expect(math?.image?.size != FormatToolbar.rowSymbol("function")?.size)
+        // The bug this guards: `pi` is an SF Symbols 6 name, so on macOS 14 the
+        // lookup returns nil and the button draws an empty image. It is now a
+        // drawn glyph, which every supported version has.
+        #expect((math?.image?.size.width ?? 0) > 0)
+        #expect((math?.image?.size.height ?? 0) > 0)
+        #expect(math?.image?.isTemplate == true, "would not tint on the accent fill")
         _ = doc
     }
 

--- a/Tests/EdmundTests/FormattingTests.swift
+++ b/Tests/EdmundTests/FormattingTests.swift
@@ -556,3 +556,125 @@ private func mk(_ content: String, _ sel: NSRange) -> EditorTextView {
         #expect(e.rawSource.contains("Line"))
     }
 }
+
+// MARK: - Subscript / superscript
+//
+// `sub` and `sup` are already in SyntaxHighlighter.htmlFormatTags, so the editor
+// renders them; these cover the commands that write them.
+
+@MainActor @Suite struct FormatSubSuperscriptTests {
+
+    @Test func subscriptWrapsSelection() {
+        let e = mk("H2O", NSRange(location: 1, length: 1))
+        e.formatSubscript(nil)
+        #expect(e.rawSource == "H<sub>2</sub>O")
+        #expect(e.selectedRange() == NSRange(location: 6, length: 1))
+    }
+
+    @Test func subscriptIsInvertible() {
+        let e = mk("H2O", NSRange(location: 1, length: 1))
+        e.formatSubscript(nil)
+        e.formatSubscript(nil)
+        #expect(e.rawSource == "H2O")
+        #expect(e.selectedRange() == NSRange(location: 1, length: 1))
+    }
+
+    @Test func superscriptWrapsWordAtCaret() {
+        let e = mk("x squared", NSRange(location: 4, length: 0))  // "x sq|uared"
+        e.formatSuperscript(nil)
+        #expect(e.rawSource == "x <sup>squared</sup>")
+        e.formatSuperscript(nil)
+        #expect(e.rawSource == "x squared")
+    }
+
+    @Test func superscriptIsIndependentOfSubscript() {
+        let e = mk("n", NSRange(location: 0, length: 1))
+        e.formatSuperscript(nil)
+        #expect(e.rawSource == "<sup>n</sup>")
+    }
+}
+
+// MARK: - Attach image
+
+@MainActor @Suite struct FormatAttachImageTests {
+
+    /// `imageDestination` reads the document's directory, so the editor needs a
+    /// document with a fileURL. `EditorTextView.document` is weak — the caller
+    /// must hold on to the returned document for the life of the test.
+    private func editorInDocument(at path: String, _ content: String = "",
+                                  _ sel: NSRange = NSRange(location: 0, length: 0))
+    -> (EditorTextView, NSDocument) {
+        let e = mk(content, sel)
+        let doc = NSDocument()
+        doc.fileURL = URL(fileURLWithPath: path)
+        e.document = doc
+        return (e, doc)
+    }
+
+    @Test func pathBelowDocumentIsRelative() {
+        let (e, doc) = editorInDocument(at: "/notes/journal.md")
+        #expect(e.imageDestination(for: URL(fileURLWithPath: "/notes/img/cat.png")) == "img/cat.png")
+        _ = doc
+    }
+
+    @Test func siblingFileIsRelative() {
+        let (e, doc) = editorInDocument(at: "/notes/journal.md")
+        #expect(e.imageDestination(for: URL(fileURLWithPath: "/notes/cat.png")) == "cat.png")
+        _ = doc
+    }
+
+    @Test func pathOutsideDocumentDirectoryStaysAbsolute() {
+        let (e, doc) = editorInDocument(at: "/notes/journal.md")
+        #expect(e.imageDestination(for: URL(fileURLWithPath: "/elsewhere/cat.png"))
+                == "/elsewhere/cat.png")
+        _ = doc
+    }
+
+    /// A sibling *directory* whose name merely starts with the document's
+    /// directory name must not be mistaken for a child ("/notes" vs "/notesx").
+    @Test func siblingDirectoryWithSharedPrefixStaysAbsolute() {
+        let (e, doc) = editorInDocument(at: "/notes/journal.md")
+        #expect(e.imageDestination(for: URL(fileURLWithPath: "/notesx/cat.png"))
+                == "/notesx/cat.png")
+        _ = doc
+    }
+
+    /// A raw space or `)` would truncate the `![](…)` destination.
+    @Test func spacesAndParensArePercentEncoded() {
+        let (e, doc) = editorInDocument(at: "/notes/journal.md")
+        #expect(e.imageDestination(for: URL(fileURLWithPath: "/notes/my cat (1).png"))
+                == "my%20cat%20%281%29.png")
+        _ = doc
+    }
+
+    /// Round-trips through the same decode Read mode uses to resolve the path.
+    @Test func encodedDestinationDecodesBackToTheFilename() {
+        let (e, doc) = editorInDocument(at: "/notes/journal.md")
+        let dest = e.imageDestination(for: URL(fileURLWithPath: "/notes/my cat (1).png"))
+        #expect(dest.removingPercentEncoding == "my cat (1).png")
+        _ = doc
+    }
+
+    @Test func insertsSyntaxWithCaretInAltSlot() {
+        let (e, doc) = editorInDocument(at: "/notes/journal.md")
+        e.insertImage(at: URL(fileURLWithPath: "/notes/cat.png"))
+        #expect(e.rawSource == "![](cat.png)")
+        #expect(e.selectedRange() == NSRange(location: 2, length: 0))  // "![|](cat.png)"
+        _ = doc
+    }
+
+    @Test func insertsAtTheCaretWithinExistingText() {
+        let (e, doc) = editorInDocument(at: "/notes/journal.md", "see ", NSRange(location: 4, length: 0))
+        e.insertImage(at: URL(fileURLWithPath: "/notes/cat.png"))
+        #expect(e.rawSource == "see ![](cat.png)")
+        _ = doc
+    }
+
+    @Test func storageMatchesOracleAfterInsert() {
+        let (e, doc) = editorInDocument(at: "/notes/journal.md", "see ", NSRange(location: 4, length: 0))
+        e.insertImage(at: URL(fileURLWithPath: "/notes/cat.png"))
+        drainAllStyling(e)
+        assertMatchesFullRecomposeOracle(e)
+        _ = doc
+    }
+}


### PR DESCRIPTION
Populates the formatting toolbar and replaces the format popup menu with an
Apple Notes-style popover, plus the commands and caret detection behind them.

The default toolbar is unchanged from what ships today — flexible space and
the view-mode button, alone on the right. Everything here is opt-in through
Customize Toolbar, so nobody's bar changes without them asking.

## What's in it

**Toolbar items** — Format, Checklist, Table, Image, Link, Share. All in the
allowed set; `centeredItemIdentifiers` centres the formatting group for anyone
who drags it in (flexible space does not: measured on a 1500pt window, a
leading one absorbed all 1077pt of slack and the group stayed right).

**Format popover** — replaces the `NSMenu` popup. Two icon rows (bold, italic,
underline, strikethrough, highlight; code, math, subscript, superscript) over
the block styles, with the caret's active inline styles filled in the accent
and the active block style checkmarked. Rows share three fixed columns —
checkmark, marker, title — so `•`, `1.`, `▎`, `$`, `†` and the callout pencil
all line up on one left edge however wide each is. Titles preview what they
apply: headings step down in size, Code Block is set in the mono face.

**New commands** — `formatSubscript`, `formatSuperscript`, `formatAttachImage`,
plus `EditorTextView+ActiveStyles` for the caret detection the popover reads.

**Tooltips** follow the platform convention: no secondary-click hints (AppKit
does not advertise those — Safari's back button holds a history menu and says
only "Show the previous page"), and the view-mode tooltip names the action the
click performs, flipping "Switch to Read View" / "Switch to Edit View" with
the state rather than stating the state back.

**`logtoolbar`/`logwindows` repro commands** — report toolbar item state and
tooltips, and each window's `NSWindow.windowNumber`, which is the CGWindowID
`screencapture -l` takes. A freshly built binary has no Screen Recording grant
of its own, so having the app report its own window id is the only way to grab
one from a script.

## Verification

- `swift test` — 1364 tests in 194 suites green.
- Live `screencapture` of the toolbar and the popover in light and dark, with
  the icon extents and row geometry measured against Apple Notes' own popup
  (`misc/frontend-refs/notes-toolbar-format-menu.png`, scale taken from the
  12pt traffic lights).
- Popover row and icon clicks driven through the ReproScript harness, asserted
  against the resulting source.
- Not verified live: hover highlight on the plain Checklist/Table items. Real
  mouse input cannot be driven in this environment; `isBordered` is the
  documented API for it and is asserted headlessly.

## Merged with main's format bar

Main's Mail-style format bar landed while this branch was out, bringing a
second "which formatting is in effect here" scan and its own
`formatSubscript`/`formatSuperscript`. Both surfaces now read **one** scan:
main's delimiter version, kept under this branch's clearer file name
`EditorTextView+ActiveStyles.swift`, extended with the fenced code/math block
case a line scan cannot see. The popover's state wiring follows the format
bar's shape, and the menu-era delegate helpers that read the old API are gone.

Toolbar and format bar are complementary: the bar is hidden by default, the
toolbar group is off the default bar and dragged in from Customize Toolbar.
