### PR TITLE
fix(documents): stop reopen opening a second blank document

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
   test:
     name: test
     runs-on: macos-14
+    # The suite runs in ~2 minutes. A test that blocks the main thread (a modal
+    # alert with nobody to dismiss it, say) otherwise sits until the 6-hour
+    # ceiling — billed at the 10x macOS rate the whole way.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
 

--- a/Sources/edmd/App/Document.swift
+++ b/Sources/edmd/App/Document.swift
@@ -97,6 +97,22 @@ class Document: NSDocument, HeadingNavigable {
 
     // MARK: - Window Setup
 
+    /// Whether this document has anything a restored window could hand back: a
+    /// file on disk, or unsaved edits. False only for an untitled document
+    /// nobody has typed into.
+    private var isWorthRestoring: Bool { fileURL != nil || isDocumentEdited }
+
+    /// Every edit funnels through here (`EditorTextView+EditFlow.swift`), as does
+    /// saving, so this is where a window becomes worth restoring — or stops
+    /// being, if the last edit is undone away.
+    override func updateChangeCount(_ change: NSDocument.ChangeType) {
+        super.updateChangeCount(change)
+        let restorable = isWorthRestoring
+        for controller in windowControllers where controller.window?.isRestorable != restorable {
+            controller.window?.isRestorable = restorable
+        }
+    }
+
     override func makeWindowControllers() {
         // Default content size for first launch. Any saved size is applied as a
         // full window frame at the end of setup (below), once the toolbar is in
@@ -126,7 +142,15 @@ class Document: NSDocument, HeadingNavigable {
         // the preference applies — AppDelegate.applicationShouldTerminate turns
         // this off before terminating when it is disabled, so nothing is archived
         // and the next launch starts fresh.
-        window.isRestorable = true
+        //
+        // A blank untitled document is the exception: there is nothing in it for
+        // a crash to hand back, and archiving it means the next launch restores
+        // it — through `NSDocumentController`'s own restoration path, which
+        // neither `reopenDocument` nor `applicationShouldOpenUntitledFile` gates,
+        // so it lands *on top of* the startup document as a second blank window
+        // with "Reopen windows" off. It earns the flag on its first edit
+        // (`updateChangeCount`).
+        window.isRestorable = isWorthRestoring
         window.minSize = NSSize(width: 320, height: 400)
         window.backgroundColor = NSColor.textBackgroundColor
 

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -101,13 +101,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     }
 
     // Reopen a new untitled document when the app is activated with no windows.
+    //
+    // Returning false is what keeps it to *one* document: `true` lets AppKit run
+    // its own reopen handling, which for a document-based app with no windows
+    // opens a second untitled document of its own (`_doOpenUntitled` →
+    // `applicationShouldOpenUntitledFile`, which says yes for the same
+    // preference). That is the double window in #278.
+    //
+    // Miniaturized windows count as visible, so the `!flag` branch is only
+    // reached when there is genuinely nothing to bring back — nothing else for
+    // AppKit's default handling to do here.
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        if !flag {
-            if AppSettings.startupAction == .createNewDocument {
-                NSDocumentController.shared.newDocument(nil)
-            }
+        guard !flag else { return true }
+        if AppSettings.startupAction == .createNewDocument {
+            NSDocumentController.shared.newDocument(nil)
         }
-        return true
+        return false
     }
 
     // MARK: - Settings

--- a/Sources/edmd/App/main.swift
+++ b/Sources/edmd/App/main.swift
@@ -112,6 +112,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     // reached when there is genuinely nothing to bring back — nothing else for
     // AppKit's default handling to do here.
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        Self.shouldHandleReopen(hasVisibleWindows: flag)
+    }
+
+    /// The decision itself, as a type method so tests can exercise it without
+    /// building an `AppDelegate`: the stored `updaterController` starts Sparkle
+    /// on init, and a failed check puts up a *modal* alert that would sit on the
+    /// main thread forever in a test run.
+    static func shouldHandleReopen(hasVisibleWindows flag: Bool) -> Bool {
         guard !flag else { return true }
         if AppSettings.startupAction == .createNewDocument {
             NSDocumentController.shared.newDocument(nil)

--- a/Tests/EdmundTests/ReopenHandlingTests.swift
+++ b/Tests/EdmundTests/ReopenHandlingTests.swift
@@ -42,6 +42,29 @@ struct ReopenHandlingTests {
         #expect(shouldHandleReopen(hasVisibleWindows: false) == false)
     }
 
+    /// The other way a second blank document appeared: after an *unclean* exit
+    /// (crash, force quit) `applicationShouldTerminate` never runs, so the blank
+    /// startup window stays archived and AppKit restores it at the next launch —
+    /// through `NSDocumentController`'s restoration path, which neither
+    /// `reopenDocument` nor `applicationShouldOpenUntitledFile` gates. An
+    /// untitled document with nothing typed into it now isn't archived at all.
+    @Test("A blank untitled window is archived only once it has been edited")
+    func untitledWindowEarnsRestorability() {
+        let document = Document()
+        document.makeWindowControllers()
+        let window = document.windowControllers.first?.window
+
+        #expect(window?.isRestorable == false)
+
+        // Crash recovery still applies the moment there is unsaved work.
+        document.updateChangeCount(.changeDone)
+        #expect(window?.isRestorable == true)
+
+        // …and stops applying if that work is undone away again.
+        document.updateChangeCount(.changeUndone)
+        #expect(window?.isRestorable == false)
+    }
+
     /// A miniaturized window still counts as visible, so this is the branch for
     /// windows that are merely hidden behind others — AppKit brings them
     /// forward, which is exactly the default handling we want to keep.

--- a/Tests/EdmundTests/ReopenHandlingTests.swift
+++ b/Tests/EdmundTests/ReopenHandlingTests.swift
@@ -24,11 +24,12 @@ struct ReopenHandlingTests {
 
     /// Standing in for AppKit's own reopen handling, which only ever runs when
     /// the delegate returns `true`.
+    ///
+    /// The type method, not an `AppDelegate` instance: building one starts
+    /// Sparkle (the stored `updaterController`), and a check that fails puts up
+    /// a modal alert — which in a test run is a main thread nobody comes back to.
     private func shouldHandleReopen(hasVisibleWindows: Bool) -> Bool {
-        // `NSApp` is nil until something asks for the shared application; the
-        // delegate ignores the sender, but the parameter still has to be real.
-        AppDelegate().applicationShouldHandleReopen(NSApplication.shared,
-                                                    hasVisibleWindows: hasVisibleWindows)
+        AppDelegate.shouldHandleReopen(hasVisibleWindows: hasVisibleWindows)
     }
 
     @Test("With no windows left, the delegate claims the reopen")
@@ -50,19 +51,25 @@ struct ReopenHandlingTests {
     /// untitled document with nothing typed into it now isn't archived at all.
     @Test("A blank untitled window is archived only once it has been edited")
     func untitledWindowEarnsRestorability() {
+        // A bare window rather than `makeWindowControllers()`, which builds the
+        // whole document window (toolbar included) — the same reason every other
+        // suite here assembles its own view stack.
         let document = Document()
-        document.makeWindowControllers()
-        let window = document.windowControllers.first?.window
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+                              styleMask: [.titled], backing: .buffered, defer: true)
+        document.addWindowController(NSWindowController(window: window))
 
-        #expect(window?.isRestorable == false)
+        // Nothing typed in yet: nothing a restored window could hand back.
+        document.updateChangeCount(.changeCleared)
+        #expect(window.isRestorable == false)
 
         // Crash recovery still applies the moment there is unsaved work.
         document.updateChangeCount(.changeDone)
-        #expect(window?.isRestorable == true)
+        #expect(window.isRestorable == true)
 
         // …and stops applying if that work is undone away again.
         document.updateChangeCount(.changeUndone)
-        #expect(window?.isRestorable == false)
+        #expect(window.isRestorable == false)
     }
 
     /// A miniaturized window still counts as visible, so this is the branch for

--- a/Tests/EdmundTests/ReopenHandlingTests.swift
+++ b/Tests/EdmundTests/ReopenHandlingTests.swift
@@ -1,0 +1,58 @@
+import Testing
+import AppKit
+@testable import edmd
+
+/// Regression for #278: activating the app with every window closed — a Dock
+/// click, or opening the still-running app again — produced *two* blank
+/// documents instead of one.
+///
+/// `applicationShouldHandleReopen` made the document itself and then returned
+/// `true`, which is AppKit's "carry on with your normal handling". For a
+/// document-based app with no windows that normal handling is
+/// `_doOpenUntitled` → `applicationShouldOpenUntitledFile`, which answers yes
+/// to the same "Create New Document" preference — so AppKit added a second
+/// one. Captured live from two stacks under a single `_handleAEReopen:`.
+///
+/// AppKit's half of that race is out of reach in-process (there is no way to
+/// make it run its default reopen handling here), so what is checkable is the
+/// contract the fix rests on: once the delegate has handled the no-window
+/// case, it must answer `false` so nothing else opens a document. Verified
+/// against the running app: one `Untitled` per reopen, where 0.4.2 gave two.
+@MainActor
+@Suite("Reopen handling")
+struct ReopenHandlingTests {
+
+    /// Standing in for AppKit's own reopen handling, which only ever runs when
+    /// the delegate returns `true`.
+    private func shouldHandleReopen(hasVisibleWindows: Bool) -> Bool {
+        // `NSApp` is nil until something asks for the shared application; the
+        // delegate ignores the sender, but the parameter still has to be real.
+        AppDelegate().applicationShouldHandleReopen(NSApplication.shared,
+                                                    hasVisibleWindows: hasVisibleWindows)
+    }
+
+    @Test("With no windows left, the delegate claims the reopen")
+    func claimsReopenWithNoWindows() {
+        let saved = AppSettings.startupAction
+        defer { AppSettings.startupAction = saved }
+
+        // "Do Nothing" is the branch with no side effects: no document is made,
+        // and AppKit must not make one either.
+        AppSettings.startupAction = .doNothing
+        #expect(shouldHandleReopen(hasVisibleWindows: false) == false)
+    }
+
+    /// A miniaturized window still counts as visible, so this is the branch for
+    /// windows that are merely hidden behind others — AppKit brings them
+    /// forward, which is exactly the default handling we want to keep.
+    @Test("With windows still open, AppKit's default handling is left alone")
+    func defersToAppKitWithWindows() {
+        let saved = AppSettings.startupAction
+        defer { AppSettings.startupAction = saved }
+
+        for action in AppSettings.StartupAction.allCases {
+            AppSettings.startupAction = action
+            #expect(shouldHandleReopen(hasVisibleWindows: true) == true)
+        }
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -412,6 +412,18 @@ Notable subsystems:
      the draft files are never deleted. Once skipped, AppKit drops the draft
      from its restore record, so turning the preference back on later does not
      resurrect old drafts; the file is still on disk.
+
+  The blank-document-on-startup preference (`startupAction`) has its own pair of
+  routes, and they are easy to double up: at launch AppKit asks
+  `applicationShouldOpenUntitledFile`, but on a *reopen* (Dock click, or opening
+  the still-running app again) it asks `applicationShouldHandleReopen` first and
+  then — if that returns `true` — runs its own handling, which for a document app
+  with no windows opens an untitled document through
+  `applicationShouldOpenUntitledFile` as well. Making the document in the reopen
+  delegate *and* returning `true` therefore produced two blank windows (#278);
+  the delegate returns `false` once it has handled the no-window case.
+  Miniaturized windows count as visible, so that branch only runs when there is
+  genuinely nothing to bring back.
 - **Diagnostic logging** (`EdmundCore/Diagnostics/Log.swift`): always-on
   (opt-out) file logger. `Log.{debug,info,error}(_:category:)` and
   `Log.measure(_:) { … }` (single-line durations) write to

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -397,7 +397,16 @@ Notable subsystems:
   1. *Window restoration.* Document windows are `isRestorable = true` for the
      whole session so a crash can hand back unsaved work;
      `AppDelegate.applicationShouldTerminate` clears the flag on a **clean**
-     quit when the preference is off, so nothing is archived.
+     quit when the preference is off, so nothing is archived. A blank untitled
+     document is the exception: it holds nothing a crash could hand back, so
+     `Document` leaves its window unarchived and gives it the flag on the first
+     edit (`updateChangeCount`) instead. An *unclean* exit never runs
+     `applicationShouldTerminate`, and what AppKit restores from that archive
+     arrives through `NSDocumentController`'s own restoration path
+     (`_restorePersistentDocumentWithState:` → `_openUntitledDocumentOfType:`),
+     which neither route-2's `reopenDocument` nor
+     `applicationShouldOpenUntitledFile` sees — so a blank window that *is*
+     archived cannot be stopped downstream.
   2. *Drafts.* With autosave-in-place on (`Document.autosavesInPlace` =
      `autoSaveWithVersions`, default on), every unsaved **untitled** document is
      kept by AppKit as a draft in `~/Library/Autosave Information/Unsaved edmd

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 ### Fixed
 - ⌘W now closes the window — the File menu was missing its Close item, so the shortcut did nothing. ⌥⌘W closes all windows, as elsewhere on macOS.
 - Opening the app again after closing every window no longer creates two blank documents (#278)
+- A blank document left open when the app crashed or was force-quit no longer comes back as a second window at the next launch (#278)
 
 ## [0.4.2] - 2026-08-11
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Fixed
 - ⌘W now closes the window — the File menu was missing its Close item, so the shortcut did nothing. ⌥⌘W closes all windows, as elsewhere on macOS.
+- Opening the app again after closing every window no longer creates two blank documents (#278)
 
 ## [0.4.2] - 2026-08-11
 


### PR DESCRIPTION
Fixes #278.

## The bug

With "Quit when all windows are closed" off, closing every window leaves the app running — so "launch Edmund again" is a **reopen**, not a launch. `AppDelegate.applicationShouldHandleReopen` created the blank document itself and then returned `true`, which tells AppKit to also run its normal reopen handling. For a document app with no windows that handling is `_doOpenUntitled` → `applicationShouldOpenUntitledFile`, which says yes to the same "Create New Document" preference. Two blank documents from one activation.

Captured live as two `makeUntitledDocument` stacks under a single `_handleAEReopen:`, one from the delegate and one from AppKit.

That also answers the question on the issue: with "Quit when all windows are closed" **on** the bug does not appear, because the app quits with the last window and the next start is a real launch.

## The fix

`applicationShouldHandleReopen` returns `false` once it has handled the no-window case. Measured first: a miniaturized window reports `hasVisibleWindows = true`, so that branch only runs when there is genuinely nothing to bring back — un-minimizing from the Dock is unaffected.

Deleting the manual `newDocument(nil)` and letting AppKit's path do the work was the other option, and was rejected: `applicationShouldOpenUntitledFile` also gates on `CommandLine.arguments.count <= 1`, so after an `edmd file.md` launch it would suppress reopen-created documents for the rest of the session.

## Second commit: blank windows and state restoration

A second route to a stray blank document turned up during the investigation. An unclean exit (crash, force quit) never runs `applicationShouldTerminate`, so a blank startup window stays archived with `isRestorable = true` and AppKit can restore it at the next launch — through `NSDocumentController`'s own restoration path (`_restorePersistentDocumentWithState:` → `_openUntitledDocumentOfType:`), which neither `reopenDocument` (the draft gate from #267) nor `applicationShouldOpenUntitledFile` sees, so neither existing gate can stop it downstream.

Gated at the source instead: a document with no file on disk and no edits has nothing for a crash to hand back, so its window is not archived. It becomes restorable on the first edit and stops being if that edit is undone — `updateChangeCount` is the funnel every edit and every save already goes through, so crash recovery of unsaved work is unchanged.

Evidence bar for this one is lower and the commit message says so: the restore path was captured live during the #278 investigation, but it did not reproduce afterwards on a clean profile (an isolated bundle id, launched and SIGKILLed, wrote no `~/Library/Saved Application State` entry at all, so patched and unpatched binaries both came back with one window). The guard is correct-by-construction rather than repro-verified.

## Verification

- Live A/B on an ad-hoc-signed bundle with an isolated bundle id and defaults domain: before, two documents per reopen; after, one. "Do Nothing" opens none, on launch and on reopen.
- `ReopenHandlingTests` fails against the unfixed source.
- Full suite: 1401 tests in 200 suites, green.

Docs: ARCHITECTURE §7's "enforced in two places" note now covers both preference pairs; CHANGELOG under Unreleased.
