### PR TITLE
Delete the auto-inserted closer along with its opener

### DIFF
--- a/Sources/EdmundCore/Editing/EditorTextView+AutoPairs.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+AutoPairs.swift
@@ -5,7 +5,8 @@ import AppKit
 // Typing an opening bracket or quote inserts its closing partner and leaves the
 // caret between the two; typing a closing character that is already sitting to
 // the right of the caret steps over it instead of inserting a second one.
-// Gated by `autoCloseBracketsEnabled` (Settings ▸ Edit ▸ Editing).
+// Deleting an opening character while its partner still sits next to it removes
+// both. Gated by `autoCloseBracketsEnabled` (Settings ▸ Edit ▸ Editing).
 //
 // Everything goes through `super.insertText`, so the edit takes the normal
 // pipeline (shouldChangeText → undo record → didChangeText → resync). The caret
@@ -66,6 +67,29 @@ extension EditorTextView {
         if between <= (textStorage?.length ?? 0) {
             setSelectedRange(NSRange(location: between, length: 0))
         }
+    }
+
+    /// Deleting an opening character takes its closing partner with it, but only
+    /// while the two are still adjacent — the state auto-closing just left behind.
+    /// Once anything sits between them the pair is ordinary text and the closer
+    /// stays put.
+    public override func deleteBackward(_ sender: Any?) {
+        let target = selectedRange()
+        guard autoCloseBracketsEnabled,
+              !hasMarkedText(),
+              target.length == 0,
+              let opener = character(at: target.location - 1),
+              let closer = Self.autoPairs[opener],
+              character(at: target.location) == closer
+        else {
+            super.deleteBackward(sender)
+            return
+        }
+
+        // Delete both as one selection, so it takes the normal edit pipeline and
+        // undoes in a single step.
+        setSelectedRange(NSRange(location: target.location - 1, length: 2))
+        super.deleteBackward(sender)
     }
 
     /// Whether typing `ch` at `location` should bring a closing partner along.

--- a/Sources/EdmundCore/Editing/EditorTextView+AutoPairs.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+AutoPairs.swift
@@ -86,9 +86,13 @@ extension EditorTextView {
             return
         }
 
-        // Delete both as one selection, so it takes the normal edit pipeline and
-        // undoes in a single step.
-        setSelectedRange(NSRange(location: target.location - 1, length: 2))
+        // Drop the closer with AppKit's own forward delete, then let the normal
+        // backward delete take the opener. Selecting both and deleting the
+        // selection in one go looks tidier but crashes: NSTextView's
+        // post-edit `updateFontPanel` re-reads the selection we just set, which
+        // by then runs past the end of the shrunken storage
+        // (NSMutableRLEArray … Out of bounds).
+        super.deleteForward(sender)
         super.deleteBackward(sender)
     }
 

--- a/Tests/EdmundTests/AutoPairTests.swift
+++ b/Tests/EdmundTests/AutoPairTests.swift
@@ -95,6 +95,66 @@ struct EditorTextViewAutoPairTests {
         #expect(editor.rawSource == "(paste)")
     }
 
