### PR TITLE
test(reopen): wait on the completion, not a fixed 0.5s settle

### DIFF
--- a/Tests/EdmundTests/DraftReopenTests.swift
+++ b/Tests/EdmundTests/DraftReopenTests.swift
@@ -21,9 +21,17 @@ struct DraftReopenTests {
         return url
     }
 
-    /// Lets AppKit's asynchronous open finish (or not happen at all).
-    private func settle() {
-        RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+    /// Lets AppKit's asynchronous open finish (or not happen at all). Polls in
+    /// short slices instead of blocking one fixed interval: a flat 0.5s settle
+    /// raced under full-suite load — the completion simply had not fired yet, so
+    /// the test reported `completions → 0` as if the product had refused to call
+    /// back. The cap only elapses when the callback genuinely never comes.
+    private func settle(until done: () -> Bool) {
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+            if done() { return }
+        }
     }
 
     @Test("A draft is not reopened when reopening windows is off")
@@ -45,7 +53,7 @@ struct DraftReopenTests {
             completions += 1
             reopened = document
         }
-        settle()
+        settle { completions > 0 }
 
         #expect(completions == 1)
         #expect(reopened == nil)


### PR DESCRIPTION
`DraftReopenTests` blocked the run loop for a flat 0.5s, then asserted the completion had fired. Under full-suite load it sometimes had not — the run failed with `completions → 0`, which reads as "the product refused to call back" but is really the test's own clock.

It has been failing on CI intermittently for a while, and started reproducing locally once #268 landed and added 43 tests, shifting the timing: **2 of 5 full-suite runs red** on `main` at 867f5a3.

`settle()` now polls in 20ms slices and returns as soon as the caller's condition holds, capping at 5s so a callback that genuinely never arrives still fails the test. Faster in the common case (the isolated test settles in ~7ms).

**5/5 green** locally on Swift 6.0.3 with the same suite that was 2/5 red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)