### PR TITLE
docs: record AX chrome-driving traps in the live-repro skill

### DIFF
--- a/.claude/skills/edmund-live-repro-and-diagnostics/SKILL.md
+++ b/.claude/skills/edmund-live-repro-and-diagnostics/SKILL.md
@@ -5,9 +5,11 @@ description: >
   interpretation guides, and working scripts. Load when a bug involves LIVE
   behavior (caret, IME, drag, viewport timing), when a unit test cannot
   reproduce a report, when you need to read diagnostic traces, drive the
-  running app with scripted keystrokes, or measure pixels from a screenshot.
-  Contains the repro escalation ladder, the ReproScript driver, the CGEvent
-  fallback, and screencapture measurement, plus scripts/ helpers. Not the
+  running app with scripted keystrokes, measure pixels from a screenshot, or
+  drive non-editor chrome (menu bar, context menus, Settings panes) via
+  Accessibility. Contains the repro escalation ladder, the ReproScript driver,
+  the CGEvent fallback, screencapture measurement, and the AX chrome-driving
+  traps (§5b), plus scripts/ helpers. Not the
   symptom→mechanism table (edmund-debugging-playbook), not the campaign
   (edmund-caret-integrity-campaign), not build hygiene (edmund-build-and-env).
 ---
@@ -273,6 +275,51 @@ before "simplifying" it:
 
 ---
 
+## 5b. AX-driving chrome: menu bar, context menus, Settings
+
+Traps from verifying the Appearance pane for PR #268 (macOS 26, on
+`feat/font-cascade`). They apply to any task that reads or presses Edmund's
+non-editor UI — Settings panes, menu bar, context menus — from a script.
+
+- **Menu-bar AX clicks are silent no-ops until the app has been activated
+  once.** With no live responder chain, auto-validation marks every item
+  except Quit disabled, and System Events' `click menu item` *returns the
+  item* — it looks like success — without firing it. Raise first
+  (`ui-harness.sh raise`), THEN click. (The §5a table's "raise before the
+  first AX query" row covers window enumeration; this one is worse because
+  nothing errors.)
+- **AX stops vending a deactivated app's windows** — System Events AND the
+  raw AX C API both come up empty shortly after the app loses focus.
+  Re-`raise` immediately before EACH interaction, in the same breath; a
+  script that raises once at the top finds a windowless app three calls
+  later.
+- **The AX C API drives a background app without any activation** —
+  `AXUIElementCreateApplication` + `kAXWindowsAttribute` +
+  `AXUIElementPerformAction` work where System Events demands an activation
+  first. `scripts/axfind.swift <pid> <windowTitle>
+  --dump|--press <t>|--showmenu <t>` walks the tree (role, title, position,
+  actions per element) and presses by title; exit 3 means window or target
+  not found — read that as "the UI did not reach the expected state", never
+  as success.
+- **SwiftUI `.contextMenu` on a `Button` lists `AXShowMenu` but performing it
+  fails with -25204** (`kAXErrorActionUnsupported`) on macOS 26 — the action
+  is advertised, not implemented. Fallback: post a real CGEvent right-click
+  at the control's screen coordinates (the §4 path;
+  `scripts/rightclick.swift <x> <y>`), after which the menu's items are
+  ordinary `AXMenuItem`s that `AXPress` fine.
+- **Force `@AppStorage`-backed settings-UI state at launch via
+  NSArgumentDomain** — `-settings.appearance.fontsByScriptExpanded YES` —
+  skipping the disclosure click-through AND never writing the user's real
+  UserDefaults (same mechanism as the §5a `-settings.appearance.mode dark`
+  row). Dict values take old-style plist syntax:
+  `-EditorFontCascade '{ han = "Songti SC"; }'`.
+- **The Settings window's title follows the selected pane** (state
+  restoration) — look it up as `"Appearance"`, not `"Settings"`.
+- Rapid launch/kill cycles while iterating on any of this → the savedState
+  reset (§5, ARCHITECTURE §8) un-glues the window server again.
+
+---
+
 ## 6. The loop, end to end
 
 1. Verbose trace from the occurrence → find the **first bad line**, walk
@@ -303,9 +350,11 @@ mechanism.
 | `capture-window.sh <needle> <out.png>` | Screenshot a window by id + report bounds | **exercised** 2026-07-26 (its old JXA lookup never worked — see §5) |
 | `ui-harness.sh <subcommand>` | Launch / raise / read find-bar state / toggle replace / capture, appearance per-launch | **every subcommand exercised** 2026-07-26 |
 | `ui-measure.py box\|runs\|rows` | Ink bounding box, control gaps, colour transitions | **exercised** 2026-07-26 |
