### PR TITLE
fix(scroll): keep the caret measurable at the document's end

### DIFF
--- a/Sources/EdmundCore/TextView/EditorTextView+TypewriterScroll.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView+TypewriterScroll.swift
@@ -260,7 +260,15 @@ extension EditorTextView {
         guard let loc = tlm.location(tlm.documentRange.location, offsetBy: offset)
         else { return nil }
         tlm.ensureLayout(for: NSTextRange(location: loc))
-        guard let fragment = tlm.textLayoutFragment(for: loc) else { return nil }
+        // TextKit 2 has no fragment *at* `documentRange.endLocation` — the caret
+        // there belongs to the last fragment (whose final line fragment is the
+        // empty trailing line when the document ends with a newline). Without
+        // this fallback every caller measuring a caret at the document's end got
+        // nil and silently did nothing: typewriter centering froze and the plain
+        // caret autoscroll stopped following, so typing past the bottom of the
+        // window ran on off-screen (#277).
+        guard let fragment = tlm.textLayoutFragment(for: loc) ?? lastLayoutFragment()
+        else { return nil }
         let frame = fragment.layoutFragmentFrame
 
         guard let paraStart = fragment.textElement?.elementRange?.location else { return frame }
@@ -270,6 +278,20 @@ extension EditorTextView {
         } ?? fragment.textLineFragments.last
         guard let line else { return frame }
         return line.typographicBounds.offsetBy(dx: frame.minX, dy: frame.minY)
+    }
+
+    /// The document's last layout fragment. One reverse step, so it costs the
+    /// layout of that fragment alone — not the walk from the document start
+    /// the rest of this file exists to avoid.
+    private func lastLayoutFragment() -> NSTextLayoutFragment? {
+        guard let tlm = textLayoutManager else { return nil }
+        var last: NSTextLayoutFragment?
+        tlm.enumerateTextLayoutFragments(from: tlm.documentRange.endLocation,
+                                         options: [.reverse, .ensuresLayout]) { frag in
+            last = frag
+            return false
+        }
+        return last
     }
 
     /// AppKit's TextKit 2 implementation of scroll-to-range kills the process

--- a/Tests/EdmundTests/BottomOverscrollTests.swift
+++ b/Tests/EdmundTests/BottomOverscrollTests.swift
@@ -71,6 +71,28 @@ struct BottomOverscrollTests {
                 "bottom overscroll missing in typewriter mode: \(editor.overscrollBottomPad)")
     }
 
+    /// The other half of #277: the caret at `documentRange.endLocation` had no
+    /// measurable line rect, so the plain autoscroll (`scrollRangeToVisible`)
+    /// silently did nothing there too — with typewriter scroll off, typing past
+    /// the bottom of the window walked the caret out of sight.
+    @Test("Plain autoscroll follows the caret typing at the document end")
+    @MainActor func autoscrollFollowsCaretAtEnd() {
+        let (editor, scroll) = makeWindowed(typewriter: false)
+        // Start with the end of the document at the bottom edge of the viewport,
+        // so the next line typed has to move the viewport to stay visible.
+        editor.setSelectedRange(NSRange(location: (editor.rawSource as NSString).length, length: 0))
+        editor.scrollRangeToVisible(editor.selectedRange())
+        editor.layoutSubtreeIfNeeded()
+        for i in 1...4 {
+            editor.insertText("new line \(i)", replacementRange: editor.selectedRange())
+            editor.insertNewline(nil)
+            editor.layoutSubtreeIfNeeded()
+            let visible = scroll.contentView.bounds
+            #expect(editor.caretIsVisible(forViewportOrigin: visible.origin),
+                    "caret left the viewport after typing line \(i)")
+        }
+    }
+
     /// The blank band below the last line is part of the text view, so clicking
     /// it puts the caret on the nearest character instead of doing nothing.
     @Test("Clicks in the blank band below the text reach the editor")

