### PR TITLE
docs(changelog): reword the 0.5.0 Added entry

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -316,7 +316,7 @@
 <p>Thanks to @arthurlee116 for their first contribution (#268)</p>
 <h3>Added</h3>
 <ul>
-<li>Fonts by script: a separate font and size for each writing system, in Settings &gt; Appearance (#268 @arthurlee116)</li>
+<li>Settings &gt; Appearance &gt; Font per script (#268 @arthurlee116)</li>
 </ul>
 ]]></description>
             <enclosure url="https://github.com/I7T5/Edmund/releases/download/v0.5.0/Edmund-0.5.0.dmg"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 Thanks to @arthurlee116 for their first contribution (#268)
 
 ### Added
-- Fonts by script: a separate font and size for each writing system, in Settings > Appearance (#268 @arthurlee116)
+- Settings > Appearance > Font per script (#268 @arthurlee116)
 
 ## [0.4.3] - 2026-08-17
 


### PR DESCRIPTION
Rewords the single 0.5.0 `Added` entry to the maintainer's phrasing:

> - Settings > Appearance > Font per script (#268 @arthurlee116)

Applied in both places that render it, so `docs/CHANGELOG.md`, the GitHub release notes and the Sparkle update dialog agree:

- `docs/CHANGELOG.md`
- the `<description>` of the 0.5.0 `<item>` in `appcast.xml`, regenerated with `scripts/changelog-to-html.py 0.5.0`

The published item's `enclosure`, `sparkle:edSignature`, `sparkle:version` and `length` are untouched — the diff is one `<li>` line. `appcast.xml` re-validated as well-formed XML.

The GitHub release body for v0.5.0 is updated separately via `gh release edit` once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)