### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -17,9 +17,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleVersion</key>
-    <string>12</string>
+    <string>13</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.4.3</string>
+    <string>0.5.0</string>
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
     <key>NSHighResolutionCapable</key>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes will be documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-08-22
+
+Thanks to @arthurlee116 for their first contribution (#268)
+
+### Added
+- Fonts by script: a separate font and size for each writing system, in Settings > Appearance (#268 @arthurlee116)
+
 ## [0.4.3] - 2026-08-17
 
 Thanks to @aahventures for their first contribution (#269)


### PR DESCRIPTION
Version bump and CHANGELOG for 0.5.0.

- `CFBundleShortVersionString` 0.4.3 → **0.5.0** (new user-facing feature)
- `CFBundleVersion` 12 → **13**

Contents: the per-script font cascade (#268) — the only feature change on main since 0.4.3.

Verified both consumers of the CHANGELOG section:
- the awk extraction used for the GitHub Release body
- `scripts/changelog-to-html.py 0.5.0` for the Sparkle update dialog — renders `<h3>` + `<ul>`, no raw markdown

1446/1446 green locally on Swift 6.0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)