+    // MARK: - Deleting the opener takes the adjacent closer with it
+
+    @Test("Deleting an opening bracket removes the adjacent closer")
+    @MainActor func deleteRemovesAdjacentCloser() {
+        let editor = makeEditor()
+        editor.loadContent("")
+        type("(", at: 0, in: editor)
+        editor.deleteBackward(nil)
+        #expect(editor.rawSource == "")
+        #expect(editor.selectedRange() == NSRange(location: 0, length: 0))
+    }
+
+    @Test("Every pair deletes as a pair")
+    @MainActor func deleteAllPairs() {
+        for text in ["()", "[]", "{}", "\"\"", "''", "``"] {
+            let editor = makeEditor()
+            editor.loadContent("a" + text + "b")
+            editor.setSelectedRange(NSRange(location: 2, length: 0))
+            editor.deleteBackward(nil)
+            #expect(editor.rawSource == "ab")
+        }
+    }
+
+    @Test("A separated pair deletes only the opener")
+    @MainActor func deleteSeparatedPair() {
+        let editor = makeEditor()
+        editor.loadContent("(x)")
+        editor.setSelectedRange(NSRange(location: 1, length: 0))
+        editor.deleteBackward(nil)
+        #expect(editor.rawSource == "x)")
+    }
+
+    @Test("Deleting the closer leaves the opener alone")
+    @MainActor func deleteCloserOnly() {
+        let editor = makeEditor()
+        editor.loadContent("()")
+        editor.setSelectedRange(NSRange(location: 2, length: 0))
+        editor.deleteBackward(nil)
+        #expect(editor.rawSource == "(")
+    }
+
+    @Test("A selected range still deletes only the selection")
+    @MainActor func deleteSelectionUntouched() {
+        let editor = makeEditor()
+        editor.loadContent("a()b")
+        editor.setSelectedRange(NSRange(location: 0, length: 2))
+        editor.deleteBackward(nil)
+        #expect(editor.rawSource == ")b")
+    }
+
+    @Test("Disabled: deleting an opener leaves the closer")
+    @MainActor func disabledDeleteLeavesCloser() {
+        let editor = makeEditor()
+        editor.autoCloseBracketsEnabled = false
+        editor.loadContent("()")
+        editor.setSelectedRange(NSRange(location: 1, length: 0))
+        editor.deleteBackward(nil)
+        #expect(editor.rawSource == ")")
+    }
+
     @Test("Replacing a selection does not auto-close")
     @MainActor func selectionReplacementUntouched() {
         let editor = makeEditor()

--- a/Tests/EdmundTests/AutoPairTests.swift
+++ b/Tests/EdmundTests/AutoPairTests.swift
@@ -145,6 +145,17 @@ struct EditorTextViewAutoPairTests {
         #expect(editor.rawSource == ")b")
     }
 
+    @Test("The pair delete undoes in one step")
+    @MainActor func deleteUndoesAsOne() {
+        let editor = makeEditor()
+        editor.loadContent("a()b")
+        editor.setSelectedRange(NSRange(location: 2, length: 0))
+        editor.deleteBackward(nil)
+        #expect(editor.rawSource == "ab")
+        editor.performUndo()
+        #expect(editor.rawSource == "a()b")
+    }
+
     @Test("Disabled: deleting an opener leaves the closer")
     @MainActor func disabledDeleteLeavesCloser() {
         let editor = makeEditor()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes will be documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Deleting an opening bracket or quote now removes its auto-inserted partner too, while the two are still next to each other
+
 ## [0.5.0] - 2026-08-22
 
 Thanks to @arthurlee116 for their first contribution (#268)


### PR DESCRIPTION
With auto-pairing on, typing `(` inserts `()` and parks the caret between the two. Backspacing over that `(` left the `)` behind as an orphan. Deleting the opener now takes the closer with it — but only while the two are still adjacent, which is exactly the state auto-closing just created. Once anything sits between them the pair is ordinary text and the closer stays put.

Covers all six configured pairs: `(`, `[`, `{`, `"`, `'`, `` ` ``. Gated by the existing `autoCloseBracketsEnabled` setting (Settings ▸ Edit ▸ Editing), so turning auto-pairing off restores plain backspace.

### Implementation note

The obvious version — select the opener and closer, delete the selection in one go — passes every headless test and then crashes the live app:

```
NSRangeException: NSMutableRLEArray objectAtIndex:effectiveRange:: Out of bounds
  -[NSTextView(NSKeyBindingCommands) deleteBackward:]
  -[NSTextView(NSSharing) setTypingAttributes:]
  -[NSTextView updateFontPanel]
  -[NSAttributedString(FallbackFont) fallbackFontInfoForSelectedRange:]
```

NSTextView's post-edit `updateFontPanel` re-reads the selection set moments earlier, which by then runs past the end of the shrunken storage. A pre-existing two-character selection delete does not crash, including at the document end — the trigger is setting the selection and deleting it within the same turn. The shipped version instead takes the closer with `super.deleteForward` and lets the ordinary backward delete take the opener, so AppKit does its own selection bookkeeping. Consecutive deletes in one block coalesce, so one backspace still undoes in one step.

### Verification

- `swift test` — 1453 tests, 204 suites, all pass. Seven new cases in `AutoPairTests`: all six pairs, separated pair keeps its closer, deleting the closer alone, selection delete untouched, setting disabled, single-step undo.
- Live ReproScript run against a debug bundle, since headless alone does not exercise the AppKit edit path that crashed. Brackets: `A()` + backspace → `AB` (both gone); `AB(C)` with the caret after `(` + backspace → `ABC)` (separated pair keeps its closer). Quotes: `"`, `'`, and `` ` `` each verified the same way. No crash.