### PR TITLE
fix(lists): Tab indents to the parent item's content column

### DIFF
--- a/Sources/EdmundCore/Editing/EditorTextView+Indentation.swift
+++ b/Sources/EdmundCore/Editing/EditorTextView+Indentation.swift
@@ -96,13 +96,104 @@ extension EditorTextView {
         return (startIdx, endIdx)
     }
 
+    // MARK: - Nesting Columns
+    //
+    // A fixed `indentUnit` is not always enough to nest. CommonMark starts a
+    // child list only at (or past) the parent item's *content* column — 2 for
+    // "- ", 3 for "2. ", 4 for "10. " — so the default 2-space unit under an
+    // ordered marker writes a sibling, not a child. The editor derives depth
+    // from leading whitespace and draws that as nested anyway, while Read mode
+    // (and GitHub, and pandoc) parse it flat. Pad Tab out to the previous
+    // sibling's content column so the bytes mean what the editor draws.
+    //
+    // ponytail: this fixes what Tab writes, not how depth is read back.
+    // `listDepth` is still `columns / listIndentUnit`, which can't model a
+    // required indent that varies by marker width — so a document that mixes
+    // 2-column bullet nesting with 3-column ordered nesting can still have a
+    // deep item drawn one level off. Upgrade path if that shows up in a real
+    // document: derive depth by walking preceding list lines with a column
+    // stack instead of dividing.
+
+    /// Marker plus the spaces after it — everything before an item's content.
+    /// Spaces-indented lines only; tab-indented ones are handled by the callers.
+    private static let listContentColumnRegex =
+        try! NSRegularExpression(pattern: #"^ *(?:[-*+]|\d{1,9}[.)])( +)"#)
+
+    private func leadingSpaces(_ line: String) -> Int {
+        line.prefix(while: { $0 == " " }).count
+    }
+
+    /// Column where `line`'s content starts — where CommonMark requires a child
+    /// list to begin — or nil if it isn't a spaces-indented list line. More than
+    /// four spaces after the marker open an indented code block inside the item
+    /// rather than widening it, so the run counts for at most four.
+    private func listContentColumn(_ line: String) -> Int? {
+        let ns = line as NSString
+        guard let m = Self.listContentColumnRegex.firstMatch(
+            in: line, range: NSRange(location: 0, length: ns.length)) else { return nil }
+        let spaces = m.range(at: 1).length
+        return m.range.length - spaces + min(spaces, 4)
+    }
+
+    /// Content column of the list line the block at `index` would become a child
+    /// of when indented — its nearest preceding sibling at the same column. nil
+    /// when there is none, so there is nothing to nest under and `indentUnit`
+    /// stands.
+    private func nestingTargetColumn(before index: Int) -> Int? {
+        let content = blocks[index].content
+        guard !content.hasPrefix("\t") else { return nil }
+        let cols = leadingSpaces(content)
+        var i = index - 1
+        while i >= 0 {
+            let line = blocks[i].content
+            guard isListLine(line), !line.hasPrefix("\t") else { return nil }
+            let c = leadingSpaces(line)
+            if c < cols { return nil }              // that's the parent, not a sibling
+            if c == cols { return listContentColumn(line) }
+            i -= 1                                  // deeper: a nephew, keep looking
+        }
+        return nil
+    }
+
+    /// The whitespace one Tab prepends to every block in the affected range.
+    /// One string for the whole range, so relative nesting inside it is kept.
+    private func indentString(from startBlock: Int) -> String {
+        guard !indentUsesTabs,
+              let target = nestingTargetColumn(before: startBlock) else { return indentUnit }
+        let cols = leadingSpaces(blocks[startBlock].content)
+        return String(repeating: " ", count: max(indentUnit.count, target - cols))
+    }
+
+    /// Columns one Shift-Tab strips, mirroring `indentString(from:)`: back to
+    /// the nearest shallower list line's column, so a padded indent undoes
+    /// cleanly instead of leaving an orphan space — which would drag the
+    /// document-wide `listIndentUnit` down to 1 and re-depth every list.
+    private func dedentColumns(from startBlock: Int) -> Int {
+        let content = blocks[startBlock].content
+        guard !content.hasPrefix("\t") else { return indentUnit.count }
+        let cols = leadingSpaces(content)
+        guard cols > 0 else { return indentUnit.count }
+        var i = startBlock - 1
+        while i >= 0 {
+            let line = blocks[i].content
+            guard isListLine(line), !line.hasPrefix("\t") else { break }
+            let c = leadingSpaces(line)
+            if c < cols { return cols - c }
+            i -= 1
+        }
+        // Nothing shallower to return to, so there was no padding to mirror:
+        // step by the plain unit, as a ragged/orphan indent always has.
+        return indentUnit.count
+    }
+
     // MARK: - Indent (Tab)
 
     private func indentListBlocks(from startBlock: Int, to endBlock: Int) {
         let sel = selectedRange()
         let rawStart = sel.location
         let rawEnd = sel.location + sel.length
-        let indentLen = (indentUnit as NSString).length
+        let indent = indentString(from: startBlock)
+        let indentLen = (indent as NSString).length
 
         // The pre-edit storage span covering exactly the affected blocks; only
         // this is replaced so layout above/below — and the viewport — is kept.
@@ -120,7 +211,7 @@ extension EditorTextView {
         var parts: [String] = []
         for (i, block) in blocks.enumerated() {
             if i >= startBlock && i <= endBlock {
-                parts.append(indentUnit + block.content)
+                parts.append(indent + block.content)
             } else {
                 parts.append(block.content)
             }
@@ -174,7 +265,7 @@ extension EditorTextView {
         let sel = selectedRange()
         let rawStart = sel.location
         let rawEnd = sel.location + sel.length
-        let maxRemove = indentUnit.count
+        let maxRemove = dedentColumns(from: startBlock)
 
         // Compute how many leading whitespace characters to strip from each block.
         var removed: [Int] = Array(repeating: 0, count: blocks.count)

--- a/Tests/EdmundTests/EditorIndentationTests.swift
+++ b/Tests/EdmundTests/EditorIndentationTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import AppKit
+import Markdown
 @testable import EdmundCore
 
 // MARK: - Tab / Shift-Tab List Indentation
@@ -426,5 +427,111 @@ struct EditorListIndentIntegrationTests {
         editor.insertTab(nil)
 
         #expect(editor.rawSource == "  - [ ] todo\n  - [x] done")
+    }
+
+    // MARK: - Nesting Columns
+    //
+    // Tab has to land the child at or past the parent item's *content* column,
+    // or CommonMark parses a sibling while the editor draws a child — the
+    // divergence that made nested lists come out flat in Read mode.
+
+    /// True when `markdown`'s first list contains a nested list, i.e. the
+    /// indentation really nests rather than only looking indented.
+    private func parsesAsNested(_ markdown: String) -> Bool {
+        func hasChildList(_ markup: Markup) -> Bool {
+            for child in markup.children {
+                if child is UnorderedList || child is OrderedList { return true }
+                if child is ListItem, hasChildList(child) { return true }
+            }
+            return false
+        }
+        return hasChildList(Document(parsing: markdown))
+    }
+
+    @Test("Tab under an ordered marker pads to the parent's content column")
+    @MainActor func tabPadsUnderOrderedMarker() {
+        let editor = makeEditor()
+        editor.loadContent("2. parent\n1. child")
+        editor.setSelectedRange(NSRange(location: 12, length: 0))
+        editor.insertTab(nil)
+        // "2. " is three columns wide, so a 2-space unit would leave a sibling.
+        #expect(editor.rawSource == "2. parent\n   1. child")
+        #expect(parsesAsNested(editor.rawSource))
+    }
+
+    @Test("What Tab nests in the editor, Read mode renders nested")
+    @MainActor func tabbedNestingReachesReadMode() {
+        let editor = makeEditor()
+        editor.loadContent("2. parent\n1. child")
+        editor.setSelectedRange(NSRange(location: 12, length: 0))
+        editor.insertTab(nil)
+        // The reported bug: the editor drew this nested while Read mode — which
+        // parses the bytes, not the drawn indent — rendered a flat sibling.
+        let html = HTMLRenderer.render(markdown: editor.rawSource)
+        #expect(html.contains("<ol><li>child</li></ol>"))
+    }
+
+    @Test("Tab under a wide ordered marker pads further")
+    @MainActor func tabPadsUnderWideOrderedMarker() {
+        let editor = makeEditor()
+        editor.loadContent("10. parent\n1. child")
+        editor.setSelectedRange(NSRange(location: 13, length: 0))
+        editor.insertTab(nil)
+        #expect(editor.rawSource == "10. parent\n    1. child")
+        #expect(parsesAsNested(editor.rawSource))
+    }
+
+    @Test("Tab under a bullet keeps the plain indent unit")
+    @MainActor func tabUnderBulletIsUnchanged() {
+        let editor = makeEditor()
+        editor.loadContent("- parent\n- child")
+        editor.setSelectedRange(NSRange(location: 11, length: 0))
+        editor.insertTab(nil)
+        #expect(editor.rawSource == "- parent\n  - child")
+        #expect(parsesAsNested(editor.rawSource))
+    }
+
+    @Test("A wider indent unit is never narrowed to the content column")
+    @MainActor func tabKeepsWiderUnit() {
+        let editor = makeEditor()
+        editor.indentWidth = 4
+        editor.loadContent("2. parent\n1. child")
+        editor.setSelectedRange(NSRange(location: 12, length: 0))
+        editor.insertTab(nil)
+        #expect(editor.rawSource == "2. parent\n    1. child")
+    }
+
+    @Test("Tab nests a second level under a padded parent")
+    @MainActor func tabPadsSecondLevel() {
+        let editor = makeEditor()
+        editor.loadContent("2. parent\n   1. child\n   1. grandchild")
+        editor.setSelectedRange(NSRange(location: 25, length: 0))
+        editor.insertTab(nil)
+        #expect(editor.rawSource == "2. parent\n   1. child\n      1. grandchild")
+    }
+
+    @Test("Shift-Tab undoes a padded indent exactly")
+    @MainActor func shiftTabUndoesPaddedIndent() {
+        let editor = makeEditor()
+        editor.loadContent("2. parent\n   1. child")
+        editor.setSelectedRange(NSRange(location: 15, length: 0))
+        editor.insertBacktab(nil)
+        // All three columns come off. Removing a bare indentUnit would strand
+        // one space here, dragging the document's detected indent unit down to
+        // 1 and re-depthing every list in it. The item rejoins the outer run,
+        // so renumbering relabels it 3.
+        #expect(editor.rawSource == "2. parent\n3. child")
+    }
+
+    @Test("Tab then Shift-Tab round-trips under an ordered marker")
+    @MainActor func paddedIndentRoundTrips() {
+        let editor = makeEditor()
+        editor.loadContent("2. parent\n3. child")
+        editor.setSelectedRange(NSRange(location: 12, length: 0))
+        editor.insertTab(nil)
+        #expect(editor.rawSource == "2. parent\n   1. child")
+        editor.setSelectedRange(NSRange(location: 15, length: 0))
+        editor.insertBacktab(nil)
+        #expect(editor.rawSource == "2. parent\n3. child")
     }
 }

--- a/Tests/EdmundTests/ListRenumberingTests.swift
+++ b/Tests/EdmundTests/ListRenumberingTests.swift
@@ -155,7 +155,9 @@ struct ListRenumberingTests {
         let end = (editor.rawSource as NSString).range(of: "3. Three").upperBound
         editor.setSelectedRange(NSRange(location: start, length: end - start))
         editor.insertTab(nil)
-        #expect(editor.rawSource == "1. One\n  1. Two\n  2. Three\n2. Four")
+        // Three columns, not two: "1. " is that wide, and CommonMark only
+        // nests a child list at or past the parent item's content column.
+        #expect(editor.rawSource == "1. One\n   1. Two\n   2. Three\n2. Four")
     }
 
     @Test("Indenting a single item into a brand-new sublist restarts at 1")
@@ -165,20 +167,20 @@ struct ListRenumberingTests {
         let caret = (editor.rawSource as NSString).range(of: "2. Two").location
         editor.setSelectedRange(NSRange(location: caret, length: 0))
         editor.insertTab(nil)
-        #expect(editor.rawSource == "1. One\n  1. Two\n2. Three")
+        #expect(editor.rawSource == "1. One\n   1. Two\n2. Three")
     }
 
     @Test("Indenting a list item renumbers both the old and new level")
     @MainActor func indentRenumbersBothLevels() {
         let editor = makeEditor()
-        editor.loadContent("1. a\n2. b\n  1. x\n  2. y\n3. c")
+        editor.loadContent("1. a\n2. b\n   1. x\n   2. y\n3. c")
         // Tab-indent "2. b" into the nested (depth-1) run: the old top-level
         // run loses a member (c should renumber 3→2), and the nested run
         // gains a new head (x, y should renumber to 3, 4 after b's "2.").
         let caret = (editor.rawSource as NSString).range(of: "2. b").location
         editor.setSelectedRange(NSRange(location: caret, length: 0))
         editor.insertTab(nil)
-        #expect(editor.rawSource == "1. a\n  2. b\n  3. x\n  4. y\n2. c")
+        #expect(editor.rawSource == "1. a\n   2. b\n   3. x\n   4. y\n2. c")
     }
 
     @Test("Dedenting a list item renumbers both the old and new level")


### PR DESCRIPTION
Nested lists shown as nested in the editor rendered flat in Read mode (and print, QuickLook, and HTML export).

## Root cause

Edmund has two independent list-nesting models:

- **Editor**: `listDepth(leadingWhitespace:)` = leading columns ÷ `listIndentUnit`. Blocks are parsed per line, so nesting is never structural — purely whitespace arithmetic.
- **Read mode / print / QuickLook / export**: all go through `HTMLRenderer`, which walks swift-markdown's real CommonMark tree.

CommonMark starts a child list only at or past the parent item's *content column* — 2 for `- `, 3 for `2. `, 4 for `10. `. Tab prepended a fixed `indentUnit`, defaulting to 2, so under an ordered marker Edmund's own Tab key wrote a **sibling** while the editor drew it nested. Read mode was right; the editor was lying.

## Fix

Tab now pads out to the previous sibling's content column when the fixed unit falls short. Shift-Tab mirrors it, stripping back to the nearest shallower list line so a padded indent undoes cleanly instead of leaving an orphan space (which would drag the document-wide `listIndentUnit` down to 1 and re-depth every list).

Bullets at width 2 are untouched — 2 is already `- `'s content column — so only ordered nesting moves. Output stays CommonMark-faithful: no divergence from GitHub or pandoc, no setting to change, nothing to warn about.

## Tests

8 new tests in `EditorIndentationTests`, verified at three levels: exact byte output, real cmark nesting via `Document(parsing:)`, and Read mode's actual HTML (`<ol><li>child</li></ol>`).

Three `ListRenumberingTests` expectations encoded the old 2-space indent and moved to 3; one of their fixtures was itself markdown that never nested in CommonMark and was corrected.

Full suite: 1454 tests in 204 suites, green.

## Known ceiling

Marked `ponytail:` in the code — this fixes what Tab *writes*, not how depth is *read back*. `listDepth` is still a division, which can't model an indent requirement that varies by marker width, so a document mixing 2-column bullet nesting with 3-column ordered nesting can still draw a deep item one level off. Upgrade path if that shows up in a real document: walk preceding list lines with a column stack instead of dividing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jt55DsfAoyUtew3b3y7qv3
