### PR TITLE
feat(mermaid): Mermaid diagrams as an Extension (beautiful-mermaid in JavaScriptCore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ sparkle_private_key.txt
 
 # Payload build lives in I7T5/edmund-extensions; local copy kept for convenience.
 scripts/build-ratex-payload.sh
+scripts/build-mermaid-payload.sh

--- a/LICENSES/beautiful-mermaid.txt
+++ b/LICENSES/beautiful-mermaid.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Craft Docs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSES/elkjs.txt
+++ b/LICENSES/elkjs.txt
@@ -1,0 +1,264 @@
+# Eclipse Public License - v 2.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+PUBLIC LICENSE (“AGREEMENT”). ANY USE, REPRODUCTION OR DISTRIBUTION OF
+THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+## 1. DEFINITIONS
+
+“Contribution” means:
+
+-   a\) in the case of the initial Contributor, the initial content
+    Distributed under this Agreement, and
+-   b\) in the case of each subsequent Contributor:
+    -   i\) changes to the Program, and
+    -   ii\) additions to the Program;
+
+    where such changes and/or additions to the Program originate from
+    and are Distributed by that particular Contributor. A Contribution
+    “originates” from a Contributor if it was added to the Program by
+    such Contributor itself or anyone acting on such Contributor's
+    behalf. Contributions do not include changes or additions to the
+    Program that are not Modified Works.
+
+“Contributor” means any person or entity that Distributes the Program.
+
+“Licensed Patents” mean patent claims licensable by a Contributor which
+are necessarily infringed by the use or sale of its Contribution alone
+or when combined with the Program.
+
+“Program” means the Contributions Distributed in accordance with this
+Agreement.
+
+“Recipient” means anyone who receives the Program under this Agreement
+or any Secondary License (as applicable), including Contributors.
+
+“Derivative Works” shall mean any work, whether in Source Code or other
+form, that is based on (or derived from) the Program and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+
+“Modified Works” shall mean any work in Source Code or other form that
+results from an addition to, deletion from, or modification of the
+contents of the Program, including, for purposes of clarity any new file
+in Source Code form that contains any contents of the Program. Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program solely
+in each case in order to link to, bind by name, or subclass the Program
+or Modified Works thereof.
+
+“Distribute” means the acts of a) distributing or b) making available in
+any manner that enables the transfer of a copy.
+
+“Source Code” means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+
+“Secondary License” means either the GNU General Public License, Version
+2.0, or any later versions of that license, including any exceptions or
+additional permissions as identified by the initial Contributor.
+
+## 2. GRANT OF RIGHTS
+
+-   a\) Subject to the terms of this Agreement, each Contributor hereby
+    grants Recipient a non-exclusive, worldwide, royalty-free copyright
+    license to reproduce, prepare Derivative Works of, publicly display,
+    publicly perform, Distribute and sublicense the Contribution of such
+    Contributor, if any, and such Derivative Works.
+-   b\) Subject to the terms of this Agreement, each Contributor hereby
+    grants Recipient a non-exclusive, worldwide, royalty-free patent license
+    under Licensed Patents to make, use, sell, offer to sell, import and
+    otherwise transfer the Contribution of such Contributor, if any, in
+    Source Code or other form. This patent license shall apply to the
+    combination of the Contribution and the Program if, at the time the
+    Contribution is added by the Contributor, such addition of the
+    Contribution causes such combination to be covered by the
+    Licensed Patents. The patent license shall not apply to any other
+    combinations which include the Contribution. No hardware per se is
+    licensed hereunder.
+-   c\) Recipient understands that although each Contributor grants the
+    licenses to its Contributions set forth herein, no assurances are
+    provided by any Contributor that the Program does not infringe the
+    patent or other intellectual property rights of any other entity. Each
+    Contributor disclaims any liability to Recipient for claims brought by
+    any other entity based on infringement of intellectual property rights
+    or otherwise. As a condition to exercising the rights and licenses
+    granted hereunder, each Recipient hereby assumes sole responsibility to
+    secure any other intellectual property rights needed, if any. For
+    example, if a third party patent license is required to allow Recipient
+    to Distribute the Program, it is Recipient's responsibility to acquire
+    that license before distributing the Program.
+-   d\) Each Contributor represents that to its knowledge it has sufficient
+    copyright rights in its Contribution, if any, to grant the copyright
+    license set forth in this Agreement.
+-   e\) Notwithstanding the terms of any Secondary License, no Contributor
+    makes additional grants to any Recipient (other than those set forth in
+    this Agreement) as a result of such Recipient's receipt of the Program
+    under the terms of a Secondary License (if permitted under the terms of
+    Section 3).
+
+## 3. REQUIREMENTS
+
+3.1 If a Contributor Distributes the Program in any form, then:
+
+-   a\) the Program must also be made available as Source Code, in accordance
+    with section 3.2, and the Contributor must accompany the Program with a
+    statement that the Source Code for the Program is available under this
+    Agreement, and informs Recipients how to obtain it in a reasonable
+    manner on or through a medium customarily used for software exchange;
+    and
+-   b\) the Contributor may Distribute the Program under a license different
+    than this Agreement, provided that such license:
+    -   i\) effectively disclaims on behalf of all other Contributors all
+        warranties and conditions, express and implied, including warranties or
+        conditions of title and non-infringement, and implied warranties or
+        conditions of merchantability and fitness for a particular purpose;
+    -   ii\) effectively excludes on behalf of all other Contributors all
+        liability for damages, including direct, indirect, special, incidental
+        and consequential damages, such as lost profits;
+    -   iii\) does not attempt to limit or alter the recipients' rights in the
+        Source Code under section 3.2; and
+    -   iv\) requires any subsequent distribution of the Program by any party to
+        be under a license that satisfies the requirements of this section 3.
+
+3.2 When the Program is Distributed as Source Code:
+
+-   a\) it must be made available under this Agreement, or if the Program (i)
+    is combined with other material in a separate file or files made
+    available under a Secondary License, and (ii) the initial Contributor
+    attached to the Source Code the notice described in Exhibit A of this
+    Agreement, then the Program may be made available under the terms of
+    such Secondary Licenses, and
+-   b\) a copy of this Agreement must be included with each copy of
+    the Program.
+
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability (‘notices’) contained within the Program from any copy of
+the Program which they Distribute, provided that Contributors may add
+their own appropriate notices.
+
+## 4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While this
+license is intended to facilitate the commercial use of the Program, the
+Contributor who includes the Program in a commercial product offering
+should do so in a manner which does not create potential liability for
+other Contributors. Therefore, if a Contributor includes the Program in
+a commercial product offering, such Contributor (“Commercial
+Contributor”) hereby agrees to defend and indemnify every other
+Contributor (“Indemnified Contributor”) against any losses, damages and
+costs (collectively “Losses”) arising from claims, lawsuits and other
+legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the
+Program in a commercial product offering. The obligations in this
+section do not apply to any claims or Losses relating to any actual or
+alleged intellectual property infringement. In order to qualify, an
+Indemnified Contributor must: a) promptly notify the Commercial
+Contributor in writing of such claim, and b) allow the Commercial
+Contributor to control, and cooperate with the Commercial Contributor
+in, the defense and any related settlement negotiations. The Indemnified
+Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those
+performance claims and warranties, and if a court requires any other
+Contributor to pay any damages as a result, the Commercial Contributor
+must pay those damages.
+
+## 5. NO WARRANTY {#warranty}
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN “AS IS”
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs or
+equipment, and unavailability or interruption of operations.
+
+## 6. DISCLAIMER OF LIABILITY {#disclaimer}
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+## 7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further action
+by the parties hereto, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including
+a cross-claim or counterclaim in a lawsuit) alleging that the Program
+itself (excluding combinations of the Program with other software or
+hardware) infringes such Recipient's patent(s), then such Recipient's
+rights granted under Section 2(b) shall terminate as of the date such
+litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails
+to comply with any of the material terms or conditions of this Agreement
+and does not cure such failure in a reasonable period of time after
+becoming aware of such noncompliance. If all Recipient's rights under
+this Agreement terminate, Recipient agrees to cease use and distribution
+of the Program as soon as reasonably practicable. However, Recipient's
+obligations under this Agreement and any licenses granted by Recipient
+relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and may
+only be modified in the following manner. The Agreement Steward reserves
+the right to publish new versions (including revisions) of this
+Agreement from time to time. No one other than the Agreement Steward has
+the right to modify this Agreement. The Eclipse Foundation is the
+initial Agreement Steward. The Eclipse Foundation may assign the
+responsibility to serve as the Agreement Steward to a suitable separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always be
+Distributed subject to the version of the Agreement under which it was
+received. In addition, after a new version of the Agreement is
+published, Contributor may elect to Distribute the Program (including
+its Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted
+under this Agreement are reserved. Nothing in this Agreement is intended
+to be enforceable by any entity that is not a Contributor or Recipient.
+No third-party beneficiary rights are created under this Agreement.
+
+## Exhibit A – Form of Secondary Licenses Notice {#exhibit-a}
+
+“This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set forth
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}.”
+
+> Simply including a copy of this Agreement, including this Exhibit A is
+> not sufficient to license the Source Code under Secondary Licenses.
+>
+> If it is not possible or desirable to put the notice in a particular
+> file, then You may include the notice in a location (such as a LICENSE
+> file in a relevant directory) where a recipient would be likely to
+> look for such a notice.
+>
+> You may add additional accurate notices of copyright ownership.