+| `axfind.swift <pid> <title> --dump\|--press\|--showmenu <t>` | AX-dump/press a **background** app's window elements via the AX C API — no activation needed (§5b) | **exercised** 2026-08-18 (Appearance pane, PR #268) |
+| `rightclick.swift <x> <y>` | Real CGEvent right-click at screen coords — the `.contextMenu` fallback (§5b) | **exercised** 2026-08-18 |
 | `launch-debug.sh <file.md> [script.repro]` | Build + assemble EdmundDbg.app + direct-exec with flags | **verify on first use** (assumes arm64 debug triple; guards user instance) |
 
-All pass `bash -n`. One caveat on `launch-debug.sh`: its header claims a bare
+All shell scripts pass `bash -n`. One caveat on `launch-debug.sh`: its header claims a bare
 `.build/debug/edmd` "never makes a window". That is **not true** — the find-bar
 work drove the bare debug binary for a whole session and it windows fine, which
 is what `ui-harness.sh launch` does. The EdmundDbg bundle is still the right
@@ -338,3 +387,8 @@ grep -n 'healing storage edit' Sources/EdmundCore/TextView/EditorTextView+EditFl
 
 Re-verify the scripts against `docs/dev-guides/live-repro-guide.md` §4 if the debug-bundle
 assembly recipe changes.
+
+§5b and scripts `axfind.swift` / `rightclick.swift` added 2026-08-18 from the
+PR #268 Appearance-pane verification on `feat/font-cascade` (macOS 26) — the
+scripts were rescued verbatim from `/tmp/edmund-cascade-check/` per §5a's
+fixtures-not-scratch rule.

--- a/.claude/skills/edmund-live-repro-and-diagnostics/scripts/axfind.swift
+++ b/.claude/skills/edmund-live-repro-and-diagnostics/scripts/axfind.swift
@@ -1,0 +1,95 @@
+// axfind.swift — dump or press AX elements of any process's windows, WITHOUT
+// activating the app. System Events cannot enumerate a background process's
+// windows ("can't get window … until activated once"); the AX C API can, and
+// AXPress/AXShowMenu land on background windows fine.
+//
+//   swift axfind.swift <pid> <windowTitle> --dump
+//   swift axfind.swift <pid> <windowTitle> --press <title>
+//   swift axfind.swift <pid> <windowTitle> --showmenu <title>
+//
+// Exit 3 when the window or the target is not found (the caller's signal that
+// the UI did not reach the expected state — never silently succeed).
+import Cocoa
+
+let args = CommandLine.arguments
+guard args.count > 3, let pid = Int32(args[1]) else {
+    FileHandle.standardError.write("usage: axfind.swift <pid> <windowTitle> --dump|--press <t>|--showmenu <t>\n".data(using: .utf8)!)
+    exit(64)
+}
+let windowTitle = args[2]
+let mode = args[3]
+let target = args.count > 4 ? args[4] : nil
+
+func attr<T>(_ el: AXUIElement, _ name: String) -> T? {
+    var v: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(el, name as CFString, &v) == .success else { return nil }
+    return v as? T
+}
+
+func actions(_ el: AXUIElement) -> [String] {
+    var names: CFArray?
+    guard AXUIElementCopyActionNames(el, &names) == .success else { return [] }
+    return (names as? [String]) ?? []
+}
+
+func point(_ el: AXUIElement) -> CGPoint {
+    guard let v: AXValue = attr(el, kAXPositionAttribute) else { return .zero }
+    var p = CGPoint.zero
+    AXValueGetValue(v, .cgPoint, &p)
+    return p
+}
+
+func size(_ el: AXUIElement) -> CGSize {
+    guard let v: AXValue = attr(el, kAXSizeAttribute) else { return .zero }
+    var s = CGSize.zero
+    AXValueGetValue(v, .cgSize, &s)
+    return s
+}
+
+let app = AXUIElementCreateApplication(pid)
+guard let windows: [AXUIElement] = attr(app, kAXWindowsAttribute) else {
+    FileHandle.standardError.write("no windows\n".data(using: .utf8)!)
+    exit(3)
+}
+guard let win = windows.first(where: { (attr($0, kAXTitleAttribute) as String?) == windowTitle }) else {
+    FileHandle.standardError.write("no window titled \(windowTitle); have: \(windows.compactMap { attr($0, kAXTitleAttribute) as String? })\n".data(using: .utf8)!)
+    exit(3)
+}
+
+var hits: [(AXUIElement, String, String)] = []
+
+func walk(_ el: AXUIElement, _ depth: Int) {
+    let role: String = attr(el, kAXRoleAttribute) ?? "?"
+    let title: String = attr(el, kAXTitleAttribute) ?? attr(el, kAXDescriptionAttribute) ?? ""
+    if let target, title == target { hits.append((el, role, title)) }
+    if mode == "--dump" {
+        let p = point(el), s = size(el)
+        print("\(String(repeating: "  ", count: depth))\(role) \"\(title)\" at (\(Int(p.x)),\(Int(p.y))) \(Int(s.width))x\(Int(s.height)) [\(actions(el).joined(separator: ","))]")
+    }
+    for child in (attr(el, kAXChildrenAttribute) as [AXUIElement]?) ?? [] {
+        walk(child, depth + 1)
+    }
+}
+walk(win, 0)
+
+if mode == "--dump" { exit(0) }
+
+// Among title matches, prefer elements that actually vend the requested
+// action (the script rows' Select… carries AXShowMenu; the font rows' does
+// not), then honor an optional trailing occurrence index.
+let wanted = mode == "--showmenu" ? kAXShowMenuAction : kAXPressAction
+let capable = hits.filter { actions($0.0).contains(wanted) }
+let pool = capable.isEmpty ? hits : capable
+let index = (args.count > 5 ? Int(args[5]) : nil) ?? 0
+guard pool.indices.contains(index) else {
+    FileHandle.standardError.write("no element titled \(target ?? "?") at index \(index) in \(windowTitle)\n".data(using: .utf8)!)
+    exit(3)
+}
+let hit = pool[index]
+let action = mode == "--showmenu" ? kAXShowMenuAction : kAXPressAction
+let err = AXUIElementPerformAction(hit.0, action as CFString)
+if err != .success {
+    FileHandle.standardError.write("\(action) failed: \(err.rawValue)\n".data(using: .utf8)!)
+    exit(3)
+}
+print("\(action) on \(hit.1) \"\(hit.2)\" at \(point(hit.0))")