--- a/Tests/EdmundTests/TypewriterCenteringTests.swift
+++ b/Tests/EdmundTests/TypewriterCenteringTests.swift
@@ -119,6 +119,35 @@ struct TypewriterCenteringTests {
         }
     }
 
+    /// #277: typing on the *last* line kept the caret pinned where it was and
+    /// the text ran off the bottom of the window. The caret sits at
+    /// `documentRange.endLocation` there, where TextKit 2 reports no layout
+    /// fragment — so `lineRect` returned nil, centering bailed out silently, and
+    /// each new line pushed the caret further below the viewport.
+    @Test("Caret keeps centering while typing at the document end")
+    @MainActor func centersWhileTypingAtEnd() {
+        let (editor, scroll) = makeWindowed()
+        var doc = ""
+        for i in 1...100 { doc += "Line \(i) content here for the document body.\n" }
+        editor.loadContent(doc)
+        ensureFullLayout(editor); editor.sizeToFit(); editor.layoutSubtreeIfNeeded()
+
+        editor.setSelectedRange(NSRange(location: (editor.rawSource as NSString).length, length: 0))
+        editor.scrollCursorToCenter()
+        for i in 1...6 {
+            editor.insertText("new line \(i)", replacementRange: editor.selectedRange())
+            editor.insertNewline(nil)
+            editor.layoutSubtreeIfNeeded()
+            let off = editor.selectedRange().location
+            guard let lr = editor.lineRect(forCharacterAt: off) else {
+                Issue.record("no line rect for the caret at the document end (line \(i))"); return
+            }
+            let screenMid = lr.midY + editor.textContainerOrigin.y - scroll.contentView.bounds.origin.y
+            let delta = abs(screenMid - scroll.contentView.bounds.height / 2)
+            #expect(delta < 4, "after typing line \(i) the caret is \(delta)pt off center")
+        }
+    }
+
     /// A document shorter than the window: with no padding the clamp range is
     /// [0, 0] and centering could not move the viewport at all.
     @Test("Caret centers in a document shorter than the viewport")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 ## [Unreleased]
 
 ### Fixed
+- Typewriter scroll kept centering while typing on the last line of the document, instead of letting the text run off the bottom of the window (#277 @lluminate). The caret autoscroll had the same blind spot with typewriter scroll off.
 - ⌘W now closes the window — the File menu was missing its Close item, so the shortcut did nothing. ⌥⌘W closes all windows, as elsewhere on macOS.
 
 ## [0.4.2] - 2026-08-11


### PR DESCRIPTION
Fixes #277.

## What was happening

Typing on the **last line** ran the text off the bottom of the window: typewriter scroll stopped following the caret entirely.

The caret sits at `documentRange.endLocation` there, and TextKit 2 reports **no layout fragment at that location** — so `lineRect(forCharacterAt:)` returned nil. Every caller that measures the caret degrades to "do nothing" on nil, so centering bailed out silently and each new line pushed the caret further out of sight.

Not an overscroll problem: the half-viewport of room below the last line was there all along, but nothing was measuring the caret to use it.

## The fix

Fall back to the document's last layout fragment when there is none at the location. Its final line fragment is the empty trailing line when the document ends in a newline — exactly where that caret draws.

Fixing it in `lineRect` rather than in the typewriter path also covers the sibling callers that were equally blind: with typewriter scroll **off**, the plain caret autoscroll (`scrollRangeToVisible`) also did nothing at the document's end, so typing past the bottom of the window walked the caret out of sight there too.

## Verification

- Two regression tests, both confirmed to fail without the fix (`no line rect for the caret at the document end`; `caret left the viewport after typing line 1`) and pass with it — one per mode, since both paths were broken.
- Full suite: 1400 tests, all pass.
- **Live**, on a real build: the same repro script against a pre-fix binary leaves the viewport parked at line 1 while typing lands ~65 lines off-screen; with the fix the caret holds at the viewport's center across five typed lines. Identical edits in both runs (`logsel` 3171 → 3225), so the viewport is the only variable.