--- a/LICENSES/entities.txt
+++ b/LICENSES/entities.txt
@@ -1,0 +1,11 @@
+Copyright (c) Felix Böhm
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ The list is by no means exhaustive, and neither was it meant to be. I just wante
 - Apple, Iowan Old Style, [Tomorrow Light](https://github.com/chriskempson/tomorrow-theme) and [One Dark](https://github.com/atom/atom/tree/master/packages/one-dark-syntax) for the aesthetics
 - [create-dmg](https://github.com/sindresorhus/create-dmg), [screenshot-studio](screenshot-studio.com), and [shields](shields.io) for the utilities
 - Claude, [caveman](https://github.com/JuliusBrussee/caveman), and [ponytail](https://github.com/DietrichGebert/ponytail) for the engineering. 
-<!-- - [RaTeX], [beautiful-mermaid], [Shiki] for extension functionalities -->
+- [RaTeX](https://ratex.lites.dev) and [beautiful-mermaid](https://github.com/lukilabs/beautiful-mermaid) for extension functionalities
+<!-- Shiki stays out until a Shiki/TextMate backend actually ships — see CodeSyntaxBackend.swift -->
 
 Most importantly, many thanks to our contributors: 
 

--- a/Sources/EdmundCore/Diagrams/MermaidRelease.swift
+++ b/Sources/EdmundCore/Diagrams/MermaidRelease.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Pinned `beautiful-mermaid` (MIT) release coordinates. Never "latest" — a
+/// specific version is baked in so an update requires a new app build (and a
+/// fresh SHA-256 pin), never a moving target.
+///
+/// The runtime payload is a single `.tar.gz` holding one self-contained
+/// JavaScript file plus the licenses of everything bundled into it:
+///   `beautiful-mermaid.js`, `licenses/*`
+/// Built by `scripts/build-mermaid-payload.sh` in `I7T5/edmund-extensions` —
+/// that repo owns payload building, and hosts the result as a release asset
+/// rather than depending on npm/upstream uptime. An untracked copy of the
+/// script may sit at this repo's `scripts/` for convenience; it is gitignored,
+/// so the version over there is the one of record. A separate repo, not just a
+/// non-`v*` tag here, so a ~500 KB binary never enters this repo's history and
+/// so publishing a payload cannot touch the app's `v*` tag-driven
+/// `release.yml` at all.
+///
+/// The bundle carries `elkjs` (EPL-2.0) and `entities` (BSD-2-Clause) along
+/// with beautiful-mermaid itself; EPL-2.0 redistribution is why `licenses/`
+/// is part of the archive rather than an afterthought.
+public enum MermaidRelease {
+    /// Tracks the upstream beautiful-mermaid release the payload was built
+    /// from. 1.1.3 is the current release; it renders flowchart, state,
+    /// sequence, class, ER, and XY-chart diagrams, and its `renderMermaidSVG`
+    /// is synchronous (a direct ELK FakeWorker bypass), which is what lets it
+    /// run inside the synchronous `DocumentHTML.full` assembly.
+    public static let version = "1.1.3"
+    public static let archiveURL = URL(string: "https://github.com/I7T5/edmund-extensions/releases/download/mermaid-assets-1.1.3/beautiful-mermaid-1.1.3.tar.gz")!
+    /// Lowercase hex SHA-256 of the pinned `.tar.gz`, verified by downloading
+    /// the hosted asset and hashing that — not the local build. The two can
+    /// differ: the build script is byte-stable on one machine but not across
+    /// `tar`/`gzip` implementations, so the local artifact is evidence about
+    /// this machine, not about what users will actually fetch.
+    ///
+    /// Empty until the asset is published, which leaves `isConfigured` false —
+    /// the extension then shows in Settings but reports the payload as
+    /// unavailable rather than attempting a download that cannot be verified.
+    public static let archiveSHA256 = ""
+
+    /// Whether a real artifact hash has been pinned.
+    public static var isConfigured: Bool { payload.isConfigured }
+
+    /// Coordinates for the shared installer. A version-stamped directory means
+    /// a new pinned version installs fresh.
+    public static let payload = ExtensionPayload(
+        directoryName: "Diagrams/beautiful-mermaid-\(version)",
+        archiveURL: archiveURL,
+        archiveSHA256: archiveSHA256,
+        sentinelFile: "beautiful-mermaid.js")
+}

--- a/Sources/EdmundCore/Diagrams/MermaidRelease.swift
+++ b/Sources/EdmundCore/Diagrams/MermaidRelease.swift
@@ -33,10 +33,11 @@ public enum MermaidRelease {
     /// `tar`/`gzip` implementations, so the local artifact is evidence about
     /// this machine, not about what users will actually fetch.
     ///
-    /// Empty until the asset is published, which leaves `isConfigured` false —
-    /// the extension then shows in Settings but reports the payload as
-    /// unavailable rather than attempting a download that cannot be verified.
-    public static let archiveSHA256 = ""
+    /// Empty leaves `isConfigured` false — the extension then shows in Settings
+    /// but reports the payload as unavailable rather than attempting a download
+    /// that cannot be verified. That was the state until the asset went up.
+    public static let archiveSHA256 =
+        "6c7dfaeff7fbf7ef9c88eb9531ab332b929db819d75200d333e483001eef1ab7"
 
     /// Whether a real artifact hash has been pinned.
     public static var isConfigured: Bool { payload.isConfigured }

--- a/Sources/EdmundCore/Diagrams/MermaidRenderer.swift
+++ b/Sources/EdmundCore/Diagrams/MermaidRenderer.swift
@@ -1,0 +1,181 @@
+import AppKit
+import JavaScriptCore
+
+/// Colours a diagram is drawn with. beautiful-mermaid derives every internal
+/// custom property (`--_node-fill`, `--_line`, `--_arrow`, …) from these two by
+/// mixing them at fixed percentages, so passing the page's background and body
+/// ink is enough to make a diagram sit in the document rather than on it.
+///
+/// ponytail: two fields, not the library's full seven. `line`/`accent`/`muted`/
+/// `surface`/`border` are overrides for palettes that can't be derived — add
+/// them if a diagram ever needs to disagree with the page, not before.
+struct MermaidStyle: Hashable {
+    let backgroundHex: String
+    let foregroundHex: String
+
+    /// The subset of the library's `RenderOptions` we set, as JSON.
+    ///
+    /// `font` is deliberately not set. The library's default (Inter) is absent
+    /// on macOS, so the emitted rule falls through to `system-ui, sans-serif` —
+    /// a UI face, which is what diagram labels want, and whose metrics are
+    /// close to what the library's character-width heuristic was calibrated
+    /// against. Passing the editor's serif body font would risk labels
+    /// overflowing their boxes, since the box sizes come from that heuristic
+    /// rather than from real font metrics.
+    var optionsJSON: String {
+        #"{"bg":"\#(backgroundHex)","fg":"\#(foregroundHex)"}"#
+    }
+
+    /// Read mode's own palette for the given appearance, so a diagram matches
+    /// the page it is embedded in.
+    @MainActor
+    static func readMode(dark: Bool) -> MermaidStyle {
+        MermaidStyle(backgroundHex: HTMLTheme.backgroundColor(dark: dark).hexString,
+                     foregroundHex: EditorTheme.bodyTextColorResolved(dark: dark).hexString)
+    }
+}
+
+/// Renders Mermaid diagram source to SVG using `beautiful-mermaid` (MIT), run
+/// as plain JavaScript in JavaScriptCore — the "Mermaid" extension's engine.
+///
+/// Not ready until `install()` has downloaded, verified and evaluated the
+/// payload; until then `svg(source:style:)` returns nil and every caller falls
+/// back to showing the fenced code block as ordinary code. Every failure mode
+/// (no network, hash mismatch, JS load error, a diagram the library can't
+/// parse) degrades that same way — never crash, never install or trust an
+/// unverified artifact.
+///
+/// Rendering is genuinely synchronous, which is the reason for hosting the
+/// library here rather than in a WKWebView: `DocumentHTML.full` is a
+/// synchronous `@MainActor` function, and an async renderer would force that
+/// whole export path — Read mode, HTML export and PDF — to become async.
+@MainActor
+public final class MermaidRenderer {
+    public static let shared = MermaidRenderer()
+
+    /// Whether the user has the extension enabled. Rendering is refused when
+    /// false even if the payload is installed, so disabling takes effect
+    /// without an uninstall.
+    public var isEnabled = false
+
+    private let installer: ExtensionPayloadInstaller
+    private var context: JSContext?
+    private var render: JSValue?
+
+    /// Rendered SVG, keyed on source + palette. Diagram layout is the
+    /// expensive part (~29 ms steady-state, ~113 ms for the first one), and
+    /// Read mode re-renders the whole document on every keystroke-driven
+    /// refresh, so an unbounded miss rate here would be felt.
+    private let cache = NSCache<NSString, NSString>()
+
+    public init(installer: ExtensionPayloadInstaller = ExtensionPayloadInstaller(payload: MermaidRelease.payload)) {
+        self.installer = installer
+        cache.countLimit = 64
+    }
+
+    /// Whether the payload is loaded and rendering can be attempted.
+    public var isReady: Bool { render != nil }
+
+    /// The installer's current state, for Settings to surface (downloading %,
+    /// verifying, ready, failed → retry).
+    public var installState: ExtensionInstallState {
+        get async { await installer.state }
+    }
+
+    /// Downloads/verifies/installs (if needed) and evaluates the payload.
+    /// Safe to call repeatedly; a no-op once already `isReady`.
+    public func install() async {
+        guard !isReady, let dir = try? await installer.ensureInstalled() else { return }
+        load(dir: dir)
+    }
+
+    /// Unloads the library and removes its files from disk. Safe to call even
+    /// if never installed.
+    public func uninstall() async {
+        unload()
+        await installer.uninstall()
+    }
+
+    /// Evaluates the payload in a fresh `JSContext`. Internal so tests can
+    /// load an unpacked payload directly, without a network fixture.
+    func load(dir: URL) {
+        let file = dir.appendingPathComponent(MermaidRelease.payload.sentinelFile)
+        guard let source = try? String(contentsOf: file, encoding: .utf8),
+              let ctx = JSContext() else {
+            Log.error("Mermaid: cannot read payload at \(file.path)")
+            return
+        }
+
+        ctx.exceptionHandler = { _, exception in
+            Log.error("Mermaid JS exception: \(exception?.toString() ?? "unknown")")
+        }
+        // The payload's console shim forwards here when the host provides it.
+        let logHook: @convention(block) (String, String) -> Void = { level, message in
+            Log.error("Mermaid JS [\(level)]: \(message)")
+        }
+        ctx.setObject(logHook, forKeyedSubscript: "__edmundLog" as NSString)
+
+        ctx.evaluateScript(source)
+        guard let fn = ctx.objectForKeyedSubscript("__edmundRenderMermaid"), !fn.isUndefined else {
+            Log.error("Mermaid: payload did not define __edmundRenderMermaid")
+            return
+        }
+        context = ctx
+        render = fn
+        cache.removeAllObjects()
+    }
+
+    func unload() {
+        render = nil
+        context = nil
+        cache.removeAllObjects()
+    }
+
+    /// Renders `source` to a self-contained SVG string, or nil when the
+    /// extension is disabled, not installed, or the diagram doesn't parse.
+    ///
+    /// The bridge returns `"ERROR: …"` rather than throwing: an exception
+    /// crossing the JSContext boundary is much harder to attribute than a
+    /// sentinel string, and a malformed diagram is an expected input here, not
+    /// an exceptional one.
+    func svg(source: String, style: MermaidStyle) -> String? {
+        guard isEnabled, let render else { return nil }
+
+        let key = "\(style.backgroundHex)|\(style.foregroundHex)|\(source)" as NSString
+        if let hit = cache.object(forKey: key) { return hit as String }
+
+        guard let result = render.call(withArguments: [source, style.optionsJSON])?.toString(),
+              result.hasPrefix("<svg") else {
+            // Malformed diagram source is normal user input mid-typing; the
+            // caller falls back to a plain code block. Not logged at error.
+            return nil
+        }
+        guard Self.isSafeSVG(result) else {
+            Log.error("Mermaid: rejected an SVG that failed the safety check")
+            return nil
+        }
+        cache.setObject(result as NSString, forKey: key)
+        return result
+    }
+
+    /// Read mode's page promises to reach the network for nothing and to run
+    /// no script. The payload's shim already strips the webfont `@import`, so
+    /// this is the trust boundary that checks it actually did — the SVG is
+    /// spliced into the document as live markup, not as an opaque image.
+    ///
+    /// `url(#…)` is explicitly allowed: same-document fragment references are
+    /// how every arrowhead is drawn (nine of them in a five-node flowchart).
+    /// Rejecting `url(` outright would silently strip the arrowheads off every
+    /// diagram.
+    nonisolated static func isSafeSVG(_ svg: String) -> Bool {
+        let lowered = svg.lowercased()
+        for forbidden in ["<script", "<foreignobject", "<iframe", "javascript:", "@import", "<!entity", "<use"] {
+            if lowered.contains(forbidden) { return false }
+        }
+        // Any url(...) that is not a same-document fragment reference.
+        if lowered.range(of: #"url\(\s*(?!#)"#, options: .regularExpression) != nil { return false }
+        // on* event-handler attributes (onload=, onclick=, …).
+        if lowered.range(of: #"\son[a-z]+\s*="#, options: .regularExpression) != nil { return false }
+        return true
+    }
+}

--- a/Sources/EdmundCore/Export/DocumentHTML.swift
+++ b/Sources/EdmundCore/Export/DocumentHTML.swift
@@ -23,6 +23,7 @@ enum DocumentHTML {
                      baseURL: URL? = nil,
                      options: ReadRenderOptions = .default) -> String {
         var body = HTMLRenderer.render(markdown: markdown, options: options)
+        body = fillMermaid(body, dark: dark)
         body = fillMath(body, theme: theme, dark: dark)
         body = fillImages(body, baseURL: baseURL, options: options)
         let css = HTMLTheme.css(theme, callouts: callouts, dark: dark,
@@ -37,6 +38,53 @@ enum DocumentHTML {
         </style></head>
         <body><div class="page">\(body)</div></body></html>
         """
+    }
+
+    // MARK: Mermaid (diagram source → inline SVG)
+
+    // Group 1 is the block's `edmund-l<N>` source-line anchor (see
+    // `HTMLRenderer.addingAnchorID`), carried through into the replacement so
+    // the anchor survives this pass. Group 2 is the base64 diagram source,
+    // group 3 the wrapped code block used as the fallback.
+    //
+    // The `</div></div>` tail is what ends the match: the wrapped
+    // `code-block-wrap` div contains only an `<a>` and a `<pre>`, never
+    // another div, so the first adjacent pair of closing tags is this
+    // placeholder's own.
+    private static let mermaidPattern =
+        "<div( id=\"[^\"]*\")? class=\"mermaid-diagram\" data-source=\"([^\"]*)\">(.*?)</div></div>"
+
+    /// Replaces each mermaid placeholder with an inline SVG, or unwraps it back
+    /// to the plain code block when the extension is disabled, not installed,
+    /// or the diagram doesn't parse.
+    ///
+    /// Runs before `fillMath` so a diagram is never scanned for `$…$` math.
+    private static func fillMermaid(_ html: String, dark: Bool) -> String {
+        // No early-out when the extension is off: the placeholder is markup
+        // `HTMLRenderer` always emits, so this pass must run to unwrap it even
+        // when nothing can render. Skipping it would leak `data-source="…"`
+        // into the finished document.
+        let style = MermaidStyle.readMode(dark: dark)
+        return replaceMatches(html, pattern: mermaidPattern) { groups in
+            let id = groups[1]
+            // Unwrapping drops the outer div, so the source-line anchor has to
+            // move onto the code block it wrapped — otherwise a fenced diagram
+            // that failed to render becomes a hole in Read mode's scroll-sync
+            // anchor list.
+            let wrapOpen = "<div class=\"code-block-wrap\""
+            let fallback = (groups[3].hasPrefix(wrapOpen)
+                ? "<div\(id) class=\"code-block-wrap\"" + groups[3].dropFirst(wrapOpen.count)
+                : groups[3]) + "</div>"
+            guard let data = Data(base64Encoded: groups[2]),
+                  let source = String(data: data, encoding: .utf8),
+                  let svg = MermaidRenderer.shared.svg(source: source, style: style) else {
+                return fallback
+            }
+            // `role="img"` with the source as the label: a screen reader
+            // otherwise walks the SVG's individual text nodes and reads the
+            // diagram's labels in layout order, which is meaningless.
+            return "<div\(id) class=\"mermaid-diagram\" role=\"img\" aria-label=\"\(HTMLRenderer.attr(source))\">\(svg)</div>"
+        }
     }
 
     // MARK: Math (active engine → PNG data URI)

--- a/Sources/EdmundCore/Export/HTMLRenderer.swift
+++ b/Sources/EdmundCore/Export/HTMLRenderer.swift
@@ -283,7 +283,20 @@ struct HTMLRenderer: MarkupVisitor {
         // swift-markdown includes a trailing newline on the block's code.
         let code = raw.hasSuffix("\n") ? String(raw.dropLast()) : raw
         let pre = "<pre><code\(lang)>\(Self.highlightCode(code, language: codeBlock.language))</code></pre>"
-        return "<div class=\"code-block-wrap\">\(Self.copyButtonHTML(code: code))\(pre)</div>"
+        let block = "<div class=\"code-block-wrap\">\(Self.copyButtonHTML(code: code))\(pre)</div>"
+        guard MermaidSyntax.matches(language: codeBlock.language) else { return block }
+        // This visitor is pure and non-isolated, so it can't reach the
+        // @MainActor renderer; it emits a placeholder that `DocumentHTML`
+        // fills in a later pass. The diagram source rides along base64-encoded
+        // so no amount of markdown punctuation can break out of the attribute.
+        //
+        // The code block is WRAPPED rather than replaced: when the extension
+        // is off, not installed, or the diagram doesn't parse, the fill pass
+        // unwraps to exactly this markup — a normal code block, copy button
+        // and syntax coloring included — so the fallback needs no separate
+        // implementation and can't drift from the real thing.
+        let source = Data(code.utf8).base64EncodedString()
+        return "<div class=\"mermaid-diagram\" data-source=\"\(source)\">\(block)</div>"
     }
 
     /// A code block's copy button: a bare icon, hidden until the block is

--- a/Sources/EdmundCore/Export/HTMLTheme.swift
+++ b/Sources/EdmundCore/Export/HTMLTheme.swift
@@ -198,6 +198,23 @@ enum HTMLTheme {
           /* tab-size: browsers default to 8; match the common editor convention of 4. */
           tab-size: 4; -moz-tab-size: 4; }
     pre code { color: var(--fg); background: none; padding: 0; font-size: var(--mono-size); }
+    /* A rendered diagram centres in the column and never overflows it. The SVG
+       carries intrinsic width/height, so capping width alone would squash it —
+       `height: auto` keeps the aspect ratio. A diagram wider than the column
+       (a long sequence chart) scrolls horizontally rather than forcing the
+       page to. */
+    .mermaid-diagram { margin: 1em 0; overflow-x: auto; }
+    .mermaid-diagram svg { display: block; margin: 0 auto; max-width: 100%; height: auto;
+      /* The diagram reads --line/--accent/--muted/--surface/--border and falls
+         back to shades derived from its own --bg/--fg when they are unset. The
+         page happens to define --accent (the link colour), which inherits into
+         the SVG and was painting arrowheads link-blue — arrows aren't links,
+         and they'd drift again with any new page variable. `initial` makes a
+         custom property guaranteed-invalid, so each var() takes its fallback:
+         the diagram derives entirely from the two colours we pass it. --bg/--fg
+         are set inline on the <svg> and are unaffected. */
+      --line: initial; --accent: initial; --muted: initial;
+      --surface: initial; --border: initial; }
     /* Copy button: a bare hover-revealed icon, matching Obsidian's read-mode
        treatment. `.code-block-wrap` takes over `pre`'s outer margin so the
        button can be positioned absolutely inside it without moving `pre`. */
@@ -408,7 +425,7 @@ enum HTMLTheme {
          so callout backgrounds, code blocks, and highlights survive printing. */
       * { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
       .callout, pre, blockquote, .table-wrap, .math-display,
-      .math-display-block { break-inside: avoid; }
+      .math-display-block, .mermaid-diagram { break-inside: avoid; }
       h1, h2, h3, h4, h5, h6 { break-after: avoid; }
       thead { display: table-header-group; }
     }

--- a/Sources/EdmundCore/Export/ReadModeWebView.swift
+++ b/Sources/EdmundCore/Export/ReadModeWebView.swift
@@ -33,6 +33,17 @@ public final class ReadModeWebView: WKWebView {
         coordinator.owner = self
         navigationDelegate = coordinator
         if #available(macOS 13.3, *) { isInspectable = true }
+
+        // A rendering engine was enabled, installed, or removed (e.g. the
+        // Mermaid extension toggled in Settings). Re-render so diagrams appear
+        // or fall back to code blocks without the user leaving and re-entering
+        // Read mode. Same treatment as an appearance flip; the scroll position
+        // is preserved by `reloadHTML()`.
+        NotificationCenter.default.addObserver(
+            forName: .renderEngineChanged, object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.reloadHTML() }
+        }
     }
 
     @available(*, unavailable)

--- a/Sources/EdmundCore/Extensions/EdmundExtension.swift
+++ b/Sources/EdmundCore/Extensions/EdmundExtension.swift
@@ -103,11 +103,21 @@ public protocol EdmundExtension: AnyObject {
     /// `false` when there's no update-checking source — the "Update" button
     /// stays hidden rather than lying about freshness.
     var hasUpdate: Bool { get }
+    /// Whether this build has a verifiable payload pinned for the extension.
+    /// `false` means "not available in this build yet" — Settings says so
+    /// instead of offering a download that can never succeed. Defaults to
+    /// `true` for an extension with nothing to download.
+    var payloadIsConfigured: Bool { get }
+}
+
+public extension EdmundExtension {
+    var payloadIsConfigured: Bool { true }
 }
 
 /// Catalog of the app's built-in extensions. SwiftMath itself is not an
-/// extension — it's the always-on default — so today's only entry is the
-/// RaTeX-powered "Advanced Math" option layered over it.
+/// extension — it's the always-on default — so the RaTeX-powered "Advanced
+/// Math" option is layered over it, while "Mermaid" adds a capability the app
+/// has none of by default.
 ///
 /// This is a static array, not a fetched registry — there's no backend here.
 /// A real registry, if one gets built later, should follow the shape
@@ -116,7 +126,7 @@ public protocol EdmundExtension: AnyObject {
 /// noted for later, not built now.
 @MainActor
 public enum ExtensionRegistry {
-    public static let all: [EdmundExtension] = [AdvancedMathExtension.shared]
+    public static let all: [EdmundExtension] = [AdvancedMathExtension.shared, MermaidExtension.shared]
 }
 
 /// "Advanced Math" — an opt-in, KaTeX-compatible math engine (RaTeX), run as
@@ -163,6 +173,7 @@ public final class AdvancedMathExtension: EdmundExtension {
     // No update-checking source exists yet — same "scaffold now, wire later"
     // shape as the install flow itself.
     public let hasUpdate = false
+    public var payloadIsConfigured: Bool { RaTeXRelease.isConfigured }
 
     public let renderer: RaTeXRenderer
 

--- a/Sources/EdmundCore/Extensions/EdmundExtension.swift
+++ b/Sources/EdmundCore/Extensions/EdmundExtension.swift
@@ -121,7 +121,7 @@ public enum ExtensionRegistry {
 
 /// "Advanced Math" — an opt-in, KaTeX-compatible math engine (RaTeX), run as
 /// sandboxed WebAssembly in JavaScriptCore rather than shipped in the binary.
-/// See `RaTeXRelease`/`RaTeXInstaller`/`WasmMathHost` for the download,
+/// See `RaTeXRelease`/`ExtensionPayloadInstaller`/`WasmMathHost` for the download,
 /// verify, and load machinery this wraps.
 @MainActor
 public final class AdvancedMathExtension: EdmundExtension {
@@ -172,7 +172,7 @@ public final class AdvancedMathExtension: EdmundExtension {
 
     /// The installer's current state, for Settings to surface a specific
     /// reason on failure (e.g. RaTeX not configured in this build yet).
-    public var installState: MathExtensionState {
+    public var installState: ExtensionInstallState {
         get async { await renderer.installState }
     }
 

--- a/Sources/EdmundCore/Extensions/EdmundExtension.swift
+++ b/Sources/EdmundCore/Extensions/EdmundExtension.swift
@@ -87,8 +87,12 @@ public protocol EdmundExtension: AnyObject {
     var repositoryURL: URL? { get }
     /// Human-readable installed footprint, e.g. "3.2 MB". `nil` if unknown.
     var installedSizeDescription: String? { get }
-    /// When this extension's payload was last published, for a relative
-    /// "X days/months/years ago" display. `nil` hides the row.
+    /// When this **extension** last shipped a new `version` — not when its
+    /// upstream payload was published. The pane shows it beside the
+    /// extension's own version, so a date from the payload's release schedule
+    /// would describe a different thing than the number above it. Bump it
+    /// whenever `version` changes. Relative display ("X months ago"); `nil`
+    /// hides the row.
     var lastUpdated: Date? { get }
     /// Download count, if there's a real source for it. `nil` hides the row
     /// — no extension here has a live analytics backend yet, so this should
@@ -158,11 +162,12 @@ public final class AdvancedMathExtension: EdmundExtension {
     public let repositoryURL: URL? = nil
     // Measured from the built payload: 2.6 MB wasm + 540 KB fonts + 8 KB glue.
     public let installedSizeDescription: String? = "3.2 MB"
-    // ratex-wasm@0.1.12's actual npm publish date (verified against the
-    // registry, not a guess) — not Edmund's own commit date.
+    // When v1.0.0 of *this extension* shipped (`fe4cf3b`), not when the RaTeX
+    // wasm it downloads was published — the row sits under the version above
+    // and has to describe the same thing.
     public let lastUpdated: Date? = {
         var c = DateComponents()
-        c.year = 2026; c.month = 6; c.day = 25
+        c.year = 2026; c.month = 7; c.day = 28
         return Calendar(identifier: .gregorian).date(from: c)
     }()
     // No real download-analytics source exists for this extension.

--- a/Sources/EdmundCore/Extensions/ExtensionPayloadInstaller.swift
+++ b/Sources/EdmundCore/Extensions/ExtensionPayloadInstaller.swift
@@ -1,8 +1,8 @@
 import Foundation
 import CryptoKit
 
-/// Install-state machine for the RaTeX extension's payload archive.
-public enum MathExtensionState: Equatable, Sendable {
+/// Install-state machine for an extension's payload archive.
+public enum ExtensionInstallState: Equatable, Sendable {
     case notInstalled
     case downloading(progress: Double)
     case verifying
@@ -10,30 +10,57 @@ public enum MathExtensionState: Equatable, Sendable {
     case failed(String)
 }
 
-public enum RaTeXInstallError: Error, Equatable {
+public enum ExtensionInstallError: Error, Equatable {
     case notConfigured
     case downloadFailed(URL)
     case hashMismatch
     case unpackFailed
 }
 
-/// Downloads, SHA-256-verifies, and atomically installs the pinned RaTeX
-/// payload (`.tar.gz` of wasm + glue + KaTeX fonts) into Application Support.
-/// The download is verified before it is ever unpacked, so a corrupted or
-/// tampered archive is never installed; a failure at any step leaves
-/// `state == .failed` and throws — the caller (`RaTeXRenderer`) stays
-/// not-ready and `MathRendering` falls back to SwiftMath, never crashing.
-public actor RaTeXInstaller {
-    public private(set) var state: MathExtensionState = .notInstalled
+/// Where one extension's runtime payload lives and how to recognise a good
+/// install. Everything that differs between payloads is here; the installer
+/// itself is identical for all of them.
+public struct ExtensionPayload: Sendable {
+    /// Path under Application Support's `Edmund/`, version-stamped by the
+    /// caller (e.g. `"Math/ratex-0.1.14"`) so a new pinned version installs
+    /// fresh instead of merging into an old directory.
+    public let directoryName: String
+    public let archiveURL: URL
+    /// Lowercase hex SHA-256 of the pinned `.tar.gz`.
+    public let archiveSHA256: String
+    /// A file the unpacked archive must contain. Doubles as the unpack
+    /// sanity check and the "is this install still good" probe on relaunch.
+    public let sentinelFile: String
 
-    public init() {}
+    public init(directoryName: String, archiveURL: URL, archiveSHA256: String, sentinelFile: String) {
+        self.directoryName = directoryName
+        self.archiveURL = archiveURL
+        self.archiveSHA256 = archiveSHA256
+        self.sentinelFile = sentinelFile
+    }
 
-    /// Directory the pinned version installs into:
-    /// `~/Library/Application Support/Edmund/Math/ratex-<version>/`. A
-    /// version-stamped path means a new pinned version installs fresh.
-    public static var installDirectory: URL {
+    /// Whether a real artifact hash has been pinned.
+    public var isConfigured: Bool { !archiveSHA256.isEmpty }
+
+    /// `~/Library/Application Support/Edmund/<directoryName>/`
+    public var installDirectory: URL {
         FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("Edmund/Math/ratex-\(RaTeXRelease.version)", isDirectory: true)
+            .appendingPathComponent("Edmund/\(directoryName)", isDirectory: true)
+    }
+}
+
+/// Downloads, SHA-256-verifies, and atomically installs a pinned extension
+/// payload (`.tar.gz`) into Application Support. The download is verified
+/// before it is ever unpacked, so a corrupted or tampered archive is never
+/// installed; a failure at any step leaves `state == .failed` and throws — the
+/// calling renderer stays not-ready and the app degrades to its built-in
+/// default, never crashing.
+public actor ExtensionPayloadInstaller {
+    public let payload: ExtensionPayload
+    public private(set) var state: ExtensionInstallState = .notInstalled
+
+    public init(payload: ExtensionPayload) {
+        self.payload = payload
     }
 
     /// Name of the stamp file recording the verified archive hash of a
@@ -43,7 +70,7 @@ public actor RaTeXInstaller {
     /// Removes the installed version directory, if any, and resets `state`.
     /// Best-effort — a missing/already-gone directory is not an error.
     public func uninstall() {
-        try? FileManager.default.removeItem(at: Self.installDirectory)
+        try? FileManager.default.removeItem(at: payload.installDirectory)
         state = .notInstalled
     }
 
@@ -51,20 +78,20 @@ public actor RaTeXInstaller {
     /// unpacking if needed) and returns the install directory.
     public func ensureInstalled() async throws -> URL {
         do {
-            guard RaTeXRelease.isConfigured else { throw RaTeXInstallError.notConfigured }
-            let dir = Self.installDirectory
+            guard payload.isConfigured else { throw ExtensionInstallError.notConfigured }
+            let dir = payload.installDirectory
             if isVerifiedInstall(dir) {
                 state = .installed
                 return dir
             }
 
             state = .downloading(progress: 0)
-            let archive = try await download(RaTeXRelease.archiveURL)
+            let archive = try await download(payload.archiveURL)
 
             state = .verifying
-            try verify(archive, sha256: RaTeXRelease.archiveSHA256)
+            try verify(archive, sha256: payload.archiveSHA256)
 
-            try installAtomically(archive: archive, sha256: RaTeXRelease.archiveSHA256, into: dir)
+            try installAtomically(archive: archive, sha256: payload.archiveSHA256, into: dir)
             state = .installed
             return dir
         } catch {
@@ -74,21 +101,22 @@ public actor RaTeXInstaller {
     }
 
     /// A completed install is trusted on relaunch when its stamp records the
-    /// pinned hash and the wasm file is present. The download was hash-verified
-    /// before it was unpacked; the stamp just avoids re-downloading. (The
-    /// unpacked dir lives in the user's Application Support; we don't re-hash
-    /// every file on each launch — the trust boundary is the verified download.)
+    /// pinned hash and the sentinel file is present. The download was
+    /// hash-verified before it was unpacked; the stamp just avoids
+    /// re-downloading. (The unpacked dir lives in the user's Application
+    /// Support; we don't re-hash every file on each launch — the trust
+    /// boundary is the verified download.)
     private func isVerifiedInstall(_ dir: URL) -> Bool {
         let stamp = (try? String(contentsOf: dir.appendingPathComponent(Self.stampName), encoding: .utf8))?
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        return stamp == RaTeXRelease.archiveSHA256
-            && FileManager.default.fileExists(atPath: dir.appendingPathComponent("ratex_wasm_bg.wasm").path)
+        return stamp == payload.archiveSHA256
+            && FileManager.default.fileExists(atPath: dir.appendingPathComponent(payload.sentinelFile).path)
     }
 
     private func download(_ url: URL) async throws -> Data {
         let (data, response) = try await URLSession.shared.data(from: url)
         guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
-            throw RaTeXInstallError.downloadFailed(url)
+            throw ExtensionInstallError.downloadFailed(url)
         }
         return data
     }
@@ -98,7 +126,7 @@ public actor RaTeXInstaller {
     // fixture.
     func verify(_ data: Data, sha256 expected: String) throws {
         let digest = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
-        guard digest == expected else { throw RaTeXInstallError.hashMismatch }
+        guard digest == expected else { throw ExtensionInstallError.hashMismatch }
     }
 
     /// Unpacks the verified `.tar.gz` into a temp dir, stamps it with the
@@ -115,8 +143,8 @@ public actor RaTeXInstaller {
         let unpacked = tmp.appendingPathComponent("unpacked", isDirectory: true)
         try fm.createDirectory(at: unpacked, withIntermediateDirectories: true)
         try untar(tarball, into: unpacked)
-        guard fm.fileExists(atPath: unpacked.appendingPathComponent("ratex_wasm_bg.wasm").path) else {
-            throw RaTeXInstallError.unpackFailed
+        guard fm.fileExists(atPath: unpacked.appendingPathComponent(payload.sentinelFile).path) else {
+            throw ExtensionInstallError.unpackFailed
         }
         try sha256.write(to: unpacked.appendingPathComponent(Self.stampName), atomically: true, encoding: .utf8)
 
@@ -125,9 +153,8 @@ public actor RaTeXInstaller {
         try fm.moveItem(at: unpacked, to: dir)
     }
 
-    /// Extracts a gzip tarball with the system `tar`. The archive stores its
-    /// files at the root (`ratex_wasm_bg.wasm`, `ratex_wasm.js`, `fonts/…`),
-    /// so they land directly in `dir`.
+    /// Extracts a gzip tarball with the system `tar`. Payload archives store
+    /// their files at the root, so they land directly in `dir`.
     private func untar(_ tarball: URL, into dir: URL) throws {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
@@ -136,6 +163,6 @@ public actor RaTeXInstaller {
         proc.standardError = FileHandle.nullDevice
         try proc.run()
         proc.waitUntilExit()
-        guard proc.terminationStatus == 0 else { throw RaTeXInstallError.unpackFailed }
+        guard proc.terminationStatus == 0 else { throw ExtensionInstallError.unpackFailed }
     }
 }

--- a/Sources/EdmundCore/Extensions/MermaidExtension.swift
+++ b/Sources/EdmundCore/Extensions/MermaidExtension.swift
@@ -39,11 +39,12 @@ public final class MermaidExtension: EdmundExtension {
     // Measured from the unpacked payload: a 1.49 MB bundled JS file plus three
     // license texts.
     public let installedSizeDescription: String? = "1.5 MB"
-    // beautiful-mermaid 1.1.3's actual npm publish date (read from the registry,
-    // not a guess) — not Edmund's own commit date.
+    // When v1.0.0 of *this extension* shipped, not when the beautiful-mermaid
+    // it downloads was published (2026-01-28) — the row sits under the version
+    // above and has to describe the same thing.
     public let lastUpdated: Date? = {
         var c = DateComponents()
-        c.year = 2026; c.month = 1; c.day = 28
+        c.year = 2026; c.month = 8; c.day = 1
         return Calendar(identifier: .gregorian).date(from: c)
     }()
     // No real download-analytics source exists for this extension.

--- a/Sources/EdmundCore/Extensions/MermaidExtension.swift
+++ b/Sources/EdmundCore/Extensions/MermaidExtension.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// "Mermaid" — renders ```` ```mermaid ```` fenced code blocks as diagrams in
+/// Read mode and in HTML/PDF export, using `beautiful-mermaid` (MIT) run as
+/// plain JavaScript in JavaScriptCore rather than shipped in the binary.
+/// See `MermaidRelease`/`MermaidRenderer` for the download, verify, and load
+/// machinery this wraps.
+///
+/// Edit mode deliberately still shows the raw fence as a code block; see
+/// `docs/architecture/reader-and-export.md`.
+@MainActor
+public final class MermaidExtension: EdmundExtension {
+    public static let shared = MermaidExtension()
+
+    public let id = "mermaid"
+    public let name = "Mermaid"
+    /// This is Edmund's packaging version, not beautiful-mermaid's — the
+    /// upstream project is named and linked in `summary` instead (mirrors how
+    /// Obsidian plugins version themselves separately from any library they
+    /// wrap).
+    public let summary = AttributedString(
+        inlineMarkdown:
+            "Render Mermaid diagrams with code block syntax (```mermaid) using "
+            + "[beautiful-mermaid](https://github.com/lukilabs/beautiful-mermaid). "
+            + "Currently supports flowcharts, state, sequence, class, ER, and XY Charts (bar, line, combined).")
+    public let version = "1.0.0"
+    public var isInstalled: Bool { renderer.isReady }
+    /// This extension provides diagram rendering, not math.
+    public var mathRenderer: MathRenderer? { nil }
+
+    // I7T5 (i7t5.com) is this extension's author. beautiful-mermaid itself
+    // (the library it wraps) is Craft Docs' separate project; that credit
+    // belongs in this extension's own README once it has one, not asserted
+    // here as authorship of this repo. No dedicated extension repo exists yet;
+    // stub until it does.
+    public let developer: ExtensionDeveloper? =
+        ExtensionDeveloper(name: "I7T5", profileURL: URL(string: "https://i7t5.com"))
+    public let repositoryURL: URL? = nil
+    // Measured from the unpacked payload: a 1.49 MB bundled JS file plus three
+    // license texts.
+    public let installedSizeDescription: String? = "1.5 MB"
+    // beautiful-mermaid 1.1.3's actual npm publish date (read from the registry,
+    // not a guess) — not Edmund's own commit date.
+    public let lastUpdated: Date? = {
+        var c = DateComponents()
+        c.year = 2026; c.month = 1; c.day = 28
+        return Calendar(identifier: .gregorian).date(from: c)
+    }()
+    // No real download-analytics source exists for this extension.
+    public let downloadCount: Int? = nil
+    // No README exists at a stable URL yet (extension has no repo of its own).
+    public let longDescriptionURL: URL? = nil
+    public let donateURL: URL? = nil
+    // No update-checking source exists yet — same "scaffold now, wire later"
+    // shape as the install flow itself.
+    public let hasUpdate = false
+    public var payloadIsConfigured: Bool { MermaidRelease.isConfigured }
+
+    public let renderer: MermaidRenderer
+
+    init(renderer: MermaidRenderer = MermaidRenderer.shared) {
+        self.renderer = renderer
+    }
+
+    /// The installer's current state, for Settings to surface a specific
+    /// reason on failure (e.g. the payload not published for this build yet).
+    public var installState: ExtensionInstallState {
+        get async { await renderer.installState }
+    }
+
+    /// Downloads/verifies/installs (if needed) and loads the library. Safe to
+    /// call repeatedly; a no-op once already loaded. Callers still need to set
+    /// `MermaidRenderer.shared.isEnabled` for rendering to actually happen
+    /// (Settings does this on enable).
+    public func download() async {
+        await renderer.install()
+    }
+
+    public func uninstall() async {
+        await renderer.uninstall()
+    }
+}

--- a/Sources/EdmundCore/Math/MathRenderer.swift
+++ b/Sources/EdmundCore/Math/MathRenderer.swift
@@ -153,12 +153,16 @@ public final class MathRendering {
     /// Call after switching the active engine (or finishing an install) so
     /// on-screen equations re-render with the new engine.
     public func engineDidChange() {
-        NotificationCenter.default.post(name: .mathEngineChanged, object: nil)
+        NotificationCenter.default.post(name: .renderEngineChanged, object: nil)
     }
 }
 
 public extension Notification.Name {
-    /// Posted by `MathRendering.engineDidChange()`. Editors observe this and
-    /// recompose their math blocks (narrowest recompose that covers them).
-    static let mathEngineChanged = Notification.Name("EdmundCore.mathEngineChanged")
+    /// Posted when a rendering engine is switched, installed, or uninstalled —
+    /// by `MathRendering.engineDidChange()`, and by `AppSettings` when an
+    /// extension is enabled or disabled. Editors observe this and recompose
+    /// their blocks (narrowest recompose that covers them); Read mode
+    /// re-renders. Deliberately not math-specific: one signal for "what draws
+    /// this document changed" beats one per engine.
+    static let renderEngineChanged = Notification.Name("EdmundCore.renderEngineChanged")
 }

--- a/Sources/EdmundCore/Math/RaTeX/RaTeXRelease.swift
+++ b/Sources/EdmundCore/Math/RaTeX/RaTeXRelease.swift
@@ -38,4 +38,12 @@ public enum RaTeXRelease {
 
     /// Whether a real artifact hash has been pinned.
     public static var isConfigured: Bool { !archiveSHA256.isEmpty }
+
+    /// Coordinates for the shared installer. A version-stamped directory means
+    /// a new pinned version installs fresh.
+    public static let payload = ExtensionPayload(
+        directoryName: "Math/ratex-\(version)",
+        archiveURL: archiveURL,
+        archiveSHA256: archiveSHA256,
+        sentinelFile: "ratex_wasm_bg.wasm")
 }

--- a/Sources/EdmundCore/Math/RaTeX/RaTeXRenderer.swift
+++ b/Sources/EdmundCore/Math/RaTeX/RaTeXRenderer.swift
@@ -11,16 +11,17 @@ import AppKit
 public final class RaTeXRenderer: MathRenderer {
     public let id = "ratex@\(RaTeXRelease.version)"
     private let host: WasmMathHost
-    private let installer: RaTeXInstaller
+    private let installer: ExtensionPayloadInstaller
 
     public var isReady: Bool { host.isLoaded }
     /// The installer's current state, for Settings to surface (downloading
     /// %, verifying, ready, failed → retry).
-    public var installState: MathExtensionState {
+    public var installState: ExtensionInstallState {
         get async { await installer.state }
     }
 
-    public init(host: WasmMathHost = WasmMathHost(), installer: RaTeXInstaller = RaTeXInstaller()) {
+    public init(host: WasmMathHost = WasmMathHost(),
+                installer: ExtensionPayloadInstaller = ExtensionPayloadInstaller(payload: RaTeXRelease.payload)) {
         self.host = host
         self.installer = installer
     }

--- a/Sources/EdmundCore/Math/RaTeX/WasmMathHost.swift
+++ b/Sources/EdmundCore/Math/RaTeX/WasmMathHost.swift
@@ -8,7 +8,7 @@ import JavaScriptCore
 /// (`TextEncoder`/`TextDecoder`) and is an ES module we flatten to plain
 /// globals so `initSync(bytes)` can byte-init it with no `fetch`.
 ///
-/// Install directory layout (produced by `RaTeXInstaller`):
+/// Install directory layout (produced by `ExtensionPayloadInstaller`):
 ///   `ratex_wasm_bg.wasm`, `ratex_wasm.js`, `fonts/KaTeX_*.ttf`
 ///
 /// Confined to the main actor: the only callers (`mathOverlay`,

--- a/Sources/EdmundCore/Model/MermaidSyntax.swift
+++ b/Sources/EdmundCore/Model/MermaidSyntax.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Shared recognition for Mermaid fenced-code info strings. Mermaid permits
+/// whitespace after the language name, so only the first info-string word
+/// selects the renderer; the complete code body is passed through unchanged.
+enum MermaidSyntax {
+    static func matches(language: String?) -> Bool {
+        language?
+            .split(whereSeparator: \.isWhitespace)
+            .first?
+            .lowercased() == "mermaid"
+    }
+}

--- a/Sources/EdmundCore/TextView/EditorTextView.swift
+++ b/Sources/EdmundCore/TextView/EditorTextView.swift
@@ -505,8 +505,8 @@ public class EditorTextView: NSTextView {
         // (which would reset every fragment to a height estimate).
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(mathEngineDidChange(_:)),
-            name: .mathEngineChanged,
+            selector: #selector(renderEngineDidChange(_:)),
+            name: .renderEngineChanged,
             object: nil
         )
     }
@@ -524,7 +524,7 @@ public class EditorTextView: NSTextView {
     }
     #endif
 
-    @objc private func mathEngineDidChange(_ note: Notification) {
+    @objc private func renderEngineDidChange(_ note: Notification) {
         guard !blocks.isEmpty else { return }
         recomposeDirty(IndexSet(integersIn: 0..<blocks.count),
                       cursorInRaw: selectedRange().location)

--- a/Sources/edmd/Settings/AppSettings.swift
+++ b/Sources/edmd/Settings/AppSettings.swift
@@ -325,11 +325,12 @@ enum AppSettings {
         applyExtensionStates()
     }
 
-    /// Wires enabled extensions into the app's live state: today, whether
-    /// "Advanced Math" is enabled decides `MathRendering.shared.alternate`
-    /// (RaTeX vs. falling back to SwiftMath), and on-screen equations
-    /// restyle via `engineDidChange()`. Called at launch and whenever an
-    /// extension is enabled/disabled in Settings.
+    /// Wires enabled extensions into the app's live state: whether "Advanced
+    /// Math" is enabled decides `MathRendering.shared.alternate` (RaTeX vs.
+    /// falling back to SwiftMath), and whether "Mermaid" is enabled decides
+    /// whether `MermaidRenderer.shared` will render diagrams at all. On-screen
+    /// content restyles via `.renderEngineChanged`. Called at launch and
+    /// whenever an extension is enabled/disabled in Settings.
     @MainActor static func applyExtensionStates() {
         let mathExt = AdvancedMathExtension.shared
         if isExtensionEnabled(mathExt.id) {
@@ -346,6 +347,19 @@ enum AppSettings {
         } else {
             MathRendering.shared.alternate = nil
         }
+
+        // Same shape for Mermaid, minus the fallback: there is no built-in
+        // diagram engine to degrade to, so "disabled" simply means the fenced
+        // block stays a code block.
+        let mermaidExt = MermaidExtension.shared
+        MermaidRenderer.shared.isEnabled = isExtensionEnabled(mermaidExt.id)
+        if MermaidRenderer.shared.isEnabled {
+            Task {
+                await mermaidExt.download()
+                NotificationCenter.default.post(name: .renderEngineChanged, object: nil)
+            }
+        }
+
         MathRendering.shared.engineDidChange()
     }
 

--- a/Sources/edmd/Settings/ExtensionsSettingsView.swift
+++ b/Sources/edmd/Settings/ExtensionsSettingsView.swift
@@ -263,6 +263,7 @@ struct ExtensionsSettingsView: View {
         return ExtensionRow(
             name: ext.name,
             isEnabled: enabledIDs.contains(ext.id),
+            isInstalled: ext.isInstalled,
             isEmphasized: isEmphasized,
             dotInset: Self.dotInset,
             dotGutter: Self.dotGutter,
@@ -308,6 +309,7 @@ struct ExtensionsSettingsView: View {
 private struct ExtensionRow: View {
     let name: String
     let isEnabled: Bool
+    let isInstalled: Bool
     let isEmphasized: Bool
     let dotInset: CGFloat
     let dotGutter: CGFloat
@@ -317,10 +319,12 @@ private struct ExtensionRow: View {
     /// by hand here, so nothing else is going to adjust the label for it.
     /// A disabled extension is dimmed two steps down from an enabled one —
     /// tertiary, not secondary — so the difference is visible at a glance next to
-    /// an enabled row rather than only in comparison.
+    /// an enabled row rather than only in comparison. Dimming means *disabled*,
+    /// so it applies only under "Installed": a recommended row has nothing to
+    /// enable yet, and dimming it would read as a state it can't be in.
     private var labelColor: Color {
         if isEmphasized { return Color(nsColor: .selectedMenuItemTextColor) }
-        return Color(nsColor: isEnabled ? .labelColor : .tertiaryLabelColor)
+        return Color(nsColor: isEnabled || !isInstalled ? .labelColor : .tertiaryLabelColor)
     }
 
     /// Dimmer than the name it marks, so it reads as a quiet indicator rather

--- a/Sources/edmd/Settings/ExtensionsSettingsView.swift
+++ b/Sources/edmd/Settings/ExtensionsSettingsView.swift
@@ -423,7 +423,7 @@ private struct ExtensionDetailView: View {
         // in the background outside this view (AppSettings.applyExtensionStates
         // re-installing a previously-enabled extension at launch) — catch that
         // by refreshing on the same notification that signals a real change.
-        .onReceive(NotificationCenter.default.publisher(for: .mathEngineChanged)) { _ in
+        .onReceive(NotificationCenter.default.publisher(for: .renderEngineChanged)) { _ in
             isInstalled = ext.isInstalled
         }
     }
@@ -507,11 +507,12 @@ private struct ExtensionDetailView: View {
             if ext.isInstalled {
                 isInstalled = true
             } else {
-                // Only real extension today; a generic "download failed"
-                // would be technically true but less useful here — say why.
-                downloadError = RaTeXRelease.isConfigured
+                // A generic "download failed" would be technically true but
+                // less useful when the payload was never published for this
+                // build — that download can never succeed, so say so.
+                downloadError = ext.payloadIsConfigured
                     ? "Download failed. Try again."
-                    : "RaTeX isn't available in this build yet."
+                    : "\(ext.name) isn't available in this build yet."
             }
         }
     }

--- a/Tests/EdmundTests/ExtensionRegistryTests.swift
+++ b/Tests/EdmundTests/ExtensionRegistryTests.swift
@@ -69,4 +69,78 @@ struct ExtensionRegistryTests {
         // No update-checking source exists yet.
         #expect(ext.hasUpdate == false)
     }
+
+    // MARK: - Mermaid
+
+    @Test("Mermaid is registered and not installed before its payload is downloaded")
+    @MainActor func mermaidListed() {
+        #expect(ExtensionRegistry.all.count == 2)
+        let ext = ExtensionRegistry.all.first { $0.id == "mermaid" }
+        #expect(ext != nil)
+        #expect(ext?.name == "Mermaid")
+        #expect(ext?.isInstalled == false)
+        // This one provides diagram rendering, not a math engine.
+        #expect(ext?.mathRenderer == nil)
+    }
+
+    @Test("Extension IDs are unique — they key the persisted enabled set")
+    @MainActor func idsAreUnique() {
+        let ids = ExtensionRegistry.all.map(\.id)
+        #expect(Set(ids).count == ids.count)
+    }
+
+    @Test("Mermaid's version is Edmund's own packaging version, not the library's")
+    @MainActor func mermaidVersioning() {
+        let ext = MermaidExtension.shared
+        #expect(ext.version == "1.0.0")
+        // beautiful-mermaid's own version is named in MermaidRelease, and the
+        // library is credited in `summary` — not conflated with this number.
+        #expect(ext.version != MermaidRelease.version)
+        #expect(String(ext.summary.characters).split(separator: " ").count <= 30)
+    }
+
+    @Test("Mermaid's summary keeps its triple-backtick fence and links the library")
+    @MainActor func mermaidSummaryLinks() {
+        let summary = MermaidExtension.shared.summary
+        let text = String(summary.characters)
+
+        // The fence spelling is the whole point of the sentence — a markdown
+        // parser that swallowed it (a code span opened by ``` and never
+        // closed) would leave the user guessing at the syntax. Inline-only
+        // parsing preserves it verbatim.
+        #expect(text.contains("(```mermaid)"))
+        // The link markup is consumed, not shown.
+        #expect(!text.contains("https://"))
+        #expect(!text.contains("]("))
+
+        let links = summary.runs.compactMap(\.link)
+        #expect(links == [URL(string: "https://github.com/lukilabs/beautiful-mermaid")])
+        // …and it is "beautiful-mermaid" that carries it, not the whole sentence.
+        let linked = summary.runs.filter { $0.link != nil }
+            .map { String(summary[$0.range].characters) }
+        #expect(linked == ["beautiful-mermaid"])
+
+        // Every diagram type the description claims is one the payload can
+        // actually render (asserted end-to-end in MermaidJSIntegrationTests).
+        for kind in ["flowchart", "state", "sequence", "class", "ER", "XY Chart"] {
+            #expect(text.contains(kind), "summary should mention \(kind)")
+        }
+    }
+
+    @Test("Mermaid's metadata fields are honest about what's actually known")
+    @MainActor func mermaidMetadata() {
+        let ext = MermaidExtension.shared
+        #expect(ext.developer?.name == "I7T5")
+        #expect(ext.developer?.profileURL != nil)
+        #expect(ext.installedSizeDescription != nil)
+        #expect(ext.lastUpdated != nil)
+        #expect(ext.repositoryURL == nil)
+        #expect(ext.longDescriptionURL == nil)
+        #expect(ext.downloadCount == nil)
+        #expect(ext.donateURL == nil)
+        #expect(ext.hasUpdate == false)
+        // Tracks the release pin, so Settings can say "not available in this
+        // build yet" instead of offering a download that cannot be verified.
+        #expect(ext.payloadIsConfigured == MermaidRelease.isConfigured)
+    }
 }

--- a/Tests/EdmundTests/MermaidJSIntegrationTests.swift
+++ b/Tests/EdmundTests/MermaidJSIntegrationTests.swift
@@ -139,4 +139,29 @@ struct MermaidJSIntegrationTests {
         #expect(darkSVG.contains("--bg:#292929"))
         #expect(darkSVG != first)
     }
+
+    // Exercises the pinned coordinates themselves — downloads
+    // `MermaidRelease.archiveURL`, checks it against `archiveSHA256`, installs,
+    // and renders. This is the only test that can catch a payload that was
+    // never uploaded, a moved/renamed release asset, or a hash pinned from a
+    // local build that doesn't match the hosted file. Opt-in via `MERMAID_LIVE`
+    // because it needs the network and writes to the real Application Support
+    // install directory, so it must not run in CI or on an offline machine.
+    // Mirrors `RaTeXWasmIntegrationTests.pinnedReleaseInstalls`.
+    @Test("Pinned release URL and SHA-256 install and render for real")
+    @MainActor func pinnedReleaseInstalls() async throws {
+        guard ProcessInfo.processInfo.environment["MERMAID_LIVE"] != nil else { return }
+
+        let renderer = MermaidRenderer()
+        renderer.isEnabled = true
+        await renderer.install()
+        #expect(renderer.isReady, "install failed — check the pinned URL and SHA-256")
+
+        let svg = try #require(renderer.svg(source: "graph TD\n  A[One] --> B[Two]", style: style))
+        #expect(svg.hasPrefix("<svg"))
+        // The labels prove the JS actually laid the diagram out, rather than a
+        // stub or an error string that happens to start with "<svg".
+        #expect(svg.contains("One"))
+        #expect(svg.contains("Two"))
+    }
 }

--- a/Tests/EdmundTests/MermaidJSIntegrationTests.swift
+++ b/Tests/EdmundTests/MermaidJSIntegrationTests.swift
@@ -1,0 +1,142 @@
+import Testing
+import Foundation
+import CryptoKit
+@testable import EdmundCore
+
+// End-to-end Mermaid tests. Opt-in so they never run in CI or on a machine
+// without the payload; each skips (passing with no assertions) when the env
+// var is unset.
+//
+//   MERMAID_ARCHIVE=<path to beautiful-mermaid-<v>.tar.gz>
+//     Exercises installer-unpack → JSCore-load → SVG-render against a local
+//     payload, without shipping the ~500 KB artifact into the repo.
+//     Build one with scripts/build-mermaid-payload.sh.
+@Suite("Mermaid — JS integration (gated on MERMAID_ARCHIVE)")
+struct MermaidJSIntegrationTests {
+
+    private var archiveURL: URL? {
+        ProcessInfo.processInfo.environment["MERMAID_ARCHIVE"].map { URL(fileURLWithPath: $0) }
+    }
+    private func sha256(_ d: Data) -> String {
+        SHA256.hash(data: d).map { String(format: "%02x", $0) }.joined()
+    }
+    private var style: MermaidStyle {
+        MermaidStyle(backgroundHex: "#FFFFFF", foregroundHex: "#27272A")
+    }
+
+    /// Unpacks the payload into a temp dir and returns a loaded, enabled renderer.
+    @MainActor
+    private func loadedRenderer(into dir: URL) async throws -> MermaidRenderer {
+        let data = try Data(contentsOf: #require(archiveURL))
+        let installer = ExtensionPayloadInstaller(payload: MermaidRelease.payload)
+        try await installer.installAtomically(archive: data, sha256: sha256(data), into: dir)
+
+        let renderer = MermaidRenderer()
+        renderer.load(dir: dir)
+        renderer.isEnabled = true
+        return renderer
+    }
+
+    @Test("Unpack, load, and render every supported diagram type")
+    @MainActor func endToEnd() async throws {
+        guard archiveURL != nil else { return }   // skipped without the local payload
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mermaid-it-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let renderer = try await loadedRenderer(into: dir)
+
+        #expect(renderer.isReady)
+
+        // The payload redistributes third-party work — beautiful-mermaid (MIT),
+        // elkjs (EPL-2.0) and entities (BSD-2) — so the license text has to
+        // travel inside the archive that lands on disk, not just live in the
+        // hosting repo. EPL-2.0 in particular requires it.
+        let fm = FileManager.default
+        #expect(fm.fileExists(atPath: dir.appendingPathComponent("beautiful-mermaid.js").path))
+        #expect(fm.fileExists(atPath: dir.appendingPathComponent("licenses/LICENSE-beautiful-mermaid").path))
+        #expect(fm.fileExists(atPath: dir.appendingPathComponent("licenses/LICENSE-elkjs").path))
+        #expect(fm.fileExists(atPath: dir.appendingPathComponent("licenses/LICENSE-entities").path))
+
+        // The six types the extension's description claims.
+        let diagrams: [(String, String)] = [
+            ("flowchart", "graph TD\n  A[Write] --> B[Preview]\n  B --> C{Export?}\n  C -->|PDF| D[Print]"),
+            ("state", "stateDiagram-v2\n  [*] --> Idle\n  Idle --> Running: start\n  Running --> [*]"),
+            ("sequence", "sequenceDiagram\n  Alice->>Bob: Hello\n  Bob-->>Alice: Hi"),
+            ("class", "classDiagram\n  class Doc { +String title\n +save() }\n  Doc <|-- Markdown"),
+            ("er", "erDiagram\n  DOC ||--o{ BLOCK : contains"),
+            ("xychart", "xychart-beta\n  title \"Sales\"\n  x-axis [jan, feb, mar]\n  y-axis \"Rev\" 0 --> 100\n  bar [30, 60, 90]\n  line [30, 60, 90]"),
+        ]
+        for (name, source) in diagrams {
+            let svg = renderer.svg(source: source, style: style)
+            #expect(svg != nil, "\(name) should render")
+            #expect(svg?.hasPrefix("<svg") == true, "\(name) should be an SVG")
+        }
+    }
+
+    @Test("Rendered SVG is self-contained: no webfont import, no script, arrowheads intact")
+    @MainActor func selfContained() async throws {
+        guard archiveURL != nil else { return }
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mermaid-it-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let renderer = try await loadedRenderer(into: dir)
+
+        let svg = try #require(renderer.svg(source: "graph TD\n  A[Write] --> B[Preview]", style: style))
+
+        // Read mode's page reaches the network for nothing. The payload shim
+        // strips the Google Fonts @import; this asserts it actually did.
+        #expect(!svg.contains("@import"))
+        #expect(!svg.contains("fonts.googleapis.com"))
+        #expect(!svg.contains("<script"))
+
+        // Colour custom properties and color-mix() are deliberately KEPT —
+        // WebKit resolves both, and the <svg> tag carries --bg/--fg inline, so
+        // the result is still self-contained. Flattening them in JS would only
+        // matter for a CoreSVG raster path, which read mode doesn't use.
+        #expect(svg.contains("--bg:#FFFFFF"))
+        #expect(svg.contains("var(--"))
+
+        // Labels and arrowheads are the whole point of a diagram.
+        #expect(svg.contains("Write"))
+        #expect(svg.contains("Preview"))
+        #expect(svg.contains("<marker"))
+        #expect(svg.contains("url(#arrowhead)"))
+    }
+
+    @Test("Malformed diagram source returns nil rather than throwing")
+    @MainActor func malformedSource() async throws {
+        guard archiveURL != nil else { return }
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mermaid-it-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let renderer = try await loadedRenderer(into: dir)
+
+        #expect(renderer.svg(source: "not a diagram at all {{{", style: style) == nil)
+        #expect(renderer.svg(source: "", style: style) == nil)
+
+        // A disabled extension refuses to render even with the payload loaded,
+        // so toggling it off takes effect without an uninstall.
+        renderer.isEnabled = false
+        #expect(renderer.svg(source: "graph TD\n  A --> B", style: style) == nil)
+    }
+
+    @Test("Repeat renders are served from cache and stay identical")
+    @MainActor func cacheHits() async throws {
+        guard archiveURL != nil else { return }
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mermaid-it-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let renderer = try await loadedRenderer(into: dir)
+
+        let source = "graph TD\n  A[One] --> B[Two]"
+        let first = try #require(renderer.svg(source: source, style: style))
+        let second = try #require(renderer.svg(source: source, style: style))
+        #expect(first == second)
+
+        // A different palette is a different cache entry, not a stale hit.
+        let dark = MermaidStyle(backgroundHex: "#292929", foregroundHex: "#DDDDDD")
+        let darkSVG = try #require(renderer.svg(source: source, style: dark))
+        #expect(darkSVG.contains("--bg:#292929"))
+        #expect(darkSVG != first)
+    }
+}

--- a/Tests/EdmundTests/MermaidPayloadTests.swift
+++ b/Tests/EdmundTests/MermaidPayloadTests.swift
@@ -1,0 +1,102 @@
+import Testing
+import Foundation
+@testable import EdmundCore
+
+@Suite("Mermaid — payload scaffold")
+struct MermaidPayloadTests {
+
+    // MARK: Fence recognition
+
+    @Test("A mermaid info string selects the renderer, other languages don't")
+    func fenceRecognition() {
+        #expect(MermaidSyntax.matches(language: "mermaid"))
+        // Mermaid permits whitespace after the language name, so only the
+        // first info-string word decides.
+        #expect(MermaidSyntax.matches(language: "mermaid  "))
+        #expect(MermaidSyntax.matches(language: "mermaid theme=dark"))
+        #expect(MermaidSyntax.matches(language: "MERMAID"))
+        #expect(MermaidSyntax.matches(language: "Mermaid"))
+
+        #expect(!MermaidSyntax.matches(language: "swift"))
+        #expect(!MermaidSyntax.matches(language: "mermaidjs"))
+        #expect(!MermaidSyntax.matches(language: ""))
+        #expect(!MermaidSyntax.matches(language: nil))
+    }
+
+    // MARK: Release pin
+
+    @Test("The payload is pinned to a version-stamped directory and a sentinel file")
+    func payloadShape() {
+        let payload = MermaidRelease.payload
+        #expect(payload.directoryName == "Diagrams/beautiful-mermaid-\(MermaidRelease.version)")
+        #expect(payload.sentinelFile == "beautiful-mermaid.js")
+        #expect(payload.archiveURL.absoluteString.contains(MermaidRelease.version))
+        // A version-stamped install directory means a new pin installs fresh
+        // rather than merging into the previous version's files.
+        #expect(payload.installDirectory.path.hasSuffix("Edmund/Diagrams/beautiful-mermaid-\(MermaidRelease.version)"))
+    }
+
+    @Test("The pinned hash is either absent or a real lowercase SHA-256")
+    func hashPinIsHonest() {
+        // Empty is legitimate: it means the asset isn't published yet, and
+        // `isConfigured` stays false so nothing tries to download something it
+        // cannot verify. What must never happen is a malformed pin.
+        let hash = MermaidRelease.archiveSHA256
+        #expect(MermaidRelease.isConfigured == !hash.isEmpty)
+        if !hash.isEmpty {
+            #expect(hash.count == 64)
+            #expect(hash == hash.lowercased())
+            #expect(hash.allSatisfy { $0.isHexDigit })
+        }
+    }
+
+    // MARK: Renderer, before anything is installed
+
+    @Test("A renderer with no payload returns nil instead of crashing")
+    @MainActor func rendererNotReady() {
+        let renderer = MermaidRenderer()
+        #expect(!renderer.isReady)
+
+        // Disabled and not installed.
+        #expect(renderer.svg(source: "graph TD\n A --> B", style: .init(backgroundHex: "#FFFFFF", foregroundHex: "#000000")) == nil)
+
+        // Enabled but still not installed — the caller falls back to showing
+        // the fence as a plain code block.
+        renderer.isEnabled = true
+        #expect(renderer.svg(source: "graph TD\n A --> B", style: .init(backgroundHex: "#FFFFFF", foregroundHex: "#000000")) == nil)
+    }
+
+    @Test("Uninstalling before ever installing is safe")
+    @MainActor func uninstallWithoutInstall() async {
+        let renderer = MermaidRenderer()
+        await renderer.uninstall()   // must not crash
+        #expect(!renderer.isReady)
+    }
+
+    @Test("Style JSON carries the page palette and sets no font")
+    func styleJSON() {
+        let json = MermaidStyle(backgroundHex: "#FFFFFF", foregroundHex: "#27272A").optionsJSON
+        #expect(json == ##"{"bg":"#FFFFFF","fg":"#27272A"}"##)
+        // Passing the editor's serif body font would risk labels overflowing
+        // boxes sized by the library's Inter-calibrated width heuristic.
+        #expect(!json.contains("font"))
+    }
+
+    // MARK: SVG safety filter
+
+    @Test("The safety filter allows arrowhead refs but rejects script and network reach")
+    func svgSafetyFilter() {
+        // url(#…) is how every arrowhead is drawn — rejecting `url(` outright
+        // would silently strip the arrowheads off every diagram.
+        #expect(MermaidRenderer.isSafeSVG(#"<svg><path marker-end="url(#arrowhead)"/></svg>"#))
+        #expect(MermaidRenderer.isSafeSVG(#"<svg><style>svg { --_line: color-mix(in srgb, var(--fg) 50%, var(--bg)); }</style></svg>"#))
+
+        #expect(!MermaidRenderer.isSafeSVG("<svg><script>alert(1)</script></svg>"))
+        #expect(!MermaidRenderer.isSafeSVG(#"<svg><image href="javascript:alert(1)"/></svg>"#))
+        #expect(!MermaidRenderer.isSafeSVG("<svg><style>@import url('https://fonts.googleapis.com/x');</style></svg>"))
+        #expect(!MermaidRenderer.isSafeSVG(#"<svg><rect fill="url(https://evil.example/x)"/></svg>"#))
+        #expect(!MermaidRenderer.isSafeSVG(#"<svg onload="alert(1)"></svg>"#))
+        #expect(!MermaidRenderer.isSafeSVG(#"<svg><foreignObject><body/></foreignObject></svg>"#))
+        #expect(!MermaidRenderer.isSafeSVG(#"<svg><use href="http://evil.example/x"/></svg>"#))
+    }
+}

--- a/Tests/EdmundTests/MermaidReadModeTests.swift
+++ b/Tests/EdmundTests/MermaidReadModeTests.swift
@@ -1,0 +1,163 @@
+import Testing
+import Foundation
+import CryptoKit
+@testable import EdmundCore
+
+@Suite("Mermaid — read mode and export")
+struct MermaidReadModeTests {
+
+    private let markdown = """
+    # Doc
+
+    ```mermaid
+    graph TD
+      A[Write] --> B[Preview]
+    ```
+
+    Tail paragraph.
+    """
+
+    // MARK: Placeholder emission (no renderer involved)
+
+    @Test("A mermaid fence is wrapped in a placeholder carrying its source")
+    func placeholderEmitted() {
+        let html = HTMLRenderer.render(markdown: markdown)
+        #expect(html.contains("class=\"mermaid-diagram\""))
+        #expect(html.contains("data-source=\""))
+
+        // The source rides base64-encoded so no markdown punctuation can break
+        // out of the attribute.
+        let source = "graph TD\n  A[Write] --> B[Preview]"
+        #expect(html.contains(Data(source.utf8).base64EncodedString()))
+    }
+
+    @Test("A non-mermaid fence is left completely alone")
+    func otherLanguagesUntouched() {
+        let html = HTMLRenderer.render(markdown: "```swift\nlet x = 1\n```")
+        #expect(!html.contains("mermaid-diagram"))
+        #expect(html.contains("code-block-wrap"))
+    }
+
+    // MARK: Fallback — the extension off / not installed
+
+    @Test("With no renderer, a mermaid fence renders as an ordinary code block")
+    @MainActor func fallbackIsAPlainCodeBlock() {
+        MermaidRenderer.shared.isEnabled = false
+
+        let full = DocumentHTML.full(markdown: markdown, theme: .default,
+                                     callouts: [:], dark: false)
+        // No placeholder leaks into the finished document…
+        #expect(!full.contains("data-source="))
+        // …and what's left is a real code block, copy button and all, so the
+        // fallback can't drift from how every other fence renders.
+        // Matched as an element: ".code-block-wrap" also appears in the
+        // stylesheet, so a bare substring check could never fail.
+        #expect(full.contains("class=\"code-block-wrap\">"))
+        // The code is syntax-highlighted into spans, so the fence body is only
+        // contiguous a token at a time.
+        #expect(full.contains("Preview"))
+        // NOT `!contains("<svg")` — the copy button's icon is an inline SVG on
+        // every code block. An arrowhead marker ref is mermaid-only.
+        #expect(!full.contains("url(#arrowhead)"))
+    }
+
+    @Test("The unwrapped fallback keeps the block's source-line anchor")
+    @MainActor func fallbackKeepsScrollAnchor() {
+        MermaidRenderer.shared.isEnabled = false
+
+        let full = DocumentHTML.full(markdown: markdown, theme: .default,
+                                     callouts: [:], dark: false)
+        // The fence starts on line 3. Losing this id would punch a hole in
+        // Read mode's scroll-sync anchor list exactly where the diagram is.
+        #expect(full.contains("<div id=\"edmund-l3\" class=\"code-block-wrap\""))
+    }
+
+    // MARK: Rendered output (gated on a real payload)
+
+    private var archiveURL: URL? {
+        ProcessInfo.processInfo.environment["MERMAID_ARCHIVE"].map { URL(fileURLWithPath: $0) }
+    }
+
+    @MainActor
+    private func withLoadedRenderer(_ body: (URL) async throws -> Void) async throws {
+        guard let archiveURL else { return }   // skipped without the local payload
+        let data = try Data(contentsOf: archiveURL)
+        let sha = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mermaid-rm-\(UUID().uuidString)", isDirectory: true)
+        defer {
+            try? FileManager.default.removeItem(at: dir)
+            MermaidRenderer.shared.unload()
+            MermaidRenderer.shared.isEnabled = false
+        }
+        let installer = ExtensionPayloadInstaller(payload: MermaidRelease.payload)
+        try await installer.installAtomically(archive: data, sha256: sha, into: dir)
+
+        // DocumentHTML reaches the shared instance directly, so the test has to
+        // stand that one up rather than inject its own.
+        MermaidRenderer.shared.load(dir: dir)
+        MermaidRenderer.shared.isEnabled = true
+        try await body(dir)
+    }
+
+    @Test("An installed, enabled extension inlines the diagram as SVG")
+    @MainActor func rendersInlineSVG() async throws {
+        try await withLoadedRenderer { _ in
+            let full = DocumentHTML.full(markdown: markdown, theme: .default,
+                                         callouts: [:], dark: false)
+
+            #expect(full.contains("<svg"))
+            #expect(full.contains("Write"))
+            #expect(full.contains("url(#arrowhead)"))
+            // The placeholder is consumed and the code-block fallback is gone.
+            #expect(!full.contains("data-source="))
+            #expect(!full.contains("class=\"code-block-wrap\">"))
+            // Read mode's page reaches the network for nothing and runs no
+            // script — the CSP meta is belt-and-braces, this is the check that
+            // nothing needing them got inlined.
+            #expect(!full.contains("@import"))
+            #expect(!full.contains("fonts.googleapis.com"))
+
+            // Screen readers get the diagram source, not the SVG's text nodes
+            // read out in layout order.
+            #expect(full.contains("role=\"img\""))
+            #expect(full.contains("aria-label=\"graph TD"))
+
+            // The source-line anchor survives the fill pass.
+            #expect(full.contains("<div id=\"edmund-l3\" class=\"mermaid-diagram\""))
+        }
+    }
+
+    @Test("The diagram picks up the page palette for the target appearance")
+    @MainActor func followsAppearance() async throws {
+        try await withLoadedRenderer { _ in
+            let light = DocumentHTML.full(markdown: markdown, theme: .default,
+                                          callouts: [:], dark: false)
+            let dark = DocumentHTML.full(markdown: markdown, theme: .default,
+                                         callouts: [:], dark: true)
+            #expect(light != dark)
+            // Resolved against the requested appearance rather than the current
+            // one, because an export can target either.
+            let lightBG = HTMLTheme.backgroundColor(dark: false).hexString
+            let darkBG = HTMLTheme.backgroundColor(dark: true).hexString
+            #expect(light.contains("--bg:\(lightBG)"))
+            #expect(dark.contains("--bg:\(darkBG)"))
+        }
+    }
+
+    @Test("A diagram that doesn't parse falls back to the code block")
+    @MainActor func malformedFallsBack() async throws {
+        try await withLoadedRenderer { _ in
+            let bad = """
+            ```mermaid
+            not a diagram at all {{{
+            ```
+            """
+            let full = DocumentHTML.full(markdown: bad, theme: .default,
+                                         callouts: [:], dark: false)
+            #expect(!full.contains("url(#arrowhead)"))
+            #expect(full.contains("class=\"code-block-wrap\">"))
+            #expect(full.contains("a diagram at all"))
+        }
+    }
+}

--- a/Tests/EdmundTests/RaTeXScaffoldTests.swift
+++ b/Tests/EdmundTests/RaTeXScaffoldTests.swift
@@ -5,7 +5,7 @@ import AppKit
 @testable import EdmundCore
 
 // `.serialized`: a couple of tests manipulate the shared real install
-// directory (`RaTeXInstaller.installDirectory`); running them in parallel
+// directory (`RaTeXRelease.payload.installDirectory`); running them in parallel
 // races (one removes the dir while another writes into it).
 @Suite("RaTeX — scaffold", .serialized)
 struct RaTeXScaffoldTests {
@@ -35,10 +35,10 @@ struct RaTeXScaffoldTests {
 
     @Test("Hash verify accepts a matching digest and rejects a mismatch")
     func hashVerification() async throws {
-        let installer = RaTeXInstaller()
+        let installer = ExtensionPayloadInstaller(payload: RaTeXRelease.payload)
         let data = Data("hello ratex".utf8)
 
-        await #expect(throws: RaTeXInstallError.hashMismatch) {
+        await #expect(throws: ExtensionInstallError.hashMismatch) {
             try await installer.verify(data, sha256: "0000000000000000000000000000000000000000000000000000000000000000")
         }
         try await installer.verify(data, sha256: sha256Hex(data))   // does not throw
@@ -63,7 +63,7 @@ struct RaTeXScaffoldTests {
         try tar.run(); tar.waitUntilExit()
         let archive = try Data(contentsOf: tarball)
 
-        let installer = RaTeXInstaller()
+        let installer = ExtensionPayloadInstaller(payload: RaTeXRelease.payload)
         let dir = fm.temporaryDirectory.appendingPathComponent("ratex-inst-\(UUID().uuidString)", isDirectory: true)
         defer { try? fm.removeItem(at: dir) }
 
@@ -78,8 +78,8 @@ struct RaTeXScaffoldTests {
 
     @Test("Uninstall removes the version directory and resets state")
     func uninstallRemovesInstallDirectory() async throws {
-        let installer = RaTeXInstaller()
-        let dir = RaTeXInstaller.installDirectory
+        let installer = ExtensionPayloadInstaller(payload: RaTeXRelease.payload)
+        let dir = RaTeXRelease.payload.installDirectory
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         try Data("stale".utf8).write(to: dir.appendingPathComponent("ratex_wasm_bg.wasm"))
 
@@ -92,8 +92,8 @@ struct RaTeXScaffoldTests {
 
     @Test("Uninstall is safe to call when nothing was ever installed")
     func uninstallWithoutInstallDoesNotThrow() async {
-        let installer = RaTeXInstaller()
-        try? FileManager.default.removeItem(at: RaTeXInstaller.installDirectory)   // ensure absent
+        let installer = ExtensionPayloadInstaller(payload: RaTeXRelease.payload)
+        try? FileManager.default.removeItem(at: RaTeXRelease.payload.installDirectory)   // ensure absent
         await installer.uninstall()   // must not crash
         let state = await installer.state
         #expect(state == .notInstalled)

--- a/Tests/EdmundTests/RaTeXWasmIntegrationTests.swift
+++ b/Tests/EdmundTests/RaTeXWasmIntegrationTests.swift
@@ -29,7 +29,7 @@ struct RaTeXWasmIntegrationTests {
         guard let archiveURL else { return }   // skipped without the local payload
         let data = try Data(contentsOf: archiveURL)
 
-        let installer = RaTeXInstaller()
+        let installer = ExtensionPayloadInstaller(payload: RaTeXRelease.payload)
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("ratex-it-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: dir) }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -187,7 +187,8 @@ rawSource ─BlockParser─▶ [Block] ─SyntaxHighlighter─▶ spans ─style
 | List indent guides | Faint vertical hairlines on list items: one per *ancestor* level spanning the item, plus the item's own column beside its wrapped continuation lines. Offsets from `listGuideOffsets(depth:slotWidth:)` (`Rendering/EditorTextView+ListRendering.swift`), written to `.listGuides` **whether or not the setting is on** — the fragment gates the drawing, so toggling is a re-vend, never a restyle. `EditorTextView.showListIndentGuides`; Settings ▸ Edit. Geometry traps (container-relative offsets, `lineFragmentPadding`): [`architecture/editor-affordances.md`](architecture/editor-affordances.md). |
 | Line numbers | `TextView/EditorTextView+LineNumbers.swift` — source line numbers (Settings ▸ Edit ▸ Lines, off by default), `EditorTextView.showLineNumbers`. **Two placements over one walk**, and the placement is **not** a setting: it follows whether the margin can hold them (beside the content by default, a `LineNumberRulerView` at the window edge otherwise). Also home to `line(forOffset:)`/`offset(forLine:)`, binary-searching the cached `lineStarts`. Editor-only; never printed. Placement rules, the macOS 14 SIGSEGV, draw rules and the tabular-figure face: [`architecture/editor-affordances.md`](architecture/editor-affordances.md). |
 | Focus mode | `TextView/EditorTextView+FocusMode.swift` — dims all but the lines the selection touches (Settings ▸ Edit ▸ Editor, View ▸ Focus Mode; off by default), `EditorTextView.focusMode`. **One transparency layer around `DecoratedTextLayoutFragment.draw`**, so text and its decorations fade as one composite; it cannot be a scrim (NSTextView composites fragments *after* `draw(_:)` returns). Editor-only. Why, and the measurements: [`architecture/editor-affordances.md`](architecture/editor-affordances.md). |
-| Read mode / Export | `Export/` — `HTMLRenderer` (MarkupVisitor → HTML; callout/checkbox icons are inline Lucide SVGs from `LucideIcons`), `HTMLTheme` (EditorTheme → CSS), `DocumentHTML` (assembly + asset inlining: math + local images → data URIs), `ReadModeWebView`, `MarkdownPrinter` (PDF/Print). `Document.refreshReadView()` keeps an open Read view in sync with edits and theme changes. |
+| Read mode / Export | `Export/` — `HTMLRenderer` (MarkupVisitor → HTML; callout/checkbox icons are inline Lucide SVGs from `LucideIcons`), `HTMLTheme` (EditorTheme → CSS), `DocumentHTML` (assembly + asset inlining: math + local images → data URIs, Mermaid diagrams → inline SVG), `ReadModeWebView`, `MarkdownPrinter` (PDF/Print). `Document.refreshReadView()` keeps an open Read view in sync with edits and theme changes. |
+| Extensions | `Extensions/` — `EdmundExtension` (protocol + metadata), `ExtensionRegistry.all` (a static array; there is no backend), `ExtensionPayloadInstaller` (download → SHA-256 verify → unpack → stamp → atomic move, shared by every payload). Two entries: **Advanced Math** (RaTeX WASM, `Math/RaTeX/`) and **Mermaid** (`beautiful-mermaid` JS, `Diagrams/`). Neither is bundled — each is a pinned, hash-verified payload fetched at runtime and hosted in JavaScriptCore, so the shipped binary stays 100% Swift and the default app size is unchanged. Enable state persists in `settings.extensions.enabledIDs`; `AppSettings.applyExtensionStates()` wires it to the live renderers and posts `.renderEngineChanged`. Settings ▸ Extensions. **Not** a third-party code-loading mechanism — see the header of `EdmundExtension.swift`. |
 | Icons | `Model/LucideIcons.swift` — vendored [Lucide](https://lucide.dev) SVGs (ISC, `LICENSES/lucide.txt`). Callout headers use them in **both** modes: Read inlines the SVG (CSS-tinted via `currentColor`); Edit rasterizes to a tinted `NSImage` overlay. SF Symbols can't ship in exported PDFs (license); app-chrome SF Symbols are fine (in-app UI). Edit-mode task checkboxes still use SF Symbols (on-screen only); Read-mode checkboxes are a composed Lucide SVG. |
 | Edit behaviors | `Editing/EditorTextView+{List,Blockquote}Continuation.swift`, `+Indentation.swift`, `+AutoPairs.swift`, `+ListRenumbering.swift` |
 | Hard wrap | `Editing/HardWrap.swift` (pure `wrap`/`unwrap`) + `Editing/EditorTextView+HardWrap.swift` (Edit ▸ Hard Wrap Paragraphs). Settings ▸ Edit ▸ Document, off by default; read at **load/save time in `Document`**, not pushed onto the editor. Treated as a property of the *file*: opening a wrapped file joins its paragraphs, save re-wraps, and **only files that arrived wrapped are wrapped** (`wasHardWrapped`). The column is **derived from the file's own existing breaks**, not guessed. Requires strict line breaks. Full rules, GFM constraints and perf numbers: [`architecture/hard-wrap.md`](architecture/hard-wrap.md). |
@@ -839,11 +840,20 @@ Gatekeeper on first launch; the README documents the
 ID + notarization (§8) would remove the prompt entirely.
 
 **Never release anything through this pipeline except the main app.** The
-tag flow builds and ships `Edmund.app` only. Extension payloads (e.g. the
-RaTeX WASM) have their own hosting/release path — never bundled into or
+tag flow builds and ships `Edmund.app` only. Extension payloads (the RaTeX
+WASM, the `beautiful-mermaid` JS bundle) have their own hosting/release path
+in `I7T5/edmund-extensions`, on non-`v*` tags — never bundled into or
 triggered by an Edmund version tag. (The RaTeX WASM asset was pulled from
 release pending `erweixin/RaTeX` inline-mode support and the Advanced Math
 extension's repo migration — see `misc/backlog.md`.)
+
+A payload's pinned SHA-256 is taken from the **hosted** asset, never the local
+build: the build scripts are byte-stable on one machine but not across
+`tar`/`gzip` implementations, so a local artifact is evidence about that
+machine, not about what users will fetch. Until an asset is published its hash
+stays empty, `isConfigured` is false, and Settings says the extension "isn't
+available in this build yet" rather than offering a download that cannot be
+verified.
 
 ---
 
@@ -859,6 +869,20 @@ Dependencies and prior art worth consulting before designing something new:
   signing/appcast quirks).
 - [Lucide](https://lucide.dev) — vendored icon SVGs (ISC),
   `Model/LucideIcons.swift`.
+- [beautiful-mermaid](https://github.com/lukilabs/beautiful-mermaid) — the
+  Mermaid extension's engine (MIT, by Craft Docs). Runtime-downloaded, not
+  bundled. Its `renderMermaidSVG` is synchronous, which is what lets it run
+  inside the synchronous `DocumentHTML.full` assembly instead of forcing the
+  whole export path async. The payload also carries
+  [elkjs](https://github.com/kieler/elkjs) (**EPL-2.0** — its license text
+  travels inside the payload archive, which is the distribution vehicle; no
+  elkjs code enters this repo or the app binary) and
+  [entities](https://github.com/fb55/entities) (BSD-2-Clause).
+  Read mode's Mermaid support adapts the render-pipeline shape from
+  [#235](https://github.com/I7T5/Edmund/pull/235) by
+  [@CaliLuke](https://github.com/CaliLuke) — fence recognition, the
+  placeholder/fill split, the SVG safety filter and the diagram CSS — with a
+  JavaScriptCore backend in place of that PR's Swift + ELK one.
 - [nodes-app/swift-markdown-engine](https://github.com/nodes-app/swift-markdown-engine)
   — an independent AppKit + TextKit 2 live-preview markdown engine (Apache
   2.0, macOS 14+). Solves the same problems with different trade-offs —

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -877,7 +877,10 @@ Dependencies and prior art worth consulting before designing something new:
   [elkjs](https://github.com/kieler/elkjs) (**EPL-2.0** — its license text
   travels inside the payload archive, which is the distribution vehicle; no
   elkjs code enters this repo or the app binary) and
-  [entities](https://github.com/fb55/entities) (BSD-2-Clause).
+  [entities](https://github.com/fb55/entities) (BSD-2-Clause). All three texts
+  are mirrored in `LICENSES/` — the code isn't vendored here, but the app does
+  hand it to users at runtime, so the terms should be findable without
+  unpacking a tarball.
   Read mode's Mermaid support adapts the render-pipeline shape from
   [#235](https://github.com/I7T5/Edmund/pull/235) by
   [@CaliLuke](https://github.com/CaliLuke) — fence recognition, the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes will be documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Added
+- **Mermaid extension**: renders ` ```mermaid ` code blocks as diagrams in Read mode, HTML export and PDF (vector). Supports flowcharts, state, sequence, class, ER, and XY charts, via [beautiful-mermaid](https://github.com/lukilabs/beautiful-mermaid). Opt-in from Settings > Extensions; the engine is downloaded and hash-verified at runtime, so it adds nothing to the app's size until you enable it. Edit mode still shows the fence as a code block. Adapted in part from #235 (@CaliLuke)
+
+### Changed
+- Extension payloads (Advanced Math, Mermaid) now share one download/verify/install path
+
+
 ## [0.3.0] - 2026-07-27
 
 Settings stuff. 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -77,7 +77,7 @@ Funsies
 ## v2.x
 
 Official extensions
-- [ ] Mermaid diagrams (Read mode only)
+- [x] Mermaid diagrams (Read mode only)
 - [ ] Slides (read mode preview)
 - [ ] Typst: Import from / Export to Typst
 

--- a/docs/architecture/reader-and-export.md
+++ b/docs/architecture/reader-and-export.md
@@ -34,7 +34,7 @@ flowchart LR
 | --- | --- |
 | `HTMLRenderer.swift` | `MarkupVisitor` → HTML; raw-HTML filtering; line anchors |
 | `HTMLTheme.swift` | `EditorTheme` → CSS |
-| `DocumentHTML.swift` | Page assembly, CSP meta, asset inlining (math + local images → data URIs), the image-policy chokepoint |
+| `DocumentHTML.swift` | Page assembly, CSP meta, asset inlining (math + local images → data URIs, Mermaid → inline SVG), the image-policy chokepoint |
 | `ReadModeWebView.swift` | The sandboxed webview + scroll-position mapping |
 | `MarkdownPrinter.swift` | Same HTML through `WKWebView.printOperation` — real vector (selectable) text |
 
@@ -54,6 +54,52 @@ sits inside the paragraph's `<p>`. **This is a deliberate divergence**: Edit
 mode still flows that case inline, because breaking the line around the run
 needs a line break where the source has no break character, which
 storage==rawSource forbids. A `$$` inside code stays literal.
+
+### Mermaid diagrams (the "Mermaid" extension)
+
+A ` ```mermaid ` fence renders as an **inline SVG**, in Read mode, HTML export
+and PDF (vector — strictly better than math's PNGs). Off unless the Mermaid
+extension is enabled and its payload installed; see ARCHITECTURE §Extensions.
+
+Two passes, because `HTMLRenderer` is pure and non-isolated and so cannot reach
+the `@MainActor` renderer:
+
+1. `HTMLRenderer.visitCodeBlock` **wraps** its ordinary code block in
+   `<div class="mermaid-diagram" data-source="<base64>">…</div>`. Base64 so no
+   markdown punctuation can break out of the attribute.
+2. `DocumentHTML.fillMermaid` (before `fillMath`, so a diagram is never scanned
+   for `$…$`) replaces the placeholder with the SVG — or unwraps it.
+
+**Wrapping rather than replacing is the point.** Every fallback — extension
+disabled, payload absent, diagram doesn't parse — unwraps to exactly the markup
+a normal fence produces, copy button and syntax colouring included, so the
+fallback cannot drift from the real thing. The pass must run **even when the
+extension is off**, or raw `data-source="…"` placeholders leak into the
+finished document. Unwrapping moves the block's `edmund-l<N>` anchor onto the
+code block, or a fenced diagram becomes a hole in Read mode's scroll-sync
+anchors.
+
+The SVG is spliced in as live markup, not an opaque image, so
+`MermaidRenderer.isSafeSVG` is a trust boundary: it rejects script,
+`foreignObject`, `use`, event-handler attributes, `@import`, and any `url()`
+that is not a same-document fragment reference. **`url(#…)` must stay
+allowed** — that is how every arrowhead is drawn (nine in a five-node
+flowchart); rejecting `url(` outright silently strips them all.
+
+Colours: only `--bg`/`--fg` are passed, and the library derives the rest by
+mixing them at fixed percentages. The CSS rule resets `--line`/`--accent`/
+`--muted`/`--surface`/`--border` to `initial` on the SVG, because the page
+defines `--accent` (the link colour) on `:root` and it inherits in — arrowheads
+were being painted link-blue. No font is passed either: the library's box sizes
+come from an Inter-calibrated character-width heuristic, so the editor's serif
+body face would risk labels overflowing their boxes.
+
+**This is a deliberate divergence**: Edit mode still shows the raw fence as a
+code block. Rendering there needs a raster `NSImage`, and CoreSVG (what
+`NSImage(data:)` uses) is tuned for SF Symbols and would likely drop the `<text>`
+and `<marker>` elements — a diagram with no labels or arrowheads. The
+alternative, an async offscreen `WKWebView` snapshot, reintroduces the
+fragment-height-estimate churn documented in ARCHITECTURE §6.1.
 
 ## 3. Specs
 


### PR DESCRIPTION
The Mermaid extension from `feat/mermaid-extension` (Aug 12), brought up to date with `main`:

- refactor(extensions): share the payload installer across extensions
- feat(mermaid): host beautiful-mermaid in JavaScriptCore
- feat(extensions): add the Mermaid extension entry and settings wiring
- feat(mermaid): render diagrams in Read mode and export
- docs(mermaid): document the extension, its payload rules, and its credits
- fix(settings): dim only installed extensions in the sidebar
- docs(mermaid): mirror the payload's license texts in LICENSES/
- fix(extensions): last-updated describes the extension, not its payload
- feat(mermaid): pin the published payload's hash
- test(mermaid): cover the pinned release end to end

Merge notes: `ExtensionsSettingsView` now uses main's shared `SettingsSidebarRow` (the branch's local row struct is gone); its "dim only installed-but-disabled extensions" rule is kept as `isDimmed: !isEnabled && ext.isInstalled`. ARCHITECTURE keeps main's rows plus the branch's Extensions row. The branch's `docs/CHANGELOG.md` entry is **not** included — that file is the maintainer's.

1770 tests green; `swift build -c release` passes.