--- a/.claude/skills/edmund-live-repro-and-diagnostics/scripts/rightclick.swift
+++ b/.claude/skills/edmund-live-repro-and-diagnostics/scripts/rightclick.swift
@@ -1,0 +1,24 @@
+// rightclick.swift — post a real right-mouse-down/up at screen coordinates.
+// SwiftUI's .contextMenu does not reliably perform AXShowMenu on macOS 26
+// (kAXErrorActionUnsupported despite listing the action); a context menu is a
+// mouse-only path, so drive it with a real HID event — the repo's sanctioned
+// fallback for mouse-shaped interactions (edmund-live-repro §4).
+//
+//   swift rightclick.swift <x> <y>     # screen points, global coordinates
+import Cocoa
+
+let args = CommandLine.arguments
+guard args.count > 2, let x = Double(args[1]), let y = Double(args[2]) else {
+    FileHandle.standardError.write("usage: rightclick.swift <x> <y>\n".data(using: .utf8)!)
+    exit(64)
+}
+let p = CGPoint(x: x, y: y)
+for type in [CGEventType.rightMouseDown, .rightMouseUp] {
+    guard let ev = CGEvent(mouseEventSource: nil, mouseType: type, mouseCursorPosition: p, mouseButton: .right) else {
+        FileHandle.standardError.write("event creation failed\n".data(using: .utf8)!)
+        exit(1)
+    }
+    ev.post(tap: .cghidEventTap)
+    usleep(60_000)
+}
+print("right-clicked at \(Int(x)),\(Int(y))")


### PR DESCRIPTION
## Summary

Documents the Accessibility chrome-driving traps discovered while verifying the Appearance settings pane for #268, and rescues the two helper scripts from `/tmp` into the live-repro skill's `scripts/` directory — per the skill's own fixtures-not-scratch rule.

- New **§5b** in `edmund-live-repro-and-diagnostics`: seven traps for driving Edmund's non-editor UI (Settings panes, menu bar, context menus) from scripts, all verified on macOS 26:
  - menu-bar AX clicks silently no-op until the app is activated once (auto-validation disables every item except Quit, and `click menu item` still *returns* the item)
  - AX stops vending a deactivated app's windows — re-raise before each interaction, not once at the top
  - the AX C API (`AXUIElementCreateApplication` + `AXUIElementPerformAction`) drives a background app where System Events demands activation
  - SwiftUI `.contextMenu` advertises `AXShowMenu` but performing it fails with -25204; the fallback is a real CGEvent right-click, after which menu items `AXPress` normally
  - NSArgumentDomain launch args force `@AppStorage` settings-UI state without touching the user's real UserDefaults (dict values in old-style plist syntax)
  - the Settings window's title follows the selected pane
  - rapid launch/kill cycles re-glue via the savedState reset
- New scripts: `axfind.swift` (dump/press AX elements of a background app's windows by title) and `rightclick.swift` (CGEvent right-click at screen coordinates), both copied verbatim from the #268 verification session and added to the scripts table with exercised dates.

No code changes — skill documentation and helper scripts only.

## Test plan

- [x] Both scripts compile and run (`swift axfind.swift` / `swift rightclick.swift` print usage, exit 64)
- [x] Every §5b cross-reference resolves (§4 CGEvent driver, §5a harness table's raise row, ARCHITECTURE §8)
- [x] The traps themselves were each hit and worked around live during the #268 verification (2026-08-18)
